### PR TITLE
[Qwen3-TTS] Skip unused Talker tokenizer for non-reference variants

### DIFF
--- a/sglang_omni/models/qwen3_tts/engine_builder.py
+++ b/sglang_omni/models/qwen3_tts/engine_builder.py
@@ -21,6 +21,21 @@ def _is_truthy(value: Any) -> bool:
     return False
 
 
+def _talker_requires_speech_tokenizer(model: Any) -> bool:
+    """Return whether this Talker checkpoint can consume reference audio.
+
+    Base checkpoints use the speech tokenizer to encode reference audio. The
+    CustomVoice and VoiceDesign request paths reject reference audio entirely,
+    so keeping a second full speech-tokenizer copy on the Talker is unnecessary.
+
+    Unknown/future model types conservatively keep the historical behavior.
+    """
+
+    model_type = str(getattr(model, "tts_model_type", "base"))
+    normalized = model_type.replace("-", "").replace("_", "").strip().lower()
+    return normalized not in {"customvoice", "voicedesign"}
+
+
 class Qwen3TtsEngineBuilder(TtsEngineBuilder):
     model_name = "Qwen3-TTS"
     context_length = 8192
@@ -78,13 +93,14 @@ class Qwen3TtsEngineBuilder(TtsEngineBuilder):
         from transformers import AutoProcessor
 
         model = model_worker.model_runner.model
-        speech_tokenizer = qwen3_stages._load_qwen3_tts_tokenizer(
-            checkpoint_dir,
-            device=device,
-            dtype=self.dtype,
-            attn_implementation=self.attn_implementation,
-        )
-        model.load_speech_tokenizer(speech_tokenizer)
+        if _talker_requires_speech_tokenizer(model):
+            speech_tokenizer = qwen3_stages._load_qwen3_tts_tokenizer(
+                checkpoint_dir,
+                device=device,
+                dtype=self.dtype,
+                attn_implementation=self.attn_implementation,
+            )
+            model.load_speech_tokenizer(speech_tokenizer)
         processor = AutoProcessor.from_pretrained(
             checkpoint_dir,
             fix_mistral_regex=True,

--- a/tests/unit_test/qwen3_tts/test_pipeline.py
+++ b/tests/unit_test/qwen3_tts/test_pipeline.py
@@ -4825,6 +4825,41 @@ def test_qwen3_tts_sampled_subtalker_requires_semantic_positions(
         )
 
 
+@pytest.mark.parametrize(
+    ("model_type", "expected"),
+    [
+        ("base", True),
+        ("custom_voice", False),
+        ("customvoice", False),
+        ("custom-voice", False),
+        ("voice_design", False),
+        ("voicedesign", False),
+        ("voice-design", False),
+        ("future_variant", True),
+    ],
+)
+def test_qwen3_tts_talker_tokenizer_loading_policy(
+    model_type: str,
+    expected: bool,
+) -> None:
+    from sglang_omni.models.qwen3_tts.engine_builder import (
+        _talker_requires_speech_tokenizer,
+    )
+
+    assert (
+        _talker_requires_speech_tokenizer(SimpleNamespace(tts_model_type=model_type))
+        is expected
+    )
+
+
+def test_qwen3_tts_talker_tokenizer_loading_defaults_to_safe_behavior() -> None:
+    from sglang_omni.models.qwen3_tts.engine_builder import (
+        _talker_requires_speech_tokenizer,
+    )
+
+    assert _talker_requires_speech_tokenizer(SimpleNamespace())
+
+
 def test_qwen3_tts_engine_disables_torch_compile_by_default() -> None:
     from sglang_omni.models.qwen3_tts.engine_builder import Qwen3TtsEngineBuilder
 


### PR DESCRIPTION
## Summary

Qwen3-TTS currently loads a full speech tokenizer into the Talker for every checkpoint, while the vocoder also loads its own tokenizer.

CustomVoice and VoiceDesign reject reference audio and do not use Talker-side reference codec encoding. This PR skips the Talker speech-tokenizer load for those two non-reference variants while preserving the historical behavior for Base and unknown/future model types.

The change is intentionally limited to the Talker loading policy. It does not change Base tokenizer loading, vocoder tokenizer loading, request preparation, or codec execution.

## Validation

Validation has two layers:

1. The original H200 campaign measured loading, fixed GPU residency, and warmed serving performance against upstream `main@94fd2f272b6a68bd3001728400ce46da1124f68b` with production candidate `41503b5600f18e1b1d3c4e5a89c3c6922fbe3545`.
2. After newer Qwen3-TTS serving changes landed, including the CustomVoice / VoiceDesign codec-output change in #1852, exact output correctness was revalidated on current `main@2125406365502f381b3d0520c5c63ded9ccdece4`. The integration candidate was `5ec620f59010cdc5d7afd5218773c77676d24fc1`, and the harness verified that the supplied current-main baseline itself was the merge base before launching any GPU work.

### Loading and memory

Using a fixed KV capacity of 1,088,900 tokens in the original H200 campaign:

| Metric | Baseline | Candidate | Delta |
| --- | ---: | ---: | ---: |
| Talker + vocoder tokenizer loads | 2 | 1 | -1 full load |
| Ready GPU residency | 124253 MiB | 123935 MiB | -318 MiB |
| Post-request GPU residency | 124757 MiB | 124481 MiB | -276 MiB |

KV capacity is unchanged because the Talker tokenizer is loaded after KV-pool sizing.

### Current-main correctness confirmation

Both affected non-reference variants were tested with two fresh-server cyclic AB/BA rounds on H200, for four cells per variant. The final correctness runner hashes both the full WAV response and the decoded PCM frame bytes.

| Variant | WAV parity | Decoded PCM parity | Baseline tokenizer loads | Candidate tokenizer loads | Request failures |
| --- | --- | --- | --- | --- | ---: |
| CustomVoice | byte-identical across all 4 cells | byte-identical across all 4 cells | 2, 2 | 1, 1 | 0 |
| VoiceDesign | byte-identical across all 4 cells | byte-identical across all 4 cells | 2, 2 | 1, 1 | 0 |

WAV metadata was also identical across all cells for both variants.

This confirms that removing the unused Talker-side speech tokenizer preserves the exact generated audio for both affected variants on the current integration tree, including the current default codec-output path.

### Warmed serving performance

Each fresh server in the original performance campaign first ran a c1/c16/c32 priming sweep that was discarded before measurement. Workload token counts and generated audio duration were identical between arms, with zero request failures.

To check fresh-server variance, the AB/BA comparison was repeated three times, giving six paired fresh-server measurements per concurrency.

| Concurrency | Mean candidate QPS delta | Range | Approx. 95% CI |
| --- | ---: | ---: | ---: |
| 1 | +4.95% | +0.56% to +9.93% | +1.52% to +8.37% |
| 16 | -0.62% | -6.65% to +3.56% | -4.11% to +2.86% |
| 32 | +0.28% | -3.30% to +5.28% | -3.29% to +3.86% |

The c16/c32 measurements fluctuate around zero rather than showing a stable arm effect. At c1, the candidate was faster in all six pairs; this is reported as an observed trend rather than a claimed optimization because the mechanism was not investigated.

Overall, there is no material warmed-serving performance regression.

### Tests

The full Qwen3-TTS unit suite passed on the validated production candidate. Focused loading-policy coverage lives in `tests/unit_test/qwen3_tts/test_pipeline.py` and covers Base, CustomVoice, VoiceDesign, unknown, and missing model-type behavior.

The current-main exact-parity confirmation used `qwen3_tts/issue20_tokenizer_residency/run_pr1870_final_correctness.py` from `charliechenye/sglang-scripts:qwen3-tts-issue20-tokenizer-residency`.

* Related architecture issue: #1873
* Qwen3-TTS optimization roadmap: #1754
* Research and experiment history: charliechenye/sglang-omni#20