### PR TITLE
[Fix][MOSS-TTS] Use model context metadata for speech input limits

### DIFF
--- a/docs/cookbook/moss_tts.md
+++ b/docs/cookbook/moss_tts.md
@@ -47,6 +47,10 @@ components it uses instead of loading a complete codec copy.
 The bounded 24 GB and 32 GB configurations explicitly move preprocessing to
 CPU. They retain BF16 compute unless `compute_dtype` is overridden.
 
+Speech input admission follows the text backbone's context metadata rather than
+the generic 4,096-character precheck. Requests that exceed the effective model
+context are rejected with an OpenAI-compatible HTTP 400 error.
+
 For the bounded 32 GB qualification layout, use:
 
 ```bash

--- a/docs/cookbook/moss_tts_local.md
+++ b/docs/cookbook/moss_tts_local.md
@@ -40,6 +40,10 @@ sgl-omni serve \
 
 A matching config file is available at `examples/configs/moss_tts_local.yaml`.
 
+Speech input admission follows the text backbone's context metadata rather than
+the generic 4,096-character precheck. Requests that exceed the effective model
+context are rejected with an OpenAI-compatible HTTP 400 error.
+
 ## Synthesizing Speech
 
 ### Basic Speech

--- a/sglang_omni/config/schema.py
+++ b/sglang_omni/config/schema.py
@@ -39,6 +39,8 @@ def stage_process_name(stage: "StageConfig") -> str:
 
 logger = logging.getLogger(__name__)
 
+MAX_SPEECH_INPUT_CHARS: int = 4096
+
 
 class CommConfig(BaseModel):
     """Per-stage communication buffer and Mooncake options.
@@ -459,6 +461,7 @@ class PipelineConfig(BaseModel):
     condition_on_previous_text: ClassVar[bool] = (
         False  # Whether the model can condition on the previous text.
     )
+    max_speech_input_chars: ClassVar[int | None] = MAX_SPEECH_INPUT_CHARS
 
     stage_config_types: ClassVar[dict[str, type[StageConfig]]] = {}
     """Stage name -> ``StageConfig`` subclass for this pipeline's stage types.

--- a/sglang_omni/models/moss_tts/config.py
+++ b/sglang_omni/models/moss_tts/config.py
@@ -49,6 +49,7 @@ class MossTTSPipelineConfig(PipelineConfig):
 
     architecture: ClassVar[str] = "MossTTSDelayModel"
     requires_model_capabilities: ClassVar[bool] = True
+    max_speech_input_chars: ClassVar[int | None] = None
     architecture_aliases: ClassVar[tuple[str, ...]] = (
         "MossTTSDelay",
         "MossTTSDelayForConditionalGeneration",

--- a/sglang_omni/models/moss_tts/engine_builder.py
+++ b/sglang_omni/models/moss_tts/engine_builder.py
@@ -4,17 +4,34 @@
 from __future__ import annotations
 
 import importlib
+from collections.abc import Mapping
 from typing import Any
 
 from sglang_omni.models.moss_tts import request_builders
+from sglang_omni.models.moss_tts.hf_loading import (
+    MOSS_TTS_DEFAULT_CONTEXT_LENGTH,
+    resolve_moss_tts_context_length,
+)
 from sglang_omni.scheduling.engine_factory import TtsEngineBuilder
 
 
 class MossTtsEngineBuilder(TtsEngineBuilder):
     model_name = "MOSS-TTS"
-    context_length = 8192
+    context_length = MOSS_TTS_DEFAULT_CONTEXT_LENGTH
     model_arch_override = "MossTTSDelaySGLangModel"
+    supports_context_length_override = True
     supports_breakable_prefill_cuda_graph = True
+
+    def resolve_context_length(
+        self,
+        checkpoint_dir: str,
+        *,
+        server_args_overrides: Mapping[str, Any] | None = None,
+    ) -> int:
+        return resolve_moss_tts_context_length(
+            checkpoint_dir,
+            server_args_overrides=server_args_overrides,
+        )
 
     def generation_defaults(
         self,
@@ -27,7 +44,7 @@ class MossTtsEngineBuilder(TtsEngineBuilder):
             "disable_cuda_graph": False,
             "disable_overlap_schedule": True,
             "enable_torch_compile": False,
-            "max_prefill_tokens": 8192,
+            "max_prefill_tokens": min(self.context_length, 8192),
             "sampling_backend": "pytorch",
             "trust_remote_code": True,
         }

--- a/sglang_omni/models/moss_tts/hf_loading.py
+++ b/sglang_omni/models/moss_tts/hf_loading.py
@@ -3,10 +3,118 @@
 
 from __future__ import annotations
 
+import copy
 import json
-from collections.abc import Iterator
+import math
+from collections.abc import Iterator, Mapping
 from contextlib import contextmanager
+from numbers import Integral, Real
 from typing import Any
+
+from sglang.srt.utils.hf_transformers import (
+    CONTEXT_LENGTH_KEYS,
+    get_config,
+    get_context_length,
+    get_hf_text_config,
+)
+
+MOSS_TTS_DEFAULT_CONTEXT_LENGTH = 8192
+
+
+def _validate_context_length_metadata(text_config: Any) -> bool:
+    context_value = None
+    for key in CONTEXT_LENGTH_KEYS:
+        value = getattr(text_config, key, None)
+        if value is None:
+            continue
+        if isinstance(value, bool) or not isinstance(value, Integral):
+            raise ValueError(
+                f"MOSS-TTS context metadata {key} must be an integer, got {value!r}"
+            )
+        context_value = int(value)
+        break
+    if context_value is None:
+        return False
+    rope_scaling = getattr(text_config, "rope_scaling", None)
+    if not rope_scaling:
+        return True
+    if not isinstance(rope_scaling, Mapping):
+        raise ValueError(
+            "MOSS-TTS context metadata rope_scaling must be a mapping, "
+            f"got {rope_scaling!r}"
+        )
+    if (
+        "original_max_position_embeddings" in rope_scaling
+        or rope_scaling.get("rope_type") == "llama3"
+    ):
+        return True
+    factor = rope_scaling.get("factor", 1)
+    if isinstance(factor, bool) or not isinstance(factor, Real):
+        raise ValueError(
+            "MOSS-TTS context metadata rope_scaling.factor must be a finite "
+            f"number, got {factor!r}"
+        )
+    try:
+        factor_is_finite = math.isfinite(float(factor))
+    except (OverflowError, TypeError, ValueError) as exc:
+        raise ValueError(
+            "MOSS-TTS context metadata rope_scaling.factor must be a finite "
+            f"number, got {factor!r}"
+        ) from exc
+    if not factor_is_finite:
+        raise ValueError(
+            "MOSS-TTS context metadata rope_scaling.factor must be a finite "
+            f"number, got {factor!r}"
+        )
+    try:
+        scaled_value = factor * context_value
+        scaled_integer = int(scaled_value)
+    except (OverflowError, TypeError, ValueError) as exc:
+        raise ValueError(
+            "MOSS-TTS context metadata rope_scaling.factor produces an "
+            f"invalid context length: {factor!r} * {context_value!r}"
+        ) from exc
+    if scaled_value != scaled_integer:
+        raise ValueError(
+            "MOSS-TTS context metadata rope_scaling.factor must produce an "
+            f"integer context length, got {factor!r} * {context_value!r}"
+        )
+    return True
+
+
+def resolve_moss_tts_context_length(
+    checkpoint_dir: str,
+    *,
+    server_args_overrides: Mapping[str, Any] | None = None,
+) -> int:
+    """Resolve MOSS-TTS text context from the runtime model settings."""
+    overrides = server_args_overrides or {}
+    raw_model_override_args = overrides.get("json_model_override_args", "{}")
+    try:
+        model_override_args = json.loads(raw_model_override_args)
+    except (TypeError, json.JSONDecodeError) as exc:
+        raise ValueError(
+            "json_model_override_args must be a valid JSON object string"
+        ) from exc
+    if not isinstance(model_override_args, Mapping):
+        raise ValueError("json_model_override_args must decode to a JSON object")
+
+    config_kwargs: dict[str, Any] = {
+        "trust_remote_code": overrides.get("trust_remote_code", True),
+        "model_config_parser": overrides.get("model_config_parser", "auto"),
+        "model_override_args": dict(model_override_args),
+    }
+    config_file = overrides.get("decrypted_config_file")
+    if config_file and config_file.strip():
+        config_kwargs["_configuration_file"] = config_file.strip()
+    config = copy.deepcopy(get_config(checkpoint_dir, **config_kwargs))
+    text_config = get_hf_text_config(config)
+    if not _validate_context_length_metadata(text_config):
+        return MOSS_TTS_DEFAULT_CONTEXT_LENGTH
+    try:
+        return int(get_context_length(text_config))
+    except (OverflowError, TypeError, ValueError) as exc:
+        raise ValueError("MOSS-TTS context metadata is invalid") from exc
 
 
 @contextmanager

--- a/sglang_omni/models/moss_tts/hf_loading.py
+++ b/sglang_omni/models/moss_tts/hf_loading.py
@@ -32,6 +32,11 @@ def _validate_context_length_metadata(text_config: Any) -> bool:
                 f"MOSS-TTS context metadata {key} must be an integer, got {value!r}"
             )
         context_value = int(value)
+        if context_value <= 0:
+            raise ValueError(
+                f"MOSS-TTS context metadata {key} must be a positive integer, "
+                f"got {value!r}"
+            )
         break
     if context_value is None:
         return False
@@ -78,6 +83,11 @@ def _validate_context_length_metadata(text_config: Any) -> bool:
         raise ValueError(
             "MOSS-TTS context metadata rope_scaling.factor must produce an "
             f"integer context length, got {factor!r} * {context_value!r}"
+        )
+    if scaled_integer <= 0:
+        raise ValueError(
+            "MOSS-TTS context metadata rope_scaling.factor must produce a "
+            f"positive context length, got {factor!r} * {context_value!r}"
         )
     return True
 

--- a/sglang_omni/models/moss_tts_local/config.py
+++ b/sglang_omni/models/moss_tts_local/config.py
@@ -115,6 +115,7 @@ class MossTTSLocalPipelineConfig(PipelineConfig):
 
     architecture: ClassVar[str] = "MossTTSLocalModel"
     requires_model_capabilities: ClassVar[bool] = True
+    max_speech_input_chars: ClassVar[int | None] = None
     architecture_aliases: ClassVar[tuple[str, ...]] = (
         "MossTTSLocal",
         "MossTTSLocalForConditionalGeneration",

--- a/sglang_omni/models/moss_tts_local/engine_builder.py
+++ b/sglang_omni/models/moss_tts_local/engine_builder.py
@@ -4,8 +4,13 @@
 from __future__ import annotations
 
 import importlib
+from collections.abc import Mapping
 from typing import Any
 
+from sglang_omni.models.moss_tts.hf_loading import (
+    MOSS_TTS_DEFAULT_CONTEXT_LENGTH,
+    resolve_moss_tts_context_length,
+)
 from sglang_omni.models.moss_tts_local import request_builders
 from sglang_omni.models.moss_tts_local import stages as moss_local_stages
 from sglang_omni.scheduling.engine_factory import TtsEngineBuilder
@@ -13,8 +18,20 @@ from sglang_omni.scheduling.engine_factory import TtsEngineBuilder
 
 class MossTtsLocalEngineBuilder(TtsEngineBuilder):
     model_name = "MOSS-TTS Local"
-    context_length = 8192
+    context_length = MOSS_TTS_DEFAULT_CONTEXT_LENGTH
     model_arch_override = "MossTTSLocalSGLangModel"
+    supports_context_length_override = True
+
+    def resolve_context_length(
+        self,
+        checkpoint_dir: str,
+        *,
+        server_args_overrides: Mapping[str, Any] | None = None,
+    ) -> int:
+        return resolve_moss_tts_context_length(
+            checkpoint_dir,
+            server_args_overrides=server_args_overrides,
+        )
 
     def __init__(
         self,
@@ -52,7 +69,7 @@ class MossTtsLocalEngineBuilder(TtsEngineBuilder):
             "disable_cuda_graph": False,
             "disable_overlap_schedule": True,
             "enable_torch_compile": False,
-            "max_prefill_tokens": 8192,
+            "max_prefill_tokens": min(self.context_length, 8192),
             "sampling_backend": "pytorch",
             "trust_remote_code": True,
         }

--- a/sglang_omni/scheduling/engine_factory.py
+++ b/sglang_omni/scheduling/engine_factory.py
@@ -5,7 +5,8 @@ from __future__ import annotations
 
 from abc import ABC, abstractmethod
 from collections.abc import Mapping
-from typing import Any
+from numbers import Integral
+from typing import Any, ClassVar
 
 from sglang_omni.scheduling.generation_batch_policy import (
     CudaGraphBackend,
@@ -27,6 +28,19 @@ def _operator_selected_prefill_graph_backend(
     return "backend" in nested_prefill_overrides(server_args_overrides)
 
 
+def _normalize_context_length(value: Any, *, model_name: str) -> int:
+    if isinstance(value, bool) or not isinstance(value, Integral):
+        raise ValueError(
+            f"{model_name} context length must be a positive integer, got {value!r}"
+        )
+    context_length = int(value)
+    if context_length <= 0:
+        raise ValueError(
+            f"{model_name} resolved an invalid context length: {context_length}"
+        )
+    return context_length
+
+
 class SGLangGenerationEngineBuilder(ABC):
     """Build the model-neutral parts of a SGLang AR engine stage.
 
@@ -39,6 +53,7 @@ class SGLangGenerationEngineBuilder(ABC):
     model_name: str
     context_length: int
     model_arch_override: str | None = None
+    supports_context_length_override: ClassVar[bool] = False
     # Set True only by builders whose model has adopted the breakable prefill
     # CUDA graph contract; a deployment override cannot enable it otherwise.
     supports_breakable_prefill_cuda_graph: bool = False
@@ -72,6 +87,26 @@ class SGLangGenerationEngineBuilder(ABC):
 
         self.pre_infra_setup(checkpoint_dir)
 
+        requested_context_length = (
+            server_args_overrides.get("context_length")
+            if server_args_overrides is not None
+            else None
+        )
+        if (
+            requested_context_length is not None
+            and self.supports_context_length_override
+        ):
+            context_length = requested_context_length
+        else:
+            context_length = self.resolve_context_length(
+                checkpoint_dir,
+                server_args_overrides=server_args_overrides,
+            )
+        self.context_length = _normalize_context_length(
+            context_length,
+            model_name=self.model_name,
+        )
+
         operator_selected_prefill_backend = _operator_selected_prefill_graph_backend(
             server_args_overrides
         )
@@ -80,6 +115,12 @@ class SGLangGenerationEngineBuilder(ABC):
             **self.generation_defaults(dtype=dtype),
         )
         self.adjust_overrides(overrides)
+        if "context_length" in overrides:
+            if not self.supports_context_length_override:
+                raise ValueError(
+                    f"{self.model_name} does not support a context_length override"
+                )
+            overrides.pop("context_length")
         # Left unset, SGLang re-detects off a CUDA-first ladder that can contradict
         # placement. It owns the type, not the index.
         resolved_type = torch.device(device).type
@@ -203,6 +244,15 @@ class SGLangGenerationEngineBuilder(ABC):
 
     def pre_infra_setup(self, checkpoint_dir: str) -> None:
         del checkpoint_dir
+
+    def resolve_context_length(
+        self,
+        checkpoint_dir: str,
+        *,
+        server_args_overrides: Mapping[str, Any] | None = None,
+    ) -> int:
+        del checkpoint_dir, server_args_overrides
+        return self.context_length
 
     def validate_before_infrastructure(self, server_args: Any) -> None:
         del server_args

--- a/sglang_omni/serve/launcher.py
+++ b/sglang_omni/serve/launcher.py
@@ -434,6 +434,7 @@ async def _run_server(
                 pipeline_config.speech_reference_text_excludes_instructions
             ),
             additional_speech_languages=pipeline_config.additional_speech_languages,
+            max_speech_input_chars=pipeline_config.max_speech_input_chars,
             enable_realtime=enable_realtime,
             supports_realtime_audio_output=(
                 type(pipeline_config).code2wav_stage() is not None

--- a/sglang_omni/serve/openai_api.py
+++ b/sglang_omni/serve/openai_api.py
@@ -58,6 +58,7 @@ from sglang_omni.client.audio import (
     select_audio_delta,
 )
 from sglang_omni.config import ResolvedAudioChunking
+from sglang_omni.config.schema import MAX_SPEECH_INPUT_CHARS
 from sglang_omni.http.admin_auth import (
     make_admin_auth_dependency,
     resolve_admin_api_key,
@@ -102,7 +103,6 @@ from sglang_omni.serve.protocol import (
 from sglang_omni.serve.speech_errors import (
     SpeechAPIError,
     bad_request,
-    internal_error,
     openai_error_payload,
     speech_error_response,
     speech_generation_error,
@@ -183,6 +183,7 @@ def create_app(
     speech_reference_text_required: bool = False,
     speech_reference_text_excludes_instructions: bool = False,
     additional_speech_languages: frozenset[str] = frozenset(),
+    max_speech_input_chars: int | None = MAX_SPEECH_INPUT_CHARS,
     enable_realtime: bool = False,
     supports_realtime_audio_output: bool = False,
     allowed_local_media_path: str | None = None,
@@ -210,6 +211,8 @@ def create_app(
         speech_reference_text_excludes_instructions: Whether a reference
             transcript and style instructions are mutually exclusive.
         additional_speech_languages: Pipeline-specific accepted languages.
+        max_speech_input_chars: Maximum accepted input characters, or ``None``
+            to defer length validation to model-specific context checks.
         enable_realtime: If True, mount the WebSocket ``/v1/realtime``
             endpoint (OpenAI Realtime API).
         supports_realtime_audio_output: Whether the mounted realtime endpoint
@@ -261,6 +264,7 @@ def create_app(
             speech_reference_text_excludes_instructions
         ),
         additional_speech_languages=additional_speech_languages,
+        max_speech_input_chars=max_speech_input_chars,
         allowed_local_media_path=allowed_local_media_path,
         allowed_media_domains=allowed_media_domains,
         voice_store=app.state.speaker_sample_store,
@@ -1211,16 +1215,16 @@ def _speech_generation_failure_response(
     unexpected_message: str | None = None,
 ) -> JSONResponse:
     mapped = speech_generation_error(exc)
-    if mapped.status_code == 503:
+    if mapped.status_code not in (400, 503):
+        logger.exception(
+            unexpected_message or "Error generating speech for request %s",
+            request_id,
+        )
+    else:
         logger.warning(
             "Rejecting speech request %s: %s",
             request_id,
             mapped.message,
-        )
-    else:
-        logger.exception(
-            unexpected_message or "Error generating speech for request %s",
-            request_id,
         )
     return speech_error_response(mapped)
 
@@ -1334,8 +1338,18 @@ def _register_speech_batch(app: FastAPI) -> None:
         except SpeechAPIError as exc:
             return speech_error_response(exc)
         except Exception as exc:
-            logger.exception("Error generating speech batch for request %s", request_id)
-            return speech_error_response(internal_error(str(exc)))
+            mapped = speech_generation_error(exc)
+            if mapped.status_code not in (400, 503):
+                logger.exception(
+                    "Error generating speech batch for request %s", request_id
+                )
+            else:
+                logger.warning(
+                    "Rejecting speech batch request %s: %s",
+                    request_id,
+                    mapped.message,
+                )
+            return speech_error_response(mapped)
 
         response = SpeechBatchResponse.model_validate(response)
         return JSONResponse(content=response.model_dump(exclude_none=True))

--- a/sglang_omni/serve/openai_errors.py
+++ b/sglang_omni/serve/openai_errors.py
@@ -3,6 +3,8 @@
 
 from __future__ import annotations
 
+import re
+
 _BAD_REQUEST_MARKERS = (
     "Unsupported language:",
     "longer than the model's context length",
@@ -16,8 +18,14 @@ _BAD_REQUEST_MARKERS = (
     "multimodal_train_inputs",
     "disallowed special token",
 )
+_BAD_REQUEST_PATTERNS = (
+    re.compile(r"^Request\s+\S+\s+exceeds the maximum number of tokens:"),
+    re.compile(r"^Request\s+\S+\s+requires too many SWA KV tokens for"),
+)
 
 
-def is_bad_request_error(exc: Exception) -> bool:
+def is_bad_request_error(exc: BaseException) -> bool:
     message = str(exc)
-    return any(marker in message for marker in _BAD_REQUEST_MARKERS)
+    return any(marker in message for marker in _BAD_REQUEST_MARKERS) or any(
+        pattern.search(message) is not None for pattern in _BAD_REQUEST_PATTERNS
+    )

--- a/sglang_omni/serve/speech_errors.py
+++ b/sglang_omni/serve/speech_errors.py
@@ -9,6 +9,7 @@ from typing import Any
 from fastapi.responses import JSONResponse
 
 from sglang_omni.admission import QueueFullError
+from sglang_omni.serve.openai_errors import is_bad_request_error
 
 
 @dataclass
@@ -120,7 +121,11 @@ def service_unavailable(message: str, *, param: str | None = None) -> SpeechAPIE
 
 
 def speech_generation_error(exc: BaseException) -> SpeechAPIError:
-    """Map pipeline failures to speech HTTP errors (queue-full → 503)."""
+    """Map pipeline failures to the shared speech API error contract."""
+    if isinstance(exc, SpeechAPIError):
+        return exc
     if QueueFullError.matches(exc):
         return service_unavailable(QueueFullError.MESSAGE)
+    if is_bad_request_error(exc):
+        return bad_request(str(exc))
     return internal_error(str(exc))

--- a/sglang_omni/serve/speech_service.py
+++ b/sglang_omni/serve/speech_service.py
@@ -16,6 +16,7 @@ from pydantic import ValidationError
 
 from sglang_omni.client import ClientError, GenerateRequest, SamplingParams
 from sglang_omni.client.audio import audio_encoding_unavailable_reason
+from sglang_omni.config.schema import MAX_SPEECH_INPUT_CHARS
 from sglang_omni.preprocessing.base import MediaIO
 from sglang_omni.preprocessing.resource_connector import MultiModalResourceConnector
 from sglang_omni.scheduling.streaming_vocoder import INITIAL_CODEC_CHUNK_FRAMES_PARAM
@@ -36,9 +37,9 @@ from sglang_omni.serve.protocol import (
 from sglang_omni.serve.speech_errors import (
     SpeechAPIError,
     bad_request,
-    internal_error,
     openai_error_payload,
     service_unavailable,
+    speech_generation_error,
 )
 from sglang_omni.serve.speech_limits import MAX_REFERENCE_AUDIO_BYTES
 
@@ -55,7 +56,6 @@ _TTS_TASK_TYPE_ALIASES = {
     task_type.replace("_", "").replace("-", "").lower(): task_type
     for task_type in SUPPORTED_TTS_TASK_TYPES
 }
-MAX_SPEECH_INPUT_CHARS = 4096
 _REFERENCE_AUDIO_FIELDS = ("audio_path", "ref_audio", "audio")
 _ReferenceCacheKey = tuple[Any, ...]
 
@@ -87,6 +87,7 @@ class SpeechRequestValidator:
         speech_reference_text_required: bool = False,
         speech_reference_text_excludes_instructions: bool = False,
         additional_speech_languages: frozenset[str] = frozenset(),
+        max_speech_input_chars: int | None = MAX_SPEECH_INPUT_CHARS,
         allowed_local_media_path: str | Path | None = None,
         allowed_media_domains: list[str] | None = None,
         voice_store: "SpeakerSampleStore | None" = None,
@@ -99,6 +100,14 @@ class SpeechRequestValidator:
             and required_speech_reference_count < 1
         ):
             raise ValueError("required_speech_reference_count must be greater than 0")
+        if max_speech_input_chars is not None and (
+            isinstance(max_speech_input_chars, bool)
+            or not isinstance(max_speech_input_chars, int)
+            or max_speech_input_chars < 1
+        ):
+            raise ValueError(
+                "max_speech_input_chars must be a positive integer or None"
+            )
         self.default_model = default_model
         self.requires_uploaded_voice_for_named_voice = (
             requires_uploaded_voice_for_named_voice
@@ -109,6 +118,7 @@ class SpeechRequestValidator:
         )
         self.required_speech_reference_count = required_speech_reference_count
         self.speech_reference_text_required = speech_reference_text_required
+        self.max_speech_input_chars = max_speech_input_chars
         self.speech_reference_text_excludes_instructions = (
             speech_reference_text_excludes_instructions
         )
@@ -210,9 +220,10 @@ class SpeechRequestValidator:
     def validate_input_text(self, input_text: str) -> None:
         if not isinstance(input_text, str) or not input_text.strip():
             raise bad_request("input must be a non-empty string", param="input")
-        if len(input_text) > MAX_SPEECH_INPUT_CHARS:
+        limit = self.max_speech_input_chars
+        if limit is not None and len(input_text) > limit:
             raise bad_request(
-                f"input must be at most {MAX_SPEECH_INPUT_CHARS} characters",
+                f"input must be at most {limit} characters",
                 param="input",
             )
 
@@ -427,7 +438,10 @@ class SpeechRequestValidator:
                     )
                 else:
                     results[index] = _batch_error_result(
-                        index, internal_error(str(task_result))
+                        index,
+                        _batch_item_error(
+                            speech_generation_error(task_result), index=index
+                        ),
                     )
 
         final_results = [result for result in results if result is not None]
@@ -473,7 +487,7 @@ class SpeechRequestValidator:
                 allow_format_fallback=False,
             )
         except ClientError as exc:
-            raise internal_error(str(exc)) from exc
+            raise speech_generation_error(exc) from exc
         return SpeechBatchResult(
             index=index,
             status="success",

--- a/sglang_omni/serve/speech_ws.py
+++ b/sglang_omni/serve/speech_ws.py
@@ -26,7 +26,7 @@ from sglang_omni.serve.protocol import CreateSpeechRequest, SpeechStreamSessionC
 from sglang_omni.serve.speech_errors import (
     SpeechAPIError,
     bad_request,
-    internal_error,
+    speech_generation_error,
     speech_websocket_error_payload,
 )
 from sglang_omni.serve.speech_limits import (
@@ -304,11 +304,15 @@ class SpeechWebSocketSession:
         except Exception as exc:
             failed = True
             await self._abort_request(request_id)
-            if isinstance(exc, SpeechAPIError):
-                error = exc
-            else:
-                error = internal_error(str(exc))
+            error = speech_generation_error(exc)
+            if error.status_code == 500:
                 logger.exception("TTS WebSocket sentence failed: %s", request_id)
+            else:
+                logger.warning(
+                    "Rejecting TTS WebSocket sentence %s: %s",
+                    request_id,
+                    error.message,
+                )
             await self._send_error(error)
         finally:
             if self.active_request_id == request_id:

--- a/tests/unit_test/moss_tts/test_pipeline.py
+++ b/tests/unit_test/moss_tts/test_pipeline.py
@@ -460,7 +460,7 @@ def test_moss_tts_context_probe_uses_model_default_without_metadata(
     )
 
 
-@pytest.mark.parametrize("value", [True, 1.5, float("inf"), "4096"])
+@pytest.mark.parametrize("value", [True, 1.5, float("inf"), "4096", 0, -1])
 def test_moss_tts_context_probe_rejects_invalid_metadata(
     monkeypatch: pytest.MonkeyPatch,
     value: object,
@@ -488,6 +488,14 @@ def test_moss_tts_context_probe_rejects_invalid_metadata(
         ({"factor": "2"}, "rope_scaling.factor must be a finite number"),
         ({"factor": float("inf")}, "rope_scaling.factor must be a finite number"),
         ({"factor": 1.1}, "rope_scaling.factor must produce an integer"),
+        (
+            {"factor": 0},
+            "rope_scaling.factor must produce a positive context length",
+        ),
+        (
+            {"factor": -1},
+            "rope_scaling.factor must produce a positive context length",
+        ),
     ],
 )
 def test_moss_tts_context_probe_rejects_invalid_rope_scaling(

--- a/tests/unit_test/moss_tts/test_pipeline.py
+++ b/tests/unit_test/moss_tts/test_pipeline.py
@@ -9,6 +9,7 @@ from collections import deque
 from contextlib import nullcontext
 from pathlib import Path
 from types import SimpleNamespace
+from typing import Any
 
 import numpy as np
 import pytest
@@ -102,6 +103,7 @@ def make_payload(
 
 def test_moss_tts_config_and_registry_contracts() -> None:
     config = MossTTSPipelineConfig(model_path="model")
+    assert config.max_speech_input_chars is None
     assert [stage.name for stage in config.stages] == [
         "preprocessing",
         "tts_engine",
@@ -357,8 +359,205 @@ def test_moss_tts_preprocessing_rejects_invalid_reference_cache_settings(
         stages.create_preprocessing_executor("model", **kwargs)
 
 
+@pytest.mark.parametrize(
+    ("context_length", "expected_max_prefill_tokens"),
+    [(4096, 4096), (40960, 8192)],
+)
+def test_moss_tts_engine_uses_text_backbone_context(
+    monkeypatch: pytest.MonkeyPatch,
+    context_length: int,
+    expected_max_prefill_tokens: int,
+) -> None:
+    from sglang_omni.models.moss_tts import engine_builder, hf_loading
+
+    monkeypatch.setattr(
+        hf_loading,
+        "get_config",
+        lambda model_path, **kwargs: SimpleNamespace(model_path=model_path),
+    )
+    monkeypatch.setattr(
+        hf_loading,
+        "get_hf_text_config",
+        lambda config: SimpleNamespace(max_position_embeddings=context_length),
+    )
+
+    builder = engine_builder.MossTtsEngineBuilder()
+    builder.context_length = builder.resolve_context_length("model")
+
+    assert builder.context_length == context_length
+    assert (
+        builder.generation_defaults(dtype="bfloat16")["max_prefill_tokens"]
+        == expected_max_prefill_tokens
+    )
+
+
+def test_moss_tts_context_probe_uses_runtime_model_config_inputs(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    from sglang_omni.models.moss_tts import engine_builder, hf_loading
+
+    captured: dict[str, object] = {}
+
+    def fake_get_config(model_path: str, **kwargs: Any) -> SimpleNamespace:
+        captured["model_path"] = model_path
+        captured["kwargs"] = kwargs
+        return SimpleNamespace(
+            language_config=SimpleNamespace(max_position_embeddings=4096)
+        )
+
+    monkeypatch.setattr(hf_loading, "get_config", fake_get_config)
+    monkeypatch.setattr(
+        hf_loading,
+        "get_hf_text_config",
+        lambda config: config.language_config,
+    )
+
+    context_length = engine_builder.MossTtsEngineBuilder().resolve_context_length(
+        "model",
+        server_args_overrides={
+            "trust_remote_code": False,
+            "model_config_parser": "hf",
+            "json_model_override_args": (
+                '{"language_config": {"max_position_embeddings": 4096}}'
+            ),
+            "decrypted_config_file": "/tmp/override.json",
+        },
+    )
+
+    assert context_length == 4096
+    assert captured == {
+        "model_path": "model",
+        "kwargs": {
+            "trust_remote_code": False,
+            "model_config_parser": "hf",
+            "model_override_args": {
+                "language_config": {"max_position_embeddings": 4096}
+            },
+            "_configuration_file": "/tmp/override.json",
+        },
+    }
+
+
+def test_moss_tts_context_probe_uses_model_default_without_metadata(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    from sglang_omni.models.moss_tts import engine_builder, hf_loading
+
+    monkeypatch.setattr(
+        hf_loading,
+        "get_config",
+        lambda model_path, **kwargs: SimpleNamespace(model_path=model_path),
+    )
+    monkeypatch.setattr(
+        hf_loading,
+        "get_hf_text_config",
+        lambda config: SimpleNamespace(),
+    )
+
+    assert (
+        engine_builder.MossTtsEngineBuilder().resolve_context_length("model")
+        == engine_builder.MossTtsEngineBuilder.context_length
+    )
+
+
+@pytest.mark.parametrize("value", [True, 1.5, float("inf"), "4096"])
+def test_moss_tts_context_probe_rejects_invalid_metadata(
+    monkeypatch: pytest.MonkeyPatch,
+    value: object,
+) -> None:
+    from sglang_omni.models.moss_tts import engine_builder, hf_loading
+
+    monkeypatch.setattr(
+        hf_loading,
+        "get_config",
+        lambda model_path, **kwargs: SimpleNamespace(model_path=model_path),
+    )
+    monkeypatch.setattr(
+        hf_loading,
+        "get_hf_text_config",
+        lambda config: SimpleNamespace(max_position_embeddings=value),
+    )
+
+    with pytest.raises(ValueError, match="context metadata max_position_embeddings"):
+        engine_builder.MossTtsEngineBuilder().resolve_context_length("model")
+
+
+@pytest.mark.parametrize(
+    ("rope_scaling", "match"),
+    [
+        ({"factor": "2"}, "rope_scaling.factor must be a finite number"),
+        ({"factor": float("inf")}, "rope_scaling.factor must be a finite number"),
+        ({"factor": 1.1}, "rope_scaling.factor must produce an integer"),
+    ],
+)
+def test_moss_tts_context_probe_rejects_invalid_rope_scaling(
+    monkeypatch: pytest.MonkeyPatch,
+    rope_scaling: dict[str, object],
+    match: str,
+) -> None:
+    from sglang_omni.models.moss_tts import engine_builder, hf_loading
+
+    monkeypatch.setattr(
+        hf_loading,
+        "get_config",
+        lambda model_path, **kwargs: SimpleNamespace(model_path=model_path),
+    )
+    monkeypatch.setattr(
+        hf_loading,
+        "get_hf_text_config",
+        lambda config: SimpleNamespace(
+            max_position_embeddings=4096,
+            rope_scaling=rope_scaling,
+        ),
+    )
+
+    with pytest.raises(ValueError, match=match):
+        engine_builder.MossTtsEngineBuilder().resolve_context_length("model")
+
+
+def test_moss_tts_context_probe_accepts_integral_rope_scaling(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    from sglang_omni.models.moss_tts import engine_builder, hf_loading
+
+    monkeypatch.setattr(
+        hf_loading,
+        "get_config",
+        lambda model_path, **kwargs: SimpleNamespace(model_path=model_path),
+    )
+    monkeypatch.setattr(
+        hf_loading,
+        "get_hf_text_config",
+        lambda config: SimpleNamespace(
+            max_position_embeddings=4096,
+            rope_scaling={"factor": 1.5},
+        ),
+    )
+
+    assert engine_builder.MossTtsEngineBuilder().resolve_context_length("model") == 6144
+
+
+def test_moss_tts_context_probe_does_not_mutate_cached_config(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    from transformers import PretrainedConfig
+
+    from sglang_omni.models.moss_tts import engine_builder, hf_loading
+
+    config = PretrainedConfig()
+    config.architectures = ["MossTTSDelayModel"]
+    config.language_config = {
+        "num_attention_heads": 8,
+        "max_position_embeddings": 4096,
+    }
+    monkeypatch.setattr(hf_loading, "get_config", lambda *args, **kwargs: config)
+
+    assert engine_builder.MossTtsEngineBuilder().resolve_context_length("model") == 4096
+    assert isinstance(config.language_config, dict)
+
+
 def test_moss_tts_engine_uses_auto_mem_fraction_by_default(monkeypatch) -> None:
-    from sglang_omni.models.moss_tts import request_builders, stages
+    from sglang_omni.models.moss_tts import hf_loading, request_builders, stages
     from sglang_omni.scheduling import (
         bootstrap,
         engine_factory,
@@ -366,11 +565,11 @@ def test_moss_tts_engine_uses_auto_mem_fraction_by_default(monkeypatch) -> None:
         sglang_backend,
     )
 
-    captured: dict[str, object] = {"build_kwargs": []}
+    captured: dict[str, object] = {"build_kwargs": [], "context_lengths": []}
 
     def fake_build_sglang_server_args(model_path, context_length, **kwargs):
         captured["model_path"] = model_path
-        captured["context_length"] = context_length
+        captured["context_lengths"].append(context_length)
         captured["build_kwargs"].append(dict(kwargs))
         return SimpleNamespace(
             disable_cuda_graph=kwargs["disable_cuda_graph"],
@@ -452,6 +651,16 @@ def test_moss_tts_engine_uses_auto_mem_fraction_by_default(monkeypatch) -> None:
         engine_factory, "_resolve_checkpoint", lambda model_path: model_path
     )
     monkeypatch.setattr(
+        hf_loading,
+        "get_config",
+        lambda model_path, **kwargs: SimpleNamespace(model_path=model_path),
+    )
+    monkeypatch.setattr(
+        hf_loading,
+        "get_hf_text_config",
+        lambda config: SimpleNamespace(max_position_embeddings=40960),
+    )
+    monkeypatch.setattr(
         request_builders,
         "make_moss_tts_scheduler_adapters",
         lambda model: (lambda payload: payload, lambda data: data),
@@ -492,7 +701,7 @@ def test_moss_tts_engine_uses_auto_mem_fraction_by_default(monkeypatch) -> None:
     assert explicit_kwargs["cuda_graph_max_bs"] == 16
     assert explicit_kwargs["enable_torch_compile"] is True
     assert explicit_kwargs["mem_fraction_static"] == 0.61
-    assert captured["context_length"] == 8192
+    assert captured["context_lengths"] == [40960, 40960]
     assert captured["model_arch_override"] == "MossTTSDelaySGLangModel"
     assert captured["defer_cuda_graph_capture"] is True
     assert captured["graph_inits"] == 2
@@ -506,6 +715,16 @@ def test_moss_tts_engine_uses_auto_mem_fraction_by_default(monkeypatch) -> None:
         "backbone",
         "sampling",
     ]
+
+    stages.create_sglang_tts_engine_executor(
+        "OpenMOSS-Team/MOSS-TTS-v1.5",
+        server_args_overrides={
+            "context_length": 4096,
+            "disable_cuda_graph": True,
+        },
+    )
+    assert captured["context_lengths"][-1] == 4096
+    assert captured["build_kwargs"][-1]["max_prefill_tokens"] == 4096
 
 
 def test_moss_tts_talker_torch_compile_dotted_flags_target_tts_engine() -> None:

--- a/tests/unit_test/moss_tts_local/test_pipeline.py
+++ b/tests/unit_test/moss_tts_local/test_pipeline.py
@@ -493,6 +493,12 @@ def test_local_vocoder_loader_only_loads_decoder_and_quantizer(
 def test_registry_resolves_local_architecture():
     config_cls = PIPELINE_CONFIG_REGISTRY.get_config("MossTTSLocalModel")
     assert config_cls is MossTTSLocalPipelineConfig
+    for variant_cls in (
+        MossTTSLocalPipelineConfig,
+        MossTTSLocalColocatedPipelineConfig,
+        MossTTSLocalSplitPipelineConfig,
+    ):
+        assert variant_cls(model_path="dummy").max_speech_input_chars is None
     # The Delay family keeps its own architecture.
     delay_cls = PIPELINE_CONFIG_REGISTRY.get_config("MossTTSDelayModel")
     assert delay_cls is not MossTTSLocalPipelineConfig
@@ -700,6 +706,7 @@ def _install_fake_moss_ar_factory(
 ):
     pytest.importorskip("PIL")
 
+    from sglang_omni.models.moss_tts import hf_loading
     from sglang_omni.models.moss_tts_local import request_builders, stages
     from sglang_omni.scheduling import bootstrap as scheduling_bootstrap
     from sglang_omni.scheduling import engine_factory, omni_scheduler, sglang_backend
@@ -735,6 +742,7 @@ def _install_fake_moss_ar_factory(
         infrastructure_calls.append(
             {
                 "mem_fraction_static": server_args.mem_fraction_static,
+                "context_length": server_args.context_length,
                 "gpu_id": gpu_id,
                 "total_gpu_memory_fraction": kwargs.get("total_gpu_memory_fraction"),
             }
@@ -788,6 +796,16 @@ def _install_fake_moss_ar_factory(
     monkeypatch.setattr(
         engine_factory, "_resolve_checkpoint", lambda model_path: model_path
     )
+    monkeypatch.setattr(
+        hf_loading,
+        "get_config",
+        lambda model_path, **kwargs: types.SimpleNamespace(model_path=model_path),
+    )
+    monkeypatch.setattr(
+        hf_loading,
+        "get_hf_text_config",
+        lambda config: types.SimpleNamespace(max_position_embeddings=32768),
+    )
     monkeypatch.setattr(omni_scheduler, "OmniScheduler", FakeScheduler)
 
     def fake_get_process_gpu_memory_bytes(gpu_id):
@@ -801,6 +819,143 @@ def _install_fake_moss_ar_factory(
     )
 
     return stages, infrastructure_calls, process_memory_queries
+
+
+@pytest.mark.parametrize(
+    ("context_length", "expected_max_prefill_tokens"),
+    [(4096, 4096), (32768, 8192)],
+)
+def test_moss_local_engine_uses_text_backbone_context(
+    monkeypatch: pytest.MonkeyPatch,
+    context_length: int,
+    expected_max_prefill_tokens: int,
+) -> None:
+    from sglang_omni.models.moss_tts import hf_loading
+    from sglang_omni.models.moss_tts_local import engine_builder
+
+    monkeypatch.setattr(
+        hf_loading,
+        "get_config",
+        lambda model_path, **kwargs: types.SimpleNamespace(model_path=model_path),
+    )
+    monkeypatch.setattr(
+        hf_loading,
+        "get_hf_text_config",
+        lambda config: types.SimpleNamespace(max_position_embeddings=context_length),
+    )
+
+    builder = engine_builder.MossTtsLocalEngineBuilder(
+        enable_async_decode=False,
+        async_decode_min_batch_size=2,
+        total_gpu_memory_fraction=None,
+        codec_mem_reserve=0.0,
+    )
+    builder.context_length = builder.resolve_context_length("model")
+
+    assert builder.context_length == context_length
+    assert (
+        builder.generation_defaults(dtype="bfloat16")["max_prefill_tokens"]
+        == expected_max_prefill_tokens
+    )
+
+
+def test_moss_local_context_probe_uses_runtime_model_config_inputs(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    from sglang_omni.models.moss_tts import hf_loading
+    from sglang_omni.models.moss_tts_local import engine_builder
+
+    captured: dict[str, object] = {}
+
+    def fake_get_config(model_path: str, **kwargs: object) -> types.SimpleNamespace:
+        captured["model_path"] = model_path
+        captured["kwargs"] = kwargs
+        return types.SimpleNamespace(
+            language_config=types.SimpleNamespace(max_position_embeddings=4096)
+        )
+
+    monkeypatch.setattr(hf_loading, "get_config", fake_get_config)
+    monkeypatch.setattr(
+        hf_loading,
+        "get_hf_text_config",
+        lambda config: config.language_config,
+    )
+
+    builder = engine_builder.MossTtsLocalEngineBuilder(
+        enable_async_decode=False,
+        async_decode_min_batch_size=2,
+        total_gpu_memory_fraction=None,
+        codec_mem_reserve=0.0,
+    )
+    context_length = builder.resolve_context_length(
+        "model",
+        server_args_overrides={
+            "trust_remote_code": False,
+            "model_config_parser": "hf",
+            "json_model_override_args": (
+                '{"language_config": {"max_position_embeddings": 4096}}'
+            ),
+            "decrypted_config_file": "/tmp/override.json",
+        },
+    )
+
+    assert context_length == 4096
+    assert captured == {
+        "model_path": "model",
+        "kwargs": {
+            "trust_remote_code": False,
+            "model_config_parser": "hf",
+            "model_override_args": {
+                "language_config": {"max_position_embeddings": 4096}
+            },
+            "_configuration_file": "/tmp/override.json",
+        },
+    }
+
+
+def test_moss_local_context_probe_uses_model_default_without_metadata(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    from sglang_omni.models.moss_tts import hf_loading
+    from sglang_omni.models.moss_tts_local import engine_builder
+
+    monkeypatch.setattr(
+        hf_loading,
+        "get_config",
+        lambda model_path, **kwargs: types.SimpleNamespace(model_path=model_path),
+    )
+    monkeypatch.setattr(
+        hf_loading,
+        "get_hf_text_config",
+        lambda config: types.SimpleNamespace(),
+    )
+
+    assert (
+        engine_builder.MossTtsLocalEngineBuilder(
+            enable_async_decode=False,
+            async_decode_min_batch_size=2,
+            total_gpu_memory_fraction=None,
+            codec_mem_reserve=0.0,
+        ).resolve_context_length("model")
+        == engine_builder.MossTtsLocalEngineBuilder.context_length
+    )
+
+
+def test_moss_local_engine_honors_context_length_override(monkeypatch):
+    stages, infrastructure_calls, _ = _install_fake_moss_ar_factory(
+        monkeypatch,
+        process_memory_bytes=None,
+    )
+
+    stages.create_sglang_tts_engine_executor(
+        "dummy",
+        server_args_overrides={
+            "context_length": 4096,
+            "disable_cuda_graph": True,
+        },
+    )
+
+    assert infrastructure_calls[0]["context_length"] == 4096
 
 
 def test_colocated_moss_ar_factory_threads_effective_budget(monkeypatch):
@@ -822,6 +977,7 @@ def test_colocated_moss_ar_factory_threads_effective_budget(monkeypatch):
     assert infrastructure_calls == [
         {
             "mem_fraction_static": pytest.approx(0.85),
+            "context_length": 32768,
             "gpu_id": 0,
             "total_gpu_memory_fraction": pytest.approx(0.95),
         }
@@ -850,6 +1006,7 @@ def test_colocated_moss_ar_factory_uses_upstream_profile_without_process_account
     assert infrastructure_calls == [
         {
             "mem_fraction_static": pytest.approx(0.85),
+            "context_length": 32768,
             "gpu_id": 0,
             "total_gpu_memory_fraction": None,
         }

--- a/tests/unit_test/pipeline/test_ipc.py
+++ b/tests/unit_test/pipeline/test_ipc.py
@@ -456,13 +456,39 @@ async def _run_launcher_with_fake_runner(
     monkeypatch.setattr(launcher, "_find_available_port", lambda host, port: port)
     monkeypatch.setattr(launcher, "MultiProcessPipelineRunner", FakeRunner)
     monkeypatch.setattr(launcher, "ProfilerControlClient", FakeProfilerControl)
-    monkeypatch.setattr(launcher, "create_app", lambda *a, **k: app)
+
+    def fake_create_app(*args, **kwargs):
+        del args
+        app.state.create_app_kwargs = kwargs
+        return app
+
+    monkeypatch.setattr(launcher, "create_app", fake_create_app)
     if serve_mock is not None:
         monkeypatch.setattr(launcher.uvicorn.Server, "serve", serve_mock)
 
     await launcher._run_server(config, port=8000)
     assert runner_ref is not None
     return runner_ref, app, profiler_calls
+
+
+@pytest.mark.asyncio
+async def test_launcher_passes_moss_tts_speech_input_limit(
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    from sglang_omni.models.moss_tts.config import MossTTSPipelineConfig
+
+    config = MossTTSPipelineConfig(
+        model_path="OpenMOSS-Team/MOSS-TTS-v1.5",
+        endpoints=EndpointsConfig(base_path=str(tmp_path)),
+    )
+    _, app, _ = await _run_launcher_with_fake_runner(
+        config=config,
+        serve_mock=AsyncMock(return_value=None),
+        monkeypatch=monkeypatch,
+    )
+
+    assert app.state.create_app_kwargs["max_speech_input_chars"] is None
 
 
 @pytest.mark.asyncio

--- a/tests/unit_test/scheduling/test_engine_factory.py
+++ b/tests/unit_test/scheduling/test_engine_factory.py
@@ -83,6 +83,55 @@ def test_tts_engine_builder_hook_contract_is_narrow() -> None:
     adjust_overrides_signature = inspect.signature(TtsEngineBuilder.adjust_overrides)
     assert list(adjust_overrides_signature.parameters) == ["self", "overrides"]
 
+    resolve_context_length_signature = inspect.signature(
+        TtsEngineBuilder.resolve_context_length
+    )
+    assert list(resolve_context_length_signature.parameters) == [
+        "self",
+        "checkpoint_dir",
+        "server_args_overrides",
+    ]
+
+
+def test_context_length_override_is_capability_gated() -> None:
+    from sglang_omni.models.arkasr.engine_builder import ArkasrEngineBuilder
+    from sglang_omni.models.moss_tts.engine_builder import MossTtsEngineBuilder
+    from sglang_omni.models.moss_tts_local.engine_builder import (
+        MossTtsLocalEngineBuilder,
+    )
+    from sglang_omni.scheduling.engine_factory import TtsEngineBuilder
+
+    assert TtsEngineBuilder.supports_context_length_override is False
+    assert ArkasrEngineBuilder.supports_context_length_override is False
+    assert MossTtsEngineBuilder.supports_context_length_override is True
+    assert MossTtsLocalEngineBuilder.supports_context_length_override is True
+
+
+@pytest.mark.parametrize(
+    "value",
+    [True, False, 1.5, 3.0, float("inf"), float("-inf"), float("nan"), "8192", None],
+)
+def test_normalize_context_length_rejects_non_integral_values(value: Any) -> None:
+    from sglang_omni.scheduling.engine_factory import _normalize_context_length
+
+    with pytest.raises(ValueError, match="context length must be a positive integer"):
+        _normalize_context_length(value, model_name="MOSS-TTS")
+
+
+@pytest.mark.parametrize("value", [0, -1])
+def test_normalize_context_length_rejects_non_positive_values(value: int) -> None:
+    from sglang_omni.scheduling.engine_factory import _normalize_context_length
+
+    with pytest.raises(ValueError, match="resolved an invalid context length"):
+        _normalize_context_length(value, model_name="MOSS-TTS")
+
+
+@pytest.mark.parametrize("value", [1, 8192])
+def test_normalize_context_length_preserves_integral_values(value: int) -> None:
+    from sglang_omni.scheduling.engine_factory import _normalize_context_length
+
+    assert _normalize_context_length(value, model_name="MOSS-TTS") == value
+
 
 def test_tts_engine_builder_phase_order_and_override_contract(monkeypatch) -> None:
     from sglang_omni.scheduling import bootstrap, sglang_backend
@@ -195,6 +244,32 @@ def test_tts_engine_builder_phase_order_and_override_contract(monkeypatch) -> No
             events.append("pre_infra_setup")
             assert checkpoint_dir == "model-resolved"
 
+        def resolve_context_length(
+            self,
+            checkpoint_dir: str,
+            *,
+            server_args_overrides: dict[str, Any] | None = None,
+        ) -> int:
+            events.append("resolve_context_length")
+            assert checkpoint_dir == "model-resolved"
+            assert server_args_overrides == {
+                "cuda_graph_max_bs": 8,
+                "torch_compile_max_bs": 8,
+                "mem_fraction_static": 0.7,
+                "max_total_tokens": TEST_MAX_TOTAL_TOKENS,
+                "max_running_requests": 2,
+                "trust_remote_code": False,
+                "model_config_parser": "hf",
+                "json_model_override_args": (
+                    '{"language_config": {"max_position_embeddings": 4096}}'
+                ),
+                "decrypted_config_file": "/tmp/override.json",
+            }
+            return super().resolve_context_length(
+                checkpoint_dir,
+                server_args_overrides=server_args_overrides,
+            )
+
         def generation_defaults(
             self,
             *,
@@ -303,12 +378,19 @@ def test_tts_engine_builder_phase_order_and_override_contract(monkeypatch) -> No
             "mem_fraction_static": 0.7,
             "max_total_tokens": TEST_MAX_TOTAL_TOKENS,
             "max_running_requests": 2,
+            "trust_remote_code": False,
+            "model_config_parser": "hf",
+            "json_model_override_args": (
+                '{"language_config": {"max_position_embeddings": 4096}}'
+            ),
+            "decrypted_config_file": "/tmp/override.json",
         },
     )
 
     assert events == [
         "resolve_checkpoint",
         "pre_infra_setup",
+        "resolve_context_length",
         "generation_defaults",
         "adjust_overrides",
         "build_server_args",
@@ -331,6 +413,12 @@ def test_tts_engine_builder_phase_order_and_override_contract(monkeypatch) -> No
     assert build_kwargs["torch_compile_max_bs"] == 8
     assert build_kwargs["mem_fraction_static"] == 0.7
     assert build_kwargs["max_total_tokens"] == TEST_MAX_TOTAL_TOKENS
+    assert build_kwargs["trust_remote_code"] is False
+    assert build_kwargs["model_config_parser"] == "hf"
+    assert build_kwargs["json_model_override_args"] == (
+        '{"language_config": {"max_position_embeddings": 4096}}'
+    )
+    assert build_kwargs["decrypted_config_file"] == "/tmp/override.json"
     assert init_graph_calls == [True]
     assert scheduler.kwargs["server_args"].disable_cuda_graph is False
     assert scheduler.kwargs["model_runner"].outbox == "outbox"

--- a/tests/unit_test/serve/test_openai_api.py
+++ b/tests/unit_test/serve/test_openai_api.py
@@ -11,7 +11,7 @@ import pytest
 from fastapi.testclient import TestClient
 
 from sglang_omni.admission import QueueFullError
-from sglang_omni.client import Client, GenerateChunk
+from sglang_omni.client import Client, ClientError, GenerateChunk
 from sglang_omni.client.audio import encode_pcm
 from sglang_omni.client.types import GenerateRequest
 from sglang_omni.pipeline.coordinator import Coordinator
@@ -181,6 +181,18 @@ class FailingSpeechGenerateClient:
         del request, request_id
         raise RuntimeError(self.error)
         yield
+
+    async def speech(
+        self,
+        request: Any,
+        *,
+        request_id: str,
+        response_format: str = "wav",
+        speed: float = 1.0,
+        allow_format_fallback: bool = True,
+    ):
+        del request, request_id, response_format, speed, allow_format_fallback
+        raise ClientError(self.error)
 
     async def abort(self, request_id: str) -> None:
         del request_id
@@ -632,6 +644,42 @@ def test_speech_stream_admission_reject_returns_503_without_traceback(
     assert not any(rec.exc_info for rec in caplog.records)
 
 
+@pytest.mark.parametrize("stream", [False, True])
+def test_speech_context_rejection_returns_400_without_traceback(
+    stream: bool,
+    caplog: pytest.LogCaptureFixture,
+) -> None:
+    message = "Requested token count exceeds the model's maximum context length"
+    client = TestClient(
+        create_app(FailingSpeechGenerateClient(message), model_name="s2-pro")
+    )
+
+    with caplog.at_level(logging.WARNING, logger="sglang_omni.serve.openai_api"):
+        response = client.post(
+            "/v1/audio/speech",
+            json={
+                "model": "s2-pro",
+                "input": "hello",
+                "voice": "default",
+                "stream": stream,
+                "response_format": "pcm" if stream else "wav",
+            },
+        )
+
+    assert response.status_code == 400
+    assert response.json()["error"] == {
+        "message": message,
+        "type": "BadRequestError",
+        "param": None,
+        "code": 400,
+    }
+    assert any(
+        rec.levelno == logging.WARNING and "Rejecting speech request" in rec.message
+        for rec in caplog.records
+    )
+    assert not any(rec.exc_info for rec in caplog.records)
+
+
 def test_speech_endpoint_rejects_invalid_request_with_openai_error() -> None:
     client = TestClient(create_app(SuccessfulSpeechClient(), model_name="tts"))
 
@@ -675,6 +723,16 @@ def test_speech_endpoint_returns_binary_audio() -> None:
     assert response.headers["x-finish-reason"] == "length"
     assert speech_client.speech_requests[0].model == "tts"
     assert speech_client.speech_requests[0].metadata["tts_params"]["voice"] == "default"
+
+
+def test_create_app_passes_model_specific_speech_input_limit() -> None:
+    app = create_app(
+        SuccessfulSpeechClient(),
+        model_name="moss-tts",
+        max_speech_input_chars=None,
+    )
+
+    assert app.state.speech_service.max_speech_input_chars is None
 
 
 @pytest.mark.parametrize("stream", [False, True])

--- a/tests/unit_test/serve/test_speech_batch.py
+++ b/tests/unit_test/serve/test_speech_batch.py
@@ -16,6 +16,10 @@ from sglang_omni.serve import create_app
 from sglang_omni.serve.openai_api import _create_speech_batch_with_disconnect_watch
 from sglang_omni.serve.speech_service import SpeechRequestValidator
 
+CONTEXT_LENGTH_ERROR = (
+    "Requested token count exceeds the model's maximum context length"
+)
+
 
 class RecordingBatchSpeechClient:
     def __init__(self) -> None:
@@ -102,6 +106,8 @@ class MixedBatchSpeechClient:
             await asyncio.sleep(0.01)
         if request.prompt == "fail":
             raise ClientError("model failed")
+        if request.prompt == "context":
+            raise RuntimeError(CONTEXT_LENGTH_ERROR)
         return SpeechResult(
             audio_bytes=f"audio:{request.prompt}".encode(),
             mime_type=f"audio/{response_format}",
@@ -460,6 +466,30 @@ def test_batch_speech_isolates_runtime_failures_and_preserves_order() -> None:
     assert all("success" not in item for item in results)
     assert results[1]["error"]["type"] == "server_error"
     assert set(client_impl.requests) == {"slow", "fail", "fast"}
+
+
+def test_batch_speech_maps_context_rejection_to_bad_request() -> None:
+    client_impl = MixedBatchSpeechClient()
+    client = TestClient(create_app(client_impl, model_name="tts"))
+
+    response = client.post(
+        "/v1/audio/speech/batch",
+        json={
+            "model": "tts",
+            "voice": "default",
+            "items": [{"input": "context"}, {"input": "fast"}],
+        },
+    )
+
+    assert response.status_code == 200
+    result = response.json()["results"][0]
+    assert result["status"] == "error"
+    assert result["error"] == {
+        "message": CONTEXT_LENGTH_ERROR,
+        "type": "BadRequestError",
+        "param": None,
+        "code": 400,
+    }
 
 
 def test_batch_speech_cancellation_aborts_started_items() -> None:

--- a/tests/unit_test/serve/test_speech_errors.py
+++ b/tests/unit_test/serve/test_speech_errors.py
@@ -23,3 +23,36 @@ def test_speech_generation_error_keeps_other_failures_as_500() -> None:
     err = speech_generation_error(RuntimeError("cuda out of memory"))
     assert err.status_code == 500
     assert "cuda out of memory" in err.message
+
+
+@pytest.mark.parametrize(
+    "message",
+    [
+        "The request is longer than the model's context length",
+        "Requested token count exceeds the model's maximum context length",
+        "Request requires more tokens than the thinker KV cache can hold",
+        "Request req-1 exceeds the maximum number of tokens: 8193 > 8192",
+        "Request req-1 requires too many SWA KV tokens for decode preallocation",
+    ],
+)
+def test_speech_generation_error_maps_context_rejection_to_400(
+    message: str,
+) -> None:
+    err = speech_generation_error(RuntimeError(message))
+
+    assert err.status_code == 400
+    assert err.error_type == "BadRequestError"
+    assert err.code == 400
+    assert err.message == message
+
+
+def test_speech_generation_error_does_not_match_unrelated_token_message() -> None:
+    err = speech_generation_error(
+        RuntimeError(
+            "kernel assertion: Request req-1 exceeds the maximum number of "
+            "tokens: temporary buffer"
+        )
+    )
+
+    assert err.status_code == 500
+    assert err.error_type == "server_error"

--- a/tests/unit_test/serve/test_speech_protocol.py
+++ b/tests/unit_test/serve/test_speech_protocol.py
@@ -662,17 +662,55 @@ def test_reference_audio_rejects_oversized_data_url(
     assert exc_info.value.param == "ref_audio"
 
 
-def test_speech_service_rejects_oversized_input(
-    monkeypatch: pytest.MonkeyPatch,
-) -> None:
-    service = SpeechRequestValidator(default_model="tts")
-    monkeypatch.setattr(speech_service, "MAX_SPEECH_INPUT_CHARS", 5)
+def test_speech_service_rejects_oversized_input() -> None:
+    service = SpeechRequestValidator(default_model="tts", max_speech_input_chars=5)
 
     with pytest.raises(SpeechAPIError) as exc_info:
         service.parse_request({"input": "hello world"})
 
     assert exc_info.value.status_code == 400
     assert exc_info.value.param == "input"
+
+
+def test_speech_service_keeps_default_input_limit() -> None:
+    service = SpeechRequestValidator(default_model="tts")
+
+    with pytest.raises(SpeechAPIError) as exc_info:
+        service.parse_request(
+            {"input": "x" * (speech_service.MAX_SPEECH_INPUT_CHARS + 1)}
+        )
+
+    assert exc_info.value.status_code == 400
+    assert exc_info.value.param == "input"
+
+
+def test_speech_input_default_is_shared_with_pipeline_schema() -> None:
+    from sglang_omni.config.schema import MAX_SPEECH_INPUT_CHARS, PipelineConfig
+
+    assert speech_service.MAX_SPEECH_INPUT_CHARS == MAX_SPEECH_INPUT_CHARS
+    assert PipelineConfig.max_speech_input_chars == MAX_SPEECH_INPUT_CHARS
+
+
+@pytest.mark.parametrize("max_speech_input_chars", [0, -1, True, 1.5])
+def test_speech_service_rejects_invalid_input_limit(
+    max_speech_input_chars: object,
+) -> None:
+    with pytest.raises(ValueError, match="positive integer or None"):
+        SpeechRequestValidator(
+            default_model="tts",
+            max_speech_input_chars=max_speech_input_chars,
+        )
+
+
+def test_speech_service_can_defer_input_length_to_model_context() -> None:
+    service = SpeechRequestValidator(
+        default_model="tts",
+        max_speech_input_chars=None,
+    )
+
+    request = service.parse_request({"input": "x" * 5000})
+
+    assert len(request.input) == 5000
 
 
 def test_reference_list_accepts_raw_local_path(tmp_path: Path) -> None:

--- a/tests/unit_test/serve/test_speech_ws.py
+++ b/tests/unit_test/serve/test_speech_ws.py
@@ -25,6 +25,10 @@ from sglang_omni.serve.speech_ws import (
     SpeechWebSocketSession,
 )
 
+CONTEXT_LENGTH_ERROR = (
+    "Requested token count exceeds the model's maximum context length"
+)
+
 
 class StreamingSpeechClient:
     def __init__(self, *, sample_rate: int = 24000) -> None:
@@ -184,6 +188,19 @@ class InvalidAudioStreamingSpeechClient:
             audio_data=object(),
             sample_rate=24000,
         )
+
+    async def abort(self, request_id: str) -> None:
+        self.aborted.append(request_id)
+
+
+class ContextRejectingStreamingSpeechClient:
+    def __init__(self) -> None:
+        self.aborted: list[str] = []
+
+    async def generate(self, request: Any, request_id: str | None = None):
+        del request, request_id
+        raise RuntimeError(CONTEXT_LENGTH_ERROR)
+        yield
 
     async def abort(self, request_id: str) -> None:
         self.aborted.append(request_id)
@@ -800,6 +817,31 @@ def test_speech_websocket_stream_exception_aborts_active_request() -> None:
         assert websocket.sent_text[-1]["type"] == "audio.done"
         assert websocket.sent_text[-1]["error"] is True
         assert session.active_request_id is None
+
+    asyncio.run(run())
+
+
+def test_speech_websocket_context_rejection_is_bad_request() -> None:
+    async def run() -> None:
+        client_impl = ContextRejectingStreamingSpeechClient()
+        websocket = RecordingWebSocket()
+        session = SpeechWebSocketSession(
+            websocket,
+            client=client_impl,
+            speech_service=SpeechRequestValidator(default_model="tts"),
+        )
+        session.config = SpeechStreamSessionConfig(stream_audio=True)
+
+        await session._generate_sentence("Hello.")
+
+        error = websocket.sent_text[-2]
+        assert error == {
+            "type": "error",
+            "message": CONTEXT_LENGTH_ERROR,
+            "error_type": "BadRequestError",
+            "code": 400,
+        }
+        assert client_impl.aborted == [f"{session.session_id}-0"]
 
     asyncio.run(run())
 


### PR DESCRIPTION
<!-- Thank you for your contribution! We appreciate it. The following guidelines will help improve your pull request and facilitate feedback. If anything is unclear, don't hesitate to submit your pull request and ask the maintainers for assistance. -->

## Motivation

MOSS-TTS Delay and MOSS-TTS Local use the text backbone context declared by their MOSS-Audio-Tokenizer checkpoints, but the speech API applied the same generic 4,096-character precheck to every model. This rejected valid MOSS-TTS inputs before the model's actual context limit was consulted, and the configured limit could diverge from the runtime model when deployment overrides changed the Hugging Face configuration.

We first saw this in a long-text benchmark: the requests failed before producing audio in most cases, and the full benchmark yielded audio for only a very small fraction of its samples. That failure exposed that request admission was disconnected from the model's real text context rather than reflecting a model-specific limit.

When the generic character cap was removed, context and KV-capacity rejections were surfaced as HTTP 500 errors. Clients could not distinguish an invalid request from a server failure, and the behavior was inconsistent across regular, streaming, batch, and WebSocket speech requests.

This PR makes the model text context the source of truth for MOSS-TTS input admission, keeps the runtime configuration and context probe aligned, and preserves the existing inference and audio-generation paths.

## Modifications

- Add a shared MOSS-TTS context resolver that uses the same configuration inputs as runtime model loading: `trust_remote_code`, `model_config_parser`, `json_model_override_args`, and the decrypted configuration file.
- Isolate the context probe from SGLang's cached configuration object and reject invalid or lossy context and RoPE-scaling values instead of silently truncating them. Use the existing 8,192-token model default only when context metadata is absent.
- Derive `max_prefill_tokens` from the resolved MOSS-TTS text context while retaining the 8,192-token prefill ceiling.
- Let MOSS-TTS Delay and MOSS-TTS Local opt out of the generic character limit so their requests are checked against the effective model context.
- Propagate the model-specific speech limit from pipeline configuration through the launcher and OpenAI-compatible speech validator.
- Map known context and KV-capacity rejections to `BadRequestError` (HTTP 400) for regular, streaming, batch, and WebSocket speech paths. Queue saturation remains HTTP 503, and unexpected failures remain HTTP 500 with traceback logs.
- Keep existing model-specific `context_length` override handlers compatible; an override is rejected only when no builder consumes it.
- Add regression coverage for runtime configuration parity, missing and malformed metadata, cached-config isolation, legacy override handling, launcher wiring, error classification, and all affected speech transports.
- Update the MOSS-TTS and MOSS-TTS Local cookbook documentation.

## Related Issues

Related to #1233 

## Accuracy Test

Not applicable to this commit. It changes context discovery, request admission, and error classification; it does not change model weights, attention kernels, decoder mathematics, or generated audio.

The preceding MOSS-Audio-Tokenizer loader and attention changes already passed the full SeedTTS quality gates for MOSS-TTS Delay and MOSS-TTS Local. This PR does not alter those numerical paths.

## Benchmark & Profiling

No throughput or profiling claim is made for this control-plane change. The context probe runs once during engine construction, before serving requests, and the request error mapping does not add work to successful inference.

Validation on the rebased branch:

- 1,035 affected MOSS-TTS, speech-service, scheduler, and compatibility tests passed.
- `pre-commit`, Ruff, `compileall`, and `git diff --check` passed.

## Known Limits

- MOSS-TTS Delay and MOSS-TTS Local no longer use the generic 4,096-character cap. Very large requests can still be fully read and partially preprocessed before the autoregressive scheduler rejects them at the model context limit. An independent body and preprocessing resource bound remains a follow-up.
- Context-error classification currently consumes the scheduler's existing error messages; a structured error code would be preferable when the upstream transport exposes one.
- Models that do not opt out retain the existing generic speech input limit.

## Checklist

- [x] Format your code according with pre-commit.
- [x] Add unit tests.
- [x] Update documentation / docstrings / example tutorials as needed.
- [x] Provide throughput / latency benchmark results and accuracy evaluation results as needed.
- [ ] For reviewers: If you haven't made any contributions to this PR and are only assisting with merging the main branch, please remove yourself as a co-author when merging the PR.

## CI

CI runs on self-hosted GPU runners and requires a maintainer to add the
`run-ci` label. Once labeled, every subsequent push re-triggers CI as
long as the label remains. Use `/tag-and-rerun-ci higgs` or
`/tag-and-rerun-ci moss` or `/tag-and-rerun-ci qwen3-tts` to select a TTS CI
model, and
`/tag-and-rerun-ci fun-asr`, `/tag-and-rerun-ci qwen3-asr` or
`/tag-and-rerun-ci whisper-asr` to select an ASR CI model. One selector from
each family can be combined, for example `/tag-and-rerun-ci moss fun-asr`.
Draft PRs are skipped even if labeled.
