### PR TITLE
[Release] Prepare SGLang-Omni 0.1.4

### DIFF
--- a/README.md
+++ b/README.md
@@ -30,7 +30,7 @@
 ## News
 
 - [2026/08] 🎵 Day-0 support for [MiniMax Music 3](https://huggingface.co/MiniMaxAI/MiniMax-Music3): lyrics + caption → 32 kHz stereo song on `/v1/audio/speech`. \[[Cookbook](https://sgl-project.github.io/sglang-omni/cookbook/minimax_music3.html)\]
-- [2026/08] 🚀 SGLang-Omni **v0.1.3** is on [PyPI](https://pypi.org/project/sglang-omni/). Install with `uv pip install --prerelease=allow "sglang-omni==0.1.3"`. \[[Installation](https://sgl-project.github.io/sglang-omni/get_started/installation.html)\]
+- [2026/09] 🚀 SGLang-Omni **v0.1.4** is on [PyPI](https://pypi.org/project/sglang-omni/). Install with `uv pip install --prerelease=allow "sglang-omni==0.1.4"`. \[[Installation](https://sgl-project.github.io/sglang-omni/get_started/installation.html)\]
 - [2026/08] 🚀 TTS architecture refactor: shared pipeline state, engine construction, reference encoding, capability metadata, and vocoder scheduling. \[[Roadmap](https://github.com/sgl-project/sglang-omni/issues/985)\] \[[Blog](https://github.com/zhaochenyang20/Awesome-ML-SYS-Tutorial/blob/main/sglang/sglang-omni/tts-refactor.md)\]
 - [2026/06] 🔥 MOSS-TTS Local Transformer v1.5 on SGLang-Omni with native-streaming 48 kHz speech. \[[Blog](https://lmsys.org/blog/2026-06-17-moss-tts-local-v15/)\] \[[Cookbook](https://sgl-project.github.io/sglang-omni/cookbook/moss_tts_local.html)\]
 - [2026/06] 🔥 Higgs Audio v3 TTS for real-time, controllable speech. \[[Blog](https://lmsys.org/blog/2026-06-04-higgs-audio-v3-tts/)\] \[[Cookbook](https://sgl-project.github.io/sglang-omni/cookbook/higgs_tts.html)\]

--- a/docs/cookbook/qwen3_omni.md
+++ b/docs/cookbook/qwen3_omni.md
@@ -17,7 +17,7 @@ pip install --upgrade pip
 pip install uv
 
 uv venv .venv -p 3.12 && source .venv/bin/activate
-uv pip install --prerelease=allow "sglang-omni==0.1.3"
+uv pip install --prerelease=allow "sglang-omni==0.1.4"
 ```
 
 See [Installation](../get_started/installation.md) for Docker digests and source installs.

--- a/docs/get_started/installation.md
+++ b/docs/get_started/installation.md
@@ -1,6 +1,6 @@
 # 🚀 Installation
 
-Current stable release: **v0.1.3** on [PyPI](https://pypi.org/project/sglang-omni/).
+Current stable release: **v0.1.4** on [PyPI](https://pypi.org/project/sglang-omni/).
 
 Choose the path for your platform. Docker is recommended for NVIDIA CUDA —
 UCX, flash-attn, SGLang, and CUDA are prebuilt. Apple Silicon has a dedicated
@@ -46,7 +46,7 @@ pip install uv
 uv venv .venv -p 3.12
 source .venv/bin/activate
 
-uv pip install --prerelease=allow "sglang-omni==0.1.3"
+uv pip install --prerelease=allow "sglang-omni==0.1.4"
 ```
 
 <a id="macos-apple-silicon"></a>
@@ -133,7 +133,7 @@ pip install uv
 uv venv .venv -p 3.12
 source .venv/bin/activate
 
-uv pip install --prerelease=allow "sglang-omni==0.1.3"
+uv pip install --prerelease=allow "sglang-omni==0.1.4"
 ```
 
 Latest on the index without a pin: `uv pip install --prerelease=allow sglang-omni`.

--- a/sglang_omni/__init__.py
+++ b/sglang_omni/__init__.py
@@ -12,7 +12,7 @@ from importlib import import_module
 
 # This is the single source for both runtime and distribution metadata. Keep
 # release bumps here; setuptools reads it through tool.setuptools.dynamic.
-__version__ = "0.1.3"
+__version__ = "0.1.4"
 
 _EXPORTS: dict[str, tuple[str, str]] = {
     # client


### PR DESCRIPTION
## Motivation

Prepare SGLang-Omni 0.1.4 as the next pinnable PyPI release from the latest merged `main` cutoff.

## Modifications

- Bump the package version from 0.1.3 to 0.1.4.
- Update the existing README announcement, stable installation commands, and Qwen3-Omni cookbook pin to 0.1.4.

## Related Issues

Related to #1399.

## Release Validation

- Built the 0.1.4 wheel and source distribution with Python 3.12.
- Passed `twine check --strict` for both distributions.
- Verified the wheel metadata reports version 0.1.4 and the current SGLang, Torch, FlashInfer, and CLI entry-point metadata.
- Passed all repository pre-commit checks.

## Accuracy Test

Not applicable; this PR changes release metadata and documentation only.

## Benchmark & Profiling

Not applicable; this PR does not change runtime or model behavior.

## Checklist

- [x] Format your code according with pre-commit.
- [ ] Add unit tests.
- [x] Update documentation / docstrings / example tutorials as needed.
- [ ] Provide throughput / latency benchmark results and accuracy evaluation results as needed.
- [ ] For reviewers: If you haven't made any contributions to this PR and are only assisting with merging the main branch, please remove yourself as a co-author when merging the PR.

## CI

CI runs on self-hosted GPU runners and requires a maintainer to add the
`run-ci` label. Once labeled, every subsequent push re-triggers CI as
long as the label remains. Use `/tag-and-rerun-ci higgs` or
`/tag-and-rerun-ci moss` or `/tag-and-rerun-ci qwen3-tts` to select a TTS CI
model, and
`/tag-and-rerun-ci fun-asr`, `/tag-and-rerun-ci qwen3-asr` or
`/tag-and-rerun-ci whisper-asr` to select an ASR CI model. One selector from
each family can be combined, for example `/tag-and-rerun-ci moss fun-asr`.
Draft PRs are skipped even if labeled.
