### PR TITLE
fix(fun_asr): read the endpoint's prompt field as the hotword list

### DIFF
--- a/docs/cookbook/fun_asr.md
+++ b/docs/cookbook/fun_asr.md
@@ -165,10 +165,11 @@ topology.
 - The endpoint accepts one uploaded file per request.
 - Each uploaded audio segment must be 30 seconds or shorter, matching the
   official Fun-ASR VAD segment limit. Split longer recordings before upload.
-- `itn` and `hotwords` are supported by the model request builder but not
-  exposed as form fields on the public transcription endpoint.
-- `prompt` is accepted by the HTTP endpoint for OpenAI compatibility, but
-  Fun-ASR-Nano currently ignores it (use `hotwords` inside the builder for
-  context biasing instead).
+- `prompt` carries context biasing: a comma-separated list of terms likely to
+  appear in the audio (names, jargon). Each term becomes a hotword in the
+  model's prompt. Biasing raises the model's preference for the supplied
+  terms; it does not force them, and an irrelevant list can hurt accuracy.
+- `itn` and explicit `hotwords` remain available to in-process callers of the
+  request builder; explicit `hotwords` take precedence over `prompt`.
 - Audio is resampled to 16 kHz before transcription.
 - bf16 is strongly recommended; fp16 can overflow to NaN in the adaptor path.

--- a/sglang_omni/models/fun_asr/request_builders.py
+++ b/sglang_omni/models/fun_asr/request_builders.py
@@ -224,6 +224,20 @@ def make_fun_asr_scheduler_adapters(
             hotwords = [hotwords_raw]
         else:
             hotwords = list(hotwords_raw)
+        if not hotwords:
+            # The transcription endpoint carries vocabulary hints in the
+            # OpenAI-compatible ``prompt`` field; nothing emits ``hotwords``
+            # over HTTP. Read the prompt as a comma-separated hotword list so
+            # biasing is reachable through the documented parameter. The join
+            # in _build_prompt_text reassembles it with ", ", so a plain
+            # comma-separated hint round-trips unchanged.
+            prompt_hint = params.get("prompt")
+            if prompt_hint:
+                hotwords = [
+                    term.strip()
+                    for term in str(prompt_hint).split(",")
+                    if term.strip()
+                ]
         prompt_text = _build_prompt_text(language, itn, hotwords)
         input_ids = _build_prompt_ids(num_audio_tokens, prompt_text)
 

--- a/sglang_omni/models/fun_asr/request_builders.py
+++ b/sglang_omni/models/fun_asr/request_builders.py
@@ -225,18 +225,12 @@ def make_fun_asr_scheduler_adapters(
         else:
             hotwords = list(hotwords_raw)
         if not hotwords:
-            # The transcription endpoint carries vocabulary hints in the
-            # OpenAI-compatible ``prompt`` field; nothing emits ``hotwords``
-            # over HTTP. Read the prompt as a comma-separated hotword list so
-            # biasing is reachable through the documented parameter. The join
-            # in _build_prompt_text reassembles it with ", ", so a plain
-            # comma-separated hint round-trips unchanged.
+            # Note(Audrey): the endpoint sends vocabulary hints as ``prompt``;
+            # comma-splitting round-trips through the ", " join below.
             prompt_hint = params.get("prompt")
             if prompt_hint:
                 hotwords = [
-                    term.strip()
-                    for term in str(prompt_hint).split(",")
-                    if term.strip()
+                    term.strip() for term in str(prompt_hint).split(",") if term.strip()
                 ]
         prompt_text = _build_prompt_text(language, itn, hotwords)
         input_ids = _build_prompt_ids(num_audio_tokens, prompt_text)

--- a/tests/unit_test/fun_asr/test_request_builders.py
+++ b/tests/unit_test/fun_asr/test_request_builders.py
@@ -380,6 +380,54 @@ def test_fun_asr_request_builder_wraps_string_hotword_as_single_entry(
     assert "热词列表：[人工智能]" in captured["prompt_text"]
 
 
+def _capture_prompt_text(monkeypatch, params):
+    monkeypatch.setattr(
+        transcription,
+        "load_audio",
+        lambda source, **kwargs: np.zeros(1600, dtype=np.float32),
+    )
+    captured = {}
+
+    class _CapturingTokenizer(_FakeTokenizer):
+        def __call__(self, text: str, *, add_special_tokens: bool = False):
+            captured["prompt_text"] = text
+            return super().__call__(text, add_special_tokens=add_special_tokens)
+
+    request_builder, _ = request_builders.make_fun_asr_scheduler_adapters(
+        tokenizer=_CapturingTokenizer(),
+        max_new_tokens=16,
+        feature_extractor=_feature_extractor(11),
+    )
+    request_builder(
+        StagePayload(
+            request_id="req-fun-asr-prompt",
+            request=OmniRequest(inputs={"audio_path": "x.wav"}, params=params),
+            data={},
+        )
+    )
+    return captured["prompt_text"]
+
+
+def test_fun_asr_prompt_field_feeds_the_hotword_list(monkeypatch) -> None:
+    """The endpoint sends vocabulary hints as ``prompt``, not ``hotwords``.
+
+    Without the fallback the hint is silently dropped and biasing is
+    unreachable over HTTP.
+    """
+    text = _capture_prompt_text(monkeypatch, {"prompt": "PyTorch, nginx, Kubernetes"})
+
+    assert "热词列表：[PyTorch, nginx, Kubernetes]" in text
+
+
+def test_fun_asr_explicit_hotwords_take_precedence_over_prompt(monkeypatch) -> None:
+    text = _capture_prompt_text(
+        monkeypatch, {"hotwords": ["人工智能"], "prompt": "PyTorch"}
+    )
+
+    assert "热词列表：[人工智能]" in text
+    assert "PyTorch" not in text
+
+
 def test_fun_asr_request_builder_rejects_prompt_overrun_of_context_length(
     monkeypatch,
 ) -> None:


### PR DESCRIPTION
## What

`fun_asr/request_builders.py` reads `params["hotwords"]`, and nothing in the repo emits that key — the transcription endpoint carries vocabulary hints in the OpenAI-compatible `prompt` field. The internal hotword mechanism is complete (`_build_prompt_text` joins the list into the prompt) and unreachable over HTTP: the endpoint returns 200 and the caller's vocabulary silently does nothing.

This is the second instance of the class #1807 fixes for qwen3_asr. Found by the params sweep in #1872.

## The change

When no explicit `hotwords` are supplied, read `prompt` as a comma-separated hotword list. `_build_prompt_text` reassembles the list with `", "`, so a plain comma-separated hint round-trips unchanged into `热词列表：[...]`. Explicit `hotwords` keep precedence, so any internal caller that already sets them is unaffected.

## Tests

Two added: the `prompt` field reaches the hotword list, and explicit `hotwords` win over `prompt`. `tests/unit_test/fun_asr/test_request_builders.py`: 12 passed.

Collaborated with Claude Code.