### PR TITLE
feat(qwen3-tts): opt-in prefill admission coalescing for AR talker

### DIFF
--- a/sglang_omni/models/qwen3_tts/engine_builder.py
+++ b/sglang_omni/models/qwen3_tts/engine_builder.py
@@ -26,8 +26,26 @@ class Qwen3TtsEngineBuilder(TtsEngineBuilder):
     context_length = 8192
     model_arch_override = "Qwen3TTSTalker"
 
-    def __init__(self, *, attn_implementation: str | None = None) -> None:
+    def __init__(
+        self,
+        *,
+        attn_implementation: str | None = None,
+        prefill_coalesce_requests: int = 0,
+        prefill_coalesce_wait_ms: float = 12.0,
+        prefill_coalesce_when_idle: bool = False,
+        prefill_coalesce_requires_pending_builds: bool = True,
+        prefill_coalesce_after_builds_during_decode: bool = True,
+    ) -> None:
         self.attn_implementation = attn_implementation
+        self.prefill_coalesce_requests = prefill_coalesce_requests
+        self.prefill_coalesce_wait_ms = prefill_coalesce_wait_ms
+        self.prefill_coalesce_when_idle = prefill_coalesce_when_idle
+        self.prefill_coalesce_requires_pending_builds = (
+            prefill_coalesce_requires_pending_builds
+        )
+        self.prefill_coalesce_after_builds_during_decode = (
+            prefill_coalesce_after_builds_during_decode
+        )
         self.wrapper: Any | None = None
         self._stream_output_builder: Any | None = None
 
@@ -126,6 +144,15 @@ class Qwen3TtsEngineBuilder(TtsEngineBuilder):
             "stream_output_builder": self._stream_output_builder,
             "request_build_max_workers": 4,
             "request_build_max_pending": 16,
+            "prefill_coalesce_requests": self.prefill_coalesce_requests,
+            "prefill_coalesce_wait_ms": self.prefill_coalesce_wait_ms,
+            "prefill_coalesce_when_idle": self.prefill_coalesce_when_idle,
+            "prefill_coalesce_requires_pending_builds": (
+                self.prefill_coalesce_requires_pending_builds
+            ),
+            "prefill_coalesce_after_builds_during_decode": (
+                self.prefill_coalesce_after_builds_during_decode
+            ),
         }
 
     def make_abort_callback(self) -> Any | None:

--- a/sglang_omni/models/qwen3_tts/stages.py
+++ b/sglang_omni/models/qwen3_tts/stages.py
@@ -127,11 +127,25 @@ def create_sglang_tts_engine_executor(
     dtype: str = "bfloat16",
     attn_implementation: str | None = None,
     server_args_overrides: dict[str, Any] | None = None,
+    prefill_coalesce_requests: int = 0,
+    prefill_coalesce_wait_ms: float = 12.0,
+    prefill_coalesce_when_idle: bool = False,
+    prefill_coalesce_requires_pending_builds: bool = True,
+    prefill_coalesce_after_builds_during_decode: bool = True,
 ) -> Any:
     from sglang_omni.models.qwen3_tts.engine_builder import Qwen3TtsEngineBuilder
 
     return Qwen3TtsEngineBuilder(
         attn_implementation=attn_implementation,
+        prefill_coalesce_requests=prefill_coalesce_requests,
+        prefill_coalesce_wait_ms=prefill_coalesce_wait_ms,
+        prefill_coalesce_when_idle=prefill_coalesce_when_idle,
+        prefill_coalesce_requires_pending_builds=(
+            prefill_coalesce_requires_pending_builds
+        ),
+        prefill_coalesce_after_builds_during_decode=(
+            prefill_coalesce_after_builds_during_decode
+        ),
     ).build(
         model_path,
         device=device,

--- a/tests/unit_test/qwen3_tts/test_prefill_coalesce.py
+++ b/tests/unit_test/qwen3_tts/test_prefill_coalesce.py
@@ -1,0 +1,91 @@
+# SPDX-License-Identifier: Apache-2.0
+
+from __future__ import annotations
+
+import inspect
+
+from sglang_omni.models.qwen3_tts import stages as qwen3_tts_stages
+from sglang_omni.models.qwen3_tts.engine_builder import Qwen3TtsEngineBuilder
+
+
+def test_qwen3_tts_prefill_coalesce_factory_defaults() -> None:
+    signature = inspect.signature(qwen3_tts_stages.create_sglang_tts_engine_executor)
+
+    assert signature.parameters["prefill_coalesce_requests"].default == 0
+    assert signature.parameters["prefill_coalesce_wait_ms"].default == 12.0
+    assert signature.parameters["prefill_coalesce_when_idle"].default is False
+    assert (
+        signature.parameters["prefill_coalesce_requires_pending_builds"].default is True
+    )
+    assert (
+        signature.parameters["prefill_coalesce_after_builds_during_decode"].default
+        is True
+    )
+
+
+def test_qwen3_tts_prefill_coalesce_defaults_forwarded_to_scheduler() -> None:
+    builder = Qwen3TtsEngineBuilder()
+    builder._stream_output_builder = object()
+
+    assert builder.extra_scheduler_kwargs() == {
+        "stream_output_builder": builder._stream_output_builder,
+        "request_build_max_workers": 4,
+        "request_build_max_pending": 16,
+        "prefill_coalesce_requests": 0,
+        "prefill_coalesce_wait_ms": 12.0,
+        "prefill_coalesce_when_idle": False,
+        "prefill_coalesce_requires_pending_builds": True,
+        "prefill_coalesce_after_builds_during_decode": True,
+    }
+
+
+def test_qwen3_tts_prefill_coalesce_opt_in_forwarded_to_scheduler() -> None:
+    builder = Qwen3TtsEngineBuilder(
+        prefill_coalesce_requests=8,
+        prefill_coalesce_wait_ms=12.0,
+        prefill_coalesce_when_idle=False,
+        prefill_coalesce_requires_pending_builds=True,
+        prefill_coalesce_after_builds_during_decode=True,
+    )
+    builder._stream_output_builder = object()
+
+    kwargs = builder.extra_scheduler_kwargs()
+    assert kwargs["prefill_coalesce_requests"] == 8
+    assert kwargs["prefill_coalesce_wait_ms"] == 12.0
+    assert kwargs["prefill_coalesce_when_idle"] is False
+    assert kwargs["prefill_coalesce_requires_pending_builds"] is True
+    assert kwargs["prefill_coalesce_after_builds_during_decode"] is True
+
+
+def test_qwen3_tts_factory_forwards_coalesce_values_to_builder(monkeypatch) -> None:
+    # Guard the full factory -> builder path: if stages.py drops the
+    # constructor passthrough while keeping the signature params, config
+    # validation passes but coalescing silently stays off in production.
+    captured: dict[str, object] = {}
+
+    class _FakeBuilder:
+        def __init__(self, **kwargs: object) -> None:
+            captured.update(kwargs)
+
+        def build(self, *args: object, **kwargs: object) -> object:
+            return object()
+
+    monkeypatch.setattr(
+        "sglang_omni.models.qwen3_tts.engine_builder.Qwen3TtsEngineBuilder",
+        _FakeBuilder,
+    )
+
+    qwen3_tts_stages.create_sglang_tts_engine_executor(
+        "model",
+        prefill_coalesce_requests=8,
+        prefill_coalesce_wait_ms=12.0,
+        prefill_coalesce_when_idle=False,
+        prefill_coalesce_requires_pending_builds=True,
+        prefill_coalesce_after_builds_during_decode=True,
+    )
+
+    assert captured["prefill_coalesce_requests"] == 8
+    assert captured["prefill_coalesce_wait_ms"] == 12.0
+    assert captured["prefill_coalesce_when_idle"] is False
+    assert captured["prefill_coalesce_requires_pending_builds"] is True
+    assert captured["prefill_coalesce_after_builds_during_decode"] is True


### PR DESCRIPTION
## Motivation

Qwen3-TTS is an AR talker whose prefill (prompt + reference-audio encoding) interferes with ongoing decode under colocated serving. #1798 profiling on H200 shows TTFC p95 grows **7.6× at c=8** and **28× at c=16** with **no GPU saturation** (throughput peaks then falls while TTFC explodes) — a classic prefill-queueing-during-decode signature, not a kernel-bound bottleneck.

Roadmap #1760 says any SGLang-backed AR stage can opt into PD via `pd_capable`, but PD infrastructure (#1773) is not yet merged and needs a model resume adapter. The cheaper, same-mechanism lever is **prefill admission coalescing** (#1554 pattern), already shipped for `whisper_asr` and `higgs_tts`. This PR wires that opt-in for Qwen3-TTS, default OFF, so operators can tune it without waiting for PD.

## Modifications

- `sglang_omni/models/qwen3_tts/engine_builder.py`: `Qwen3TtsEngineBuilder.__init__` accepts `prefill_coalesce_*` args and forwards them in `extra_scheduler_kwargs()`.
- `sglang_omni/models/qwen3_tts/stages.py`: `create_sglang_tts_engine_executor` exposes the same args and passes them to the builder.
- `tests/unit_test/qwen3_tts/test_prefill_coalesce.py`: 4 contract tests.

The base `FactoryArgs` schema (already on main) exposes the dotted CLI overrides, so operators opt in via `--tts_engine.factory.prefill_coalesce_requests N`. No config.py change is needed; the default `FactoryArgs(dtype="bfloat16")` leaves coalesce OFF (None values are filtered by `resolve_stage_typed_kwargs`).

## Accuracy results

No model-side change; coalescing is a scheduling policy that does not alter generated audio. The A/B at c=16 produced identical audio (same seed/requests).

## Benchmark / profiling data

Colocated baseline on hyper01 GPU 3 (H200), `seed-tts-eval-arrow` en, 80 samples per cell:

| Concurrency | TTFC p95 (s) | vs c=1 | Throughput (req/s) |
|---:|---:|---:|---:|
| 1 | 0.299 | 1.0× | 1.70 |
| 8 | 2.277 | 7.6× | 6.21 |
| 16 | 8.370 | 28.0× | 4.73 |

GPU is not saturated at the knee (throughput falls from c=8→c=16 while TTFC explodes), confirming prefill/decode interference rather than compute saturation.

### Layer 4 A/B @ c=16

Settings: `prefill_coalesce_requests=8`, `wait_ms=12`, `when_idle=false`, `requires_pending_builds=true`, `after_builds_during_decode=true`.

| Variant | TTFC p95 (s) | Throughput (req/s) |
|---|---:|---:|
| Baseline | 8.370 | 4.73 |
| Coalesce | **−19.8%** | −0.04 (noise) |

Coalescing cuts TTFC p95 by **19.8%** with throughput unchanged — the single highest near-term e2e win without extra hardware. PD opt-in remains the medium-term path once #1773 lands; a head-to-head (PD vs coalescing) will then decide whether PD's extra GPU is worth it.

## Tests

4 unit tests in `tests/unit_test/qwen3_tts/test_prefill_coalesce.py`:
- factory signature defaults (opt-in, off)
- builder `extra_scheduler_kwargs()` forwards defaults
- builder forwards opt-in values
- **factory → builder value forwarding** (monkeypatch builder, call `create_sglang_tts_engine_executor` with non-defaults, assert captured kwargs) — guards against silently dropping the value at the constructor call while keeping the signature

All 4 pass on the cluster (sglang installed); the factory-forwarding test was verified to FAIL when the stages.py passthrough is broken and PASS when intact.

## Related issues

- #1798 (profiling methodology)
- #1760 (PD roadmap; ASR/TTS talker opt-in)
- #1554 (prefill coalescing pattern)
- #1773 (PD infra, not yet merged)
