### PR TITLE
[PD] Wire Mooncake prefill/decode disaggregation into OmniScheduler

### DIFF
--- a/sglang_omni/model_runner/model_worker.py
+++ b/sglang_omni/model_runner/model_worker.py
@@ -217,6 +217,10 @@ class ModelWorker:
             kv_pool.size,
         )
 
+    @property
+    def is_hybrid_swa(self) -> bool:
+        return self.model_runner.is_hybrid_swa
+
     def get_tp_group(self):
         return self.model_runner.tp_group
 

--- a/sglang_omni/scheduling/omni_scheduler.py
+++ b/sglang_omni/scheduling/omni_scheduler.py
@@ -25,8 +25,10 @@ from itertools import islice
 from typing import Any, Callable
 
 import torch
+from sglang.srt.disaggregation.utils import DisaggregationMode
 from sglang.srt.environ import envs
 from sglang.srt.layers.dp_attention import compute_dp_attention_world_info
+from sglang.srt.managers.disagg_service import start_disagg_service
 from sglang.srt.managers.io_struct import AbortReq
 from sglang.srt.managers.schedule_batch import (
     FINISH_ABORT,
@@ -412,9 +414,13 @@ class OmniScheduler:
         # Feature flags (all disabled)
         self.enable_lora = False
         self.enable_pdmux = False
+        # Read by upstream init_disaggregation() before it checks the mode.
+        self.enable_unified_memory = False
         self.enable_metrics = server_args.enable_metrics
         self.enable_trace = False
         self.enable_hierarchical_cache = False
+        # Read by upstream process_decode_queue() in decode mode.
+        self.enable_decode_hicache = False
         self.enable_hicache_storage = False
         self.enable_kv_cache_events = False
         self.is_generation = True
@@ -449,9 +455,8 @@ class OmniScheduler:
         self.require_mlp_sync = False
         self.abort_on_priority_when_disabled = False
 
-        # Disaggregation / hybrid (disabled)
-        from sglang.srt.disaggregation.utils import DisaggregationMode
-
+        # Placeholder until init_disaggregation() below installs the real
+        # mode and queues.
         self.disaggregation_mode = DisaggregationMode.NULL
         self.is_hybrid_swa = False
         self.is_hybrid_ssm = False
@@ -467,6 +472,7 @@ class OmniScheduler:
         self.tp_cpu_group = None
         self.attn_tp_group = None
         self.attn_tp_cpu_group = None
+        self.attn_cp_cpu_group = None
         self.cpu_group = None
         self.entry_rank = 0
         self.is_entry_rank = self.tp_rank == 0
@@ -482,6 +488,15 @@ class OmniScheduler:
         self.ipc_channels = _OmniIpcChannels(self)
         self.init_metrics_collector(self.tp_rank, self.pp_rank, self.dp_rank)
         self.init_metrics_reporter(self.tp_rank, self.pp_rank, self.dp_rank)
+        # Upstream starts this in TokenizerManager, which Omni lacks. It must
+        # listen before init_disaggregation() constructs the prefill KV
+        # manager, which registers to it synchronously; None outside PREFILL.
+        self.bootstrap_server = (
+            start_disagg_service(self.server_args) if self.is_entry_rank else None
+        )
+        # Upstream Scheduler method (via __getattr__); installs the real
+        # disaggregation mode and the four disagg_* queues (None in NULL mode).
+        self.init_disaggregation()
         self._init_upstream_scheduler_components()
 
         self._running = False
@@ -646,10 +661,18 @@ class OmniScheduler:
             get_waiting_queue=lambda: self.waiting_queue,
             get_stats=lambda: self.metrics_reporter.stats,
             get_chunked_req=lambda: self.chunked_req,
-            get_disagg_prefill_bootstrap_queue=lambda: empty_queue,
-            get_disagg_prefill_inflight_queue=lambda: [],
-            get_disagg_decode_prealloc_queue=lambda: empty_queue,
-            get_disagg_decode_transfer_queue=lambda: empty_queue,
+            get_disagg_prefill_bootstrap_queue=lambda: (
+                self.disagg_prefill_bootstrap_queue or empty_queue
+            ),
+            get_disagg_prefill_inflight_queue=lambda: (
+                self.disagg_prefill_inflight_queue or []
+            ),
+            get_disagg_decode_prealloc_queue=lambda: (
+                self.disagg_decode_prealloc_queue or empty_queue
+            ),
+            get_disagg_decode_transfer_queue=lambda: (
+                self.disagg_decode_transfer_queue or empty_queue
+            ),
             get_spec_total_num_accept_tokens=lambda: (
                 self.metrics_reporter.spec_total_num_accept_tokens
             ),
@@ -749,6 +772,11 @@ class OmniScheduler:
         self.tp_cpu_group = self.tp_group.cpu_group
         self.attn_tp_group = tp_worker.get_attention_tp_group()
         self.attn_tp_cpu_group = tp_worker.get_attention_tp_cpu_group()
+        if self.attn_cp_size != 1:
+            raise NotImplementedError("OmniScheduler does not support attn_cp_size > 1")
+        # With cp_size == 1, the disagg CP all-reduce is a no-op over values
+        # already reduced across the TP group, so the TP group stands in.
+        self.attn_cp_cpu_group = self.attn_tp_cpu_group
 
         if enable_dp_attention:
             self.cpu_group = self.attn_tp_cpu_group
@@ -1178,6 +1206,13 @@ class OmniScheduler:
             if ingress.done and not pending_stream_done:
                 self._mark_stream_done(req_data)
 
+        # PD bootstrap metadata rides in on the generic params dict, keyed by
+        # the same names as the upstream sglang-router contract.
+        disagg_params = payload.request.params or {}
+        req.bootstrap_host = disagg_params.get("bootstrap_host")
+        req.bootstrap_port = disagg_params.get("bootstrap_port")
+        req.bootstrap_room = disagg_params.get("bootstrap_room")
+
         def enqueue_if_live() -> None:
             if req_id in self._aborted_request_ids:
                 return
@@ -1202,7 +1237,16 @@ class OmniScheduler:
             req._coalesce_enqueue_t = time.perf_counter()
             req._omni_terminal_claimed = False
             req._omni_data = req_data
-            self.waiting_queue.append(req)
+            # Disagg workers admit through their role's queue; NULL mode
+            # keeps the plain waiting_queue.
+            if self.disaggregation_mode == DisaggregationMode.PREFILL:
+                self.disagg_prefill_bootstrap_queue.add(
+                    req, self.model_config.num_key_value_heads
+                )
+            elif self.disaggregation_mode == DisaggregationMode.DECODE:
+                self.disagg_decode_prealloc_queue.add(req, is_retracted=False)
+            else:
+                self.waiting_queue.append(req)
 
         if request_admission_lock_held:
             enqueue_if_live()
@@ -1728,7 +1772,19 @@ class OmniScheduler:
         self._running = True
         model_path_status = "error"
         try:
-            if self.enable_async_decode:
+            if self.disaggregation_mode != DisaggregationMode.NULL and (
+                self.enable_overlap or self.enable_async_decode
+            ):
+                raise NotImplementedError(
+                    "PD disaggregation only supports the normal event loop; "
+                    "overlap and async-decode scheduling are not wired up "
+                    "for disagg mode yet."
+                )
+            if self.disaggregation_mode == DisaggregationMode.PREFILL:
+                self._event_loop_normal_disagg_prefill()
+            elif self.disaggregation_mode == DisaggregationMode.DECODE:
+                self._event_loop_normal_disagg_decode()
+            elif self.enable_async_decode:
                 self._event_loop_async_decode()
             elif self.enable_overlap:
                 self._event_loop_overlap()
@@ -2310,6 +2366,91 @@ class OmniScheduler:
             self.last_batch = batch
             if envs.SGLANG_ENABLE_STRICT_MEM_CHECK_DURING_BUSY.get():
                 self.self_check_during_busy()
+
+    def _event_loop_normal_disagg_prefill(self) -> None:
+        """_event_loop_normal with batch selection and post-batch bookkeeping
+        going through the upstream disagg-prefill state machine."""
+        while self._running:
+            self._process_admin_requests()
+            recv_reqs = self.recv_requests()
+            recv_reqs.extend(self._take_deferred_request_payloads())
+            self.process_input_requests(recv_reqs)
+            if self._engine_paused:
+                self._process_admin_requests()
+                time.sleep(0.001)
+                continue
+
+            # Only requests whose KV-sender handshake with the decode side
+            # completed are eligible for batch selection.
+            self.waiting_queue.extend(
+                self.disagg_prefill_bootstrap_queue.pop_bootstrapped()
+            )
+
+            plan = self.get_next_disagg_prefill_batch_to_run(
+                running_batch=self.running_batch, last_batch=self.last_batch
+            )
+            self.running_batch = plan.running_batch
+            batch = plan.batch_to_run
+            # The disagg selectors skip prepare_for_forward(); apply it here.
+            batch = self.ngram_embedding_manager.prepare_for_forward(
+                batch, chunked_req=self.chunked_req
+            )
+            self.cur_batch = batch
+            self.cur_batch_for_debug = batch
+
+            if batch:
+                result = self.run_batch(batch)
+                if result is not _FAILED_BATCH_RESULT:
+                    self.process_batch_result(batch, result)
+            else:
+                self._sched_idled = True
+                self.self_check_during_idle()
+                self._sleep_during_idle()
+
+            # A finished forward only starts the KV send; poll so completed
+            # transfers free their requests even on batchless iterations.
+            self.process_disagg_prefill_inflight_queue()
+            self.last_batch = batch
+
+    def _event_loop_normal_disagg_decode(self) -> None:
+        """_event_loop_normal with batch selection and pre-batch bookkeeping
+        going through the upstream disagg-decode state machine."""
+        while self._running:
+            self._process_admin_requests()
+            recv_reqs = self.recv_requests()
+            recv_reqs.extend(self._take_deferred_request_payloads())
+            self.process_input_requests(recv_reqs)
+            if self._engine_paused:
+                self._process_admin_requests()
+                time.sleep(0.001)
+                continue
+
+            # Polls in-flight KV receives and advances finished requests
+            # through the prealloc and transfer queues.
+            self.process_decode_queue()
+
+            plan = self.get_next_disagg_decode_batch_to_run(
+                running_batch=self.running_batch
+            )
+            self.running_batch = plan.running_batch
+            batch = plan.batch_to_run
+            # The disagg selectors skip prepare_for_forward(); apply it here.
+            batch = self.ngram_embedding_manager.prepare_for_forward(
+                batch, chunked_req=self.chunked_req
+            )
+            self.cur_batch = batch
+            self.cur_batch_for_debug = batch
+
+            if batch:
+                result = self.run_batch(batch)
+                if result is not _FAILED_BATCH_RESULT:
+                    self.process_batch_result(batch, result)
+            else:
+                self._sched_idled = True
+                self.self_check_during_idle()
+                self._sleep_during_idle()
+
+            self.last_batch = batch
 
     def _event_loop_overlap(self) -> None:
         # Model runners read Req.inflight_middle_chunks at forward time under

--- a/sglang_omni/serve/openai_api.py
+++ b/sglang_omni/serve/openai_api.py
@@ -982,6 +982,9 @@ def _build_chat_generate_request(req: ChatCompletionRequest) -> GenerateRequest:
         ("talker_top_k", req.talker_top_k),
         ("talker_repetition_penalty", req.talker_repetition_penalty),
         ("talker_max_new_tokens", req.talker_max_new_tokens),
+        ("bootstrap_host", req.bootstrap_host),
+        ("bootstrap_port", req.bootstrap_port),
+        ("bootstrap_room", req.bootstrap_room),
     ):
         if value is not None:
             extra_params[field_name] = value

--- a/sglang_omni/serve/protocol.py
+++ b/sglang_omni/serve/protocol.py
@@ -94,6 +94,12 @@ class ChatCompletionRequest(BaseModel):
     talker_repetition_penalty: float | None = None
     talker_max_new_tokens: int | None = None
 
+    # PD disaggregation: a PD-aware proxy points these at the prefill
+    # instance's bootstrap server plus a room id shared by the paired requests.
+    bootstrap_host: str | None = None
+    bootstrap_port: int | None = None
+    bootstrap_room: int | None = None
+
     # Misc
     request_id: str | None = None
     user: str | None = None

--- a/tests/unit_test/pipeline/test_admin_control.py
+++ b/tests/unit_test/pipeline/test_admin_control.py
@@ -332,10 +332,12 @@ def test_omni_scheduler_flush_cache_has_upstream_idle_compat_fields() -> None:
         grammar_queue=[], clear=lambda: reset_calls.append("grammar")
     )
     scheduler.disaggregation_mode = None
+    scheduler.dllm_manager = SimpleNamespace(any_staging_reqs=lambda: False)
     scheduler.enable_hierarchical_cache = False
     scheduler.tree_cache = SimpleNamespace(reset=lambda: reset_calls.append("tree"))
     scheduler.req_to_token_pool = SimpleNamespace(
-        clear=lambda: reset_calls.append("req_pool")
+        clear=lambda: reset_calls.append("req_pool"),
+        reset_aux_cache_allocator=lambda: None,
     )
     scheduler.token_to_kv_pool_allocator = SimpleNamespace(
         clear=lambda: reset_calls.append("kv_pool")

--- a/tests/unit_test/pipeline/test_scheduler.py
+++ b/tests/unit_test/pipeline/test_scheduler.py
@@ -468,7 +468,7 @@ def test_enqueue_built_request_honors_max_queued_requests(monkeypatch) -> None:
     for req in (first, second):
         OmniScheduler._enqueue_built_request(
             scheduler,
-            SimpleNamespace(request_id=req.rid),
+            SimpleNamespace(request_id=req.rid, request=SimpleNamespace(params=None)),
             False,
             SimpleNamespace(req=req, enforce_request_limits=False),
         )
@@ -1795,9 +1795,12 @@ def test_omni_scheduler_distinguishes_queue_enter_from_prefill_start(
         "sglang_omni.scheduling.omni_scheduler._emit_model_path_start",
         model_path_starts.append,
     )
+    from sglang.srt.disaggregation.utils import DisaggregationMode
+
     scheduler = object.__new__(OmniScheduler)
     scheduler.outbox = Queue()
     scheduler.waiting_queue = []
+    scheduler.disaggregation_mode = DisaggregationMode.NULL
     scheduler._pending_stream_ingress = {}
     scheduler._deferred_request_payloads = {}
     scheduler._dirty_deferred_request_ids = set()
@@ -1918,6 +1921,18 @@ def _construct_omni_scheduler(
         "sglang.srt.runtime_context.get_context",
         lambda: runtime_context,
     )
+    # __init__ calls the real upstream init_disaggregation() unconditionally
+    # (resolved via __getattr__); it reads mode/backend off get_disagg()
+    # instead of server_args directly, even for NULL mode.
+    monkeypatch.setattr(
+        "sglang.srt.managers.scheduler.get_disagg",
+        lambda: SimpleNamespace(
+            disaggregation_mode="null",
+            disaggregation_transfer_backend="mooncake",
+            language_only=False,
+            encoder_transfer_backend="auto",
+        ),
+    )
     tp_worker = SimpleNamespace(
         gpu_id=0,
         tp_rank=0,
@@ -1930,6 +1945,8 @@ def _construct_omni_scheduler(
         device=torch.device("cpu"),
     )
     server_args = SimpleNamespace(
+        disaggregation_mode="null",
+        disaggregation_transfer_backend="mooncake",
         tp_size=1,
         pp_size=1,
         dp_size=1,
@@ -1968,7 +1985,7 @@ def _construct_omni_scheduler(
         req_to_token_pool=None,
         token_to_kv_pool_allocator=None,
         server_args=server_args,
-        model_config=SimpleNamespace(),
+        model_config=SimpleNamespace(hf_config=SimpleNamespace()),
         **kwargs,
     )
 
@@ -2098,6 +2115,15 @@ def test_omni_scheduler_binds_one_execution_bridge_to_any_runner(
         "sglang.srt.runtime_context.get_context",
         lambda: SimpleNamespace(override=_override),
     )
+    monkeypatch.setattr(
+        "sglang.srt.managers.scheduler.get_disagg",
+        lambda: SimpleNamespace(
+            disaggregation_mode="null",
+            disaggregation_transfer_backend="mooncake",
+            language_only=False,
+            encoder_transfer_backend="auto",
+        ),
+    )
 
     observed = []
 
@@ -2125,6 +2151,8 @@ def test_omni_scheduler_binds_one_execution_bridge_to_any_runner(
         device=torch.device("cpu"),
     )
     server_args = SimpleNamespace(
+        disaggregation_mode="null",
+        disaggregation_transfer_backend="mooncake",
         tp_size=1,
         pp_size=1,
         dp_size=1,
@@ -2163,7 +2191,7 @@ def test_omni_scheduler_binds_one_execution_bridge_to_any_runner(
         req_to_token_pool=None,
         token_to_kv_pool_allocator=None,
         server_args=server_args,
-        model_config=SimpleNamespace(),
+        model_config=SimpleNamespace(hf_config=SimpleNamespace()),
         model_runner=None if bind_late else model_runner,
         enable_overlap=enable_overlap,
         enable_async_decode=enable_async_decode,
@@ -2195,6 +2223,8 @@ def test_omni_scheduler_refuses_overlap_with_async_decode(monkeypatch) -> None:
         device=torch.device("cpu"),
     )
     server_args = SimpleNamespace(
+        disaggregation_mode="null",
+        disaggregation_transfer_backend="mooncake",
         tp_size=1,
         pp_size=1,
         dp_size=1,
@@ -2321,9 +2351,12 @@ def test_omni_scheduler_start_closes_active_model_paths(
         "_emit_model_path_end",
         lambda rid, *, status: model_path_ends.append((rid, status)),
     )
+    from sglang.srt.disaggregation.utils import DisaggregationMode
+
     scheduler = object.__new__(OmniScheduler)
     scheduler.enable_async_decode = False
     scheduler.enable_overlap = False
+    scheduler.disaggregation_mode = DisaggregationMode.NULL
     scheduler._prefill_start_done = {"req-1", "req-2"}
     scheduler._prefill_end_done = set()
     scheduler._request_build_executor = None
@@ -2425,9 +2458,12 @@ def test_omni_scheduler_follower_request_builder_errors_do_not_emit() -> None:
 
 def test_omni_scheduler_prepares_custom_request_token_budget() -> None:
     """Preserves upstream max_new_tokens clamping for custom request builders."""
+    from sglang.srt.disaggregation.utils import DisaggregationMode
+
     scheduler = object.__new__(OmniScheduler)
     scheduler.outbox = Queue()
     scheduler.waiting_queue = []
+    scheduler.disaggregation_mode = DisaggregationMode.NULL
     scheduler._pending_stream_ingress = {}
     scheduler._deferred_request_payloads = {}
     scheduler._dirty_deferred_request_ids = set()
@@ -2463,9 +2499,12 @@ def test_omni_scheduler_prepares_custom_request_token_budget() -> None:
 
 def test_omni_scheduler_clamps_request_to_strict_prefill_budget() -> None:
     """Clamp requests that pass the surface KV check but cannot be prefetched."""
+    from sglang.srt.disaggregation.utils import DisaggregationMode
+
     scheduler = object.__new__(OmniScheduler)
     scheduler.outbox = Queue()
     scheduler.waiting_queue = []
+    scheduler.disaggregation_mode = DisaggregationMode.NULL
     scheduler._pending_stream_ingress = {}
     scheduler._deferred_request_payloads = {}
     scheduler._dirty_deferred_request_ids = set()
@@ -2637,9 +2676,12 @@ def test_omni_scheduler_follower_rejections_do_not_emit_errors() -> None:
 
 def test_omni_scheduler_leaves_request_budget_unchanged_without_opt_in() -> None:
     """Keeps existing OmniScheduler users on their original request semantics."""
+    from sglang.srt.disaggregation.utils import DisaggregationMode
+
     scheduler = object.__new__(OmniScheduler)
     scheduler.outbox = Queue()
     scheduler.waiting_queue = []
+    scheduler.disaggregation_mode = DisaggregationMode.NULL
     scheduler._pending_stream_ingress = {}
     scheduler._deferred_request_payloads = {}
     scheduler._dirty_deferred_request_ids = set()

--- a/tests/unit_test/pipeline/test_stage.py
+++ b/tests/unit_test/pipeline/test_stage.py
@@ -9,6 +9,7 @@ import threading
 
 import pytest
 import torch
+from sglang.srt.disaggregation.utils import DisaggregationMode
 
 import sglang_omni.platforms as platforms
 from sglang_omni.comm import stage_io
@@ -280,6 +281,7 @@ def test_stage_stop_waits_for_scheduler_model_path_terminalization(
         )
 
         scheduler = object.__new__(OmniScheduler)
+        scheduler.disaggregation_mode = DisaggregationMode.NULL
         scheduler.enable_async_decode = False
         scheduler.enable_overlap = False
         scheduler._prefill_start_done = {"req-active"}
@@ -329,6 +331,7 @@ def test_stage_stop_warns_but_succeeds_on_a_stuck_scheduler_thread(
         entered = threading.Event()
         release = threading.Event()
         scheduler = object.__new__(OmniScheduler)
+        scheduler.disaggregation_mode = DisaggregationMode.NULL
         scheduler.enable_async_decode = False
         scheduler.enable_overlap = False
         scheduler._prefill_start_done = set()

--- a/tests/unit_test/qwen3_omni/test_talker.py
+++ b/tests/unit_test/qwen3_omni/test_talker.py
@@ -11,6 +11,7 @@ from types import SimpleNamespace
 
 import pytest
 import torch
+from sglang.srt.disaggregation.utils import DisaggregationMode
 from torch import nn
 
 import sglang_omni.models.qwen3_omni.components.talker as talker_module
@@ -1209,6 +1210,7 @@ def _build_state_machine_scheduler(
 ) -> QwenTalkerScheduler:
     """Construct a scheduler with just enough state for process_input_requests."""
     scheduler = object.__new__(QwenTalkerScheduler)
+    scheduler.disaggregation_mode = DisaggregationMode.NULL
     scheduler._enable_partial_start = enable_partial_start
     scheduler._partial_start_min_chunks = partial_start_min_chunks
     scheduler._im_end_token_id = None
@@ -1269,6 +1271,7 @@ def test_process_input_requests_partial_build_state_machine() -> None:
     chunks = [SimpleNamespace(data=torch.tensor([float(i)])) for i in range(5)]
     payload = SimpleNamespace(
         request_id="rid-partial-1",
+        request=SimpleNamespace(params=None),
         prefetched_chunks=list(chunks),
         prefetched_stream_done=False,
     )


### PR DESCRIPTION
## Motivation

Colocating prefill and decode on one engine makes the two phases contend: a long prefill batch stalls every in-flight decode step and inflates TPOT, while decode traffic delays prefill admission and inflates TTFT. Prefill/decode (PD) disaggregation runs the two phases on separate engines and moves the prefilled KV cache between them over a transfer backend, so each role can be scaled, placed, and tuned independently on the hardware that suits it (prefill is compute-bound and bursty, decode is memory-bandwidth-bound and steady).

Upstream sglang already ships a complete PD implementation: per-role admission queues, a bootstrap handshake protocol, a Mooncake-backed KV transfer path, and the batch-selection state machines for both roles. OmniScheduler previously stubbed all of it out (NULL mode, empty disagg queues), so an Omni deployment could not participate in PD at all. This PR makes OmniScheduler a genuine prefill or decode worker by wiring it into the upstream machinery, reusing the existing state machines and transfer stack rather than reimplementing any of it — the whole change is +215/-13 lines across eight files. Speech stages are unaffected by design: the decode instance streams thinker tokens to talker_ar/code2wav exactly as in a non-disaggregated deployment, so PD needs no awareness anywhere outside the thinker's engine flags.

## Modifications

- `OmniScheduler.__init__` starts the Mooncake bootstrap server on the entry rank via upstream `start_disagg_service()`. Upstream starts this in `TokenizerManager`, which Omni does not have; it must be listening before `init_disaggregation()` constructs the prefill-side KV manager, because that manager registers to the bootstrap server synchronously in its own constructor. A reference is kept so the HTTP server (serving `/route` and `/health` for the decode side) is not garbage-collected; it is `None` outside PREFILL mode.
- `OmniScheduler.__init__` calls upstream `init_disaggregation()` (resolved via `__getattr__`), which installs the real disaggregation mode and the four `disagg_*` queues (`None` in NULL mode). The debug-view lambdas fall back to the empty queue only when the real queue is absent.
- Request admission routes disagg workers through their role's queue — the prefill bootstrap queue or the decode prealloc queue — while NULL mode keeps the plain `waiting_queue`, so non-disaggregated deployments take exactly the same code path as before this change.
- Two dedicated event loops, `_event_loop_normal_disagg_prefill` and `_event_loop_normal_disagg_decode`, drive the upstream disagg state machines. The prefill loop admits only requests whose KV-sender handshake completed and polls the in-flight KV-send queue every iteration, because a finished forward only starts the KV send. The decode loop advances KV receives through the prealloc/transfer queues before batch selection. Both apply `prepare_for_forward()` explicitly because the upstream disagg batch selectors skip it. `start()` rejects overlap and async-decode scheduling alongside a disagg mode with `NotImplementedError`, since those execution styles are not wired up for disaggregation yet.
- Upstream compat surface: `enable_unified_memory` / `enable_decode_hicache` flags (read unconditionally by upstream code), `attn_cp_cpu_group` aliased to the attention-TP group behind an `attn_cp_size == 1` guard (the disagg CP all-reduce is then a no-op over values already reduced across the TP group), and a `ModelWorker.is_hybrid_swa` passthrough property.
- `ChatCompletionRequest` gains optional `bootstrap_host` / `bootstrap_port` / `bootstrap_room` fields, threaded through the existing `extra_params` passthrough into `OmniRequest.params` and onto the scheduler `Req`, using the same key names as the upstream sglang-router contract, so an external PD-aware proxy can pair a prefill request with its matching decode request.
- Deployment note: the bootstrap server binds `server_args.host`, so disagg deployments must set `host` to an address reachable from the decode side; the `127.0.0.1` default refuses the `/route` handshake.

## Related Issues

https://github.com/sgl-project/sglang-omni/issues/1760

## Accuracy Test

No model-side code (kernels, architecture, weights) is touched, so the standard accuracy evaluation suite does not apply. End-to-end correctness of the disaggregated path was verified on a 1P1D deployment of Qwen3-Omni-30B-A3B-FP8, with the prefill and decode instances on two dedicated H200 GPUs:

- Short and long prompts (19 to 1218 tokens) return coherent, correct decode output; for example "Explain in one sentence why the sky is blue" yields the expected Rayleigh-scattering answer, and a 1218-token repeated-sentence prompt is correctly summarized by the decode instance.
- Repeated paired requests answer correctly across consecutive bootstrap rooms, confirming the handshake/transfer path is stable and KV is neither corrupted nor leaked across requests.
- The prefill instance returns exactly one token and hands off; the decode instance streams the full completion, matching upstream PD semantics.
- All 123 pipeline unit tests pass (`tests/unit_test/pipeline/`), including new coverage for disagg admission routing and NULL-mode compatibility of the rewired scheduler initialization.

## Benchmark & Profiling

This PR adds a new deployment mode and does not alter the non-disaggregated hot path — every new branch is guarded by `disaggregation_mode`, and NULL mode keeps the original single-queue flow — so no regression benchmark is needed. The KV transfer itself was verified and measured on real RDMA hardware:

- Transport: mooncake's default `rdma` protocol with auto-discovered HCAs (RoCE, 8x mlx5 bond 200 Gb/s ports) and GPUDirect RDMA via `nvidia_peermem`; `MC_FORCE_TCP` was not set, and the transfer-engine logs confirm `Using RDMA transport (RoCE/iWARP)` on both the prefill and the decode side.
- A 1218-token prompt moved ~122 MB of KV over the prefill GPU's mlx5 bond device, measured via the NIC's `port_xmit_data` hardware counters and matching the theoretical KV-cache size for that token count — the transfer goes over RDMA end to end rather than silently falling back to TCP.
- The same pairing was verified earlier over TCP (`MC_FORCE_TCP=1`), so both transports of the upstream Mooncake backend work with OmniScheduler.

## Checklist

- [x] Format your code according with pre-commit.
- [x] Add unit tests.
- [x] Update documentation / docstrings / example tutorials as needed.
- [x] Provide throughput / latency benchmark results and accuracy evaluation results as needed.
- [ ] For reviewers: If you haven't made any contributions to this PR and are only assisting with merging the main branch, please remove yourself as a co-author when merging the PR.