### PR TITLE
[CI] Add Qwen3-Omni stage 11 for process-replica smoke test

### DIFF
--- a/.github/workflows/test-qwen3-omni-ci.yaml
+++ b/.github/workflows/test-qwen3-omni-ci.yaml
@@ -29,7 +29,7 @@ env:
 #   stage-1-thinker -> stage-2-tts -> stage-3-mmmu -> stage-4-mmmu-talker
 #     -> stage-5-mmsu -> stage-6-mmsu-talker -> stage-7-videomme
 #     -> stage-8-videomme-talker -> stage-9-videoamme
-#     -> stage-10-videoamme-talker-tp2
+#     -> stage-10-videoamme-talker-tp2 -> stage-11-process-replicas
 
 jobs:
   stage-1-thinker:
@@ -501,3 +501,45 @@ jobs:
             */videoamme_audio*/videoamme_results.json
           artifact-upload-name: qwen3-omni-videoamme-talker-tp2-results
           artifact-upload-path: /tmp/**/videoamme_audio*/videoamme_results.json
+
+  stage-11-process-replicas:
+    name: stage 11 - process replicas
+    needs: stage-10-videoamme-talker-tp2
+    if: always() && !cancelled()
+    runs-on: [self-hosted, h100]
+    timeout-minutes: 30
+    container:
+      image: hongccc/sglang-omni@sha256:02a85f00438c901c72a2eb2ef738974a807f63af3d13084445604f3344067b19
+      options: >-
+        --rm
+        -e NVIDIA_VISIBLE_DEVICES
+        -e OMNI_CI_CPUSET
+        --cap-add=SYS_PTRACE
+        -v /dev/shm:/dev/shm
+        -v /data/omni-ci:/data/omni-ci
+        -v /data/cache/huggingface:/github/home/.cache/huggingface
+        -v /data/cache/huggingface:/root/.cache/huggingface
+    steps:
+      - name: Checkout code
+        uses: actions/checkout@v4
+
+      - uses: ./.github/actions/omni-setup
+        with:
+          venv-name: omni
+
+      - name: Run process-replica smoke test
+        shell: bash
+        run: |
+          source omni/bin/activate
+          export PYTHONPATH=$PWD
+          bash .github/scripts/run_flaky_pytest.sh \
+            pytest tests/test_model/test_qwen3_omni_process_replicas.py -v -s -x
+        env:
+          HF_ENDPOINT: https://huggingface.co
+          TORCHINDUCTOR_CACHE_DIR: ${{ env.OMNI_CI_HOME }}/.torchinductor
+
+      - name: Post-stage cleanup
+        if: always()
+        uses: ./.github/actions/omni-post-stage
+        with:
+          stage-label: process replicas

--- a/examples/configs/qwen3_omni_speech_code2wav_replica2_ci.yaml
+++ b/examples/configs/qwen3_omni_speech_code2wav_replica2_ci.yaml
@@ -18,8 +18,6 @@ stages:
     gpu_memory_fraction: 0.02
   audio_encoder:
     gpu_memory_fraction: 0.02
-  mm_aggregate:
-    gpu_memory_fraction: 0.02
   thinker:
     gpu_memory_fraction: 0.78
   talker_ar:

--- a/examples/configs/qwen3_omni_speech_code2wav_replica2_ci.yaml
+++ b/examples/configs/qwen3_omni_speech_code2wav_replica2_ci.yaml
@@ -13,33 +13,16 @@ processes:
     num_replicas: 2
     replica_devices: [0, 1]
 
-stage_overrides:
+stages:
   image_encoder:
-    runtime:
-      resources:
-        total_gpu_memory_fraction: 0.02
-
+    gpu_memory_fraction: 0.02
   audio_encoder:
-    runtime:
-      resources:
-        total_gpu_memory_fraction: 0.02
-
+    gpu_memory_fraction: 0.02
   mm_aggregate:
-    runtime:
-      resources:
-        total_gpu_memory_fraction: 0.02
-
+    gpu_memory_fraction: 0.02
   thinker:
-    runtime:
-      resources:
-        total_gpu_memory_fraction: 0.78
-
+    gpu_memory_fraction: 0.78
   talker_ar:
-    runtime:
-      resources:
-        total_gpu_memory_fraction: 0.10
-
+    gpu_memory_fraction: 0.10
   code2wav:
-    runtime:
-      resources:
-        total_gpu_memory_fraction: 0.02
+    gpu_memory_fraction: 0.02

--- a/examples/configs/qwen3_omni_speech_replica2.yaml
+++ b/examples/configs/qwen3_omni_speech_replica2.yaml
@@ -25,16 +25,12 @@ config_cls: Qwen3OmniSpeechPipelineConfig
 name: qwen3-omni-speech-replica2
 model_path: Qwen/Qwen3-Omni-30B-A3B-Instruct
 
-stage_overrides:
+stages:
   talker_ar:
-    runtime:
-      resources:
-        total_gpu_memory_fraction: 0.123
+    gpu_memory_fraction: 0.123
 
   code2wav:
-    runtime:
-      resources:
-        total_gpu_memory_fraction: 0.014
+    gpu_memory_fraction: 0.014
 
 processes:
   talker_ar:

--- a/tests/test_model/test_qwen3_omni_process_replicas.py
+++ b/tests/test_model/test_qwen3_omni_process_replicas.py
@@ -201,6 +201,7 @@ def test_pcm_equivalence_rejects_samples_outside_tolerance() -> None:
         _assert_pcm_equivalent(baseline, replica)
 
 
+@pytest.mark.benchmark
 @requires_gpus
 def test_every_replica_serves_audio(replica_server, baseline_pcm: np.ndarray):
     port: int = replica_server.port


### PR DESCRIPTION
## Motivation

Spotted that the process-replica smoke test (`tests/test_model/test_qwen3_omni_process_replicas.py`, introduced in #1175) does not actually run in CI. Adding it as CI's Qwen3-Omni stage 11 as confirmed by maintainers.

## Changes

- Add `stage-11-process-replicas` at the tail of the Qwen3-Omni CI serial chain (`needs: stage-10-videoamme-talker-tp2`), same template as the neighboring stages, running `pytest tests/test_model/test_qwen3_omni_process_replicas.py -v -s -x`. `--cap-add=SYS_PTRACE` is kept since this multi-process deployment passes fds between stage processes the same way the TP=2 stage does.
- Mark the main test `@pytest.mark.benchmark` so both unit-test jobs deselect it (removing the misleading SKIPPED) instead of running it — this matches the convention of the other heavyweight Qwen3-Omni tests (e.g. `test_qwen3_omni_videoamme_ci.py`). The two CPU-only helper tests are deliberately left unmarked so they keep running in the CPU unit-test job.

## Cost

Neighboring stages take 2-5 min each, stage 10 (TP=2) takes ~5 min, and the heaviest (stage 2) takes ~16 min (measured on run 33434352481). This test starts two servers sequentially (single-instance baseline + 2-GPU replica deployment) plus 5 audio requests, so ~10-20 min is expected; the job is capped at `timeout-minutes: 30`. We can tighten the cap once the first real run gives us the actual number.