### PR TITLE
test(scheduling): pin the _CountingInbox claim invariant

### DIFF
--- a/sglang_omni/scheduling/threaded_simple_scheduler.py
+++ b/sglang_omni/scheduling/threaded_simple_scheduler.py
@@ -21,7 +21,21 @@ _ABORTED_REQUEST_ID_RETAINED = 5000
 
 
 class _CountingInbox(_queue_mod.Queue):
-    """Track queued and claimed ``new_request`` ids."""
+    """Track queued and claimed ``new_request`` ids.
+
+    An id is queued on ``_put``, moves to claimed on ``_get``, and is dropped on
+    ``release_claim``. ``is_reachable`` reads both ledgers, so an abort that
+    arrives between the dequeue and the ``_pending`` registration is still routed
+    to ``_queued_aborts`` instead of being recorded as speculative.
+
+    Invariant: every dequeued ``new_request`` must reach ``release_claim``. The
+    dispatch loop in :meth:`ThreadedSimpleScheduler.start` pairs the two in a
+    ``finally``. A future drain path that bypasses dispatch must reconcile
+    ``_claimed_counts`` itself, or ``is_reachable`` stays true forever and later
+    aborts pile up unconsumed in the unbounded ``_queued_aborts``. Note that
+    ``queue.Queue.shutdown`` holds ``self.mutex`` while it drains, so such a path
+    cannot call ``release_claim``, which takes the same non-reentrant lock.
+    """
 
     def _init(self, maxsize: int) -> None:
         super()._init(maxsize)

--- a/tests/unit_test/scheduling/test_threaded_simple_scheduler.py
+++ b/tests/unit_test/scheduling/test_threaded_simple_scheduler.py
@@ -342,6 +342,8 @@ def test_running_abort_survives_speculative_eviction() -> None:
 
 def test_dispatch_drains_claim_accounting() -> None:
     scheduler = ThreadedSimpleScheduler(lambda payload: payload, max_concurrency=2)
+    scheduler.enqueue(_request("aborted", "must-not-run"))
+    scheduler.abort("aborted")
 
     with _running(scheduler):
         for i in range(4):

--- a/tests/unit_test/scheduling/test_threaded_simple_scheduler.py
+++ b/tests/unit_test/scheduling/test_threaded_simple_scheduler.py
@@ -338,3 +338,46 @@ def test_running_abort_survives_speculative_eviction() -> None:
                 scheduler.outbox.get(timeout=0.2)
         finally:
             release.set()
+
+
+def test_dispatch_drains_claim_accounting() -> None:
+    scheduler = ThreadedSimpleScheduler(lambda payload: payload, max_concurrency=2)
+
+    with _running(scheduler):
+        for i in range(4):
+            scheduler.enqueue(_request(f"req-{i}", f"payload-{i}"))
+        for _ in range(4):
+            scheduler.outbox.get(timeout=5.0)
+        _wait_until(lambda: not scheduler.inbox._claimed_counts)
+
+    assert not scheduler.inbox._request_counts
+    assert not scheduler.inbox.is_reachable("req-0")
+
+
+def test_drain_without_release_strands_the_claim_ledger() -> None:
+    """Pin what an immediate drain costs, so a future drain path has to fix it.
+
+    ``_CountingInbox._get`` moves an id from the queued ledger to the claimed
+    ledger, and only the dispatch ``finally`` in ``start`` releases it. A drain
+    that bypasses dispatch therefore strands the id. ``Queue.shutdown`` is the
+    concrete future case: it calls ``self._get()`` in a loop, and it arrived in
+    Python 3.13, which ``requires-python`` does not admit yet. Driving ``_get``
+    directly reproduces that path on a supported interpreter.
+    """
+    scheduler = ThreadedSimpleScheduler(lambda payload: payload, max_concurrency=1)
+    scheduler.enqueue(_request("stranded", "never-dispatched"))
+
+    with scheduler.inbox.mutex:
+        while scheduler.inbox._qsize():
+            scheduler.inbox._get()
+
+    assert not scheduler.inbox._request_counts
+    assert scheduler.inbox._claimed_counts == {"stranded": 1}
+    assert scheduler.inbox.is_reachable("stranded")
+
+    scheduler.abort("stranded")
+
+    # Nothing can consume this tombstone: the request left the queue without
+    # reaching dispatch, and _queued_aborts is deliberately unbounded.
+    assert "stranded" in scheduler._queued_aborts
+    assert not scheduler._speculative_aborts


### PR DESCRIPTION
## Motivation

`_CountingInbox` keeps `is_reachable` true across the window between the inbox
dequeue and the `_pending` registration, so an abort that lands in that window
is routed to `_queued_aborts` instead of being recorded as speculative. That
depends on one invariant: **every dequeued `new_request` must reach
`release_claim`.**

Today the invariant holds, and #1680 says why it is worth recording anyway:
nothing states the contract, and nothing fails if a future drain path breaks it.
`queue.Queue.shutdown(immediate=True)` is the concrete future case — it calls
`self._get()` in a loop, so it would move every drained id into
`_claimed_counts` and release none of them. It landed in Python 3.13, which
`requires-python = ">=3.10,<3.13"` does not admit, so this is not reachable on a
supported interpreter.

I confirmed the consequence rather than assuming it. On 3.13.5, against
`main` at 332f4fc:

```
queued  _request_counts: {'req-0': 1, 'req-1': 1, 'req-2': 1}
queued  _claimed_counts: {}
drained _request_counts: {}
drained _claimed_counts: {'req-0': 1, 'req-1': 1, 'req-2': 1}
is_reachable('req-0')  : True
_queued_aborts         : {'req-0'}
_speculative_aborts    : {}
```

The stranded claim makes `is_reachable` permanently true, so the later abort
becomes a `_queued_aborts` tombstone that nothing can ever consume — the request
left the queue without reaching dispatch — and `_queued_aborts` is deliberately
unbounded (`test_queued_aborts_past_cap_are_not_evicted`), unlike
`_speculative_aborts`.

One detail worth recording for whoever writes that drain path: `Queue.shutdown`
holds `self.mutex` while it drains, and `release_claim` takes the same lock,
which is a plain non-reentrant `_thread.lock`. Reconciling by calling
`release_claim` from inside a `shutdown` override deadlocks; the reconcile has
to happen under the lock already held.

## Modifications

- Document the invariant on `_CountingInbox`, including the drain-path
  requirement and the mutex-reentrancy note.
- `test_dispatch_drains_claim_accounting`: normal dispatch leaves both ledgers
  empty and the id unreachable.
- `test_drain_without_release_strands_the_claim_ledger`: pins what a drain that
  bypasses dispatch costs. It drives `_get` directly rather than calling
  `shutdown`, so it runs on a supported interpreter instead of being skipped.

No production behaviour changes.

This is a tripwire, not a description of a defect: I verified that adding a
`shutdown` override that clears `_claimed_counts` makes the second test fail, so
a future drain path cannot land without reading the invariant and updating the
test.

## Related Issues

Closes #1680. @SuKi2cn noted on that issue that they wanted to take it as a
regression test — I only saw the comment after writing this, and the shape is
close to what they described. Happy to close this in favour of theirs.

## Accuracy Test

Not applicable — no model-side code.

## Benchmark & Profiling

Not applicable — no runtime path changes.

## Test

`tests/unit_test/scheduling/test_threaded_simple_scheduler.py`, 15 passed on
both CPython 3.12.11 (the CI interpreter) and 3.13.5. `pre-commit run --files`
clean on both changed files.

I do not have GPU access, so I have not run the accelerator suites.

## Checklist

- [x] Format your code according with pre-commit.
- [x] Add unit tests.
- [x] Update documentation / docstrings / example tutorials as needed.
- [x] Provide throughput / latency benchmark results and accuracy evaluation results as needed.
