### PR TITLE
docs: quiet captured hf downloads

### DIFF
--- a/benchmarks/eval/benchmark_asr_seedtts.py
+++ b/benchmarks/eval/benchmark_asr_seedtts.py
@@ -15,8 +15,11 @@ Usage:
     python -m benchmarks.dataset.prepare --dataset seedtts
 
     2. Pin and launch Qwen3-ASR:
-    MODEL_PATH=$(hf download Qwen/Qwen3-ASR-1.7B \
-        --revision 7278e1e70fe206f11671096ffdd38061171dd6e5)
+    MODEL_PATH="$(
+      hf download Qwen/Qwen3-ASR-1.7B \
+        --revision 7278e1e70fe206f11671096ffdd38061171dd6e5 \
+        --quiet
+    )"
     sgl-omni serve \
         --model-path "${MODEL_PATH}" \
         --model-name Qwen/Qwen3-ASR-1.7B \

--- a/docs/cookbook/qwen3_asr.md
+++ b/docs/cookbook/qwen3_asr.md
@@ -10,7 +10,11 @@ Install `sglang-omni` by following [Installation](../get_started/installation.md
 
 ```bash
 MODEL_REVISION=7278e1e70fe206f11671096ffdd38061171dd6e5
-MODEL_PATH=$(hf download Qwen/Qwen3-ASR-1.7B --revision "${MODEL_REVISION}")
+MODEL_PATH="$(
+  hf download Qwen/Qwen3-ASR-1.7B \
+    --revision "${MODEL_REVISION}" \
+    --quiet
+)"
 ```
 
 ### Apple Silicon (MLX)

--- a/docs/cookbook/voxtral_tts.md
+++ b/docs/cookbook/voxtral_tts.md
@@ -71,7 +71,8 @@ The available voices ship inside the checkpoint as `voice_embedding/*.pt` files.
 from your downloaded snapshot:
 
 ```bash
-ls "$(hf download mistralai/Voxtral-4B-TTS-2603)/voice_embedding"
+MODEL_PATH="$(hf download mistralai/Voxtral-4B-TTS-2603 --quiet)"
+ls "${MODEL_PATH}/voice_embedding"
 ```
 
 #### Python

--- a/docs/cookbook/whisper_asr.md
+++ b/docs/cookbook/whisper_asr.md
@@ -186,7 +186,11 @@ To reproduce the async-decode comparison below, resolve the pinned checkpoint an
 
 ```bash
 MODEL_REVISION=06f233fe06e710322aca913c1bc4249a0d71fce1
-MODEL_PATH=$(hf download openai/whisper-large-v3 --revision "$MODEL_REVISION")
+MODEL_PATH="$(
+  hf download openai/whisper-large-v3 \
+    --revision "$MODEL_REVISION" \
+    --quiet
+)"
 
 CUDA_VISIBLE_DEVICES=0 sgl-omni serve \
   --model-path "$MODEL_PATH" \


### PR DESCRIPTION
## Motivation

Captured `hf download` output can include CLI status text unless `--quiet` is used. That can make `MODEL_PATH` contain more than the downloaded snapshot path and break copied cookbook and benchmark reproduction commands.

## Modifications

- Add `--quiet` to the captured Qwen3-ASR and Whisper downloads.
- Quote the multiline `MODEL_PATH` command substitutions.
- Resolve Voxtral into `MODEL_PATH` before listing `voice_embedding`.
- Apply the Qwen3-ASR fix to the duplicated SeedTTS benchmark example.

## Related Issues

#1893 

## Accuracy Test

N/A — documentation and reproduction-command changes only; no inference code changed.

## Benchmark & Profiling

N/A — no runtime or performance code changed.

## Checklist

- [x] Format your code according with pre-commit.
- [ ] Add unit tests. (N/A: command/documentation-only change)
- [x] Update documentation / docstrings / example tutorials as needed.
- [ ] Provide throughput / latency benchmark results and accuracy evaluation results as needed. (N/A)

## Validation

- `hf --version`: `1.28.0`
- Ran `hf download ... --quiet` for Qwen3-ASR and Whisper at their documented pinned revisions and for Voxtral at the current revision.
- Verified each captured value is a single local directory path with no `Downloaded path:` or ANSI status text.
- Verified `voice_embedding` exists and can be listed for Voxtral.
- `rg '\\$\\(hf download' docs benchmarks` reports only the safe Voxtral substitution, which includes `--quiet`; the other affected substitutions are multiline and also include `--quiet`.
- `python -m compileall -q benchmarks/eval/benchmark_asr_seedtts.py`
- `git diff --check`
- Shell syntax checks for the edited cookbook snippets.

No model inference test was run because this PR only changes download-path capture examples.