### PR TITLE
[Perf] Stop buffered MOSS-TD decode loops at segment boundaries

### DIFF
--- a/sglang_omni/models/moss_transcribe_diarize/config.py
+++ b/sglang_omni/models/moss_transcribe_diarize/config.py
@@ -31,6 +31,8 @@ class MossTDFactoryArgs(FactoryArgs):
 
     encoder_cache_size_bytes: int | None = Field(default=None, ge=0)
     encoder_max_batch_size: int | None = Field(default=None, ge=1)
+    buffered_no_progress_marker_segments: int = Field(default=0, ge=0)
+    buffered_no_progress_repeat_segments: int = Field(default=0, ge=0)
 
 
 class MossTDStageConfig(EngineStageConfig):

--- a/sglang_omni/models/moss_transcribe_diarize/engine_builder.py
+++ b/sglang_omni/models/moss_transcribe_diarize/engine_builder.py
@@ -49,6 +49,8 @@ class MossTranscribeDiarizeEngineBuilder(AsrEngineBuilder):
         request_build_max_workers: int,
         request_build_max_pending: int | None,
         stream_emit_interval_s: float,
+        buffered_no_progress_marker_segments: int,
+        buffered_no_progress_repeat_segments: int,
     ) -> None:
         self.max_running_requests = max_running_requests
         self.requested_max_new_tokens = max_new_tokens
@@ -75,6 +77,8 @@ class MossTranscribeDiarizeEngineBuilder(AsrEngineBuilder):
         self.request_build_max_workers = request_build_max_workers
         self.request_build_max_pending = request_build_max_pending
         self.stream_emit_interval_s = stream_emit_interval_s
+        self.buffered_no_progress_marker_segments = buffered_no_progress_marker_segments
+        self.buffered_no_progress_repeat_segments = buffered_no_progress_repeat_segments
         self.processor: Any = None
         self.tokenizer: Any = None
         self.audio_encoder_service: BatchedAudioEncoderService | None = None
@@ -178,6 +182,12 @@ class MossTranscribeDiarizeEngineBuilder(AsrEngineBuilder):
                 request_builders.make_moss_transcribe_diarize_stream_output_builder(
                     tokenizer=self.tokenizer,
                     min_emit_interval_s=self.stream_emit_interval_s,
+                    buffered_no_progress_marker_segments=(
+                        self.buffered_no_progress_marker_segments
+                    ),
+                    buffered_no_progress_repeat_segments=(
+                        self.buffered_no_progress_repeat_segments
+                    ),
                 )
             ),
             "enable_async_decode": self.enable_async_decode,

--- a/sglang_omni/models/moss_transcribe_diarize/request_builders.py
+++ b/sglang_omni/models/moss_transcribe_diarize/request_builders.py
@@ -53,6 +53,7 @@ MOSS_TD_MARKER_LOOP_REASON = "moss_td_no_progress_marker_loop"
 MOSS_TD_REPEATED_SEGMENT_REASON = "moss_td_no_progress_repeated_segment"
 _NO_PROGRESS_MAX_PENDING_TOKEN_IDS = 256
 _NO_PROGRESS_MAX_INCOMPLETE_CHARS = 65536
+_NO_PROGRESS_MAX_INCOMPLETE_DECODE_STEPS = 256
 
 # note (db-ol): dense multi speaker meetings decode to about 4.5 output
 # tokens per audio second including time markers, so 10 leaves roughly 2x
@@ -88,6 +89,7 @@ class _MossTDNoProgressState:
     marker_only_segments: int = 0
     repeated_segments: int = 0
     observed_tokens: int = 0
+    incomplete_decode_steps: int = 0
     last_content_signature: tuple[str, str, str, str] | None = None
     disabled: bool = False
 
@@ -105,7 +107,15 @@ class _MossTDNoProgressState:
             self._disable()
             return None
         self.pending_token_ids.append(token_id)
-        decoded = decode_fn(self.pending_token_ids)
+        try:
+            decoded = decode_fn(self.pending_token_ids)
+        except Exception:
+            # note (JiaxinD): tokenizer plugins can surface different ordinary
+            # exception types for malformed IDs. The optional detector must
+            # fail open instead of escalating one request into a batch failure;
+            # process-control BaseException subclasses are intentionally not caught.
+            self._disable()
+            return None
         if decoded.endswith("\ufffd"):
             return None
         if "\ufffd" in decoded:
@@ -153,10 +163,16 @@ class _MossTDNoProgressState:
         # ends exactly on a segment boundary. Streaming output cannot retract
         # an incomplete suffix, so a partial next segment postpones the stop.
         if not self.buffer.strip():
+            self.incomplete_decode_steps = 0
             return self._decision(pending_reason) if pending_reason else None
-        if len(self.buffer) > _NO_PROGRESS_MAX_INCOMPLETE_CHARS:
+        self.incomplete_decode_steps += 1
+        if (
+            len(self.buffer) > _NO_PROGRESS_MAX_INCOMPLETE_CHARS
+            or self.incomplete_decode_steps >= _NO_PROGRESS_MAX_INCOMPLETE_DECODE_STEPS
+        ):
             # note (JiaxinD): unknown output is not loop evidence. Disable the
-            # detector for this request instead of attempting a lossy resync.
+            # detector for this request instead of attempting a lossy resync
+            # or repeatedly rescanning an ever-growing incomplete segment.
             self._disable()
         return None
 
@@ -166,6 +182,7 @@ class _MossTDNoProgressState:
         self.buffer = ""
         self.marker_only_segments = 0
         self.repeated_segments = 0
+        self.incomplete_decode_steps = 0
         self.last_content_signature = None
 
     def _decision(self, reason: str) -> _NoProgressDecision:
@@ -674,7 +691,9 @@ def make_moss_transcribe_diarize_scheduler_adapters(
         if data.no_progress_termination_reason is not None:
             termination_record = {
                 "schema_version": 1,
-                "server_request_id": payload.request_id,
+                "server_request_id_sha256": hashlib.sha256(
+                    str(payload.request_id).encode("utf-8")
+                ).hexdigest(),
                 "output_sha256": hashlib.sha256(text.encode("utf-8")).hexdigest(),
                 "reason": data.no_progress_termination_reason,
                 "completed_segments": data.no_progress_completed_segments,
@@ -777,6 +796,13 @@ def make_moss_transcribe_diarize_stream_output_builder(
                     )
                     req._moss_no_progress_state = state
                 decision = state.observe_token_id(token_id, decode_no_progress_ids)
+                if decision is not None and not getattr(req, "output_ids", None):
+                    # note (JiaxinD): the scheduler callback precedes SGLang's
+                    # first prefill-token commit. Finishing at this point makes
+                    # the result processor drop the boundary token. Suppress
+                    # only this decision; a later complete decode boundary can
+                    # safely confirm the same no-progress sequence.
+                    decision = None
                 if decision is not None and getattr(req, "to_finish", None) is None:
                     req.to_finish = FINISH_MATCHED_STR(matched=decision.reason)
                     req_data.no_progress_termination_reason = decision.reason
@@ -794,10 +820,10 @@ def make_moss_transcribe_diarize_stream_output_builder(
                     req_data.no_progress_repeat_limit = repeat_limit
                     req_data.no_progress_response_mode = "buffered"
                     logger.warning(
-                        "MOSS-TD no-progress termination request_id=%s "
+                        "MOSS-TD no-progress termination request_id_sha256=%s "
                         "reason=%s completion_tokens=%d completed_segments=%d "
                         "marker_only_segments=%d repeated_segments=%d",
-                        request_id,
+                        hashlib.sha256(str(request_id).encode("utf-8")).hexdigest(),
                         decision.reason,
                         decision.detected_completion_tokens,
                         decision.completed_segments,

--- a/sglang_omni/models/moss_transcribe_diarize/request_builders.py
+++ b/sglang_omni/models/moss_transcribe_diarize/request_builders.py
@@ -3,16 +3,19 @@
 
 from __future__ import annotations
 
+import hashlib
+import json
 import logging
 import math
 import re
 import time
-from dataclasses import dataclass
+from dataclasses import dataclass, field
 from typing import Any, Callable
 
 import numpy as np
 import torch
 from sglang.srt.managers.schedule_batch import (
+    FINISH_MATCHED_STR,
     Modality,
     MultimodalDataItem,
     MultimodalInputs,
@@ -35,10 +38,21 @@ _AUDIO_PAD = "<|audio_pad|>"
 _AUDIO_START = "<|audio_start|>"
 _AUDIO_END = "<|audio_end|>"
 _SPECIAL_TOKEN_RE = re.compile(r"<\|(?:im_start|im_end|endoftext)\|>")
+_COMPLETE_SEGMENT_RE = re.compile(
+    r"^\s*\[(?P<start>\d+(?:\.\d+)?)\]\s*"
+    r"\[(?P<speaker>S\d{2,})\]"
+    r"(?P<body>.*?)"
+    r"\[(?P<end>\d+(?:\.\d+)?)\]",
+    re.DOTALL | re.IGNORECASE,
+)
 _WHISPER_ENCODER_STRIDE = 2
 DEFAULT_TEMPERATURE = 0.0
 DEFAULT_TOP_P = 0.95
 DEFAULT_TOP_K = 50
+MOSS_TD_MARKER_LOOP_REASON = "moss_td_no_progress_marker_loop"
+MOSS_TD_REPEATED_SEGMENT_REASON = "moss_td_no_progress_repeated_segment"
+_NO_PROGRESS_MAX_PENDING_TOKEN_IDS = 256
+_NO_PROGRESS_MAX_INCOMPLETE_CHARS = 65536
 
 # note (db-ol): dense multi speaker meetings decode to about 4.5 output
 # tokens per audio second including time markers, so 10 leaves roughly 2x
@@ -55,6 +69,115 @@ DEFAULT_TRANSCRIBE_DIARIZE_PROMPT = (
 )
 
 
+@dataclass(frozen=True, slots=True)
+class _NoProgressDecision:
+    reason: str
+    completed_segments: int
+    marker_only_segments: int
+    repeated_segments: int
+    detected_completion_tokens: int
+
+
+@dataclass(slots=True)
+class _MossTDNoProgressState:
+    marker_segment_limit: int
+    repeat_segment_limit: int
+    pending_token_ids: list[int] = field(default_factory=list)
+    buffer: str = ""
+    completed_segments: int = 0
+    marker_only_segments: int = 0
+    repeated_segments: int = 0
+    observed_tokens: int = 0
+    last_content_signature: tuple[str, str, str, str] | None = None
+    disabled: bool = False
+
+    def observe_token_id(
+        self,
+        token_id: int,
+        decode_fn: Callable[[list[int]], str],
+    ) -> _NoProgressDecision | None:
+        if self.disabled:
+            return None
+        self.observed_tokens += 1
+        if len(self.pending_token_ids) >= _NO_PROGRESS_MAX_PENDING_TOKEN_IDS:
+            # note (JiaxinD): some valid tokenizer IDs decode to a trailing
+            # replacement forever. Bound full-prefix decode work and fail open.
+            self._disable()
+            return None
+        self.pending_token_ids.append(token_id)
+        decoded = decode_fn(self.pending_token_ids)
+        if decoded.endswith("\ufffd"):
+            return None
+        if "\ufffd" in decoded:
+            self._disable()
+            return None
+        self.pending_token_ids.clear()
+        self.buffer += decoded
+        pending_reason: str | None = None
+
+        while match := _COMPLETE_SEGMENT_RE.match(self.buffer):
+            self.buffer = self.buffer[match.end() :]
+            self.completed_segments += 1
+            pending_reason = None
+            body = match.group("body")
+            if not body.strip():
+                self.marker_only_segments += 1
+                self.repeated_segments = 0
+                self.last_content_signature = None
+                if (
+                    self.marker_segment_limit > 0
+                    and self.marker_only_segments >= self.marker_segment_limit
+                ):
+                    pending_reason = MOSS_TD_MARKER_LOOP_REASON
+                continue
+
+            self.marker_only_segments = 0
+            signature = (
+                match.group("start"),
+                match.group("speaker"),
+                body,
+                match.group("end"),
+            )
+            if signature == self.last_content_signature:
+                self.repeated_segments += 1
+            else:
+                self.repeated_segments = 0
+                self.last_content_signature = signature
+            if (
+                self.repeat_segment_limit > 0
+                and self.repeated_segments >= self.repeat_segment_limit
+            ):
+                pending_reason = MOSS_TD_REPEATED_SEGMENT_REASON
+
+        # note (JiaxinD): a trigger is actionable only when the observed token
+        # ends exactly on a segment boundary. Streaming output cannot retract
+        # an incomplete suffix, so a partial next segment postpones the stop.
+        if not self.buffer.strip():
+            return self._decision(pending_reason) if pending_reason else None
+        if len(self.buffer) > _NO_PROGRESS_MAX_INCOMPLETE_CHARS:
+            # note (JiaxinD): unknown output is not loop evidence. Disable the
+            # detector for this request instead of attempting a lossy resync.
+            self._disable()
+        return None
+
+    def _disable(self) -> None:
+        self.disabled = True
+        self.pending_token_ids.clear()
+        self.buffer = ""
+        self.marker_only_segments = 0
+        self.repeated_segments = 0
+        self.last_content_signature = None
+
+    def _decision(self, reason: str) -> _NoProgressDecision:
+        return _NoProgressDecision(
+            reason=reason,
+            completed_segments=self.completed_segments,
+            marker_only_segments=self.marker_only_segments,
+            repeated_segments=self.repeated_segments,
+            detected_completion_tokens=self.observed_tokens,
+        )
+
+
 @dataclass
 class MossTranscribeDiarizeRequestData(SGLangARRequestData):
     prompt_token_ids: list[int] | None = None
@@ -62,6 +185,14 @@ class MossTranscribeDiarizeRequestData(SGLangARRequestData):
     audio_duration_s: float = 0.0
     language: str = "auto"
     engine_start_s: float = 0.0
+    no_progress_termination_reason: str | None = None
+    no_progress_completed_segments: int = 0
+    no_progress_marker_only_segments: int = 0
+    no_progress_repeated_segments: int = 0
+    no_progress_detected_completion_tokens: int = 0
+    no_progress_marker_limit: int = 0
+    no_progress_repeat_limit: int = 0
+    no_progress_response_mode: str = ""
     # note (db-ol): the scheduler clamps max_new_tokens to the remaining
     # context, required once the duration scaled default can exceed it.
     enforce_request_limits: bool = True
@@ -527,22 +658,44 @@ def make_moss_transcribe_diarize_scheduler_adapters(
         engine_time_s = (
             time.perf_counter() - data.engine_start_s if data.engine_start_s else 0.0
         )
+        result_data = {
+            "text": text,
+            "token_ids": output_ids,
+            "language": data.language,
+            "duration_s": data.audio_duration_s,
+            "asr_latency_s": engine_time_s,
+            "prompt_tokens": len(data.prompt_token_ids or []),
+            "completion_tokens": len(output_ids),
+            "usage": {"engine_time_s": engine_time_s},
+            "finish_reason": data.finish_reason,
+            "weight_version": getattr(data, "weight_version", None),
+            "modality": "text",
+        }
+        if data.no_progress_termination_reason is not None:
+            termination_record = {
+                "schema_version": 1,
+                "server_request_id": payload.request_id,
+                "output_sha256": hashlib.sha256(text.encode("utf-8")).hexdigest(),
+                "reason": data.no_progress_termination_reason,
+                "completed_segments": data.no_progress_completed_segments,
+                "marker_only_segments": data.no_progress_marker_only_segments,
+                "repeated_segments": data.no_progress_repeated_segments,
+                "detected_completion_tokens": data.no_progress_detected_completion_tokens,
+                "raw_completion_tokens": len(output_ids),
+                "applied_max_new_tokens": data.max_new_tokens,
+                "marker_limit": data.no_progress_marker_limit,
+                "repeat_limit": data.no_progress_repeat_limit,
+                "response_mode": data.no_progress_response_mode,
+                "complete_boundary": True,
+            }
+            logger.warning(
+                "MOSS_TD_TERMINATION_JSON %s",
+                json.dumps(termination_record, separators=(",", ":"), sort_keys=True),
+            )
         return StagePayload(
             request_id=payload.request_id,
             request=payload.request,
-            data={
-                "text": text,
-                "token_ids": output_ids,
-                "language": data.language,
-                "duration_s": data.audio_duration_s,
-                "asr_latency_s": engine_time_s,
-                "prompt_tokens": len(data.prompt_token_ids or []),
-                "completion_tokens": len(output_ids),
-                "usage": {"engine_time_s": engine_time_s},
-                "finish_reason": data.finish_reason,
-                "weight_version": getattr(data, "weight_version", None),
-                "modality": "text",
-            },
+            data=result_data,
         )
 
     return request_builder, result_adapter
@@ -552,6 +705,8 @@ def make_moss_transcribe_diarize_stream_output_builder(
     tokenizer: Any,
     eos_token_id: int | None = None,
     min_emit_interval_s: float = 0.0,
+    buffered_no_progress_marker_segments: int = 0,
+    buffered_no_progress_repeat_segments: int = 0,
 ) -> Callable[[str, Any, Any], list[OutgoingMessage]]:
     tokenizer_eos = tokenizer.eos_token_id
     resolved_eos = (
@@ -559,7 +714,7 @@ def make_moss_transcribe_diarize_stream_output_builder(
         if eos_token_id is not None
         else (int(tokenizer_eos) if tokenizer_eos is not None else None)
     )
-    return make_token_text_stream_output_builder(
+    stream_output_builder = make_token_text_stream_output_builder(
         decode_fn=lambda ids: _decode_token_ids(
             tokenizer, ids, skip_special_tokens=True
         ),
@@ -579,11 +734,86 @@ def make_moss_transcribe_diarize_stream_output_builder(
         allow_terminal_flush=False,
         emit_trailing_replacement_on_terminal=False,
     )
+    marker_limit = int(buffered_no_progress_marker_segments)
+    repeat_limit = int(buffered_no_progress_repeat_segments)
+    if marker_limit < 0 or repeat_limit < 0:
+        raise ValueError("MOSS-TD buffered no-progress limits must be non-negative")
+    if marker_limit == 0 and repeat_limit == 0:
+        return stream_output_builder
+
+    def decode_no_progress_ids(token_ids: list[int]) -> str:
+        return _decode_token_ids(
+            tokenizer,
+            token_ids,
+            skip_special_tokens=True,
+        )
+
+    def guarded_stream_output_builder(
+        request_id: str, req_data: Any, req_output: Any
+    ) -> list[OutgoingMessage]:
+        req = req_data.req
+        stage_payload = getattr(req_data, "stage_payload", None)
+        request = getattr(stage_payload, "request", None)
+        params = getattr(request, "params", None) or {}
+        token_data = getattr(req_output, "data", None)
+        if (
+            not bool(params.get("stream"))
+            and req is not None
+            and getattr(req, "inflight_middle_chunks", 0) == 0
+            and token_data is not None
+            and getattr(req, "finished_reason", None) is None
+            and getattr(req, "to_finish", None) is None
+        ):
+            try:
+                token_id = int(token_data)
+            except (TypeError, ValueError):
+                token_id = None
+            if token_id is not None and token_id != resolved_eos:
+                state = getattr(req, "_moss_no_progress_state", None)
+                if state is None:
+                    state = _MossTDNoProgressState(
+                        marker_segment_limit=marker_limit,
+                        repeat_segment_limit=repeat_limit,
+                    )
+                    req._moss_no_progress_state = state
+                decision = state.observe_token_id(token_id, decode_no_progress_ids)
+                if decision is not None and getattr(req, "to_finish", None) is None:
+                    req.to_finish = FINISH_MATCHED_STR(matched=decision.reason)
+                    req_data.no_progress_termination_reason = decision.reason
+                    req_data.no_progress_completed_segments = (
+                        decision.completed_segments
+                    )
+                    req_data.no_progress_marker_only_segments = (
+                        decision.marker_only_segments
+                    )
+                    req_data.no_progress_repeated_segments = decision.repeated_segments
+                    req_data.no_progress_detected_completion_tokens = (
+                        decision.detected_completion_tokens
+                    )
+                    req_data.no_progress_marker_limit = marker_limit
+                    req_data.no_progress_repeat_limit = repeat_limit
+                    req_data.no_progress_response_mode = "buffered"
+                    logger.warning(
+                        "MOSS-TD no-progress termination request_id=%s "
+                        "reason=%s completion_tokens=%d completed_segments=%d "
+                        "marker_only_segments=%d repeated_segments=%d",
+                        request_id,
+                        decision.reason,
+                        decision.detected_completion_tokens,
+                        decision.completed_segments,
+                        decision.marker_only_segments,
+                        decision.repeated_segments,
+                    )
+        return stream_output_builder(request_id, req_data, req_output)
+
+    return guarded_stream_output_builder
 
 
 __all__ = [
     "DEFAULT_TRANSCRIBE_DIARIZE_PROMPT",
     "MossTranscribeDiarizeRequestData",
+    "MOSS_TD_MARKER_LOOP_REASON",
+    "MOSS_TD_REPEATED_SEGMENT_REASON",
     "make_moss_transcribe_diarize_scheduler_adapters",
     "make_moss_transcribe_diarize_stream_output_builder",
     "postprocess_moss_transcribe_diarize_text",

--- a/sglang_omni/models/moss_transcribe_diarize/stages.py
+++ b/sglang_omni/models/moss_transcribe_diarize/stages.py
@@ -98,6 +98,8 @@ def create_sglang_moss_transcribe_diarize_executor(
     request_build_max_workers: int = 8,
     request_build_max_pending: int | None = 16,
     stream_emit_interval_s: float = 0.05,
+    buffered_no_progress_marker_segments: int = 0,
+    buffered_no_progress_repeat_segments: int = 0,
     server_args_overrides: dict[str, Any] | None = None,
 ):
     from sglang_omni.models.moss_transcribe_diarize.engine_builder import (
@@ -135,6 +137,8 @@ def create_sglang_moss_transcribe_diarize_executor(
         request_build_max_workers=request_build_max_workers,
         request_build_max_pending=request_build_max_pending,
         stream_emit_interval_s=stream_emit_interval_s,
+        buffered_no_progress_marker_segments=buffered_no_progress_marker_segments,
+        buffered_no_progress_repeat_segments=buffered_no_progress_repeat_segments,
     ).build(
         model_path,
         device=device,

--- a/tests/unit_test/moss_transcribe_diarize/test_pipeline.py
+++ b/tests/unit_test/moss_transcribe_diarize/test_pipeline.py
@@ -50,6 +50,8 @@ def _make_moss_engine_builder() -> MossTranscribeDiarizeEngineBuilder:
         request_build_max_workers=8,
         request_build_max_pending=16,
         stream_emit_interval_s=0.05,
+        buffered_no_progress_marker_segments=0,
+        buffered_no_progress_repeat_segments=0,
     )
 
 
@@ -79,6 +81,8 @@ def test_moss_transcribe_diarize_config_uses_single_batched_stage() -> None:
     assert factory.prefill_coalesce_when_idle is True
     assert factory.prefill_coalesce_requires_pending_builds is True
     assert factory.prefill_coalesce_after_builds_during_decode is True
+    assert factory.buffered_no_progress_marker_segments == 0
+    assert factory.buffered_no_progress_repeat_segments == 0
     assert (
         PIPELINE_CONFIG_REGISTRY.get_config(
             "MossTranscribeDiarizeForConditionalGeneration"
@@ -213,6 +217,8 @@ def test_moss_transcribe_diarize_stage_reserves_encoder_headroom() -> None:
     assert signature.parameters["mm_embedding_cache_size_bytes"].default == 0
     assert signature.parameters["encoder_chunk_buckets"].default is None
     assert signature.parameters["encoder_torch_compile"].default is False
+    assert signature.parameters["buffered_no_progress_marker_segments"].default == 0
+    assert signature.parameters["buffered_no_progress_repeat_segments"].default == 0
 
 
 def test_compile_encoder_sets_runner_and_warms_each_bucket(

--- a/tests/unit_test/moss_transcribe_diarize/test_pipeline.py
+++ b/tests/unit_test/moss_transcribe_diarize/test_pipeline.py
@@ -3,12 +3,15 @@
 from __future__ import annotations
 
 import inspect
+from pathlib import Path
 
 import httpx
 import pytest
 import torch
 from huggingface_hub.errors import RepositoryNotFoundError
 
+from sglang_omni.config.manager import ConfigManager
+from sglang_omni.config.runtime import resolve_stage_factory_args
 from sglang_omni.models.moss_transcribe_diarize import stages
 from sglang_omni.models.moss_transcribe_diarize.config import (
     MossTranscribeDiarizePipelineConfig,
@@ -25,6 +28,7 @@ from sglang_omni.scheduling.generation_batch_policy import (
     build_default_prefill_cuda_graph_bs,
     build_generation_batch_overrides,
 )
+from sglang_omni.utils.imports import import_string
 
 
 def _make_moss_engine_builder() -> MossTranscribeDiarizeEngineBuilder:
@@ -312,6 +316,8 @@ def _stub_factory_env(monkeypatch: pytest.MonkeyPatch, *, want_cuda_graph: bool)
         "init_encoder_graphs": [],
         "encoder_services": [],
         "scheduler_kwargs": [],
+        "stream_builder_kwargs": [],
+        "stream_builder_sentinel": object(),
     }
     model = SimpleNamespace(
         compile_encoder=lambda buckets, feat_len: calls["compile_encoder"].append(
@@ -385,10 +391,15 @@ def _stub_factory_env(monkeypatch: pytest.MonkeyPatch, *, want_cuda_graph: bool)
         "make_moss_transcribe_diarize_scheduler_adapters",
         lambda **k: (object(), object()),
     )
+
+    def capture_stream_builder(**kwargs: object) -> object:
+        calls["stream_builder_kwargs"].append(kwargs)
+        return calls["stream_builder_sentinel"]
+
     monkeypatch.setattr(
         request_builders,
         "make_moss_transcribe_diarize_stream_output_builder",
-        lambda **k: object(),
+        capture_stream_builder,
     )
     monkeypatch.setattr(sglang_backend, "SGLangOutputProcessor", lambda **k: object())
     monkeypatch.setattr(
@@ -421,6 +432,97 @@ def test_factory_compiles_encoder_and_skips_cuda_graph_when_flag_on(
     assert scheduler_kwargs["prefill_coalesce_when_idle"] is True
     assert scheduler_kwargs["prefill_coalesce_requires_pending_builds"] is True
     assert scheduler_kwargs["prefill_coalesce_after_builds_during_decode"] is True
+
+
+def test_factory_wires_buffered_no_progress_limits_to_stream_output_builder(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    calls = _stub_factory_env(monkeypatch, want_cuda_graph=False)
+
+    create_sglang_moss_transcribe_diarize_executor(
+        "OpenMOSS-Team/MOSS-Transcribe-Diarize",
+        device="cpu",
+        buffered_no_progress_marker_segments=3,
+        buffered_no_progress_repeat_segments=7,
+    )
+
+    stream_builder_kwargs = calls["stream_builder_kwargs"]
+    assert len(stream_builder_kwargs) == 1
+    captured_kwargs = stream_builder_kwargs[0]
+    assert (
+        captured_kwargs.get("buffered_no_progress_marker_segments"),
+        captured_kwargs.get("buffered_no_progress_repeat_segments"),
+    ) == (3, 7)
+    assert (
+        calls["scheduler_kwargs"][0]["stream_output_builder"]
+        is calls["stream_builder_sentinel"]
+    )
+
+
+@pytest.mark.parametrize("config_source", ["dotted", "yaml"])
+def test_configured_buffered_no_progress_limits_reach_output_builder(
+    monkeypatch: pytest.MonkeyPatch,
+    tmp_path: Path,
+    config_source: str,
+) -> None:
+    if config_source == "dotted":
+        config = ConfigManager(
+            MossTranscribeDiarizePipelineConfig(model_path="dummy")
+        ).merge_config(
+            [
+                ("asr.factory.device", "cpu"),
+                ("asr.factory.buffered_no_progress_marker_segments", "3"),
+                ("asr.factory.buffered_no_progress_repeat_segments", "7"),
+            ]
+        )
+    else:
+        config_path = tmp_path / "moss_td_no_progress.yaml"
+        config_path.write_text(
+            """
+config_cls: MossTranscribeDiarizePipelineConfig
+model_path: dummy
+stages:
+  asr:
+    factory:
+      device: cpu
+      buffered_no_progress_marker_segments: 3
+      buffered_no_progress_repeat_segments: 7
+""".strip(),
+            encoding="utf-8",
+        )
+        config = ConfigManager.from_file(str(config_path)).config
+        assert config is not None
+
+    calls = _stub_factory_env(monkeypatch, want_cuda_graph=False)
+    stage = next(stage for stage in config.stages if stage.name == "asr")
+    resolved_args = resolve_stage_factory_args(stage, config)
+    factory = import_string(stage.factory_path)
+    factory(**resolved_args)
+
+    assert (
+        calls["stream_builder_kwargs"][0]["buffered_no_progress_marker_segments"],
+        calls["stream_builder_kwargs"][0]["buffered_no_progress_repeat_segments"],
+    ) == (3, 7)
+    assert (
+        calls["scheduler_kwargs"][0]["stream_output_builder"]
+        is calls["stream_builder_sentinel"]
+    )
+
+
+@pytest.mark.parametrize(
+    "field_name",
+    [
+        "buffered_no_progress_marker_segments",
+        "buffered_no_progress_repeat_segments",
+    ],
+)
+def test_config_rejects_negative_buffered_no_progress_limits(
+    field_name: str,
+) -> None:
+    manager = ConfigManager(MossTranscribeDiarizePipelineConfig(model_path="dummy"))
+
+    with pytest.raises(ValueError, match=field_name):
+        manager.merge_config([(f"asr.factory.{field_name}", "-1")])
 
 
 def test_factory_context_length_override_uses_final_server_value(

--- a/tests/unit_test/moss_transcribe_diarize/test_request_builders.py
+++ b/tests/unit_test/moss_transcribe_diarize/test_request_builders.py
@@ -2,7 +2,9 @@
 
 from __future__ import annotations
 
+import hashlib
 import io
+import json
 import wave
 
 import numpy as np
@@ -202,6 +204,68 @@ def _request_builder(
         audio_encoder_service=audio_encoder_service,
     )
     return request_builder
+
+
+def _scheduler_adapters(processor: FakeProcessor | None = None):
+    processor = processor or FakeProcessor()
+    return make_moss_transcribe_diarize_scheduler_adapters(
+        processor=processor,
+        tokenizer=processor.tokenizer,
+        max_new_tokens=32,
+        context_length=TEST_CONTEXT_LENGTH,
+    )
+
+
+def test_result_adapter_omits_termination_for_normal_completion() -> None:
+    request_builder, result_adapter = _scheduler_adapters()
+    data = request_builder(_payload())
+
+    result = result_adapter(data)
+
+    assert "termination" not in result.data
+
+
+def test_result_adapter_logs_bounded_diagnostics_without_public_metadata(
+    caplog: pytest.LogCaptureFixture,
+) -> None:
+    request_builder, result_adapter = _scheduler_adapters()
+    data = request_builder(_payload())
+    data.output_ids = [10, 11, 12]
+    data.no_progress_termination_reason = "moss_td_no_progress_marker_loop"
+    data.no_progress_completed_segments = 41
+    data.no_progress_marker_only_segments = 32
+    data.no_progress_repeated_segments = 0
+    data.no_progress_detected_completion_tokens = 3
+    data.no_progress_marker_limit = 32
+    data.no_progress_repeat_limit = 3
+    data.no_progress_response_mode = "buffered"
+
+    with caplog.at_level("WARNING"):
+        result = result_adapter(data)
+
+    assert "termination" not in result.data
+    record_line = next(
+        message
+        for message in caplog.messages
+        if message.startswith("MOSS_TD_TERMINATION_JSON ")
+    )
+    record = json.loads(record_line.removeprefix("MOSS_TD_TERMINATION_JSON "))
+    assert record == {
+        "schema_version": 1,
+        "server_request_id": "req-1",
+        "output_sha256": hashlib.sha256(result.data["text"].encode()).hexdigest(),
+        "reason": "moss_td_no_progress_marker_loop",
+        "completed_segments": 41,
+        "marker_only_segments": 32,
+        "repeated_segments": 0,
+        "detected_completion_tokens": 3,
+        "raw_completion_tokens": 3,
+        "applied_max_new_tokens": 32,
+        "marker_limit": 32,
+        "repeat_limit": 3,
+        "response_mode": "buffered",
+        "complete_boundary": True,
+    }
 
 
 def test_streamlined_request_builder_preserves_exact_input_ids() -> None:

--- a/tests/unit_test/moss_transcribe_diarize/test_request_builders.py
+++ b/tests/unit_test/moss_transcribe_diarize/test_request_builders.py
@@ -6,6 +6,7 @@ import hashlib
 import io
 import json
 import wave
+from types import SimpleNamespace
 
 import numpy as np
 import pytest
@@ -97,6 +98,18 @@ class FastFakeTokenizer(FakeTokenizer):
         raise AssertionError(f"Unexpected prompt fragment: {text!r}")
 
 
+class SegmentFakeTokenizer(FastFakeTokenizer):
+    _segments = {
+        201: "[0.00][S01][0.10]",
+        202: "[0.11][S02][0.20]",
+    }
+
+    def decode(self, token_ids, **kwargs) -> str:
+        if all(token_id in self._segments for token_id in token_ids):
+            return "".join(self._segments[token_id] for token_id in token_ids)
+        return super().decode(token_ids, **kwargs)
+
+
 class FakeProcessor:
     audio_token = "<|audio_pad|>"
     audio_token_id = 151671
@@ -157,12 +170,13 @@ def _payload(
     prompt: str | None = None,
     params: dict | None = None,
     metadata: dict | None = None,
+    request_id: str = "req-1",
 ) -> StagePayload:
     request_params = dict(params or {})
     if prompt is not None:
         request_params["prompt"] = prompt
     return StagePayload(
-        request_id="req-1",
+        request_id=request_id,
         request=OmniRequest(
             inputs={"audio_bytes": _wav_bytes()},
             params=request_params,
@@ -252,7 +266,7 @@ def test_result_adapter_logs_bounded_diagnostics_without_public_metadata(
     record = json.loads(record_line.removeprefix("MOSS_TD_TERMINATION_JSON "))
     assert record == {
         "schema_version": 1,
-        "server_request_id": "req-1",
+        "server_request_id_sha256": hashlib.sha256(b"req-1").hexdigest(),
         "output_sha256": hashlib.sha256(result.data["text"].encode()).hexdigest(),
         "reason": "moss_td_no_progress_marker_loop",
         "completed_segments": 41,
@@ -263,6 +277,72 @@ def test_result_adapter_logs_bounded_diagnostics_without_public_metadata(
         "applied_max_new_tokens": 32,
         "marker_limit": 32,
         "repeat_limit": 3,
+        "response_mode": "buffered",
+        "complete_boundary": True,
+    }
+
+
+def test_guard_termination_reaches_bounded_result_diagnostic(
+    caplog: pytest.LogCaptureFixture,
+) -> None:
+    raw_request_id = "request-id-with-newline\nsecret-" * 300
+    request_id_sha256 = hashlib.sha256(raw_request_id.encode()).hexdigest()
+    processor = FakeProcessor()
+    processor.tokenizer = SegmentFakeTokenizer()
+    request_builder, result_adapter = make_moss_transcribe_diarize_scheduler_adapters(
+        processor=processor,
+        tokenizer=processor.tokenizer,
+        max_new_tokens=32,
+        context_length=TEST_CONTEXT_LENGTH,
+    )
+    data = request_builder(
+        _payload(params={"stream": False}, request_id=raw_request_id)
+    )
+    stream_output_builder = (
+        request_builders.make_moss_transcribe_diarize_stream_output_builder(
+            tokenizer=processor.tokenizer,
+            buffered_no_progress_marker_segments=2,
+            buffered_no_progress_repeat_segments=7,
+        )
+    )
+
+    with caplog.at_level("WARNING"):
+        for token_id in (201, 202):
+            assert (
+                stream_output_builder(
+                    raw_request_id,
+                    data,
+                    SimpleNamespace(data=token_id),
+                )
+                == []
+            )
+            data.req.output_ids.append(token_id)
+        data.output_ids = [201, 202]
+        result = result_adapter(data)
+
+    assert "termination" not in result.data
+    output_text = "[0.00][S01][0.10][0.11][S02][0.20]"
+    assert result.data["text"] == output_text
+    record_line = next(
+        message
+        for message in caplog.messages
+        if message.startswith("MOSS_TD_TERMINATION_JSON ")
+    )
+    record = json.loads(record_line.removeprefix("MOSS_TD_TERMINATION_JSON "))
+    assert raw_request_id not in "\n".join(caplog.messages)
+    assert record == {
+        "schema_version": 1,
+        "server_request_id_sha256": request_id_sha256,
+        "output_sha256": hashlib.sha256(output_text.encode()).hexdigest(),
+        "reason": "moss_td_no_progress_marker_loop",
+        "completed_segments": 2,
+        "marker_only_segments": 2,
+        "repeated_segments": 0,
+        "detected_completion_tokens": 2,
+        "raw_completion_tokens": 2,
+        "applied_max_new_tokens": 32,
+        "marker_limit": 2,
+        "repeat_limit": 7,
         "response_mode": "buffered",
         "complete_boundary": True,
     }

--- a/tests/unit_test/moss_transcribe_diarize/test_stream_output_builder.py
+++ b/tests/unit_test/moss_transcribe_diarize/test_stream_output_builder.py
@@ -2,6 +2,7 @@
 
 from __future__ import annotations
 
+import hashlib
 import os
 from pathlib import Path
 from types import SimpleNamespace
@@ -10,6 +11,7 @@ from typing import Any
 import pytest
 
 from sglang_omni.models.moss_transcribe_diarize.request_builders import (
+    MOSS_TD_MARKER_LOOP_REASON,
     make_moss_transcribe_diarize_stream_output_builder,
 )
 from sglang_omni.proto import OmniRequest, StagePayload
@@ -331,6 +333,28 @@ def test_marker_only_loop_stops_at_complete_segment_boundary() -> None:
     assert deltas == []
 
 
+def test_first_prefill_marker_decision_waits_for_a_decode_boundary() -> None:
+    builder = _guarded_builder(
+        {1: b"[0.00][S01][0.10]"},
+        marker_segments=1,
+    )
+    rd = _make_req_data(stream=False)
+
+    # OmniScheduler invokes the callback before SGLang commits the first
+    # prefill token to output_ids. Finishing here would make SGLang drop it.
+    assert rd.req.output_ids == []
+    assert builder("r", rd, _make_req_output(1)) == []
+
+    assert rd.req.to_finish is None
+    assert rd.no_progress_termination_reason is None
+    assert rd.req._moss_no_progress_state.disabled is False
+
+    rd.req.output_ids.append(1)
+    assert builder("r", rd, _make_req_output(1)) == []
+    assert rd.req.to_finish is not None
+    assert rd.no_progress_termination_reason == MOSS_TD_MARKER_LOOP_REASON
+
+
 def test_content_segment_resets_marker_only_progress_counter() -> None:
     vocab = {
         1: b"[0.00][S01][0.10]",
@@ -468,6 +492,42 @@ def test_interior_replacement_disables_repeat_detection() -> None:
 
     assert rd.req.to_finish is None
     assert rd.req._moss_no_progress_state.disabled is True
+
+
+@pytest.mark.parametrize("error_type", [ValueError, AttributeError, OSError])
+def test_decode_exception_disables_guard_fail_open_without_escaping(
+    error_type: type[Exception],
+) -> None:
+    class _RaisingTokenizer:
+        eos_token_id = _EOS
+
+        def __init__(self) -> None:
+            self.decode_calls = 0
+
+        def decode(self, ids, **kwargs) -> str:
+            self.decode_calls += 1
+            raise error_type("malformed token sequence")
+
+    tokenizer = _RaisingTokenizer()
+    builder = make_moss_transcribe_diarize_stream_output_builder(
+        tokenizer=tokenizer,
+        buffered_no_progress_marker_segments=2,
+    )
+    rd = _make_req_data(stream=False)
+    escaped: Exception | None = None
+
+    try:
+        builder("r", rd, _make_req_output(1))
+    except Exception as error:
+        escaped = error
+
+    assert escaped is None
+    assert rd.req.to_finish is None
+    assert rd.req._moss_no_progress_state.disabled is True
+    assert tokenizer.decode_calls == 1
+
+    assert builder("r", rd, _make_req_output(1)) == []
+    assert tokenizer.decode_calls == 1
 
 
 def test_incomplete_utf8_waits_for_byte_faithful_valid_decode() -> None:
@@ -668,3 +728,50 @@ def test_oversized_unrecognized_suffix_disables_guard_fail_open() -> None:
 
     assert rd.req.to_finish is None
     assert rd.req._moss_no_progress_state.disabled is True
+
+
+def test_many_small_incomplete_tokens_exhaust_decode_work_budget() -> None:
+    class _CountingTokenizer(_ByteTokenizer):
+        def __init__(self) -> None:
+            super().__init__({1: b"x"})
+            self.decode_calls = 0
+
+        def decode(self, ids, **kwargs) -> str:
+            self.decode_calls += 1
+            return super().decode(ids, **kwargs)
+
+    tokenizer = _CountingTokenizer()
+    builder = make_moss_transcribe_diarize_stream_output_builder(
+        tokenizer=tokenizer,
+        buffered_no_progress_marker_segments=2,
+    )
+    rd = _make_req_data(stream=False)
+
+    _observe(builder, rd, *([1] * 300))
+
+    state = rd.req._moss_no_progress_state
+    assert state.disabled is True
+    assert tokenizer.decode_calls <= 256
+    decode_calls = tokenizer.decode_calls
+
+    _observe(builder, rd, 1)
+    assert tokenizer.decode_calls == decode_calls
+
+
+def test_guard_warning_hashes_unbounded_request_id(caplog) -> None:
+    raw_request_id = "request-id-with-newline\nsecret-" * 300
+    request_id_sha256 = hashlib.sha256(raw_request_id.encode("utf-8")).hexdigest()
+    builder = _guarded_builder(
+        {1: b"[0.00][S01][0.10]"},
+        marker_segments=2,
+    )
+    rd = _make_req_data(stream=False)
+
+    _observe(builder, rd, 1)
+    builder(raw_request_id, rd, _make_req_output(1))
+
+    messages = [record.getMessage() for record in caplog.records]
+    assert raw_request_id not in "\n".join(messages)
+    assert any(
+        f"request_id_sha256={request_id_sha256}" in message for message in messages
+    )

--- a/tests/unit_test/moss_transcribe_diarize/test_stream_output_builder.py
+++ b/tests/unit_test/moss_transcribe_diarize/test_stream_output_builder.py
@@ -2,8 +2,12 @@
 
 from __future__ import annotations
 
+import os
+from pathlib import Path
 from types import SimpleNamespace
 from typing import Any
+
+import pytest
 
 from sglang_omni.models.moss_transcribe_diarize.request_builders import (
     make_moss_transcribe_diarize_stream_output_builder,
@@ -51,8 +55,21 @@ def _make_req_data(*, stream: bool = True, inflight_middle_chunks: int = 0) -> A
         ),
         data={},
     )
-    req = SimpleNamespace(inflight_middle_chunks=inflight_middle_chunks)
-    return SimpleNamespace(req=req, stage_payload=stage_payload)
+    req = SimpleNamespace(
+        inflight_middle_chunks=inflight_middle_chunks,
+        finished_reason=None,
+        output_ids=[],
+        to_finish=None,
+    )
+    return SimpleNamespace(
+        req=req,
+        stage_payload=stage_payload,
+        no_progress_termination_reason=None,
+        no_progress_completed_segments=0,
+        no_progress_marker_only_segments=0,
+        no_progress_repeated_segments=0,
+        no_progress_detected_completion_tokens=0,
+    )
 
 
 def _make_req_output(token_id: int | None) -> Any:
@@ -249,3 +266,405 @@ def test_explicit_eos_token_id_overrides_tokenizer():
 
     assert [m.data["text"] for m in builder("r", rd, _make_req_output(1))] == ["A"]
     assert builder("r", rd, _make_req_output(7)) == []
+
+
+def _guarded_builder(
+    vocab: dict[int, bytes],
+    *,
+    marker_segments: int = 0,
+    repeat_segments: int = 0,
+):
+    return make_moss_transcribe_diarize_stream_output_builder(
+        tokenizer=_ByteTokenizer(vocab),
+        buffered_no_progress_marker_segments=marker_segments,
+        buffered_no_progress_repeat_segments=repeat_segments,
+    )
+
+
+def _observe(builder, rd, *token_ids: int) -> list[str]:
+    deltas: list[str] = []
+    for token_id in token_ids:
+        messages = builder("r", rd, _make_req_output(token_id))
+        deltas.extend(message.data["text"] for message in messages)
+        rd.req.output_ids.append(token_id)
+    return deltas
+
+
+def _matched_finish_reason(rd) -> str | None:
+    if rd.req.to_finish is None:
+        return None
+    return rd.req.to_finish.to_json().get("matched")
+
+
+def test_no_progress_guard_is_zero_diff_when_disabled() -> None:
+    builder = _guarded_builder({1: b"[0.00][S01][0.10]"})
+    rd = _make_req_data(stream=False)
+
+    _observe(builder, rd, 1, 1, 1, 1)
+
+    assert rd.req.to_finish is None
+    assert not hasattr(rd.req, "_moss_no_progress_state")
+    assert rd.no_progress_termination_reason is None
+
+
+def test_marker_only_loop_stops_at_complete_segment_boundary() -> None:
+    vocab = {
+        1: b"[0.00][S01][0.10]",
+        2: b"[0.11][S02][0.20]",
+        3: b"[0.21][S01]",
+        4: b"[0.30]",
+    }
+    builder = _guarded_builder(vocab, marker_segments=3)
+    rd = _make_req_data(stream=False)
+
+    deltas = _observe(builder, rd, 1, 2, 3)
+    assert rd.req.to_finish is None
+
+    deltas.extend(_observe(builder, rd, 4))
+
+    assert _matched_finish_reason(rd) == "moss_td_no_progress_marker_loop"
+    assert rd.no_progress_termination_reason == "moss_td_no_progress_marker_loop"
+    assert rd.no_progress_completed_segments == 3
+    assert rd.no_progress_marker_only_segments == 3
+    assert rd.no_progress_repeated_segments == 0
+    assert rd.no_progress_detected_completion_tokens == 4
+    assert deltas == []
+
+
+def test_content_segment_resets_marker_only_progress_counter() -> None:
+    vocab = {
+        1: b"[0.00][S01][0.10]",
+        2: b"[0.11][S01][0.20]",
+        3: b"[0.21][S01]spoken words[0.30]",
+        4: b"[0.31][S01][0.40]",
+        5: b"[0.41][S01][0.50]",
+        6: b"[0.51][S01][0.60]",
+    }
+    builder = _guarded_builder(vocab, marker_segments=3)
+    rd = _make_req_data(stream=False)
+
+    _observe(builder, rd, 1, 2, 3, 4, 5)
+
+    assert rd.req.to_finish is None
+    assert rd.req._moss_no_progress_state.marker_only_segments == 2
+
+    _observe(builder, rd, 6)
+    assert _matched_finish_reason(rd) == "moss_td_no_progress_marker_loop"
+
+
+def test_progress_later_in_same_token_cancels_pending_marker_stop() -> None:
+    builder = _guarded_builder(
+        {
+            1: (
+                b"[0.00][S01][0.10]"
+                b"[0.11][S01][0.20]"
+                b"[0.21][S01]actual speech[0.30]"
+            )
+        },
+        marker_segments=2,
+    )
+    rd = _make_req_data(stream=False)
+
+    _observe(builder, rd, 1)
+
+    assert rd.req.to_finish is None
+    assert rd.req._moss_no_progress_state.completed_segments == 3
+    assert rd.req._moss_no_progress_state.marker_only_segments == 0
+
+
+def test_advancing_timestamps_preserve_legitimately_repeated_content() -> None:
+    vocab = {
+        1: b"[0.00][S01]yes[0.10]",
+        2: b"[0.11][S01]yes[0.20]",
+        3: b"[0.21][S01]yes[0.30]",
+        4: b"[0.31][S01]yes[0.40]",
+    }
+    builder = _guarded_builder(vocab, repeat_segments=3)
+    rd = _make_req_data(stream=False)
+
+    _observe(builder, rd, 1, 2, 3, 4)
+
+    assert rd.req.to_finish is None
+    assert rd.req._moss_no_progress_state.repeated_segments == 0
+
+
+def test_exact_content_segment_loop_stops_only_after_configured_repeat() -> None:
+    builder = _guarded_builder(
+        {1: b"[0.00][S01]same words[0.10]"},
+        repeat_segments=3,
+    )
+    rd = _make_req_data(stream=False)
+
+    _observe(builder, rd, 1, 1, 1)
+    assert rd.req.to_finish is None
+
+    _observe(builder, rd, 1)
+
+    assert _matched_finish_reason(rd) == "moss_td_no_progress_repeated_segment"
+    assert rd.no_progress_termination_reason == ("moss_td_no_progress_repeated_segment")
+    assert rd.no_progress_marker_only_segments == 0
+    assert rd.no_progress_repeated_segments == 3
+    assert rd.no_progress_detected_completion_tokens == 4
+
+
+def test_full_token_decode_keeps_distinct_unicode_bodies_non_additive() -> None:
+    vocab = {
+        1: b"[0][S01]",
+        2: b"\xe4",
+        3: b"\xbd\xa0[1]",
+        4: b"\xe5",
+        5: b"\xa5\xbd[1]",
+    }
+    tokenizer = _ByteTokenizer(vocab)
+    assert (
+        "".join(tokenizer.decode([token_id]) for token_id in (2, 3))
+        == "\ufffd\ufffd\ufffd[1]"
+    )
+    assert (
+        "".join(tokenizer.decode([token_id]) for token_id in (4, 5))
+        == "\ufffd\ufffd\ufffd[1]"
+    )
+    assert tokenizer.decode([2, 3]) == "\u4f60[1]"
+    assert tokenizer.decode([4, 5]) == "\u597d[1]"
+    builder = make_moss_transcribe_diarize_stream_output_builder(
+        tokenizer=tokenizer,
+        buffered_no_progress_repeat_segments=2,
+    )
+    rd = _make_req_data(stream=False)
+
+    _observe(builder, rd, 1, 2, 3, 1, 4, 5)
+
+    assert rd.req.to_finish is None
+    assert rd.no_progress_termination_reason is None
+
+
+def test_distinct_malformed_body_bytes_never_form_an_exact_repeat() -> None:
+    builder = make_moss_transcribe_diarize_stream_output_builder(
+        tokenizer=_ByteTokenizer(
+            {
+                1: b"[0][S01]",
+                2: b"\x80[1]",
+                3: b"\x81[1]",
+            }
+        ),
+        buffered_no_progress_repeat_segments=2,
+    )
+    rd = _make_req_data(stream=False)
+
+    _observe(builder, rd, 1, 2, 1, 3)
+
+    assert rd.req.to_finish is None
+    assert rd.req._moss_no_progress_state.disabled is True
+
+
+def test_interior_replacement_disables_repeat_detection() -> None:
+    builder = make_moss_transcribe_diarize_stream_output_builder(
+        tokenizer=_ByteTokenizer({1: b"[0][S01]ok\x80[1]"}),
+        buffered_no_progress_repeat_segments=2,
+    )
+    rd = _make_req_data(stream=False)
+
+    _observe(builder, rd, 1, 1)
+
+    assert rd.req.to_finish is None
+    assert rd.req._moss_no_progress_state.disabled is True
+
+
+def test_incomplete_utf8_waits_for_byte_faithful_valid_decode() -> None:
+    builder = make_moss_transcribe_diarize_stream_output_builder(
+        tokenizer=_ByteTokenizer(
+            {
+                1: b"[0][S01]",
+                2: b"\xe4",
+                3: b"\xbd\xa0[1]",
+            }
+        ),
+        buffered_no_progress_repeat_segments=2,
+    )
+    rd = _make_req_data(stream=False)
+
+    _observe(builder, rd, 1, 2)
+    assert rd.req.to_finish is None
+    assert rd.req._moss_no_progress_state.completed_segments == 0
+
+    _observe(builder, rd, 3, 1, 2, 3, 1, 2, 3)
+
+    assert _matched_finish_reason(rd) == "moss_td_no_progress_repeated_segment"
+    assert rd.req._moss_no_progress_state.disabled is False
+
+
+def test_cached_qwen2_trailing_replacement_disables_bounded_guard_fail_open() -> None:
+    snapshot_value = os.environ.get("MOSS_TD_TEST_TOKENIZER_SNAPSHOT")
+    if not snapshot_value:
+        pytest.skip("set MOSS_TD_TEST_TOKENIZER_SNAPSHOT to the cached MOSS snapshot")
+
+    from transformers import Qwen2Tokenizer
+
+    snapshot = Path(snapshot_value)
+    tokenizer = Qwen2Tokenizer.from_pretrained(snapshot, local_files_only=True)
+    assert tokenizer.decode(
+        [94], skip_special_tokens=True, clean_up_tokenization_spaces=False
+    ).endswith("\ufffd")
+
+    decode_lengths: list[int] = []
+    original_decode = tokenizer.decode
+
+    def recording_decode(token_ids, *args, **kwargs):
+        decode_lengths.append(len(token_ids))
+        return original_decode(token_ids, *args, **kwargs)
+
+    tokenizer.decode = recording_decode
+    builder = make_moss_transcribe_diarize_stream_output_builder(
+        tokenizer=tokenizer,
+        buffered_no_progress_marker_segments=2,
+    )
+    rd = _make_req_data(stream=False)
+
+    for _ in range(1025):
+        assert builder("req-1", rd, _make_req_output(94)) == []
+
+    state = rd.req._moss_no_progress_state
+    assert state.disabled is True
+    assert state.pending_token_ids == []
+    assert state.buffer == ""
+    assert max(decode_lengths) <= 256
+    assert rd.req.to_finish is None
+    assert rd.no_progress_termination_reason is None
+
+    observed_tokens = state.observed_tokens
+    decode_calls = len(decode_lengths)
+    assert builder("req-1", rd, _make_req_output(94)) == []
+    assert state.observed_tokens == observed_tokens
+    assert len(decode_lengths) == decode_calls
+
+
+def test_buffered_thresholds_do_not_enable_streaming_termination() -> None:
+    builder = make_moss_transcribe_diarize_stream_output_builder(
+        tokenizer=_ByteTokenizer({1: b"[0][S01][1]"}),
+        buffered_no_progress_marker_segments=2,
+    )
+    buffered = _make_req_data(stream=False)
+    streaming = _make_req_data(stream=True)
+
+    _observe(builder, buffered, 1, 1)
+    _observe(builder, streaming, 1, 1)
+
+    assert _matched_finish_reason(buffered) == "moss_td_no_progress_marker_loop"
+    assert streaming.req.to_finish is None
+    assert not hasattr(streaming.req, "_moss_no_progress_state")
+
+
+@pytest.mark.parametrize(
+    "second_segment",
+    [b"[0][S01] body[1]", b"[0][s01]body[1]"],
+)
+def test_exact_repeat_identity_preserves_body_and_speaker_bytes(
+    second_segment: bytes,
+) -> None:
+    builder = _guarded_builder(
+        {1: b"[0][S01]body[1]", 2: second_segment},
+        repeat_segments=2,
+    )
+    rd = _make_req_data(stream=False)
+
+    _observe(builder, rd, 1, 2)
+
+    assert rd.req.to_finish is None
+    assert rd.req._moss_no_progress_state.repeated_segments == 0
+
+
+def test_marker_only_silence_stops_without_inventing_content() -> None:
+    builder = _guarded_builder(
+        {
+            1: b"[0.00][S01][0.10]",
+            2: b"[0.11][S01][0.20]",
+        },
+        marker_segments=2,
+    )
+    rd = _make_req_data(stream=False)
+
+    _observe(builder, rd, 1, 2)
+
+    assert _matched_finish_reason(rd) == "moss_td_no_progress_marker_loop"
+    assert rd.no_progress_completed_segments == 2
+
+
+def test_incomplete_or_malformed_segment_never_triggers() -> None:
+    builder = _guarded_builder(
+        {
+            1: b"[0.00][S01][0.10]",
+            2: b"[0.11][S01]",
+            3: b"[bad",
+            4: b"]not-a-segment",
+        },
+        marker_segments=2,
+    )
+    rd = _make_req_data(stream=False)
+
+    _observe(builder, rd, 1, 2, 3, 4)
+
+    assert rd.req.to_finish is None
+    assert rd.req._moss_no_progress_state.completed_segments == 1
+
+
+def test_chunked_prefill_tokens_do_not_advance_no_progress_state() -> None:
+    builder = _guarded_builder(
+        {1: b"[0.00][S01][0.10]"},
+        marker_segments=2,
+    )
+    rd = _make_req_data(stream=False, inflight_middle_chunks=1)
+
+    _observe(builder, rd, 1, 1)
+    assert not hasattr(rd.req, "_moss_no_progress_state")
+
+    rd.req.inflight_middle_chunks = 0
+    _observe(builder, rd, 1)
+    assert rd.req.to_finish is None
+
+
+@pytest.mark.parametrize("terminal_field", ["finished_reason", "to_finish"])
+def test_terminal_or_cancelled_request_does_not_allocate_guard_state(
+    terminal_field: str,
+) -> None:
+    builder = _guarded_builder(
+        {1: b"[0.00][S01][0.10]"},
+        marker_segments=2,
+    )
+    rd = _make_req_data(stream=False)
+    setattr(rd.req, terminal_field, object())
+
+    _observe(builder, rd, 1, 1)
+
+    assert not hasattr(rd.req, "_moss_no_progress_state")
+    assert rd.no_progress_termination_reason is None
+
+
+def test_guard_stops_observing_after_terminal_decision() -> None:
+    builder = _guarded_builder(
+        {1: b"[0.00][S01][0.10]"},
+        marker_segments=2,
+    )
+    rd = _make_req_data(stream=False)
+
+    _observe(builder, rd, 1, 1)
+    completed_segments = rd.req._moss_no_progress_state.completed_segments
+    _observe(builder, rd, 1)
+
+    assert completed_segments == 2
+    assert rd.req._moss_no_progress_state.completed_segments == completed_segments
+
+
+def test_oversized_unrecognized_suffix_disables_guard_fail_open() -> None:
+    builder = _guarded_builder(
+        {
+            1: b"x" * 65537,
+            2: b"[0.00][S01][0.10]",
+        },
+        marker_segments=2,
+    )
+    rd = _make_req_data(stream=False)
+
+    _observe(builder, rd, 1, 2, 2)
+
+    assert rd.req.to_finish is None
+    assert rd.req._moss_no_progress_state.disabled is True

--- a/tests/unit_test/serve/test_openai_api.py
+++ b/tests/unit_test/serve/test_openai_api.py
@@ -4,6 +4,7 @@ from __future__ import annotations
 
 import asyncio
 import base64
+import json
 import logging
 from typing import Any
 
@@ -317,6 +318,53 @@ class SuccessfulTranscriptionClient:
             text="hello world",
             finish_reason="stop",
         )
+
+
+class DiagnosticTranscriptionClient(SuccessfulTranscriptionClient):
+    termination = {
+        "reason": "moss_td_no_progress_marker_loop",
+        "completed_segments": 41,
+        "marker_only_segments": 32,
+        "repeated_segments": 0,
+        "detected_completion_tokens": 518,
+        "applied_max_new_tokens": 4096,
+    }
+
+    async def completion(
+        self,
+        request: GenerateRequest,
+        *,
+        request_id: str,
+        audio_format: str = "wav",
+    ):
+        from sglang_omni.client.types import CompletionResult, UsageInfo
+
+        del request, audio_format
+        result = CompletionResult(
+            request_id=request_id,
+            text="[0.00][S01][0.18]",
+            finish_reason="stop",
+            usage=UsageInfo(completion_tokens=518),
+        )
+        result.termination = self.termination
+        return result
+
+    async def generate(
+        self,
+        request: GenerateRequest,
+        request_id: str | None = None,
+    ):
+        from sglang_omni.client.types import UsageInfo
+
+        del request
+        chunk = GenerateChunk(
+            request_id=request_id or "transcription-1",
+            text="[0.00][S01][0.18]",
+            finish_reason="stop",
+            usage=UsageInfo(completion_tokens=518),
+        )
+        chunk.termination = self.termination
+        yield chunk
 
 
 class ChunkRecordingTranscriptionClient:
@@ -2478,6 +2526,8 @@ def test_transcription_endpoint_returns_text_json() -> None:
 
     assert response.status_code == 200
     assert response.json() == {"text": "hello world"}
+    assert "x-termination-reason" not in response.headers
+    assert "x-finish-reason" not in response.headers
     assert transcription_client.requests
     request = transcription_client.requests[0]
     assert request.model == "openai/whisper-large-v3"
@@ -2777,6 +2827,66 @@ def test_transcription_stream_emits_delta_done_and_sentinel() -> None:
     assert '"delta":"hello "' in body
     assert '"delta":"world"' in body
     assert '"text":"hello world"' in body
+    done_line = next(
+        line for line in body.splitlines() if '"type":"transcript.text.done"' in line
+    )
+    done = json.loads(done_line.removeprefix("data: "))
+    assert "termination" not in done
+    assert "finish_reason" not in done
+    assert "completion_tokens" not in done
+
+
+def test_transcription_does_not_surface_internal_diagnostics_in_headers() -> None:
+    client = TestClient(
+        create_app(
+            DiagnosticTranscriptionClient(),
+            model_name="OpenMOSS-Team/MOSS-Transcribe-Diarize",
+        )
+    )
+
+    response = client.post(
+        "/v1/audio/transcriptions",
+        data={"model": "OpenMOSS-Team/MOSS-Transcribe-Diarize"},
+        files={"file": ("sample.wav", b"RIFF", "audio/wav")},
+    )
+
+    assert response.status_code == 200
+    assert response.json() == {"text": "[0.00][S01][0.18]"}
+    assert not any(
+        name.startswith(("x-termination-", "x-finish-", "x-completion-"))
+        or name == "x-applied-max-new-tokens"
+        for name in response.headers
+    )
+
+
+def test_transcription_stream_does_not_surface_internal_diagnostics() -> None:
+    client = TestClient(
+        create_app(
+            DiagnosticTranscriptionClient(),
+            model_name="OpenMOSS-Team/MOSS-Transcribe-Diarize",
+        )
+    )
+
+    response = client.post(
+        "/v1/audio/transcriptions",
+        data={
+            "model": "OpenMOSS-Team/MOSS-Transcribe-Diarize",
+            "stream": "true",
+        },
+        files={"file": ("sample.wav", b"RIFF", "audio/wav")},
+    )
+
+    assert response.status_code == 200
+    done_line = next(
+        line
+        for line in response.text.splitlines()
+        if '"type":"transcript.text.done"' in line
+    )
+    done = json.loads(done_line.removeprefix("data: "))
+    assert done == {
+        "type": "transcript.text.done",
+        "text": "[0.00][S01][0.18]",
+    }
 
 
 def test_transcription_stream_maps_input_length_error_to_400() -> None:


### PR DESCRIPTION
## Motivation

Pathological buffered MOSS-Transcribe-Diarize requests can keep emitting timestamp/speaker markers or the same complete segment after useful transcription progress has stopped. Those requests retain active decode slots and reduce effective single-replica batch occupancy.

A duration-scaled token budget cannot distinguish a legitimate long transcript from output that has stopped making progress. This PR adds an opt-in semantic detector that only terminates at a complete MOSS segment boundary.

This is complementary to #1840: that PR bounds short/empty-audio decode by duration and exposes `repetition_penalty`; this PR detects marker-only and exact-segment repetition while decoding. The policies can be evaluated independently or stacked, although both touch the MOSS-TD request builder.

## Modifications

- Add opt-in marker-only and exact repeated-segment thresholds. Both default to `0`, so current production behavior is unchanged until explicitly enabled.
- Incrementally inspect buffered, non-streaming output and terminate only at a complete segment boundary.
- Exclude streaming requests because emitted output cannot be retracted safely.
- Fail open on malformed/replacement-heavy tokenizer output, tokenizer exceptions, or bounded detector work limits.
- Preserve the first prefill token by waiting for a later decode boundary before applying a stop decision.
- Emit bounded, hashed termination diagnostics without adding detector metadata to the public response.
- Add config, pipeline wiring, scheduler/result-adapter, API non-leakage, and detector regression tests.

## Related Issues

- Related: #975
- Complementary mitigation: #1840

## Accuracy Test

The feature is disabled by default. Fresh fixed-image CPU validation on this exact PR head passed:

```text
209 passed, 16 warnings in 32.99s
```

The suite covers normal completions, complete-boundary termination, content resets, repeated segments, streaming exclusion, first-prefill ordering, tokenizer fail-open paths, bounded pending/incomplete state, config wiring, and absence of termination metadata from public API responses.

Current model-quality A/B is still pending. Before enabling nonzero thresholds by default, we will run a loop-heavy cohort plus a healthy transcription/diarization cohort and report CER, cpCER, DER, output completeness, and termination attribution.

## Benchmark & Profiling

No current E2E throughput result is claimed for this buffered detector yet. Historical gains from duration-based hard-budget experiments are not evidence for this implementation.

Planned online validation compares feature-off and configured detector arms on one replica, reporting QPS/makespan, p50/p95/p99 latency, realized batch occupancy, GPU utilization, detector trigger counts, and quality metrics. Results will be added to this draft after the online run.

## Checklist

- [x] Format your code according with pre-commit.
- [x] Add unit tests.
- [ ] Update documentation / docstrings / example tutorials as needed.
- [ ] Provide throughput / latency benchmark results and accuracy evaluation results as needed.
- [ ] For reviewers: If you haven't made any contributions to this PR and are only assisting with merging the main branch, please remove yourself as a co-author when merging the PR.

## CI

This is intentionally a draft while online performance and model-quality A/B are collected. Draft PRs are skipped by self-hosted CI.