### PR TITLE
[Runtime] Native CUDA IPC weight sharing for same-GPU process replicas

### DIFF
--- a/docs/basic_usage/mps_dp.md
+++ b/docs/basic_usage/mps_dp.md
@@ -104,8 +104,10 @@ The state root is created with mode `0700`; an existing root must already be a
 non-symlink directory owned by the current user with that mode. Native MPS
 rejects `CUDA_MPS_PIPE_DIRECTORY` in the parent, pipeline, or stage environment
 instead of overwriting or joining an external daemon. It likewise rejects
-`SGLANG_OMNI_WEIGHT_SHARE` in those locations: CUDA IPC weight sharing remains
-the one deployment shape that still uses `examples/mps_dp/launch.sh` below.
+`SGLANG_OMNI_WEIGHT_SHARE` in those locations: inside one pipeline, CUDA IPC
+weight sharing is requested with `--weight-share on` and the runtime assigns
+replica roles itself, while the `examples/mps_dp/launch.sh` recipe below sets
+that variable for its own separate serve processes.
 
 ## Deploy
 
@@ -192,6 +194,8 @@ The throughput results in the table and H100 case study are from an 80 GB H100 w
 ## Shared weights across replicas (opt-in, default off)
 
 By default every replica loads its own full copy of the AR backbone (7.60 GiB for Higgs 3-4B — about a third of a DP3 footprint). Since all replicas run the same read-only weights on the same GPU, the launcher can instead share **one** copy over CUDA IPC:
+
+> If your replicas live inside one pipeline (`processes.<name>.num_replicas` with a repeated `replica_devices` entry), prefer `sgl-omni serve --weight-share on`: the runtime assigns leader and follower roles, orders startup and shutdown around them, and needs no environment variable. See [Process Topology, Replicas, and GPU Sharing](process_topology.md). The `WEIGHT_SHARE=1` recipe below covers the other shape, several independent `serve` processes supervised by the script; the architecture support table applies to both.
 
 **Scope and contract.** This is opt-in (`WEIGHT_SHARE=1`, default off) and gated to **validated architectures with tp=pp=1**; anything else is rejected before any resource is created, because a model that writes per-request state into a shared parameter would corrupt co-located replicas. An architecture audit alone does not enable sharing: a model is supported only after the documented launcher command passed end-to-end validation (shared N=2 boot under MPS, health, attach verification, concurrent-request correctness, clean teardown) at the current revision. `WEIGHT_SHARE=1` requires `CONFIG`, so the supported-config check runs in preflight, before the MPS daemon, state directory, or any replica exists. Each supported architecture carries a share policy: registered tensors the model writes at serving time (per-step decode staging scratch) are classified **replica-private** — every replica keeps its own storage for them and only the immutable weights alias one storage. Leader and follower derive the classification from the same policy and fail closed on any disagreement (it is part of the manifest). Sharing is a whole-group lifecycle: the leader must outlive followers, restart the whole run together (never a single replica), online weight updates are refused while sharing is active, and each follower requires an explicit `MAX_TOTAL_TOKENS` (its dummy weights are freed before KV profiling, so KV sizing must be pinned). `autodp.sh` sizes a **maximum *estimated*** DP (boot-validated), not an absolute safe maximum; because its sizing assumes sharing, it defaults `WEIGHT_SHARE=1`, while `launch.sh` itself defaults off.
 

--- a/docs/basic_usage/process_topology.md
+++ b/docs/basic_usage/process_topology.md
@@ -197,15 +197,11 @@ config_cls: Qwen3OmniSpeechPipelineConfig
 name: qwen3-omni-speech-replica2
 model_path: Qwen/Qwen3-Omni-30B-A3B-Instruct
 
-stage_overrides:
+stages:
   talker_ar:
-    runtime:
-      resources:
-        total_gpu_memory_fraction: 0.123
+    gpu_memory_fraction: 0.123
   code2wav:
-    runtime:
-      resources:
-        total_gpu_memory_fraction: 0.014
+    gpu_memory_fraction: 0.014
 
 processes:
   talker_ar:
@@ -230,22 +226,40 @@ examples/configs/qwen3_omni_speech_replica2.yaml --port 8091`; the full file is
 
 ### Replicas on one GPU
 
-Repeat the device id and declare the memory budget. Without `--mps`, the
-replicas time-slice the GPU:
+Repeat the device id and declare the memory budget for every GPU stage on
+that card. Without `--mps`, the replicas time-slice the GPU. MOSS TTS local is
+used here because its engine factory accepts `gpu_id` and its architecture is
+on the weight-share allowlist, so the same file also serves the next example:
 
 ```yaml
+config_cls: MossTTSLocalPipelineConfig
+name: mossl
+model_path: OpenMOSS-Team/MOSS-TTS-Local-Transformer-v1.5
+
 stages:
-  talker_ar:
-    gpu_memory_fraction: 0.45
+  preprocessing:
+    gpu: 0
+    gpu_memory_fraction: 0.05
+  tts_engine:
+    gpu: 0
+    gpu_memory_fraction: 0.35
+    engine:
+      mem_fraction_static: 0.30
+      max_total_tokens: 30000
+  vocoder:
+    gpu: 0
+    gpu_memory_fraction: 0.15
+
 processes:
-  talker_ar:
+  pipeline:
     num_replicas: 2
-    replica_devices: [1, 1]
+    replica_devices: [0, 0]
 ```
 
 ### Replicas on one GPU with MPS and weight sharing
 
-Same config, plus the two runtime flags:
+Same config, plus the two runtime flags. `max_total_tokens` above is what
+weight sharing requires of the engine stage:
 
 ```bash
 sgl-omni serve --config <config.yaml> --mps on --weight-share on --port 8091

--- a/docs/basic_usage/process_topology.md
+++ b/docs/basic_usage/process_topology.md
@@ -1,0 +1,274 @@
+# Process Topology, Replicas, and GPU Sharing
+
+Four mechanisms decide how an SGLang-Omni pipeline occupies its GPUs. They
+compose, and each answers a different question:
+
+1. **Process topology** defines which stages run together.
+2. **Process replicas** define how many copies run.
+3. **Placement** defines where they run.
+4. **CUDA MPS** improves kernel scheduling between processes on one GPU.
+5. **CUDA IPC weight sharing** removes duplicate weight copies on one GPU.
+
+| Mechanism | Configured per | What it changes | What it does not do |
+|---|---|---|---|
+| Process topology | `StageConfig.process` | non-TP logical Process membership; TP materializes per rank | replica count, placement |
+| Process replica | `PipelineConfig.processes[<name>]` | copies a whole logical Process, sticky per request | model parallelism for one request, MPS |
+| Placement | `replica_devices` | the GPU each replica or rank lands on | GPU context scheduling |
+| CUDA MPS | `mps` | kernel overlap between colocated CUDA contexts | routing, weight or KV sharing |
+| CUDA IPC weight sharing | `weight_share` | followers alias the leader's immutable weights | KV, CUDA graphs, sampler, request state |
+
+Which one you want:
+
+| Your question | Mechanism | What it will not solve |
+|---|---|---|
+| Which stages share one OS process and its local state? | Process topology | replica count and GPU placement |
+| Which bottleneck Process needs more capacity? | Process replica | model parallelism for a single request |
+| Which GPU does each replica run on? | `replica_devices` | CUDA context scheduling |
+| How do colocated processes use idle compute? | CUDA MPS | replica creation and request routing |
+| Full replicas on one GPU do not fit in VRAM? | CUDA IPC weight sharing | KV, CUDA graph, and request-state sharing |
+
+## Stages and process topology
+
+A stage is one logical execution unit of the pipeline DAG. It declares its
+factory, wiring (`next`, `stream_to`, `wait_for`), GPU, TP size, runtime
+resources, and process name.
+
+For a non-TP stage, `StageConfig.process` defines Process membership. Stages
+sharing a Process Name share an OS process, Python heap, asyncio event loop,
+and local dispatch path; GPU members also share one CUDA context. A TP stage
+owns its logical Process and materializes one OS process per rank.
+
+A logical Process is a grouping, spawn, and placement boundary. It is not a
+recovery boundary: any child stage process dying still stops the pipeline.
+
+```yaml
+stages:
+  talker_ar:
+    process: talker_ar
+  code2wav:
+    process: code2wav
+```
+
+Inspect the resolved result with `sgl-omni config resolve --config <config.yaml>
+--show config`.
+
+## Process replicas
+
+A replica copies a whole logical Process, not a single stage. Stages inside one
+Process are copied together under the same replica index. The runtime names
+physical instances `<name>@rN`, while models and routes keep referring to
+logical names.
+
+At admission the coordinator picks one replica per replicated Process the
+request touches. That binding rides the message and stays fixed for the whole
+request lifetime, across payload, stream, completion, and abort paths. The
+default policy is per-Process thread-safe round robin, chosen independently for
+each Process.
+
+```yaml
+processes:
+  talker_ar:
+    num_replicas: 2
+    replica_devices: [1, 2]
+  code2wav:
+    num_replicas: 2
+    replica_devices: [1, 2]
+```
+
+## Placement
+
+`replica_devices` sets the GPU each replica uses, including replica 0, and
+overrides the placement of every GPU stage inside that replica. CPU stages are
+unaffected and stay on the host.
+
+A GPU Process with `num_replicas > 1` must declare `replica_devices`: `N`
+device ids for a non-TP Process, `N x T` for a Process with TP size `T`. Every
+GPU stage in that Process must also come from a factory that declares a
+`gpu_id` parameter, otherwise startup refuses the placement by name; not all
+model stages do yet.
+Different replicas may repeat a device id, which is how same-GPU data
+parallelism is expressed:
+
+```yaml
+processes:
+  code2wav:
+    num_replicas: 2
+    replica_devices: [1, 1]
+```
+
+That places two non-TP replicas on GPU 1. It does not mean two ranks of one TP
+replica may share a GPU.
+
+When `replica_devices` colocates Process groups on one GPU, every GPU stage
+involved must declare `gpu_memory_fraction`, whether or not the general
+colocation check is enabled. The value is a placement-time budget, not a
+runtime memory limit:
+
+```yaml
+stages:
+  code2wav:
+    gpu_memory_fraction: 0.014
+```
+
+## CUDA MPS
+
+MPS only schedules multiple CUDA contexts on one GPU. It does not create
+replicas, choose routes, or share weights, KV, or CUDA graphs. When a single
+context already saturates the GPU, MPS can add contention and tail latency
+rather than throughput.
+
+The runtime manages the daemon itself. Modes (`--mps` on the CLI or `mps:` in
+the config, default `off`):
+
+* `off`: MPS is never touched.
+* `auto`: enabled on every GPU hosting two or more single-GPU, non-TP CUDA
+  processes of this pipeline, including process replicas.
+* `on`: one eligible process is enough, and an MPS-incapable platform is a hard
+  error instead of a warning.
+
+```bash
+sgl-omni serve --config <config.yaml> --mps auto --port 8091
+```
+
+The daemon is shared per physical GPU, keyed by device UUID. See
+[Same-GPU Data Parallelism with CUDA MPS](mps_dp.md) for the full lifecycle,
+verification, and operator notes.
+
+## CUDA IPC weight sharing
+
+Weight sharing removes duplicate weight VRAM; it does not change scheduling.
+Within one sharing group, the lowest replica index is the leader: it loads the
+checkpoint and publishes CUDA-IPC handles. Followers build the same module tree
+with dummy weights and alias the leader's immutable parameters and buffers by
+assignment. KV cache, CUDA graphs, sampler state, request state, and any tensor
+the architecture's share policy marks replica-private stay per replica.
+
+Use it to make a replica count fit, or to free VRAM for KV, CUDA graphs, and
+more replicas. It is a capacity mechanism, not a throughput optimization.
+
+```bash
+sgl-omni serve --config <config.yaml> --mps on --weight-share on --port 8091
+```
+
+`weight_share` is `off` or `on` (default `off`). When `on`, every logical
+Process whose replicas repeat a GPU id becomes a sharing group on that GPU, and
+the runtime assigns roles itself; `SGLANG_OMNI_WEIGHT_SHARE` must not be set in
+the environment. Replicas of the same Process that are alone on their GPU keep
+loading their own weights and still serve requests normally.
+
+Requirements, all checked before any process is spawned:
+
+* the sharing Process has exactly one SGLang engine stage, with `tp=pp=1`;
+* that stage pins `max_total_tokens`, because a follower attaches after its
+  dummy weights are freed and memory profiling cannot derive a stable KV
+  budget;
+* the architecture is on the share-policy allowlist, which the engine enforces
+  when the leader loads.
+
+Because sharing rides on process replicas, it is available to a model only when
+that model's GPU stage factories accept `gpu_id` as described under Placement.
+Models on the allowlist whose factories do not can still share weights through
+the multi-serve `examples/mps_dp/launch.sh` recipe.
+
+Followers are spawned only after every leader is ready, and are shut down
+before their leader. Sharing is a whole-group lifecycle: the leader must
+outlive its followers, online weight updates are refused while sharing is
+active, and a dead leader fails the pipeline rather than serving aliased
+memory. Restart the pipeline as a whole.
+
+Weight sharing does not require MPS, and MPS does not require weight sharing.
+`--mps on --weight-share on` is the usual same-GPU DP combination: MPS gives
+the replicas kernel overlap, weight sharing gives them room to fit.
+
+## Putting it together
+
+Configure in this order:
+
+1. decide which stages share a process;
+2. choose the replica count;
+3. place each replica on a GPU;
+4. enable MPS when processes share a GPU;
+5. enable weight sharing when duplicate weights are the capacity limit.
+
+### Replicas across GPUs
+
+```yaml
+config_cls: Qwen3OmniSpeechPipelineConfig
+name: qwen3-omni-speech-replica2
+model_path: Qwen/Qwen3-Omni-30B-A3B-Instruct
+
+stage_overrides:
+  talker_ar:
+    runtime:
+      resources:
+        total_gpu_memory_fraction: 0.123
+  code2wav:
+    runtime:
+      resources:
+        total_gpu_memory_fraction: 0.014
+
+processes:
+  talker_ar:
+    num_replicas: 2
+    replica_devices: [1, 2]
+  code2wav:
+    num_replicas: 2
+    replica_devices: [1, 2]
+```
+
+Resolved layout:
+
+```
+GPU 0: image_encoder + audio_encoder + thinker
+GPU 1: talker_ar@r0 + code2wav@r0
+GPU 2: talker_ar@r1 + code2wav@r1
+```
+
+Run it with `sgl-omni serve --config
+examples/configs/qwen3_omni_speech_replica2.yaml --port 8091`; the full file is
+[`qwen3_omni_speech_replica2.yaml`](https://github.com/sgl-project/sglang-omni/blob/main/examples/configs/qwen3_omni_speech_replica2.yaml).
+
+### Replicas on one GPU
+
+Repeat the device id and declare the memory budget. Without `--mps`, the
+replicas time-slice the GPU:
+
+```yaml
+stages:
+  talker_ar:
+    gpu_memory_fraction: 0.45
+processes:
+  talker_ar:
+    num_replicas: 2
+    replica_devices: [1, 1]
+```
+
+### Replicas on one GPU with MPS and weight sharing
+
+Same config, plus the two runtime flags:
+
+```bash
+sgl-omni serve --config <config.yaml> --mps on --weight-share on --port 8091
+```
+
+The leader holds the shared weights; the follower attaches over CUDA IPC and
+carries only its own KV, graphs, and request state.
+
+## Performance and correctness
+
+Replicas mainly help under queueing and higher concurrency. At low concurrency
+they can be slightly slower, because the parallelism gain does not cover
+routing and process overhead. MPS helps only when colocated processes have
+overlappable GPU work. Weight sharing saves memory and does not by itself
+improve scheduling.
+
+Validate a topology change on: serial output consistency, concurrent routing
+and request isolation, abort and recovery, clean exit of processes, ports, and
+GPU memory, and, when enabled, MPS attachment and the weight-share lifecycle.
+
+## Migration
+
+Removed interfaces and their replacements are covered in
+[Process Topology Migration](process_topology_migration.md): express process
+membership with `StageConfig.process`, and replica count and placement with the
+top-level `processes` block.

--- a/docs/index.rst
+++ b/docs/index.rst
@@ -121,6 +121,7 @@ Supported Models
    basic_usage/qwen3_omni.md
    basic_usage/audio_translations.md
    basic_usage/tts.md
+   basic_usage/process_topology.md
    basic_usage/tts_process_topology.md
    basic_usage/process_topology_migration.md
    basic_usage/omni_router.md

--- a/sglang_omni/config/schema.py
+++ b/sglang_omni/config/schema.py
@@ -584,6 +584,7 @@ class PipelineConfig(BaseModel):
     processes: dict[str, ProcessConfig] = Field(default_factory=dict)
     env_defaults: dict[str, str] = Field(default_factory=dict)
     mps: Literal["off", "on", "auto"] = "off"
+    weight_share: Literal["off", "on"] = "off"
     placement: PlacementConfig = Field(default_factory=PlacementConfig)
     placement_policy: str | None = None
     endpoints: EndpointsConfig = Field(default_factory=EndpointsConfig)

--- a/sglang_omni/mps/decision.py
+++ b/sglang_omni/mps/decision.py
@@ -23,7 +23,7 @@ class MpsProcessFact:
     contains_tp: bool
 
 
-def _process_gpu_ids(process_spec) -> set[int]:
+def process_gpu_ids(process_spec) -> set[int]:
     return {
         int(gpu_id)
         for stage_spec in process_spec.stage_specs
@@ -87,7 +87,7 @@ def collect_mps_facts(process_specs) -> tuple[MpsProcessFact, ...]:
             placement_by_process[name] = set()
             explicit_by_process[name] = set()
             contains_tp[name] = False
-        placement_by_process[name].update(_process_gpu_ids(process_spec))
+        placement_by_process[name].update(process_gpu_ids(process_spec))
         contains_tp[name] = contains_tp[name] or any(
             stage_spec.tp_size > 1 for stage_spec in process_spec.stage_specs
         )

--- a/sglang_omni/mps/runtime.py
+++ b/sglang_omni/mps/runtime.py
@@ -255,8 +255,9 @@ def _reject_process_env_overrides(process_specs) -> None:
             "native MPS does not support per-worker CUDA visibility, device "
             "ordering, external MPS, or CUDA IPC weight-sharing overrides: "
             f"{'; '.join(conflicts)}. Configure CUDA visibility and device "
-            "order in the parent environment, remove external MPS or weight "
-            "sharing settings, or use mps=off."
+            "order in the parent environment, request weight sharing with "
+            "weight_share=on instead of an environment variable, or use "
+            "mps=off."
         )
 
 
@@ -573,9 +574,9 @@ def create_for_pipeline(
     if weight_share:
         raise MpsError(
             "native MPS cannot combine with parent "
-            f"SGLANG_OMNI_WEIGHT_SHARE={weight_share!r}; remove it or use "
-            "mps=off (examples/mps_dp/launch.sh manages the weight-sharing "
-            "deployment shape)"
+            f"SGLANG_OMNI_WEIGHT_SHARE={weight_share!r}; remove it and request "
+            "weight sharing with weight_share=on, which assigns replica roles "
+            "itself, or use mps=off with the external supervisor"
         )
 
     from sglang_omni.platforms import current_platform

--- a/sglang_omni/pipeline/coordinator.py
+++ b/sglang_omni/pipeline/coordinator.py
@@ -174,9 +174,12 @@ class Coordinator:
         self._requests.clear()
         self._partial_results.clear()
 
-    async def shutdown_stages(self) -> None:
-        """Send shutdown signal to all registered stages."""
+    async def shutdown_stages(self, stage_names: Sequence[str] | None = None) -> None:
+        """Send shutdown to registered stages, or only to *stage_names*."""
+        selected = None if stage_names is None else set(stage_names)
         for name, info in self._stages.items():
+            if selected is not None and name not in selected:
+                continue
             try:
                 await self.control_plane.send_shutdown(name, info.control_endpoint)
                 logger.info("Sent shutdown to stage: %s", name)

--- a/sglang_omni/pipeline/mp_runner.py
+++ b/sglang_omni/pipeline/mp_runner.py
@@ -5,6 +5,7 @@ The runner owns the single serving path. It can start one OS process containing
 multiple non-TP stages, multiple OS processes on the same GPU, and the existing
 one-process-per-rank TP topology.
 """
+
 from __future__ import annotations
 
 import asyncio
@@ -41,6 +42,7 @@ from sglang_omni.pipeline.stage_workers import (
     StageLaunchConfig,
     StageWorkerProcessSpec,
 )
+from sglang_omni.pipeline.weight_share import WeightSharePlan, plan_weight_share
 from sglang_omni.utils.imports import import_string
 
 logger = logging.getLogger(__name__)
@@ -465,6 +467,15 @@ async def _finish_despite_cancellation(coro) -> None:
         raise cancelled
 
 
+def _wave_stage_names(wave: list[StageGroup]) -> list[str]:
+    return [
+        stage_spec.stage_name
+        for group in wave
+        for spec in group.process_specs
+        for stage_spec in spec.stage_specs
+    ]
+
+
 class MultiProcessPipelineRunner:
 
     def __init__(self, config: PipelineConfig):
@@ -479,6 +490,7 @@ class MultiProcessPipelineRunner:
         self._prep: PipelineRuntimePrep | None = None
         self._started = False
         self._mps: MpsPipelineRuntime | None = None
+        self._weight_share: WeightSharePlan | None = None
 
     @property
     def coordinator(self) -> Coordinator:
@@ -528,6 +540,20 @@ class MultiProcessPipelineRunner:
                 replica_topology=prep.replica_topology,
             )
 
+            # Note (Jiaxin Deng): roles are assigned before the coordinator
+            # binds and before any child is spawned, so an unshareable topology
+            # fails in milliseconds instead of after a leader has loaded a
+            # whole checkpoint.
+            if self._config.weight_share != "off":
+                self._weight_share = plan_weight_share(
+                    self._config,
+                    logical_process_plan=prep.logical_process_plan,
+                    process_specs=[
+                        spec for group in groups for spec in group.process_specs
+                    ],
+                    runtime_dir=prep.runtime_dir.path,
+                )
+
             terminal_stages_resolver = (
                 import_string(self._config.terminal_stages_fn)
                 if self._config.terminal_stages_fn
@@ -564,7 +590,7 @@ class MultiProcessPipelineRunner:
 
             # Note (Jiaxin Deng): daemons must predate the first CUDA init and
             # ride the same spawn-time env patching; off must touch nothing.
-            mps_env_by_process = None
+            env_by_process: dict[str, dict[str, str]] | None = None
             if self._config.mps != "off":
                 all_process_specs = [
                     spec for group in groups for spec in group.process_specs
@@ -575,28 +601,40 @@ class MultiProcessPipelineRunner:
                 )
             if self._mps is not None:
                 await self._mps.start()
-                mps_env_by_process = {
-                    spec.process_name: env
+                env_by_process = {
+                    spec.process_name: dict(env)
                     for spec in all_process_specs
                     if (env := self._mps.env_for_process(spec.process_name))
                 }
-            for group in self._groups:
-                if mps_env_by_process is None:
-                    group.spawn(ctx)
-                else:
-                    group.spawn(
-                        ctx,
-                        process_env_overrides=mps_env_by_process,
-                    )
+            if self._weight_share is not None:
+                env_by_process = env_by_process if env_by_process is not None else {}
+                for name, env in self._weight_share.env_by_process.items():
+                    env_by_process.setdefault(name, {}).update(env)
 
-            await asyncio.gather(*(g.wait_ready(timeout) for g in self._groups))
+            # Note (Jiaxin Deng): timeout is the budget for one startup wave,
+            # not for the whole call: weight sharing makes startup genuinely
+            # sequential, and splitting one budget would let a slow leader load
+            # starve the follower attach that follows it into a false timeout.
+            for wave in self._spawn_waves():
+                if not wave:
+                    continue
+                for group in wave:
+                    if env_by_process is None:
+                        group.spawn(ctx)
+                    else:
+                        group.spawn(
+                            ctx,
+                            process_env_overrides=env_by_process,
+                        )
 
-            for group in self._groups:
-                if group.any_dead():
-                    raise RuntimeError(
-                        f"Stage process(es) died during startup: "
-                        f"{group.dead_summary()}"
-                    )
+                await asyncio.gather(*(g.wait_ready(timeout) for g in wave))
+
+                for group in wave:
+                    if group.any_dead():
+                        raise RuntimeError(
+                            f"Stage process(es) died during startup: "
+                            f"{group.dead_summary()}"
+                        )
 
             if self._mps is not None:
                 await self._mps.verify()
@@ -618,7 +656,10 @@ class MultiProcessPipelineRunner:
                 total_procs,
             )
 
-        except Exception as startup_error:
+        # Note (Jiaxin Deng): one branch for both, because a cancellation
+        # without MPS used to skip cleanup entirely and strand the children it
+        # had already spawned; only the MPS release is conditional.
+        except BaseException as startup_error:
             process_start_attempts: set[str] | None = None
             if self._mps is not None:
                 process_start_attempts = self._process_start_attempts()
@@ -633,19 +674,6 @@ class MultiProcessPipelineRunner:
                     except BaseException as cleanup_error:
                         raise startup_error from cleanup_error
             raise
-        except BaseException as startup_error:
-            if self._mps is not None:
-                process_start_attempts = self._process_start_attempts()
-                try:
-                    await self._cleanup_on_failure()
-                finally:
-                    try:
-                        await self._close_mps(
-                            process_start_attempts=process_start_attempts
-                        )
-                    except BaseException as cleanup_error:
-                        raise startup_error from cleanup_error
-            raise
 
     def _process_start_attempts(self) -> set[str]:
         return {
@@ -653,6 +681,38 @@ class MultiProcessPipelineRunner:
             for group in self._groups
             for process_name in group.process_start_attempts()
         }
+
+    def _is_weight_share_follower(self, group: StageGroup) -> bool:
+        if self._weight_share is None:
+            return False
+        followers = self._weight_share.follower_process_names
+        return any(spec.process_name in followers for spec in group.process_specs)
+
+    def _spawn_waves(self) -> list[list[StageGroup]]:
+        """Partition groups so every weight-share follower starts last.
+
+        # Note (Jiaxin Deng): a follower waits for the leader's export inside
+        # the per-GPU startup lock, so a follower that wins that lock first
+        # would block the leader that has to release it.
+        """
+        if self._weight_share is None:
+            return [list(self._groups)]
+        followers = [g for g in self._groups if self._is_weight_share_follower(g)]
+        leaders_and_rest = [
+            g for g in self._groups if not self._is_weight_share_follower(g)
+        ]
+        return [leaders_and_rest, followers]
+
+    def _shutdown_waves(self) -> list[list[StageGroup]]:
+        """Retire followers before their leader.
+
+        # Note (Jiaxin Deng): a follower's aliased weights die with the leader
+        # process, so a leader that exits first turns an ordinary shutdown into
+        # the follower's liveness-monitor abort.
+        """
+        if self._weight_share is None:
+            return [list(self._groups)]
+        return list(reversed(self._spawn_waves()))
 
     async def _monitor_children(self) -> None:
         while self._started:
@@ -734,18 +794,28 @@ class MultiProcessPipelineRunner:
         await _finish_despite_cancellation(self._teardown())
 
     async def _teardown(self) -> None:
-        # Send shutdown to stages via coordinator
-        try:
-            await self._coordinator.shutdown_stages()
-        except Exception as e:
-            logger.warning("shutdown_stages error: %s", e)
-
-        # Shutdown all groups
         before_signal = self._retire_mps_clients if self._mps is not None else None
-        await asyncio.gather(
-            *(g.shutdown(before_signal=before_signal) for g in self._groups),
-            return_exceptions=True,
-        )
+        waves = self._shutdown_waves()
+        partitioned = len(waves) > 1
+        for wave in waves:
+            if not wave:
+                continue
+            # Send shutdown to stages via coordinator
+            try:
+                if partitioned:
+                    await self._coordinator.shutdown_stages(
+                        stage_names=_wave_stage_names(wave)
+                    )
+                else:
+                    await self._coordinator.shutdown_stages()
+            except Exception as e:
+                logger.warning("shutdown_stages error: %s", e)
+
+            # Shutdown this wave's groups
+            await asyncio.gather(
+                *(g.shutdown(before_signal=before_signal) for g in wave),
+                return_exceptions=True,
+            )
 
         mps_error: BaseException | None = None
         if self._mps is not None:
@@ -770,7 +840,7 @@ class MultiProcessPipelineRunner:
 
     async def _cleanup_on_failure(self) -> None:
         """Best-effort cleanup after a failed start()."""
-        for group in self._groups:
+        for group in [g for wave in self._shutdown_waves() for g in wave]:
             for spec, p in zip(group.process_specs, group.processes):
                 if p.is_alive():
                     if self._mps is not None:

--- a/sglang_omni/pipeline/weight_share.py
+++ b/sglang_omni/pipeline/weight_share.py
@@ -1,0 +1,265 @@
+# SPDX-License-Identifier: Apache-2.0
+"""Runtime-owned leader/follower assignment for CUDA IPC weight sharing.
+
+Replicas of one logical Process that land on the same physical GPU are a
+sharing group: the lowest replica index loads the checkpoint and publishes
+CUDA-IPC handles, the others alias them. This module only plans; the mechanism
+itself lives in :mod:`sglang_omni.utils.ipc_weights` and is driven by the same
+environment contract an external supervisor would use.
+
+Planning happens in the parent, before the coordinator binds and before any
+child is spawned, so an unusable configuration fails in milliseconds instead of
+after a leader has loaded a full checkpoint.
+"""
+
+from __future__ import annotations
+
+import logging
+import os
+import secrets
+from dataclasses import dataclass
+from pathlib import Path
+
+from sglang_omni.config.runtime import (
+    resolve_stage_factory_kwargs,
+    resolve_stage_typed_kwargs,
+)
+from sglang_omni.config.schema import PipelineConfig, replica_instance_name
+from sglang_omni.config.topology import LogicalProcess, LogicalProcessPlan
+from sglang_omni.mps.decision import process_gpu_ids
+from sglang_omni.utils.ipc_weights import (
+    ENV_WEIGHT_SHARE,
+    ENV_WEIGHT_SHARE_COMPAT,
+    ENV_WEIGHT_SHARE_RUN_ID,
+)
+
+logger = logging.getLogger(__name__)
+
+__all__ = [
+    "WeightShareError",
+    "WeightShareGroup",
+    "WeightSharePlan",
+    "plan_weight_share",
+]
+
+
+class WeightShareError(ValueError):
+    """Weight sharing was requested but cannot be planned for this pipeline."""
+
+
+@dataclass(frozen=True)
+class WeightShareGroup:
+    """One leader plus its followers, all on one physical GPU."""
+
+    logical_process: str
+    gpu_id: int
+    leader: str
+    followers: tuple[str, ...]
+    store_dir: Path
+
+
+@dataclass(frozen=True)
+class WeightSharePlan:
+    run_id: str
+    groups: tuple[WeightShareGroup, ...]
+    env_by_process: dict[str, dict[str, str]]
+    follower_process_names: frozenset[str]
+
+
+def plan_weight_share(
+    config: PipelineConfig,
+    *,
+    logical_process_plan: LogicalProcessPlan,
+    process_specs,
+    runtime_dir: Path,
+) -> WeightSharePlan | None:
+    """Assign weight-share roles, or return None when sharing is off."""
+
+    if config.weight_share == "off":
+        return None
+
+    if os.name != "posix":
+        raise WeightShareError(
+            "weight_share=on requires a POSIX host: the handle store relies on "
+            "flock leases and owner-only directory permissions"
+        )
+
+    _reject_external_env(process_specs)
+
+    gpu_ids_by_process = {
+        spec.process_name: process_gpu_ids(spec) for spec in process_specs
+    }
+    candidates = _collect_candidate_groups(logical_process_plan, gpu_ids_by_process)
+    if not candidates:
+        raise WeightShareError(
+            "weight_share=on but no logical Process places two or more replicas "
+            "on one GPU; declare processes.<name>.num_replicas with repeated "
+            "replica_devices entries, or use weight_share=off"
+        )
+
+    for logical_process, _, _ in candidates:
+        _validate_sharing_process(config, logical_process)
+
+    run_id = secrets.token_hex(8)
+    groups: list[WeightShareGroup] = []
+    env_by_process: dict[str, dict[str, str]] = {}
+    for logical_process, gpu_id, replica_ids in candidates:
+        store_dir = _create_store_dir(runtime_dir, logical_process.name, gpu_id)
+        members = [
+            replica_instance_name(logical_process.name, replica_id)
+            for replica_id in replica_ids
+        ]
+        leader, *followers = members
+        for index, process_name in enumerate(members):
+            role = "leader" if index == 0 else "follower"
+            env_by_process[process_name] = {
+                ENV_WEIGHT_SHARE: f"{role}:{store_dir}",
+                ENV_WEIGHT_SHARE_RUN_ID: run_id,
+            }
+        groups.append(
+            WeightShareGroup(
+                logical_process=logical_process.name,
+                gpu_id=gpu_id,
+                leader=leader,
+                followers=tuple(followers),
+                store_dir=store_dir,
+            )
+        )
+        logger.info(
+            "Weight sharing on GPU %d for process %r: leader=%s followers=%s",
+            gpu_id,
+            logical_process.name,
+            leader,
+            list(followers),
+        )
+
+    # Note (Jiaxin Deng): a stage that never shares still unpickles CUDA tensors
+    # reduced by a sharing engine, and the reduction carries a device UUID only
+    # the patched path understands, so the compat flag covers every process.
+    for spec in process_specs:
+        env_by_process.setdefault(spec.process_name, {})[ENV_WEIGHT_SHARE_COMPAT] = "1"
+
+    return WeightSharePlan(
+        run_id=run_id,
+        groups=tuple(groups),
+        env_by_process=env_by_process,
+        follower_process_names=frozenset(
+            follower for group in groups for follower in group.followers
+        ),
+    )
+
+
+def _reject_external_env(process_specs) -> None:
+    """Refuse to plan on top of a supervisor that already assigned roles."""
+
+    external = (os.environ.get(ENV_WEIGHT_SHARE) or "").strip()
+    if external:
+        raise WeightShareError(
+            f"weight_share=on but the parent environment already sets "
+            f"{ENV_WEIGHT_SHARE}={external!r}; the runtime assigns roles itself, "
+            "so unset it or use weight_share=off with the external supervisor"
+        )
+    for spec in process_specs:
+        for stage_spec in spec.stage_specs:
+            if (stage_spec.env_defaults or {}).get(ENV_WEIGHT_SHARE):
+                raise WeightShareError(
+                    f"stage {stage_spec.stage_name!r} sets {ENV_WEIGHT_SHARE} in "
+                    "its environment defaults; the runtime assigns weight-share "
+                    "roles itself, so remove it"
+                )
+
+
+def _collect_candidate_groups(
+    logical_process_plan: LogicalProcessPlan,
+    gpu_ids_by_process: dict[str, set[int]],
+) -> list[tuple[LogicalProcess, int, tuple[int, ...]]]:
+    """Find replica sets of one Process that resolve to a single shared GPU.
+
+    Replica identity comes from the logical plan, never from the OS process
+    name: a replicated TP process is named ``P@rN_tp<rank>``, which no longer
+    parses as a replica instance.
+    """
+    candidates: list[tuple[LogicalProcess, int, tuple[int, ...]]] = []
+    for process in logical_process_plan.processes:
+        if not process.is_replicated:
+            continue
+        if process.is_tensor_parallel:
+            logger.info(
+                "Weight sharing skips tensor-parallel process %r: CUDA IPC "
+                "handles are not rank qualified",
+                process.name,
+            )
+            continue
+        by_gpu: dict[int, list[int]] = {}
+        for replica_id in range(process.num_replicas):
+            process_name = replica_instance_name(process.name, replica_id)
+            gpu_ids = gpu_ids_by_process.get(process_name, set())
+            if len(gpu_ids) != 1:
+                continue
+            by_gpu.setdefault(next(iter(gpu_ids)), []).append(replica_id)
+        for gpu_id, replica_ids in sorted(by_gpu.items()):
+            if len(replica_ids) < 2:
+                continue
+            candidates.append((process, gpu_id, tuple(sorted(replica_ids))))
+        if not by_gpu:
+            logger.info(
+                "Weight sharing skips process %r: no replica resolves to a "
+                "single GPU",
+                process.name,
+            )
+    return candidates
+
+
+def _validate_sharing_process(
+    config: PipelineConfig,
+    process: LogicalProcess,
+) -> None:
+    config_cls = type(config)
+    engine_stages = [
+        stage_name
+        for stage_name in process.stage_names
+        if config_cls.stage_config_cls(stage_name).engine_stage
+    ]
+    if len(engine_stages) != 1:
+        raise WeightShareError(
+            f"weight sharing needs exactly one SGLang engine stage in process "
+            f"{process.name!r}, found {sorted(engine_stages)}"
+        )
+    stage_name = engine_stages[0]
+    stage = next(stage for stage in config.stages if stage.name == stage_name)
+    # Note (Jiaxin Deng): a follower frees its dummy weights before KV
+    # profiling, so an underived cap would over-budget KV. The child enforces
+    # this too, but only after the leader has loaded a whole checkpoint.
+    if _resolved_max_total_tokens(config, stage) is None:
+        raise WeightShareError(
+            f"weight sharing requires an explicit max_total_tokens on engine "
+            f"stage {stage_name!r} (set stages.{stage_name}.engine."
+            "max_total_tokens): a follower attaches after its dummy weights are "
+            "freed, so memory profiling cannot derive a stable KV budget"
+        )
+
+
+def _resolved_max_total_tokens(config: PipelineConfig, stage) -> int | None:
+    # Both kwarg channels can carry server args; the stage's own engine block
+    # outranks stage_factory_kwargs, matching how the worker overlays them.
+    overrides = dict(
+        resolve_stage_factory_kwargs(stage, config).get("server_args_overrides") or {}
+    )
+    overrides.update(
+        resolve_stage_typed_kwargs(stage).get("server_args_overrides") or {}
+    )
+    value = overrides.get("max_total_tokens")
+    if value is None:
+        return None
+    if isinstance(value, bool) or not isinstance(value, int) or value <= 0:
+        raise WeightShareError(
+            f"stage {stage.name!r} must define a positive integer "
+            f"max_total_tokens for weight sharing, got {value!r}"
+        )
+    return value
+
+
+def _create_store_dir(runtime_dir: Path, process_name: str, gpu_id: int) -> Path:
+    store_dir = Path(runtime_dir) / "weights" / process_name / f"gpu{gpu_id}"
+    store_dir.mkdir(parents=True, mode=0o700, exist_ok=True)
+    return store_dir

--- a/sglang_omni/utils/ipc_weights.py
+++ b/sglang_omni/utils/ipc_weights.py
@@ -58,6 +58,7 @@ logger = logging.getLogger(__name__)
 ENV_WEIGHT_SHARE = "SGLANG_OMNI_WEIGHT_SHARE"
 ENV_WEIGHT_SHARE_TIMEOUT_S = "SGLANG_OMNI_WEIGHT_SHARE_TIMEOUT_S"
 ENV_WEIGHT_SHARE_RUN_ID = "SGLANG_OMNI_WEIGHT_SHARE_RUN_ID"
+ENV_WEIGHT_SHARE_COMPAT = "SGLANG_OMNI_WEIGHT_SHARE_COMPAT"
 DEFAULT_ATTACH_TIMEOUT_S = 1800.0
 # Note (Jiaxin Deng): version 2 added per-tensor share/private classification;
 # version-1 handles predate it and must not be attached.
@@ -115,8 +116,15 @@ def get_weight_share_config(environ=None) -> WeightShareConfig | None:
 
 
 def prepare_weight_share_process_compat() -> None:
-    """Install UUID-safe CUDA reductions in every weight-sharing stage process."""
-    if get_weight_share_config() is None:
+    """Install UUID-safe CUDA reductions in every weight-sharing stage process.
+
+    # Note (Jiaxin Deng): a stage that only relays CUDA tensors never carries a
+    # weight-share role, yet it unpickles tensors reduced by a patched producer
+    # and dies without the same patch, so the whole pipeline is flagged through
+    # ENV_WEIGHT_SHARE_COMPAT rather than the sharing engines alone.
+    """
+    compat = (os.environ.get(ENV_WEIGHT_SHARE_COMPAT) or "").strip() == "1"
+    if get_weight_share_config() is None and not compat:
         return
 
     from sglang.srt.utils.patch_torch import monkey_patch_torch_reductions

--- a/sglang_omni/utils/ipc_weights.py
+++ b/sglang_omni/utils/ipc_weights.py
@@ -128,8 +128,29 @@ def prepare_weight_share_process_compat() -> None:
         return
 
     from sglang.srt.utils.patch_torch import monkey_patch_torch_reductions
+    from torch.multiprocessing import reductions
 
     monkey_patch_torch_reductions()
+    # The NPU branch of the SGLang patch never installs a CUDA reducer.
+    original = getattr(reductions, "_reduce_tensor_original", None)
+    if original is None or hasattr(reductions, "_sglang_omni_cpu_reduce_original"):
+        return
+
+    # Note (Jiaxin Deng): the SGLang patch rewrites reduction argument 6 to a
+    # device UUID unconditionally, but a CPU tensor reduces to three arguments,
+    # so any CPU tensor crossing a multiprocessing queue (TP leader fanout)
+    # raised IndexError and the message was silently dropped. Keep the original
+    # reducer for anything that is not a CUDA tensor.
+    patched = reductions.reduce_tensor
+
+    def reduce_tensor(tensor, *args, **kwargs):
+        if tensor.device.type != "cuda":
+            return original(tensor, *args, **kwargs)
+        return patched(tensor, *args, **kwargs)
+
+    reductions._sglang_omni_cpu_reduce_original = original
+    reductions.reduce_tensor = reduce_tensor
+    reductions.init_reductions()
 
 
 def handle_file_for_model(dir_path: str, model: torch.nn.Module) -> str:

--- a/tests/test_ci/test_weight_share_native.py
+++ b/tests/test_ci/test_weight_share_native.py
@@ -31,9 +31,12 @@ import subprocess
 import sys
 import time
 import urllib.request
+from collections.abc import Iterable
 from pathlib import Path
 
 import pytest
+
+from tests.test_ci.test_mps_native import _signal_test_sessions
 
 # Note (Jiaxin Deng): process replicas need an engine factory that declares
 # gpu_id, which rules out Higgs and Whisper today; MOSS TTS local is both
@@ -209,9 +212,31 @@ def _terminate(proc: subprocess.Popen, timeout: float = 180.0) -> None:
     try:
         proc.wait(timeout=timeout)
     except subprocess.TimeoutExpired:
-        proc.kill()
+        # The serve is a session leader, so its pgid reaches every stage worker;
+        # killing only the parent would leave them holding GPU memory.
+        _signal_test_sessions({proc.pid}, signal.SIGKILL)
         proc.wait(timeout=30)
         raise AssertionError("serve did not exit on SIGTERM")
+
+
+def _session_members(session_ids: Iterable[int]) -> dict[int, str]:
+    """Pids still holding resources in one of *session_ids*, from /proc.
+
+    # Note (Jiaxin Deng): a zombie is an unreaped exit status, not a worker; it
+    # holds no GPU memory and no MPS client, and this container runs without a
+    # reaping init, so counting it would fail every clean run.
+    """
+    wanted = set(session_ids)
+    members: dict[int, str] = {}
+    for stat in Path("/proc").glob("[0-9]*/stat"):
+        try:
+            fields = stat.read_text().rsplit(")", 1)[1].split()
+            state, pgrp = fields[0], int(fields[2])
+        except (OSError, IndexError, ValueError):
+            continue
+        if pgrp in wanted and state != "Z":
+            members[int(stat.parent.name)] = state
+    return members
 
 
 def _free_port() -> int:
@@ -221,9 +246,35 @@ def _free_port() -> int:
 
 
 @pytest.fixture(autouse=True)
-def _fresh_log():
+def _scoped_serves(monkeypatch):
+    """Track every serve this test starts and reap its whole session afterwards.
+
+    A failed lifecycle assertion must not leave stage workers holding GPU
+    memory and MPS clients for the next test; the serve parent may already be
+    gone by then, so cleanup keys on the session id, not the parent pid.
+    """
     LOG.unlink(missing_ok=True)
+    session_ids: set[int] = set()
+    serve = _serve
+
+    def tracked_serve(*args, **kwargs) -> subprocess.Popen:
+        proc = serve(*args, **kwargs)
+        session_ids.add(proc.pid)
+        return proc
+
+    monkeypatch.setattr(sys.modules[__name__], "_serve", tracked_serve)
     yield
+    _signal_test_sessions(session_ids, signal.SIGTERM)
+    deadline = time.monotonic() + 60
+    while _session_members(session_ids) and time.monotonic() < deadline:
+        time.sleep(1)
+    leftovers = _session_members(session_ids)
+    if leftovers:
+        _signal_test_sessions(session_ids, signal.SIGKILL)
+        time.sleep(2)
+    assert not _session_members(
+        session_ids
+    ), f"stage workers outlived their serve and had to be killed: {leftovers}"
 
 
 def _boot_and_measure(tmp_path, *, weight_share: str) -> tuple[int, str]:

--- a/tests/test_ci/test_weight_share_native.py
+++ b/tests/test_ci/test_weight_share_native.py
@@ -1,0 +1,281 @@
+# SPDX-License-Identifier: Apache-2.0
+"""Native weight-share lifecycle smoke on one GPU.
+
+Author: Jiaxin Deng
+
+Codifies the ``--weight-share on`` contract end to end on real hardware. Two
+same-GPU replicas of one pipeline are booted twice, unshared and shared, and the
+card must end up holding materially less with sharing on: that is the whole
+point of the feature, and it is measured rather than inferred from a log line.
+The same run pins the spawn order that keeps a follower from deadlocking against
+its leader, and a second case pins the failure mode operators will actually
+meet, a leader that dies while followers hold its mappings, which must fail the
+pipeline rather than serve aliased memory.
+
+Quality and throughput are out of scope; this file exists so a lifecycle
+regression fails a machine, not a user.
+
+Not wired into a workflow yet; run manually on a GPU host:
+    pytest tests/test_ci/test_weight_share_native.py -v -s -x
+"""
+
+from __future__ import annotations
+
+import json
+import os
+import re
+import shutil
+import signal
+import socket
+import subprocess
+import sys
+import time
+import urllib.request
+from pathlib import Path
+
+import pytest
+
+# Note (Jiaxin Deng): process replicas need an engine factory that declares
+# gpu_id, which rules out Higgs and Whisper today; MOSS TTS local is both
+# replica capable and on the weight-share allowlist, and its separate vocoder
+# process also exercises the reduction-compat flag.
+MODEL = os.environ.get(
+    "WEIGHT_SHARE_CI_MODEL", "OpenMOSS-Team/MOSS-TTS-Local-Transformer-v1.5"
+)
+GPU_ID = int(os.environ.get("WEIGHT_SHARE_CI_GPU", "0"))
+MAX_TOTAL_TOKENS = int(os.environ.get("WEIGHT_SHARE_CI_MAX_TOTAL_TOKENS", "30000"))
+HEALTH_TRIES = 150
+HEALTH_INTERVAL = 5
+LOG = Path("/tmp/weight-share-ci.log")
+
+pytestmark = [
+    pytest.mark.benchmark,
+    pytest.mark.accelerator,
+    pytest.mark.skipif(
+        shutil.which("nvidia-smi") is None,
+        reason="requires an NVIDIA host",
+    ),
+]
+
+
+def _config(tmp_path: Path) -> Path:
+    # The MOSS local engine shares the "pipeline" process with preprocessing,
+    # so that whole process is what gets replicated; the vocoder is a separate
+    # process and stays single, which also proves a non-sharing process still
+    # receives the CUDA reduction compat flag. Two replicas plus the vocoder
+    # must fit the placement budget: 2 x (0.05 + 0.35) + 0.15.
+    path = tmp_path / "moss_local_dp2_same_gpu.yaml"
+    path.write_text(
+        f"""config_cls: MossTTSLocalPipelineConfig
+name: mossl
+model_path: {MODEL}
+
+stages:
+  preprocessing:
+    gpu: {GPU_ID}
+    gpu_memory_fraction: 0.05
+  tts_engine:
+    gpu: {GPU_ID}
+    gpu_memory_fraction: 0.35
+    engine:
+      mem_fraction_static: 0.30
+      max_total_tokens: {MAX_TOTAL_TOKENS}
+  vocoder:
+    gpu: {GPU_ID}
+    gpu_memory_fraction: 0.15
+
+processes:
+  pipeline:
+    num_replicas: 2
+    replica_devices: [{GPU_ID}, {GPU_ID}]
+"""
+    )
+    return path
+
+
+def _serve(config: Path, port: int, *, weight_share: str) -> subprocess.Popen:
+    log = LOG.open("ab")
+    return subprocess.Popen(
+        [
+            sys.executable,
+            "-m",
+            "sglang_omni.cli",
+            "serve",
+            "--config",
+            str(config),
+            "--mps",
+            "auto",
+            "--weight-share",
+            weight_share,
+            "--port",
+            str(port),
+        ],
+        env={**os.environ},
+        stdout=log,
+        stderr=subprocess.STDOUT,
+        start_new_session=True,
+    )
+
+
+def _wait_healthy(port: int, proc: subprocess.Popen) -> None:
+    for _ in range(HEALTH_TRIES):
+        if proc.poll() is not None:
+            raise AssertionError(_with_log(f"serve died during startup (port {port})"))
+        try:
+            with urllib.request.urlopen(
+                f"http://localhost:{port}/v1/models", timeout=3
+            ):
+                return
+        except OSError:
+            time.sleep(HEALTH_INTERVAL)
+    raise AssertionError(_with_log(f"serve never became healthy (port {port})"))
+
+
+def _with_log(message: str) -> str:
+    tail = LOG.read_text(errors="replace")[-3000:] if LOG.exists() else "(no log)"
+    return f"{message}; log tail:\n{tail}"
+
+
+def _speech_ok(port: int) -> None:
+    body = json.dumps(
+        {"model": MODEL, "input": "Weight share CI check.", "response_format": "wav"}
+    ).encode()
+    request = urllib.request.Request(
+        f"http://localhost:{port}/v1/audio/speech",
+        data=body,
+        headers={"Content-Type": "application/json"},
+    )
+    with urllib.request.urlopen(request, timeout=300) as response:
+        assert response.status == 200
+        assert len(response.read()) > 1000
+
+
+def _spawned_pids() -> dict[str, int]:
+    """Read each group's pid from the runtime's own spawn log line.
+
+    # Note (Jiaxin Deng): /proc comm truncates to 15 characters, which cuts
+    # "process-pipeline@r0" short, so the log the runner already publishes is
+    # the only exact mapping available from outside the serve process.
+    """
+    pids: dict[str, int] = {}
+    if not LOG.exists():
+        return pids
+    for match in re.finditer(
+        r"StageGroup (\S+): spawned \d+ process\(es\) \(pids=\[([0-9, ]+)\]\)",
+        LOG.read_text(errors="replace"),
+    ):
+        pids[match.group(1)] = int(match.group(2).split(",")[0])
+    return pids
+
+
+def _alive(pid: int) -> bool:
+    return Path(f"/proc/{pid}").exists()
+
+
+def _gpu_uuid_from_log() -> str:
+    """Read the physical GPU this run landed on from the runtime's lock path.
+
+    # Note (Jiaxin Deng): nvidia-smi reports host pids, which do not match this
+    # container's namespace, so per-process attribution is unavailable; the card
+    # is identified by UUID instead and measured as a whole.
+    """
+    match = re.search(
+        r"startup lock for stage \S+: \S*sglang_omni_gpu_(GPU-[0-9a-fA-F-]+)_startup",
+        LOG.read_text(errors="replace"),
+    )
+    assert match is not None, _with_log("no GPU startup lock line in the log")
+    return match.group(1)
+
+
+def _gpu_used_mib(gpu_uuid: str) -> int:
+    output = subprocess.run(
+        ["nvidia-smi", "--query-gpu=uuid,memory.used", "--format=csv,noheader,nounits"],
+        capture_output=True,
+        text=True,
+        check=True,
+    ).stdout
+    for line in output.splitlines():
+        if not line.strip():
+            continue
+        uuid, used = (part.strip() for part in line.split(","))
+        if uuid == gpu_uuid:
+            return int(used)
+    raise AssertionError(f"GPU {gpu_uuid} not listed by nvidia-smi")
+
+
+def _terminate(proc: subprocess.Popen, timeout: float = 180.0) -> None:
+    if proc.poll() is None:
+        proc.send_signal(signal.SIGTERM)
+    try:
+        proc.wait(timeout=timeout)
+    except subprocess.TimeoutExpired:
+        proc.kill()
+        proc.wait(timeout=30)
+        raise AssertionError("serve did not exit on SIGTERM")
+
+
+def _free_port() -> int:
+    with socket.socket() as sock:
+        sock.bind(("127.0.0.1", 0))
+        return int(sock.getsockname()[1])
+
+
+@pytest.fixture(autouse=True)
+def _fresh_log():
+    LOG.unlink(missing_ok=True)
+    yield
+
+
+def _boot_and_measure(tmp_path, *, weight_share: str) -> tuple[int, str]:
+    proc = _serve(_config(tmp_path), (port := _free_port()), weight_share=weight_share)
+    try:
+        _wait_healthy(port, proc)
+        for _ in range(4):
+            _speech_ok(port)
+        gpu_uuid = _gpu_uuid_from_log()
+        return _gpu_used_mib(gpu_uuid), LOG.read_text(errors="replace")
+    finally:
+        _terminate(proc)
+
+
+def test_sharing_frees_a_full_weight_copy_and_orders_the_waves(tmp_path):
+    unshared, _ = _boot_and_measure(tmp_path, weight_share="off")
+    LOG.unlink(missing_ok=True)
+    shared, log = _boot_and_measure(tmp_path, weight_share="on")
+
+    # MOSS local shares an 8.44 GiB backbone, so a follower that quietly loaded
+    # its own copy would leave the card at the unshared footprint.
+    assert shared < unshared - 4000, (unshared, shared)
+
+    assert "Weight sharing on GPU" in log
+    assert "[weight-share] follower attached" in log
+    # A follower must not be spawned before its leader has exported.
+    assert (
+        log.index("StageGroup pipeline@r0: spawned")
+        < log.index("[weight-share] leader exported")
+        < log.index("StageGroup pipeline@r1: spawned")
+    )
+    assert not any(_alive(pid) for pid in _spawned_pids().values())
+
+
+def test_a_dead_leader_fails_the_pipeline(tmp_path):
+    free_port = _free_port()
+    proc = _serve(_config(tmp_path), free_port, weight_share="on")
+    try:
+        _wait_healthy(free_port, proc)
+        pids = _spawned_pids()
+        leader_pid = pids["pipeline@r0"]
+
+        os.kill(leader_pid, signal.SIGKILL)
+
+        deadline = time.monotonic() + 120
+        while time.monotonic() < deadline and proc.poll() is None:
+            time.sleep(1)
+        assert proc.poll() is not None, _with_log(
+            "serve kept running after its weight-share leader was killed"
+        )
+    finally:
+        if proc.poll() is None:
+            _terminate(proc)
+
+    assert not any(_alive(pid) for pid in pids.values())

--- a/tests/unit_test/config/test_example_replica_configs.py
+++ b/tests/unit_test/config/test_example_replica_configs.py
@@ -1,0 +1,38 @@
+# SPDX-License-Identifier: Apache-2.0
+"""The shipped replica example configs must load and compile as documented."""
+
+from __future__ import annotations
+
+from pathlib import Path
+
+import pytest
+
+from sglang_omni.config.manager import ConfigManager
+from sglang_omni.config.topology import compile_logical_processes
+
+_REPO_ROOT = Path(__file__).resolve().parents[3]
+
+_REPLICA_EXAMPLES = [
+    "examples/configs/qwen3_omni_speech_replica2.yaml",
+    "examples/configs/qwen3_omni_speech_code2wav_replica2_ci.yaml",
+]
+
+
+@pytest.mark.parametrize("relative_path", _REPLICA_EXAMPLES)
+def test_replica_example_loads_and_declares_its_placement(relative_path: str) -> None:
+    config = ConfigManager.from_file(str(_REPO_ROOT / relative_path)).config
+
+    plan, _ = compile_logical_processes(config)
+    replicated = [process for process in plan.processes if process.is_replicated]
+    assert replicated, relative_path
+    # Note (Jiaxin Deng): replica_devices colocation is only valid with a
+    # declared budget on every GPU stage it places, so the examples must carry
+    # gpu_memory_fraction for each replicated GPU stage.
+    for process in replicated:
+        for stage_name in process.stage_names:
+            stage = next(s for s in config.stages if s.name == stage_name)
+            if stage.gpu is not None:
+                assert stage.gpu_memory_fraction is not None, (
+                    relative_path,
+                    stage_name,
+                )

--- a/tests/unit_test/pipeline/test_weight_share_plan.py
+++ b/tests/unit_test/pipeline/test_weight_share_plan.py
@@ -1,0 +1,404 @@
+# SPDX-License-Identifier: Apache-2.0
+"""Leader/follower assignment for runtime-native CUDA IPC weight sharing."""
+
+from __future__ import annotations
+
+import os
+from typing import ClassVar
+
+import pytest
+
+from sglang_omni.config import (
+    EndpointsConfig,
+    EngineArgs,
+    PipelineConfig,
+    ProcessConfig,
+    StageConfig,
+)
+from sglang_omni.config.schema import EngineStageConfig
+from sglang_omni.config.topology import compile_logical_processes
+from sglang_omni.pipeline.stage_workers import StageLaunchConfig, StageWorkerProcessSpec
+from sglang_omni.pipeline.weight_share import WeightShareError, plan_weight_share
+from sglang_omni.utils.ipc_weights import (
+    ENV_WEIGHT_SHARE,
+    ENV_WEIGHT_SHARE_COMPAT,
+    ENV_WEIGHT_SHARE_RUN_ID,
+)
+
+pytestmark = pytest.mark.skipif(
+    os.name != "posix",
+    reason="weight sharing plans only on POSIX hosts",
+)
+
+
+def noop_factory():  # pragma: no cover - never constructed here
+    raise AssertionError("factory must not run")
+
+
+class _SharingPipelineConfig(PipelineConfig):
+    stage_config_types: ClassVar[dict[str, type[StageConfig]]] = {
+        "engine": EngineStageConfig,
+        "second_engine": EngineStageConfig,
+    }
+
+
+def _engine_stage(
+    name: str = "engine",
+    *,
+    process: str = "gen",
+    max_total_tokens: int | None = 30000,
+    gpu: int | None = 0,
+    tp_size: int = 1,
+) -> EngineStageConfig:
+    engine = EngineArgs()
+    if max_total_tokens is not None:
+        engine.max_total_tokens = max_total_tokens
+    return EngineStageConfig(
+        name=name,
+        process=process,
+        factory_path=f"{__name__}.noop_factory",
+        gpu=gpu,
+        gpu_memory_fraction=0.45 if gpu is not None else None,
+        tp_size=tp_size,
+        terminal=True,
+        engine=engine,
+    )
+
+
+def _make_config(
+    tmp_path,
+    *,
+    stages,
+    processes,
+    weight_share: str = "on",
+) -> PipelineConfig:
+    return _SharingPipelineConfig(
+        model_path="model",
+        entry_stage=stages[0].name,
+        stages=list(stages),
+        processes=processes,
+        weight_share=weight_share,
+        endpoints=EndpointsConfig(base_path=str(tmp_path)),
+    )
+
+
+def _spec(
+    process_name: str,
+    *,
+    stage_name: str,
+    gpu_id: int | None,
+    tp_size: int = 1,
+    env_defaults: dict[str, str] | None = None,
+) -> StageWorkerProcessSpec:
+    return StageWorkerProcessSpec(
+        process_name=process_name,
+        stage_specs=[
+            StageLaunchConfig(
+                stage_name=stage_name,
+                factory=f"{__name__}.noop_factory",
+                placement_gpu_id=gpu_id,
+                gpu_id=gpu_id,
+                tp_size=tp_size,
+                env_defaults=dict(env_defaults or {}),
+            )
+        ],
+    )
+
+
+def _plan(config: PipelineConfig, specs, tmp_path):
+    logical_plan, _ = compile_logical_processes(config)
+    return plan_weight_share(
+        config,
+        logical_process_plan=logical_plan,
+        process_specs=specs,
+        runtime_dir=tmp_path,
+    )
+
+
+def test_off_plans_nothing(tmp_path) -> None:
+    config = _make_config(
+        tmp_path,
+        stages=[_engine_stage()],
+        processes={"gen": ProcessConfig(num_replicas=2, replica_devices=[0, 0])},
+        weight_share="off",
+    )
+    specs = [
+        _spec("gen@r0", stage_name="engine@r0", gpu_id=0),
+        _spec("gen@r1", stage_name="engine@r1", gpu_id=0),
+    ]
+
+    assert _plan(config, specs, tmp_path) is None
+
+
+def test_lowest_replica_leads_and_the_rest_follow(tmp_path) -> None:
+    config = _make_config(
+        tmp_path,
+        stages=[_engine_stage()],
+        processes={"gen": ProcessConfig(num_replicas=3, replica_devices=[0, 0, 0])},
+    )
+    specs = [
+        _spec(f"gen@r{index}", stage_name=f"engine@r{index}", gpu_id=0)
+        for index in range(3)
+    ]
+
+    plan = _plan(config, specs, tmp_path)
+
+    assert plan is not None
+    (group,) = plan.groups
+    assert group.leader == "gen@r0"
+    assert group.followers == ("gen@r1", "gen@r2")
+    assert plan.follower_process_names == {"gen@r1", "gen@r2"}
+    assert plan.env_by_process["gen@r0"][ENV_WEIGHT_SHARE] == (
+        f"leader:{group.store_dir}"
+    )
+    assert plan.env_by_process["gen@r1"][ENV_WEIGHT_SHARE] == (
+        f"follower:{group.store_dir}"
+    )
+    run_ids = {env[ENV_WEIGHT_SHARE_RUN_ID] for env in plan.env_by_process.values()}
+    assert run_ids == {plan.run_id}
+    assert group.store_dir.is_dir()
+    assert oct(group.store_dir.stat().st_mode)[-3:] == "700"
+
+
+def test_a_replica_alone_on_its_gpu_keeps_loading_normally(tmp_path) -> None:
+    """replica_devices=[0, 0, 1]: the GPU-1 singleton is not a follower."""
+    config = _make_config(
+        tmp_path,
+        stages=[_engine_stage()],
+        processes={"gen": ProcessConfig(num_replicas=3, replica_devices=[0, 0, 1])},
+    )
+    specs = [
+        _spec("gen@r0", stage_name="engine@r0", gpu_id=0),
+        _spec("gen@r1", stage_name="engine@r1", gpu_id=0),
+        _spec("gen@r2", stage_name="engine@r2", gpu_id=1),
+    ]
+
+    plan = _plan(config, specs, tmp_path)
+
+    assert plan is not None
+    (group,) = plan.groups
+    assert group.gpu_id == 0
+    assert group.leader == "gen@r0"
+    assert group.followers == ("gen@r1",)
+    assert "gen@r2" not in plan.follower_process_names
+    assert ENV_WEIGHT_SHARE not in plan.env_by_process["gen@r2"]
+
+
+def test_two_gpus_each_get_their_own_leader(tmp_path) -> None:
+    config = _make_config(
+        tmp_path,
+        stages=[_engine_stage()],
+        processes={"gen": ProcessConfig(num_replicas=4, replica_devices=[0, 0, 1, 1])},
+    )
+    specs = [
+        _spec("gen@r0", stage_name="engine@r0", gpu_id=0),
+        _spec("gen@r1", stage_name="engine@r1", gpu_id=0),
+        _spec("gen@r2", stage_name="engine@r2", gpu_id=1),
+        _spec("gen@r3", stage_name="engine@r3", gpu_id=1),
+    ]
+
+    plan = _plan(config, specs, tmp_path)
+
+    assert plan is not None
+    assert [(g.gpu_id, g.leader, g.followers) for g in plan.groups] == [
+        (0, "gen@r0", ("gen@r1",)),
+        (1, "gen@r2", ("gen@r3",)),
+    ]
+    assert len({group.store_dir for group in plan.groups}) == 2
+
+
+def test_every_process_gets_the_reduction_compat_flag(tmp_path) -> None:
+    """A relay-only stage unpickles the engine's CUDA tensors and needs it too."""
+    config = _make_config(
+        tmp_path,
+        stages=[
+            _engine_stage(),
+            StageConfig(
+                name="vocoder",
+                process="vocoder",
+                factory_path=f"{__name__}.noop_factory",
+                gpu=0,
+                terminal=True,
+            ),
+        ],
+        processes={"gen": ProcessConfig(num_replicas=2, replica_devices=[0, 0])},
+    )
+    specs = [
+        _spec("gen@r0", stage_name="engine@r0", gpu_id=0),
+        _spec("gen@r1", stage_name="engine@r1", gpu_id=0),
+        _spec("vocoder", stage_name="vocoder", gpu_id=0),
+    ]
+
+    plan = _plan(config, specs, tmp_path)
+
+    assert plan is not None
+    assert all(
+        env[ENV_WEIGHT_SHARE_COMPAT] == "1" for env in plan.env_by_process.values()
+    )
+    assert set(plan.env_by_process) == {"gen@r0", "gen@r1", "vocoder"}
+
+
+def test_a_replicated_tp_process_is_skipped_not_rejected(tmp_path) -> None:
+    """Sharing one process must not fail the pipeline over an unrelated TP one."""
+    config = _make_config(
+        tmp_path,
+        stages=[
+            _engine_stage(),
+            StageConfig(
+                name="thinker",
+                process="thinker",
+                factory_path=f"{__name__}.noop_factory",
+                gpu=[1, 2],
+                tp_size=2,
+                terminal=True,
+            ),
+        ],
+        processes={
+            "gen": ProcessConfig(num_replicas=2, replica_devices=[0, 0]),
+            "thinker": ProcessConfig(num_replicas=2, replica_devices=[1, 2, 1, 2]),
+        },
+    )
+    specs = [
+        _spec("gen@r0", stage_name="engine@r0", gpu_id=0),
+        _spec("gen@r1", stage_name="engine@r1", gpu_id=0),
+        _spec("thinker@r0_tp0", stage_name="thinker@r0", gpu_id=1, tp_size=2),
+        _spec("thinker@r0_tp1", stage_name="thinker@r0", gpu_id=2, tp_size=2),
+        _spec("thinker@r1_tp0", stage_name="thinker@r1", gpu_id=1, tp_size=2),
+        _spec("thinker@r1_tp1", stage_name="thinker@r1", gpu_id=2, tp_size=2),
+    ]
+
+    plan = _plan(config, specs, tmp_path)
+
+    assert plan is not None
+    assert [group.logical_process for group in plan.groups] == ["gen"]
+    assert plan.follower_process_names == {"gen@r1"}
+
+
+def test_cpu_only_replicas_are_not_a_sharing_group(tmp_path) -> None:
+    config = _make_config(
+        tmp_path,
+        stages=[
+            _engine_stage(),
+            StageConfig(
+                name="preprocess",
+                process="pre",
+                factory_path=f"{__name__}.noop_factory",
+                next="engine",
+            ),
+        ],
+        processes={
+            "gen": ProcessConfig(num_replicas=2, replica_devices=[0, 0]),
+            "pre": ProcessConfig(num_replicas=2),
+        },
+    )
+    specs = [
+        _spec("gen@r0", stage_name="engine@r0", gpu_id=0),
+        _spec("gen@r1", stage_name="engine@r1", gpu_id=0),
+        _spec("pre@r0", stage_name="preprocess@r0", gpu_id=None),
+        _spec("pre@r1", stage_name="preprocess@r1", gpu_id=None),
+    ]
+
+    plan = _plan(config, specs, tmp_path)
+
+    assert plan is not None
+    assert [group.logical_process for group in plan.groups] == ["gen"]
+    assert plan.follower_process_names == {"gen@r1"}
+
+
+def test_on_without_any_same_gpu_replica_pair_is_rejected(tmp_path) -> None:
+    config = _make_config(
+        tmp_path,
+        stages=[_engine_stage()],
+        processes={"gen": ProcessConfig(num_replicas=2, replica_devices=[0, 1])},
+    )
+    specs = [
+        _spec("gen@r0", stage_name="engine@r0", gpu_id=0),
+        _spec("gen@r1", stage_name="engine@r1", gpu_id=1),
+    ]
+
+    with pytest.raises(WeightShareError, match="two or more replicas"):
+        _plan(config, specs, tmp_path)
+
+
+def test_engine_stage_without_a_pinned_kv_cap_is_rejected(tmp_path) -> None:
+    config = _make_config(
+        tmp_path,
+        stages=[_engine_stage(max_total_tokens=None)],
+        processes={"gen": ProcessConfig(num_replicas=2, replica_devices=[0, 0])},
+    )
+    specs = [
+        _spec("gen@r0", stage_name="engine@r0", gpu_id=0),
+        _spec("gen@r1", stage_name="engine@r1", gpu_id=0),
+    ]
+
+    with pytest.raises(WeightShareError, match="max_total_tokens"):
+        _plan(config, specs, tmp_path)
+
+
+def test_two_engine_stages_in_one_sharing_process_are_rejected(tmp_path) -> None:
+    config = _make_config(
+        tmp_path,
+        stages=[
+            _engine_stage(),
+            _engine_stage(name="second_engine", process="gen"),
+        ],
+        processes={"gen": ProcessConfig(num_replicas=2, replica_devices=[0, 0])},
+    )
+    specs = [
+        _spec("gen@r0", stage_name="engine@r0", gpu_id=0),
+        _spec("gen@r1", stage_name="engine@r1", gpu_id=0),
+    ]
+
+    with pytest.raises(WeightShareError, match="exactly one SGLang engine stage"):
+        _plan(config, specs, tmp_path)
+
+
+def test_externally_assigned_roles_are_rejected(tmp_path, monkeypatch) -> None:
+    monkeypatch.setenv(ENV_WEIGHT_SHARE, "leader:/tmp/elsewhere")
+    config = _make_config(
+        tmp_path,
+        stages=[_engine_stage()],
+        processes={"gen": ProcessConfig(num_replicas=2, replica_devices=[0, 0])},
+    )
+    specs = [
+        _spec("gen@r0", stage_name="engine@r0", gpu_id=0),
+        _spec("gen@r1", stage_name="engine@r1", gpu_id=0),
+    ]
+
+    with pytest.raises(WeightShareError, match="parent environment"):
+        _plan(config, specs, tmp_path)
+
+
+def test_a_stage_env_default_cannot_assign_a_role(tmp_path) -> None:
+    config = _make_config(
+        tmp_path,
+        stages=[_engine_stage()],
+        processes={"gen": ProcessConfig(num_replicas=2, replica_devices=[0, 0])},
+    )
+    specs = [
+        _spec(
+            "gen@r0",
+            stage_name="engine@r0",
+            gpu_id=0,
+            env_defaults={ENV_WEIGHT_SHARE: "leader:/tmp/elsewhere"},
+        ),
+        _spec("gen@r1", stage_name="engine@r1", gpu_id=0),
+    ]
+
+    with pytest.raises(WeightShareError, match="environment defaults"):
+        _plan(config, specs, tmp_path)
+
+
+def test_the_weight_share_flag_resolves_from_the_command_line(tmp_path) -> None:
+    from sglang_omni.config.manager import ConfigManager
+
+    config = _make_config(
+        tmp_path,
+        stages=[_engine_stage()],
+        processes={"gen": ProcessConfig(num_replicas=2, replica_devices=[0, 0])},
+        weight_share="off",
+    )
+    manager = ConfigManager(config)
+    merged = manager.merge_config(manager.parse_extra_args(["--weight-share", "on"]))
+
+    assert merged.weight_share == "on"

--- a/tests/unit_test/pipeline/test_weight_share_runner_wiring.py
+++ b/tests/unit_test/pipeline/test_weight_share_runner_wiring.py
@@ -1,0 +1,394 @@
+# SPDX-License-Identifier: Apache-2.0
+"""Runner-to-weight-share integration: spawn order, env merge, teardown order."""
+
+from __future__ import annotations
+
+import asyncio
+import os
+from typing import ClassVar
+
+import pytest
+
+from sglang_omni.config import (
+    EndpointsConfig,
+    EngineArgs,
+    PipelineConfig,
+    ProcessConfig,
+    StageConfig,
+)
+from sglang_omni.config.schema import EngineStageConfig
+from sglang_omni.pipeline import mp_runner
+from sglang_omni.pipeline.mp_runner import MultiProcessPipelineRunner
+from sglang_omni.pipeline.stage_workers import StageLaunchConfig, StageWorkerProcessSpec
+from sglang_omni.pipeline.weight_share import WeightShareError
+from sglang_omni.utils.ipc_weights import ENV_WEIGHT_SHARE, ENV_WEIGHT_SHARE_COMPAT
+
+pytestmark = pytest.mark.skipif(
+    os.name != "posix",
+    reason="weight sharing plans only on POSIX hosts",
+)
+
+
+def noop_factory():  # pragma: no cover - never constructed here
+    raise AssertionError("factory must not run")
+
+
+class _SharingPipelineConfig(PipelineConfig):
+    stage_config_types: ClassVar[dict[str, type[StageConfig]]] = {
+        "engine": EngineStageConfig,
+    }
+
+
+def _config(tmp_path, *, weight_share: str = "on") -> PipelineConfig:
+    engine = EngineArgs()
+    engine.max_total_tokens = 30000
+    return _SharingPipelineConfig(
+        model_path="model",
+        entry_stage="engine",
+        stages=[
+            EngineStageConfig(
+                name="engine",
+                process="gen",
+                factory_path=f"{__name__}.noop_factory",
+                gpu=0,
+                gpu_memory_fraction=0.45,
+                terminal=True,
+                engine=engine,
+            )
+        ],
+        processes={"gen": ProcessConfig(num_replicas=2, replica_devices=[0, 0])},
+        weight_share=weight_share,
+        endpoints=EndpointsConfig(base_path=str(tmp_path)),
+    )
+
+
+class _FakeCoordinator:
+    def __init__(self, events: list[str], *args, **kwargs) -> None:
+        del args, kwargs
+        self.events = events
+        self.registered: dict[str, str] = {}
+        self.shutdown_calls: list[list[str] | None] = []
+
+    async def start(self) -> None:
+        self.events.append("coordinator start")
+
+    async def run_completion_loop(self) -> None:
+        await asyncio.Event().wait()
+
+    def register_stage(self, name: str, endpoint: str) -> None:
+        self.registered[name] = endpoint
+
+    async def shutdown_stages(self, stage_names=None) -> None:
+        self.shutdown_calls.append(None if stage_names is None else list(stage_names))
+        self.events.append(f"graceful shutdown {stage_names}")
+
+    async def fail_pending_requests(self, error: BaseException) -> None:
+        del error
+
+    async def stop(self) -> None:
+        self.events.append("coordinator stop")
+
+
+class _FakeProcess:
+    def __init__(self) -> None:
+        self._alive = False
+
+    def is_alive(self) -> bool:
+        return self._alive
+
+    def terminate(self) -> None:
+        self._alive = False
+
+    def kill(self) -> None:
+        self._alive = False
+
+    def join(self, timeout=None) -> None:
+        del timeout
+
+
+class _FakeGroup:
+    process_count = 1
+
+    def __init__(
+        self,
+        events: list[str],
+        process_name: str,
+        *,
+        gpu_id: int = 0,
+        ready_error: BaseException | None = None,
+    ) -> None:
+        self.events = events
+        self.group_name = process_name
+        self.ready_error = ready_error
+        self.processes: list[_FakeProcess] = []
+        self.spawn_env = None
+        self.ready_timeout: float | None = None
+        self.dead = False
+        self.stage_control_endpoints = {
+            f"engine@r{process_name[-1]}": f"ipc://{process_name}"
+        }
+        self.process_specs = [
+            StageWorkerProcessSpec(
+                process_name=process_name,
+                stage_specs=[
+                    StageLaunchConfig(
+                        stage_name=f"engine@r{process_name[-1]}",
+                        factory=f"{__name__}.noop_factory",
+                        placement_gpu_id=gpu_id,
+                        gpu_id=gpu_id,
+                        recv_endpoint=f"ipc://{process_name}",
+                    )
+                ],
+            )
+        ]
+
+    def spawn(self, ctx, process_env_overrides=None) -> None:
+        del ctx
+        self.spawn_env = process_env_overrides
+        self.processes.append(_FakeProcess())
+        self.events.append(f"spawn {self.group_name}")
+
+    async def wait_ready(self, timeout: float) -> None:
+        self.ready_timeout = timeout
+        self.events.append(f"ready {self.group_name}")
+        if self.ready_error is not None:
+            raise self.ready_error
+
+    def any_dead(self) -> bool:
+        return self.dead
+
+    def dead_summary(self) -> str:
+        return f"{self.group_name} exited"
+
+    def process_start_attempts(self) -> set[str]:
+        return {self.group_name} if self.processes else set()
+
+    async def shutdown(self, before_signal=None) -> None:
+        del before_signal
+        self.events.append(f"shutdown {self.group_name}")
+
+    def close_control_channels(self) -> None:
+        self.events.append(f"channels closed {self.group_name}")
+
+
+def _patch(monkeypatch, events, groups) -> _FakeCoordinator:
+    coordinator = _FakeCoordinator(events)
+    monkeypatch.setattr(mp_runner, "Coordinator", lambda *a, **k: coordinator)
+    monkeypatch.setattr(mp_runner, "_build_stage_groups", lambda *a, **k: groups)
+    return coordinator
+
+
+@pytest.mark.asyncio
+async def test_no_follower_spawns_before_every_leader_is_ready(
+    tmp_path, monkeypatch
+) -> None:
+    events: list[str] = []
+    leader = _FakeGroup(events, "gen@r0")
+    follower = _FakeGroup(events, "gen@r1")
+    _patch(monkeypatch, events, [leader, follower])
+    runner = MultiProcessPipelineRunner(_config(tmp_path))
+
+    await runner.start(timeout=5.0)
+    await runner.stop()
+
+    assert events.index("ready gen@r0") < events.index("spawn gen@r1")
+
+
+@pytest.mark.asyncio
+async def test_each_wave_gets_the_whole_startup_budget(tmp_path, monkeypatch) -> None:
+    """A slow leader load must not starve the follower attach behind it."""
+    events: list[str] = []
+    leader = _FakeGroup(events, "gen@r0")
+    follower = _FakeGroup(events, "gen@r1")
+    _patch(monkeypatch, events, [leader, follower])
+    runner = MultiProcessPipelineRunner(_config(tmp_path))
+
+    await runner.start(timeout=37.0)
+    await runner.stop()
+
+    assert leader.ready_timeout == 37.0
+    assert follower.ready_timeout == 37.0
+
+
+@pytest.mark.asyncio
+async def test_a_dead_leader_stops_the_run_before_any_follower_spawns(
+    tmp_path, monkeypatch
+) -> None:
+    events: list[str] = []
+    leader = _FakeGroup(events, "gen@r0")
+    leader.dead = True
+    follower = _FakeGroup(events, "gen@r1")
+    _patch(monkeypatch, events, [leader, follower])
+    runner = MultiProcessPipelineRunner(_config(tmp_path))
+
+    with pytest.raises(RuntimeError, match="died during startup"):
+        await runner.start(timeout=5.0)
+
+    assert "spawn gen@r1" not in events
+    assert follower.spawn_env is None
+
+
+@pytest.mark.asyncio
+async def test_a_replica_alone_on_its_gpu_still_gets_spawned(
+    tmp_path, monkeypatch
+) -> None:
+    """replica_devices=[0, 0, 1]: the unshared replica is routable, so it runs."""
+    events: list[str] = []
+    groups = [
+        _FakeGroup(events, f"gen@r{index}", gpu_id=0 if index < 2 else 1)
+        for index in range(3)
+    ]
+    _patch(monkeypatch, events, groups)
+    config = _config(tmp_path)
+    config.processes["gen"] = ProcessConfig(num_replicas=3, replica_devices=[0, 0, 1])
+    runner = MultiProcessPipelineRunner(config)
+
+    await runner.start(timeout=5.0)
+    await runner.stop()
+
+    assert [event for event in events if event.startswith("spawn")] == [
+        "spawn gen@r0",
+        "spawn gen@r2",
+        "spawn gen@r1",
+    ]
+
+
+@pytest.mark.asyncio
+async def test_cancelling_startup_without_mps_still_reaps_the_children(
+    tmp_path, monkeypatch
+) -> None:
+    """Cancellation is a BaseException; cleanup must not hang off MPS."""
+    events: list[str] = []
+    leader = _FakeGroup(events, "gen@r0", ready_error=asyncio.CancelledError())
+    follower = _FakeGroup(events, "gen@r1")
+    _patch(monkeypatch, events, [leader, follower])
+    runner = MultiProcessPipelineRunner(_config(tmp_path))
+
+    with pytest.raises(asyncio.CancelledError):
+        await runner.start(timeout=5.0)
+
+    assert "channels closed gen@r0" in events
+    assert "coordinator stop" in events
+
+
+@pytest.mark.asyncio
+async def test_roles_and_the_compat_flag_reach_the_spawn_environment(
+    tmp_path, monkeypatch
+) -> None:
+    events: list[str] = []
+    leader = _FakeGroup(events, "gen@r0")
+    follower = _FakeGroup(events, "gen@r1")
+    _patch(monkeypatch, events, [leader, follower])
+    runner = MultiProcessPipelineRunner(_config(tmp_path))
+
+    await runner.start(timeout=5.0)
+    try:
+        env = leader.spawn_env
+        assert env is not None
+        assert env["gen@r0"][ENV_WEIGHT_SHARE].startswith("leader:")
+        assert env["gen@r1"][ENV_WEIGHT_SHARE].startswith("follower:")
+        assert env["gen@r0"][ENV_WEIGHT_SHARE_COMPAT] == "1"
+        assert env["gen@r1"][ENV_WEIGHT_SHARE_COMPAT] == "1"
+        assert follower.spawn_env is env
+    finally:
+        await runner.stop()
+
+
+@pytest.mark.asyncio
+async def test_mps_environment_survives_the_weight_share_merge(
+    tmp_path, monkeypatch
+) -> None:
+    events: list[str] = []
+    leader = _FakeGroup(events, "gen@r0")
+    follower = _FakeGroup(events, "gen@r1")
+    _patch(monkeypatch, events, [leader, follower])
+
+    class _FakeMps:
+        has_leases = False
+
+        async def start(self) -> None:
+            events.append("MPS acquire")
+
+        def env_for_process(self, process_name: str) -> dict[str, str]:
+            return {"CUDA_MPS_PIPE_DIRECTORY": f"/tmp/pipe/{process_name}"}
+
+        async def verify(self) -> None:
+            events.append("MPS verify")
+
+        async def probe_failures(self) -> dict[str, str]:
+            return {}
+
+        async def retire_process_clients(self, process_name: str) -> set:
+            return set()
+
+        async def close(self, *, process_start_attempts=None) -> None:
+            del process_start_attempts
+            events.append("MPS close")
+
+    monkeypatch.setattr(
+        mp_runner, "create_for_pipeline", lambda mode, specs: _FakeMps()
+    )
+    config = _config(tmp_path)
+    config.mps = "on"
+    runner = MultiProcessPipelineRunner(config)
+
+    await runner.start(timeout=5.0)
+    try:
+        env = leader.spawn_env
+        assert env["gen@r0"]["CUDA_MPS_PIPE_DIRECTORY"] == "/tmp/pipe/gen@r0"
+        assert env["gen@r0"][ENV_WEIGHT_SHARE].startswith("leader:")
+        assert env["gen@r0"][ENV_WEIGHT_SHARE_COMPAT] == "1"
+    finally:
+        await runner.stop()
+
+
+@pytest.mark.asyncio
+async def test_roles_are_planned_before_the_coordinator_binds(
+    tmp_path, monkeypatch
+) -> None:
+    """An unshareable pipeline must fail before parent resources exist."""
+    events: list[str] = []
+    group = _FakeGroup(events, "gen@r0")
+    coordinator = _patch(monkeypatch, events, [group])
+    config = _config(tmp_path)
+    config.processes["gen"] = ProcessConfig(num_replicas=2, replica_devices=[0, 1])
+    runner = MultiProcessPipelineRunner(config)
+
+    with pytest.raises(WeightShareError):
+        await runner.start(timeout=5.0)
+
+    assert "coordinator start" not in events
+    assert coordinator.shutdown_calls == []
+
+
+@pytest.mark.asyncio
+async def test_followers_shut_down_before_their_leader(tmp_path, monkeypatch) -> None:
+    events: list[str] = []
+    leader = _FakeGroup(events, "gen@r0")
+    follower = _FakeGroup(events, "gen@r1")
+    coordinator = _patch(monkeypatch, events, [leader, follower])
+    runner = MultiProcessPipelineRunner(_config(tmp_path))
+
+    await runner.start(timeout=5.0)
+    await runner.stop()
+
+    assert events.index("shutdown gen@r1") < events.index("shutdown gen@r0")
+    assert coordinator.shutdown_calls == [["engine@r1"], ["engine@r0"]]
+
+
+@pytest.mark.asyncio
+async def test_sharing_off_keeps_one_spawn_wave_and_one_broadcast(
+    tmp_path, monkeypatch
+) -> None:
+    events: list[str] = []
+    first = _FakeGroup(events, "gen@r0")
+    second = _FakeGroup(events, "gen@r1")
+    coordinator = _patch(monkeypatch, events, [first, second])
+    runner = MultiProcessPipelineRunner(_config(tmp_path, weight_share="off"))
+
+    await runner.start(timeout=5.0)
+    await runner.stop()
+
+    assert events.index("spawn gen@r1") < events.index("ready gen@r0")
+    assert first.spawn_env is None
+    assert coordinator.shutdown_calls == [None]

--- a/tests/unit_test/utils/test_ipc_weights.py
+++ b/tests/unit_test/utils/test_ipc_weights.py
@@ -13,6 +13,8 @@ from __future__ import annotations
 
 import os
 import pickle
+import subprocess
+import sys
 import threading
 import time
 
@@ -283,6 +285,34 @@ def test_reduction_compat_covers_processes_without_a_share_role(monkeypatch):
     monkeypatch.setenv(ipc_weights.ENV_WEIGHT_SHARE_COMPAT, "1")
     ipc_weights.prepare_weight_share_process_compat()
     assert calls == [1]
+
+
+def test_reduction_compat_keeps_cpu_tensors_crossing_a_queue_intact():
+    """TP leader fanout pickles CPU tensors through multiprocessing queues.
+
+    Run in a subprocess because the reductions patch is process global.
+    """
+    pytest.importorskip("sglang.srt.utils.patch_torch")
+    script = """
+import os, pickle, sys
+import torch
+from multiprocessing.reduction import ForkingPickler
+os.environ["SGLANG_OMNI_WEIGHT_SHARE_COMPAT"] = "1"
+from sglang_omni.utils.ipc_weights import prepare_weight_share_process_compat
+from sglang_omni.pipeline.tp_control import TPWorkMessage
+prepare_weight_share_process_compat()
+prepare_weight_share_process_compat()
+msg = TPWorkMessage(request_id="r1", data={"x": torch.arange(6.0).view(2, 3)})
+out = pickle.loads(ForkingPickler.dumps(msg))
+assert torch.equal(out.data["x"], msg.data["x"]), out
+assert out.data["x"].device.type == "cpu"
+print("cpu round trip ok")
+"""
+    result = subprocess.run(
+        [sys.executable, "-c", script], capture_output=True, text=True, timeout=300
+    )
+    assert result.returncode == 0, result.stderr[-2000:]
+    assert "cpu round trip ok" in result.stdout
 
 
 def test_validate_weight_share_architecture_allows_and_rejects():

--- a/tests/unit_test/utils/test_ipc_weights.py
+++ b/tests/unit_test/utils/test_ipc_weights.py
@@ -267,6 +267,24 @@ def test_handle_file_for_model_uses_class_name(tmp_path):
     )
 
 
+def test_reduction_compat_covers_processes_without_a_share_role(monkeypatch):
+    """A relay-only stage unpickles the engine's tensors and needs the patch."""
+    calls: list[int] = []
+    monkeypatch.setattr(
+        "sglang.srt.utils.patch_torch.monkey_patch_torch_reductions",
+        lambda: calls.append(1),
+    )
+    monkeypatch.delenv(ipc_weights.ENV_WEIGHT_SHARE, raising=False)
+
+    monkeypatch.delenv(ipc_weights.ENV_WEIGHT_SHARE_COMPAT, raising=False)
+    ipc_weights.prepare_weight_share_process_compat()
+    assert calls == []
+
+    monkeypatch.setenv(ipc_weights.ENV_WEIGHT_SHARE_COMPAT, "1")
+    ipc_weights.prepare_weight_share_process_compat()
+    assert calls == [1]
+
+
 def test_validate_weight_share_architecture_allows_and_rejects():
     # Note (Jiaxin Deng): exact-set locks so an arch cannot enter or leave
     # either registry without updating the expectations here. Supported means


### PR DESCRIPTION
## Motivation

Same-GPU replicas of one logical Process can now share weights over CUDA IPC from the runtime itself:

```bash
sgl-omni serve --config <config.yaml> --mps on --weight-share on
```

Until now this shape existed only under `examples/mps_dp/launch.sh`, which assigns `SGLANG_OMNI_WEIGHT_SHARE` roles to N separate serves and orders them with a sequential health gate. After #1635 made MPS native, weight sharing was the last reason that script had to exist for an in-pipeline deployment. Sharing is a capacity mechanism: it makes a replica count fit, or frees VRAM for KV and more replicas. The mechanism in `ipc_weights.py` is unchanged; only the orchestrator moves into the parent process.

## Modifications

- Add `PipelineConfig.weight_share` (`off` | `on`, default `off`).
- Add `sglang_omni/pipeline/weight_share.py`: assign leader/follower per (logical Process, GPU) from the `LogicalProcessPlan`, lowest replica index leads; skip TP, CPU-only, and single-replica-per-GPU processes; reject a sharing process without exactly one engine stage or a pinned `max_total_tokens`.
- Inject roles through the `process_env_overrides` channel MPS already uses.
- Spawn followers only after every leader is ready: a follower waits for the export inside the per-GPU startup lock, so a follower that wins the lock first blocks the leader that must release it. Each wave gets the full startup timeout.
- Shut followers down before their leader; `Coordinator.shutdown_stages()` gains an optional `stage_names` filter.
- Run `_cleanup_on_failure()` for any exception in `start()`; a cancellation with MPS off previously skipped it and left spawned children behind.
- Inject `SGLANG_OMNI_WEIGHT_SHARE_COMPAT=1` into every process of a sharing pipeline so relay-only stages get the CUDA reductions patch they need to unpickle a sharing engine's tensors.
- Make `mps/decision.py`'s `process_gpu_ids` public for reuse.
- Docs: new `docs/basic_usage/process_topology.md`; `mps_dp.md` points in-pipeline replicas at `--weight-share on`.

Scope: in-pipeline replicas only; `launch.sh` and the TTS MPS CI stage are untouched. `weight_share=off` is byte identical to before. Inherited from #1175: `replica_devices` needs every GPU stage factory to accept `gpu_id`, which today limits this to MOSS TTS local and Qwen3-ASR among the allowlisted configs; the docs say so.

## Related Issues

Builds on #1635 and #1175; reuses the sharing mechanism from #1124.

## Accuracy Test

No model-side changes. The export and attach path is the one #1124 validated for byte identity; this PR changes who assigns roles and the start and stop order.

## Benchmark & Profiling

Unit, H200 host, SGLang 0.5.18 container:

| Suite | Result |
|---|---|
| new planner + runner wiring | 23 passed |
| `test_ipc_weights.py` | 46 passed |
| pipeline, mps, config, serve, model_runner, utils | 1477 passed, 0 failed |

Failing before: reverting `mp_runner.py` to main fails 7 of 8 wiring tests (the `weight_share=off` test still passes); re-gating cleanup on MPS fails `test_cancelling_startup_without_mps_still_reaps_the_children`.

GPU, one H200, MOSS TTS local, two same-GPU replicas, `--mps auto`, `tests/test_ci/test_weight_share_native.py` (2/2 pass):

| `weight_share` | Card memory after boot + 4 requests |
|---|---:|
| off | 39897 MiB |
| on | 31207 MiB |
| saved | 8690 MiB |

The saving matches the leader's export (`321 CUDA tensors, 8.44 GiB shared zero-copy`). The run also asserts the leader exported before the follower spawned, and a second case kills the leader and requires the pipeline to fail. Not covered: per-replica request attribution. Throughput is unchanged by design.

## Checklist

- [x] Format your code according with pre-commit.
- [x] Add unit tests.
- [x] Update documentation / docstrings / example tutorials as needed.
- [x] Provide throughput / latency benchmark results and accuracy evaluation results as needed.
- [ ] For reviewers: If you haven't made any contributions to this PR and are only assisting with merging the main branch, please remove yourself as a co-author when merging the PR.
