### PR TITLE
perf(asr): serve cached checkpoints to from_pretrained without Hub revalidation

### DIFF
--- a/sglang_omni/models/arkasr/engine_builder.py
+++ b/sglang_omni/models/arkasr/engine_builder.py
@@ -9,6 +9,7 @@ from typing import Any
 from sglang.srt.managers.mm_utils import init_mm_embedding_cache
 from transformers import AutoConfig, AutoTokenizer, WhisperFeatureExtractor
 
+from sglang_omni.models.weight_loader import resolve_cached_model_path
 from sglang_omni.models.arkasr import request_builders
 from sglang_omni.models.arkasr.encoder_service import (
     ArkasrPreLMEncoderService,
@@ -96,11 +97,15 @@ class ArkasrEngineBuilder(AsrEngineBuilder):
 
     def pre_infra_setup(self, checkpoint_dir: str) -> None:
         self.model_path = checkpoint_dir
+        # When the checkpoint is fully cached, hand every from_pretrained the
+        # local directory so none of them revalidates against the Hub. On a
+        # cache miss this resolves to the original string and nothing changes.
+        local_dir = str(resolve_cached_model_path(checkpoint_dir) or checkpoint_dir)
         self.tokenizer = AutoTokenizer.from_pretrained(
-            checkpoint_dir, trust_remote_code=True
+            local_dir, trust_remote_code=True
         )
-        self.feature_extractor = WhisperFeatureExtractor.from_pretrained(checkpoint_dir)
-        hf_config = AutoConfig.from_pretrained(checkpoint_dir, trust_remote_code=True)
+        self.feature_extractor = WhisperFeatureExtractor.from_pretrained(local_dir)
+        hf_config = AutoConfig.from_pretrained(local_dir, trust_remote_code=True)
         self.merge_factor = int(getattr(hf_config, "merge_factor", 4))
         self.audio_token_id = int(getattr(hf_config, "audio_token_id", 151663))
         encoder_token_count = self.feature_extractor.nb_max_frames // 2

--- a/sglang_omni/models/fun_asr/engine_builder.py
+++ b/sglang_omni/models/fun_asr/engine_builder.py
@@ -9,6 +9,7 @@ from typing import Any
 from sglang.srt.managers.mm_utils import init_mm_embedding_cache
 from transformers import AutoFeatureExtractor, AutoTokenizer
 
+from sglang_omni.models.weight_loader import resolve_cached_model_path
 from sglang_omni.models.fun_asr import request_builders
 from sglang_omni.models.fun_asr.encoder_service import (
     FunASRPreLMEncoderService,
@@ -92,11 +93,15 @@ class FunASREngineBuilder(AsrEngineBuilder):
         self.context_length = 0
 
     def pre_infra_setup(self, checkpoint_dir: str) -> None:
+        # When the checkpoint is fully cached, hand every from_pretrained the
+        # local directory so none of them revalidates against the Hub. On a
+        # cache miss this resolves to the original string and nothing changes.
+        local_dir = str(resolve_cached_model_path(checkpoint_dir) or checkpoint_dir)
         self.tokenizer = AutoTokenizer.from_pretrained(
-            checkpoint_dir, trust_remote_code=True
+            local_dir, trust_remote_code=True
         )
         self.feature_extractor = AutoFeatureExtractor.from_pretrained(
-            checkpoint_dir, trust_remote_code=True
+            local_dir, trust_remote_code=True
         )
         encoder_token_count = int(
             fun_asr_low_frame_rate_length(self.feature_extractor.nb_max_frames)

--- a/sglang_omni/models/moss_transcribe_diarize/engine_builder.py
+++ b/sglang_omni/models/moss_transcribe_diarize/engine_builder.py
@@ -7,6 +7,7 @@ from typing import Any
 
 from sglang.srt.managers.mm_utils import init_mm_embedding_cache
 
+from sglang_omni.models.weight_loader import resolve_cached_model_path
 from sglang_omni.models.moss_transcribe_diarize import CAPABILITIES, request_builders
 from sglang_omni.models.moss_transcribe_diarize.encoder_service import (
     BatchedAudioEncoderService,
@@ -86,20 +87,24 @@ class MossTranscribeDiarizeEngineBuilder(AsrEngineBuilder):
 
         from sglang_omni.models.moss_transcribe_diarize import stages
 
+        # When the checkpoint is fully cached, hand every from_pretrained the
+        # local directory so none of them revalidates against the Hub. On a
+        # cache miss this resolves to the original string and nothing changes.
+        local_dir = str(resolve_cached_model_path(checkpoint_dir) or checkpoint_dir)
         with stages._missing_additional_chat_templates_compat():
             self.processor = AutoProcessor.from_pretrained(
-                checkpoint_dir, trust_remote_code=True
+                local_dir, trust_remote_code=True
             )
         self.tokenizer = self.processor.tokenizer
         self.max_new_tokens = (
             int(self.requested_max_new_tokens)
             if self.requested_max_new_tokens is not None
-            else stages._default_max_new_tokens(checkpoint_dir)
+            else stages._default_max_new_tokens(local_dir)
         )
         self.context_length = (
             int(self.requested_context_length)
             if self.requested_context_length is not None
-            else stages._default_context_length(checkpoint_dir)
+            else stages._default_context_length(local_dir)
         )
 
     def generation_defaults(self, *, dtype: str) -> dict[str, Any]:

--- a/sglang_omni/models/weight_loader.py
+++ b/sglang_omni/models/weight_loader.py
@@ -34,6 +34,23 @@ def resolve_dtype(dtype: str | torch.dtype | None) -> torch.dtype | None:
 
 
 @lru_cache(maxsize=4)
+def resolve_cached_model_path(model_path: str) -> Path | None:
+    """Resolve model_path to a local directory without touching the network.
+
+    Returns the path itself when it exists, the cached snapshot when the whole
+    repo is already on disk, and None otherwise. Callers fall back to their
+    original behaviour on None, so a cache miss changes nothing.
+    """
+    path = Path(model_path)
+    if path.exists():
+        return path
+    try:
+        return Path(snapshot_download(model_path, local_files_only=True))
+    except Exception:  # noqa: BLE001 - any cache miss means "not resolvable"
+        return None
+
+
+@lru_cache(maxsize=4)
 def resolve_model_path(model_path: str, *, local_files_only: bool = False) -> Path:
     """Resolve a model_path to a local path, downloading if needed."""
     path = Path(model_path)


### PR DESCRIPTION
## What

arkasr, fun_asr and moss_transcribe_diarize hand the repo id to each `from_pretrained` in `pre_infra_setup`, so every one of those calls revalidates against the Hub even when the checkpoint is fully cached. With a warm cache, loading Fun-ASR-Nano's tokenizer and feature extractor that way costs 13 Hub round trips.

This adds `resolve_cached_model_path` to the shared weight loader: it resolves a repo id to the local snapshot only when the whole repo is already on disk, never touches the network, and returns `None` otherwise. The three engine builders use it with a fallback to the original string.

## Why cache-only with a fallback

On a cache miss, nothing changes: `from_pretrained` gets the same string it got before and downloads only the files it needs, so a first install does not suddenly pull the full repo at tokenizer time. Tests that pass fake paths never hit the network. The audit for these three families also confirmed their engines load weights from the same `checkpoint_dir`, so on the warm path there is nothing extra to download either — the snapshot is already required.

(#1808 takes the stronger form for qwen3_asr, where the MLX runner needs the full repo before serving anyway. If both land I will align them on whichever shape review prefers.)

## Verification

Live, on `FunAudioLLM/Fun-ASR-Nano-2512-hf` with a warm cache:

| check | result |
|---|---|
| tokenizer / feature extractor from repo id vs resolved dir | identical — same classes, vocab 151669, same frame parameters |
| Hub requests, repo id path | 13 |
| Hub requests, resolved path | **0** |
| nonexistent repo | resolves to `None`, caller keeps original behaviour |

Unit tests for the three families match the unpatched baseline exactly (1 pre-existing platform-gated failure, 226 passed, same either way).

## Related

Part of #1877. Found while measuring #1730's cold start; same family as #1808.

Collaborated with Claude Code.