### PR TITLE
[Qwen3-TTS] Enable breakable prefill CUDA graphs by default

### DIFF
--- a/docs/cookbook/qwen3_tts.md
+++ b/docs/cookbook/qwen3_tts.md
@@ -109,6 +109,28 @@ HTTP **503** (`The request queue is full.`) before preprocessing, or later
 if the AR waiting queue or request-build backlog is full. Qwen3-TTS
 defaults to 4 request-build workers with pending depth 16.
 
+### Breakable prefill CUDA graphs
+
+Non-Base checkpoints (CustomVoice, VoiceDesign) default to the breakable
+prefill CUDA-graph backend with a token ladder up to 512:
+
+| Knob | Meaning | Default |
+|---|---|---|
+| `--tts_engine.engine.cuda_graph_backend_prefill` | Prefill graph backend (`breakable` or `eager`) | `breakable` on non-Base, unset on Base |
+| `--tts_engine.engine.cuda_graph_bs_prefill` | Prefill token-count ladder to capture | ladder through `512` |
+| `--tts_engine.engine.cuda_graph_max_bs_prefill` | Cap for the ladder | top of the ladder |
+
+The ladder is sized from the text-only prompt length distribution, and
+under load prefills coalesce into a single extend batch, so it reaches
+well past one prompt's token count. Base checkpoints keep the eager path:
+their prefills also carry reference audio, so the shape distribution
+differs and has not been measured.
+
+Opt out with `--tts_engine.engine.cuda_graph_backend_prefill eager`. The
+default costs extra graph capture during startup. Raising
+`cuda_graph_max_bs_prefill` on its own regrows the default ladder to the
+new cap; declaring `cuda_graph_bs_prefill` yourself keeps your list as is.
+
 Raising `max_running_requests` does **not** automatically raise the waiting
 bound. For a ceiling-32 experiment:
 

--- a/docs/cookbook/qwen3_tts.md
+++ b/docs/cookbook/qwen3_tts.md
@@ -116,22 +116,24 @@ prefill CUDA-graph backend with a token ladder up to 512:
 
 | Knob | Meaning | Default |
 |---|---|---|
-| `--tts_engine.engine.cuda_graph_backend_prefill` | Prefill graph backend (`breakable` or `eager`) | `breakable` on non-Base, unset on Base |
-| `--tts_engine.engine.cuda_graph_bs_prefill` | Prefill token-count ladder to capture | 19-bucket Qwen3-TTS ladder through `512` |
+| `--tts_engine.engine.cuda_graph_backend_prefill` | Prefill graph backend (`breakable` or `disabled`) | `breakable` on CustomVoice, unset elsewhere |
+| `--tts_engine.engine.cuda_graph_bs_prefill` | Prefill token-count ladder to capture | shared ladder through `512`, plus a `1` bucket |
 | `--tts_engine.engine.cuda_graph_max_bs_prefill` | Cap for the ladder | top of the ladder |
 
-The ladder is measured rather than generic. Across 1548 prefills at 10
-and 20 RPS, real extend token counts are p50 8, p90 19, p99 38, max 252,
-and requests coalesce up to 9-deep without pushing the shape past 256, so
-the buckets are dense where the mass is and keep 384/512 as headroom. A
-replay falls back to eager when its padded bucket exceeds twice the real
-token count, so the dense bottom matters: the generic ladder starts at 4
-and steps by 4, which sends every 1-3 token prefill back to eager.
+The default is the shared ladder with one bucket added. A replay falls
+back to eager when its bucket exceeds twice the real token count, and the
+shared ladder starts at 4, so a 1-token prefill lands in bucket 4 and
+misses. Measured over 3203 prefills at 10 and 20 RPS, 1301 of them (40.6%)
+are exactly one token, and they are the only shapes that fall back: 2 and
+3 already replay inside bucket 4. Adding the single `1` bucket takes the
+fallback rate to zero.
 
-Base checkpoints keep the eager path: their prefills also carry reference
-audio, so the shape distribution differs and has not been measured.
+Only CustomVoice takes this default, selected by the checkpoint's
+`tts_model_type`. Base prefills also carry reference audio, so their shape
+distribution differs, and VoiceDesign has not been measured; both keep the
+eager path.
 
-Opt out with `--tts_engine.engine.cuda_graph_backend_prefill eager`. The
+Opt out with `--tts_engine.engine.cuda_graph_backend_prefill disabled`. The
 default costs extra graph capture during startup. Raising
 `cuda_graph_max_bs_prefill` on its own regrows the default ladder to the
 new cap; declaring `cuda_graph_bs_prefill` yourself keeps your list as is.

--- a/docs/cookbook/qwen3_tts.md
+++ b/docs/cookbook/qwen3_tts.md
@@ -117,14 +117,19 @@ prefill CUDA-graph backend with a token ladder up to 512:
 | Knob | Meaning | Default |
 |---|---|---|
 | `--tts_engine.engine.cuda_graph_backend_prefill` | Prefill graph backend (`breakable` or `eager`) | `breakable` on non-Base, unset on Base |
-| `--tts_engine.engine.cuda_graph_bs_prefill` | Prefill token-count ladder to capture | ladder through `512` |
+| `--tts_engine.engine.cuda_graph_bs_prefill` | Prefill token-count ladder to capture | 19-bucket Qwen3-TTS ladder through `512` |
 | `--tts_engine.engine.cuda_graph_max_bs_prefill` | Cap for the ladder | top of the ladder |
 
-The ladder is sized from the text-only prompt length distribution, and
-under load prefills coalesce into a single extend batch, so it reaches
-well past one prompt's token count. Base checkpoints keep the eager path:
-their prefills also carry reference audio, so the shape distribution
-differs and has not been measured.
+The ladder is measured rather than generic. Across 1548 prefills at 10
+and 20 RPS, real extend token counts are p50 8, p90 19, p99 38, max 252,
+and requests coalesce up to 9-deep without pushing the shape past 256, so
+the buckets are dense where the mass is and keep 384/512 as headroom. A
+replay falls back to eager when its padded bucket exceeds twice the real
+token count, so the dense bottom matters: the generic ladder starts at 4
+and steps by 4, which sends every 1-3 token prefill back to eager.
+
+Base checkpoints keep the eager path: their prefills also carry reference
+audio, so the shape distribution differs and has not been measured.
 
 Opt out with `--tts_engine.engine.cuda_graph_backend_prefill eager`. The
 default costs extra graph capture during startup. Raising

--- a/sglang_omni/models/qwen3_tts/config.py
+++ b/sglang_omni/models/qwen3_tts/config.py
@@ -109,6 +109,30 @@ class Qwen3TTSPipelineConfig(PipelineConfig):
         return is_qwen3_tts_base_model(self.model_path)
 
 
+def qwen3_tts_checkpoint_model_type(checkpoint_dir: str) -> str:
+    """Read ``tts_model_type`` from a resolved checkpoint.
+
+    The directory name is not a reliable signal: a Base checkpoint served from
+    a path like ``/srv/checkpoints/current`` carries no marker at all. The
+    config does, and it is the same value the request path validates against.
+    Returns ``"base"`` when the field is absent, matching that path's default.
+    """
+    import json
+    import os
+
+    config_path = os.path.join(checkpoint_dir, "config.json")
+    if not os.path.isfile(config_path):
+        return "base"
+    with open(config_path, encoding="utf-8") as handle:
+        raw = json.load(handle).get("tts_model_type")
+    normalized = str(raw or "base").replace("-", "_").strip().lower()
+    if normalized == "customvoice":
+        return "custom_voice"
+    if normalized == "voicedesign":
+        return "voice_design"
+    return normalized
+
+
 def is_qwen3_tts_base_model(model_path: str) -> bool:
     qwen3_tts_parts = [
         part.replace("-", "_").casefold()

--- a/sglang_omni/models/qwen3_tts/config.py
+++ b/sglang_omni/models/qwen3_tts/config.py
@@ -103,13 +103,13 @@ class Qwen3TTSPipelineConfig(PipelineConfig):
         return kwargs
 
     def requires_uploaded_voice_for_named_voice(self) -> bool:
-        return _is_qwen3_tts_base_model(self.model_path)
+        return is_qwen3_tts_base_model(self.model_path)
 
     def supports_uploaded_voice_references(self) -> bool:
-        return _is_qwen3_tts_base_model(self.model_path)
+        return is_qwen3_tts_base_model(self.model_path)
 
 
-def _is_qwen3_tts_base_model(model_path: str) -> bool:
+def is_qwen3_tts_base_model(model_path: str) -> bool:
     qwen3_tts_parts = [
         part.replace("-", "_").casefold()
         for part in re.split(r"[/\\]+", model_path.strip())

--- a/sglang_omni/models/qwen3_tts/engine_builder.py
+++ b/sglang_omni/models/qwen3_tts/engine_builder.py
@@ -8,6 +8,7 @@ from typing import Any
 
 from sglang_omni.models.qwen3_tts import CAPABILITIES, request_builders
 from sglang_omni.models.qwen3_tts import stages as qwen3_stages
+from sglang_omni.models.qwen3_tts.config import is_qwen3_tts_base_model
 from sglang_omni.scheduling.engine_factory import TtsEngineBuilder
 from sglang_omni.scheduling.generation_batch_policy import (
     CudaGraphBackend,
@@ -45,6 +46,10 @@ class Qwen3TtsEngineBuilder(TtsEngineBuilder):
         self.prefill_coalesce_wait_ms = prefill_coalesce_wait_ms
         self.wrapper: Any | None = None
         self._stream_output_builder: Any | None = None
+        # note (luojiaxuan): the factory assigns this before generation_defaults
+        # runs, but Qwen3TTSPipelineConfig.generation_admission_defaults builds a
+        # bare builder just to read the admission keys, so it needs a value.
+        self.checkpoint_dir: str = ""
 
     def resolve_checkpoint(self, model_path: str) -> str:
         qwen3_stages.apply_qwen_tts_transformers_compatibility_patches()
@@ -64,7 +69,7 @@ class Qwen3TtsEngineBuilder(TtsEngineBuilder):
         *,
         dtype: str,
     ) -> dict[str, Any]:
-        return {
+        defaults: dict[str, Any] = {
             "max_running_requests": 16,
             "max_queued_requests": 16,
             "cuda_graph_max_bs": 32,
@@ -72,17 +77,21 @@ class Qwen3TtsEngineBuilder(TtsEngineBuilder):
             "dtype": dtype,
             "disable_cuda_graph": False,
             "disable_overlap_schedule": True,
-            # note (luojiaxuan): under load, prefills coalesce several requests
-            # into one extend batch, so the ladder must reach well past a single
-            # prompt's token count for graph replays to keep covering them.
-            "cuda_graph_backend_prefill": CudaGraphBackend.BREAKABLE,
-            "cuda_graph_bs_prefill": build_default_prefill_cuda_graph_bs(512),
             "enable_torch_compile": False,
             "mem_fraction_static": 0.85,
             "max_prefill_tokens": 8192,
             "sampling_backend": "pytorch",
             "trust_remote_code": True,
         }
+        if self.checkpoint_dir and not is_qwen3_tts_base_model(self.checkpoint_dir):
+            # note (luojiaxuan): the ladder is sized from the text-only prompt
+            # length distribution, and under load prefills coalesce into one
+            # extend batch, so it must reach well past a single prompt. Base
+            # prefills also carry reference audio, giving them a different shape
+            # distribution, so they keep the eager path until measured.
+            defaults["cuda_graph_backend_prefill"] = CudaGraphBackend.BREAKABLE
+            defaults["cuda_graph_bs_prefill"] = build_default_prefill_cuda_graph_bs(512)
+        return defaults
 
     def setup_model(
         self,

--- a/sglang_omni/models/qwen3_tts/engine_builder.py
+++ b/sglang_omni/models/qwen3_tts/engine_builder.py
@@ -9,6 +9,10 @@ from typing import Any
 from sglang_omni.models.qwen3_tts import CAPABILITIES, request_builders
 from sglang_omni.models.qwen3_tts import stages as qwen3_stages
 from sglang_omni.scheduling.engine_factory import TtsEngineBuilder
+from sglang_omni.scheduling.generation_batch_policy import (
+    CudaGraphBackend,
+    build_default_prefill_cuda_graph_bs,
+)
 
 
 def _is_truthy(value: Any) -> bool:
@@ -68,6 +72,11 @@ class Qwen3TtsEngineBuilder(TtsEngineBuilder):
             "dtype": dtype,
             "disable_cuda_graph": False,
             "disable_overlap_schedule": True,
+            # note (luojiaxuan): under load, prefills coalesce several requests
+            # into one extend batch, so the ladder must reach well past a single
+            # prompt's token count for graph replays to keep covering them.
+            "cuda_graph_backend_prefill": CudaGraphBackend.BREAKABLE,
+            "cuda_graph_bs_prefill": build_default_prefill_cuda_graph_bs(512),
             "enable_torch_compile": False,
             "mem_fraction_static": 0.85,
             "max_prefill_tokens": 8192,

--- a/sglang_omni/models/qwen3_tts/engine_builder.py
+++ b/sglang_omni/models/qwen3_tts/engine_builder.py
@@ -10,9 +10,7 @@ from sglang_omni.models.qwen3_tts import CAPABILITIES, request_builders
 from sglang_omni.models.qwen3_tts import stages as qwen3_stages
 from sglang_omni.models.qwen3_tts.config import is_qwen3_tts_base_model
 from sglang_omni.scheduling.engine_factory import TtsEngineBuilder
-from sglang_omni.scheduling.generation_batch_policy import (
-    CudaGraphBackend,
-)
+from sglang_omni.scheduling.generation_batch_policy import CudaGraphBackend
 
 
 def _is_truthy(value: Any) -> bool:

--- a/sglang_omni/models/qwen3_tts/engine_builder.py
+++ b/sglang_omni/models/qwen3_tts/engine_builder.py
@@ -12,7 +12,6 @@ from sglang_omni.models.qwen3_tts.config import is_qwen3_tts_base_model
 from sglang_omni.scheduling.engine_factory import TtsEngineBuilder
 from sglang_omni.scheduling.generation_batch_policy import (
     CudaGraphBackend,
-    build_default_prefill_cuda_graph_bs,
 )
 
 
@@ -24,6 +23,35 @@ def _is_truthy(value: Any) -> bool:
     if isinstance(value, str):
         return value.strip().lower() in {"1", "true", "yes", "y", "on"}
     return False
+
+
+# note (luojiaxuan): measured from 1548 prefills at 10 and 20 RPS on H100
+# CustomVoice. Real extend token counts are p50=8, p90=19, p99=38, max=252,
+# and requests coalesce up to 9-deep without pushing the shape past 256, so the
+# buckets are dense where the mass is and keep 384/512 only as headroom. The
+# generic ladder starts at 4 and steps by 4, which sends every 1-3 token prefill
+# over the padding factor and back to eager: 39.9% of prefills, against 0% here.
+QWEN3_TTS_PREFILL_CUDA_GRAPH_BS = (
+    1,
+    2,
+    3,
+    4,
+    6,
+    8,
+    12,
+    16,
+    20,
+    24,
+    32,
+    48,
+    64,
+    96,
+    128,
+    192,
+    256,
+    384,
+    512,
+)
 
 
 class Qwen3TtsEngineBuilder(TtsEngineBuilder):
@@ -90,7 +118,7 @@ class Qwen3TtsEngineBuilder(TtsEngineBuilder):
             # prefills also carry reference audio, giving them a different shape
             # distribution, so they keep the eager path until measured.
             defaults["cuda_graph_backend_prefill"] = CudaGraphBackend.BREAKABLE
-            defaults["cuda_graph_bs_prefill"] = build_default_prefill_cuda_graph_bs(512)
+            defaults["cuda_graph_bs_prefill"] = list(QWEN3_TTS_PREFILL_CUDA_GRAPH_BS)
         return defaults
 
     def setup_model(

--- a/sglang_omni/models/qwen3_tts/engine_builder.py
+++ b/sglang_omni/models/qwen3_tts/engine_builder.py
@@ -8,9 +8,12 @@ from typing import Any
 
 from sglang_omni.models.qwen3_tts import CAPABILITIES, request_builders
 from sglang_omni.models.qwen3_tts import stages as qwen3_stages
-from sglang_omni.models.qwen3_tts.config import is_qwen3_tts_base_model
+from sglang_omni.models.qwen3_tts.config import qwen3_tts_checkpoint_model_type
 from sglang_omni.scheduling.engine_factory import TtsEngineBuilder
-from sglang_omni.scheduling.generation_batch_policy import CudaGraphBackend
+from sglang_omni.scheduling.generation_batch_policy import (
+    CudaGraphBackend,
+    build_default_prefill_cuda_graph_bs,
+)
 
 
 def _is_truthy(value: Any) -> bool:
@@ -23,33 +26,14 @@ def _is_truthy(value: Any) -> bool:
     return False
 
 
-# note (luojiaxuan): measured from 1548 prefills at 10 and 20 RPS on H100
-# CustomVoice. Real extend token counts are p50=8, p90=19, p99=38, max=252,
-# and requests coalesce up to 9-deep without pushing the shape past 256, so the
-# buckets are dense where the mass is and keep 384/512 only as headroom. The
-# generic ladder starts at 4 and steps by 4, which sends every 1-3 token prefill
-# over the padding factor and back to eager: 39.9% of prefills, against 0% here.
-QWEN3_TTS_PREFILL_CUDA_GRAPH_BS = (
-    1,
-    2,
-    3,
-    4,
-    6,
-    8,
-    12,
-    16,
-    20,
-    24,
-    32,
-    48,
-    64,
-    96,
-    128,
-    192,
-    256,
-    384,
-    512,
-)
+# note (luojiaxuan): the generic ladder starts at 4, and a replay falls back to
+# eager when its bucket exceeds twice the real token count, so a 1-token prefill
+# lands in bucket 4 and misses. Measured over 3203 prefills at 10 and 20 RPS on
+# H100 CustomVoice, 1301 of them (40.6%) are exactly one token, and they are the
+# only shapes that fall back: 2 and 3 already replay inside bucket 4. Adding the
+# single 1 bucket takes the fallback rate to zero, so the default is the shared
+# ladder plus that bucket rather than a hand-picked list.
+QWEN3_TTS_PREFILL_CUDA_GRAPH_BS = (1,) + tuple(build_default_prefill_cuda_graph_bs(512))
 
 
 class Qwen3TtsEngineBuilder(TtsEngineBuilder):
@@ -109,7 +93,10 @@ class Qwen3TtsEngineBuilder(TtsEngineBuilder):
             "sampling_backend": "pytorch",
             "trust_remote_code": True,
         }
-        if self.checkpoint_dir and not is_qwen3_tts_base_model(self.checkpoint_dir):
+        if (
+            self.checkpoint_dir
+            and qwen3_tts_checkpoint_model_type(self.checkpoint_dir) == "custom_voice"
+        ):
             # note (luojiaxuan): the ladder is sized from the text-only prompt
             # length distribution, and under load prefills coalesce into one
             # extend batch, so it must reach well past a single prompt. Base

--- a/sglang_omni/scheduling/generation_batch_policy.py
+++ b/sglang_omni/scheduling/generation_batch_policy.py
@@ -196,6 +196,18 @@ def build_generation_batch_overrides(
         if not trimmed or trimmed[-1] != cap:
             trimmed.append(cap)
         overrides["cuda_graph_bs_prefill"] = trimmed
+    elif (
+        prefill_bs
+        and int(prefill_max_bs) > max(int(b) for b in prefill_bs)
+        and "cuda_graph_bs_prefill" not in incoming
+    ):
+        # note (luojiaxuan): a stage-supplied ladder has to grow with a raised
+        # operator cap, otherwise the builder default silently bounds the cap
+        # to its own top and the request is lost. A ladder the operator
+        # declared themselves is left alone, since they own both values.
+        overrides["cuda_graph_bs_prefill"] = build_default_prefill_cuda_graph_bs(
+            int(prefill_max_bs)
+        )
 
     return overrides
 

--- a/sglang_omni/scheduling/generation_batch_policy.py
+++ b/sglang_omni/scheduling/generation_batch_policy.py
@@ -202,12 +202,17 @@ def build_generation_batch_overrides(
         and "cuda_graph_bs_prefill" not in incoming
     ):
         # note (luojiaxuan): a stage-supplied ladder has to grow with a raised
-        # operator cap, otherwise the builder default silently bounds the cap
-        # to its own top and the request is lost. A ladder the operator
-        # declared themselves is left alone, since they own both values.
-        overrides["cuda_graph_bs_prefill"] = build_default_prefill_cuda_graph_bs(
-            int(prefill_max_bs)
-        )
+        # operator cap, otherwise the builder default silently bounds the cap to
+        # its own top and the request is lost. Append above the current top
+        # rather than rebuilding: a stage ladder carries buckets the shared one
+        # does not, such as the Qwen3-TTS 1-token bucket and MOSS-TD's small
+        # ones, and rebuilding would drop them. A ladder the operator declared
+        # themselves is left alone, since they own both values.
+        cap = int(prefill_max_bs)
+        current_top = max(int(b) for b in prefill_bs)
+        overrides["cuda_graph_bs_prefill"] = [int(b) for b in prefill_bs] + [
+            b for b in build_default_prefill_cuda_graph_bs(cap) if b > current_top
+        ]
 
     return overrides
 

--- a/tests/test_model/test_qwen3_tts_batch_invariance.py
+++ b/tests/test_model/test_qwen3_tts_batch_invariance.py
@@ -26,6 +26,12 @@ MODEL_PATH = os.environ.get(
     "QWEN3_TTS_TEST_MODEL",
     "Qwen/Qwen3-TTS-12Hz-0.6B-Base",
 )
+CUSTOM_VOICE_MODEL_PATH = os.environ.get(
+    "QWEN3_TTS_TEST_CUSTOM_VOICE_MODEL",
+    "Qwen/Qwen3-TTS-12Hz-1.7B-CustomVoice",
+)
+CUSTOM_VOICE = os.environ.get("QWEN3_TTS_TEST_CUSTOM_VOICE", "Ryan")
+CUSTOM_VOICE_LANGUAGE = os.environ.get("QWEN3_TTS_TEST_CUSTOM_LANGUAGE", "English")
 DATASET = os.environ.get("QWEN3_TTS_TEST_DATASET", DATASETS["seedtts-50"])
 SEED = 123456
 STARTUP_TIMEOUT = 600
@@ -120,17 +126,31 @@ def _payload(sample, *, subtalker_dosample: bool | None = None) -> dict:
     }
 
 
+def _custom_voice_payload(text: str, *, subtalker_dosample: bool | None = None) -> dict:
+    return {
+        "model": CUSTOM_VOICE_MODEL_PATH,
+        "input": text,
+        "voice": CUSTOM_VOICE,
+        "language": CUSTOM_VOICE_LANGUAGE,
+        "response_format": "wav",
+        "seed": SEED,
+        "max_new_tokens": 2048,
+        "stage_params": {"tts_engine": {"subtalker_dosample": subtalker_dosample}},
+    }
+
+
 @contextmanager
 def _qwen3_tts_server(
     tmp_path_factory: pytest.TempPathFactory,
     name: str,
+    model_path: str = MODEL_PATH,
 ) -> Iterator[Qwen3TTSServer]:
     config_path = tmp_path_factory.mktemp(f"qwen3_tts_{name}") / "config.yaml"
     config_path.write_text(
         yaml.safe_dump(
             {
                 "config_cls": "Qwen3TTSPipelineConfig",
-                "model_path": MODEL_PATH,
+                "model_path": model_path,
                 "enable_deterministic_inference": True,
                 "stages": {
                     "tts_engine": {
@@ -151,7 +171,7 @@ def _qwen3_tts_server(
     port = _find_available_port_range(1)
     log_file = tmp_path_factory.mktemp(f"qwen3_tts_{name}_logs") / "server.log"
     with managed_omni_server(
-        model_path=MODEL_PATH,
+        model_path=model_path,
         port=port,
         host="127.0.0.1",
         log_file=log_file,
@@ -230,6 +250,45 @@ def test_qwen3_tts_mixed_sampled_argmax_batch_invariance(
     with _qwen3_tts_server(tmp_path_factory, "b8") as server:
         mixed_b8 = asyncio.run(_generate_batch(server.base_url, payloads))
         _assert_uncached_reference_encode(server.log_file)
+        repeated_b8 = asyncio.run(_generate_batch(server.base_url, [payload] * 8))
+
+    assert mixed_b8 == b1
+    assert all(pcm == b1[0] for pcm in repeated_b1)
+    assert all(pcm == b1[0] for pcm in repeated_b8)
+
+
+@pytest.mark.benchmark
+def test_qwen3_tts_custom_voice_deterministic_batch_invariance(
+    tmp_path_factory: pytest.TempPathFactory,
+) -> None:
+    """Match batch-one and batch-eight on the checkpoints that graph prefill.
+
+    CustomVoice rejects ref_audio, so the Base tests above cannot cover it, yet
+    it is the family that takes the breakable prefill graph by default. Padded
+    graph buckets are the failure mode this guards: a bucket that changes the
+    numerics shows up as a batch-one/batch-eight mismatch.
+    """
+    if not torch.cuda.is_available():
+        pytest.skip("Qwen3-TTS batch invariance requires CUDA")
+    if not Path(DATASET).exists():
+        download_dataset(DATASET, quiet=True)
+
+    payloads = []
+    for sample in load_seedtts_samples(DATASET, 8, split="en"):
+        payloads.append(_custom_voice_payload(" ".join([sample.target_text] * 3)))
+    assert len({payload["input"] for payload in payloads}) == 8
+
+    payload = payloads[0]
+    with _qwen3_tts_server(
+        tmp_path_factory, "cv-b1", model_path=CUSTOM_VOICE_MODEL_PATH
+    ) as server:
+        b1 = asyncio.run(_generate_serial(server.base_url, payloads))
+        repeated_b1 = asyncio.run(_generate_serial(server.base_url, [payload] * 2))
+
+    with _qwen3_tts_server(
+        tmp_path_factory, "cv-b8", model_path=CUSTOM_VOICE_MODEL_PATH
+    ) as server:
+        mixed_b8 = asyncio.run(_generate_batch(server.base_url, payloads))
         repeated_b8 = asyncio.run(_generate_batch(server.base_url, [payload] * 8))
 
     assert mixed_b8 == b1

--- a/tests/test_model/test_qwen3_tts_batch_invariance.py
+++ b/tests/test_model/test_qwen3_tts_batch_invariance.py
@@ -14,6 +14,7 @@ from typing import NamedTuple
 
 import aiohttp
 import pytest
+import requests
 import torch
 import yaml
 
@@ -124,6 +125,21 @@ def _payload(sample, *, subtalker_dosample: bool | None = None) -> dict:
         "max_new_tokens": 2048,
         "stage_params": {"tts_engine": {"subtalker_dosample": subtalker_dosample}},
     }
+
+
+def _tts_engine_prefill_graph_info(base_url: str) -> dict:
+    """Read the resolved prefill-graph state from the running engine stage."""
+    response = requests.post(
+        f"{base_url}/model_info",
+        json={"stages": ["tts_engine"], "timeout_s": 30},
+        timeout=60,
+    )
+    response.raise_for_status()
+    payload = response.json()
+    items = [item for item in payload["stages"] if item.get("stage") == "tts_engine"]
+    assert len(items) == 1, payload
+    assert items[0]["success"], items[0]
+    return items[0]["data"]["prefill_cuda_graph"]
 
 
 def _custom_voice_payload(text: str, *, subtalker_dosample: bool | None = None) -> dict:
@@ -284,6 +300,12 @@ def test_qwen3_tts_custom_voice_deterministic_batch_invariance(
     ) as server:
         b1 = asyncio.run(_generate_serial(server.base_url, payloads))
         repeated_b1 = asyncio.run(_generate_serial(server.base_url, [payload] * 2))
+        # PCM equality alone stays green when the feature is absent: a stage
+        # default that fails eligibility degrades to eager with a warning. Pin
+        # that the graphs actually captured and replayed.
+        info = _tts_engine_prefill_graph_info(server.base_url)
+        assert info["backend"] == "breakable", info
+        assert info["replay_count"] > 0, info
 
     with _qwen3_tts_server(
         tmp_path_factory, "cv-b8", model_path=CUSTOM_VOICE_MODEL_PATH

--- a/tests/unit_test/qwen3_tts/test_pipeline.py
+++ b/tests/unit_test/qwen3_tts/test_pipeline.py
@@ -299,10 +299,13 @@ def test_qwen3_tts_deterministic_inference_configures_pipeline() -> None:
     assert vocoder["followup_cuda_graph"] is False
 
 
-def test_qwen3_tts_breakable_prefill_is_compatible_but_not_default_enabled() -> None:
-    """Compatibility permits explicit opt-in without changing shipped defaults."""
+def test_qwen3_tts_breakable_prefill_enabled_by_default() -> None:
     from sglang_omni.models.qwen3_tts import CAPABILITIES
     from sglang_omni.models.qwen3_tts.engine_builder import Qwen3TtsEngineBuilder
+    from sglang_omni.scheduling.generation_batch_policy import (
+        CudaGraphBackend,
+        build_default_prefill_cuda_graph_bs,
+    )
 
     builder = Qwen3TtsEngineBuilder()
     defaults = builder.generation_defaults(dtype="bfloat16")
@@ -312,8 +315,8 @@ def test_qwen3_tts_breakable_prefill_is_compatible_but_not_default_enabled() -> 
         type(builder).supports_breakable_prefill_cuda_graph
         is CAPABILITIES.supports_breakable_prefill_cuda_graph
     )
-    assert "cuda_graph_backend_prefill" not in defaults
-    assert "cuda_graph_bs_prefill" not in defaults
+    assert defaults["cuda_graph_backend_prefill"] is CudaGraphBackend.BREAKABLE
+    assert defaults["cuda_graph_bs_prefill"] == build_default_prefill_cuda_graph_bs(512)
     assert defaults["disable_cuda_graph"] is False
 
 

--- a/tests/unit_test/qwen3_tts/test_pipeline.py
+++ b/tests/unit_test/qwen3_tts/test_pipeline.py
@@ -301,11 +301,11 @@ def test_qwen3_tts_deterministic_inference_configures_pipeline() -> None:
 
 def test_qwen3_tts_breakable_prefill_enabled_by_default() -> None:
     from sglang_omni.models.qwen3_tts import CAPABILITIES
-    from sglang_omni.models.qwen3_tts.engine_builder import Qwen3TtsEngineBuilder
-    from sglang_omni.scheduling.generation_batch_policy import (
-        CudaGraphBackend,
-        build_default_prefill_cuda_graph_bs,
+    from sglang_omni.models.qwen3_tts.engine_builder import (
+        QWEN3_TTS_PREFILL_CUDA_GRAPH_BS,
+        Qwen3TtsEngineBuilder,
     )
+    from sglang_omni.scheduling.generation_batch_policy import CudaGraphBackend
 
     builder = Qwen3TtsEngineBuilder()
     builder.checkpoint_dir = "/models/Qwen3-TTS-12Hz-1.7B-CustomVoice"
@@ -317,7 +317,10 @@ def test_qwen3_tts_breakable_prefill_enabled_by_default() -> None:
         is CAPABILITIES.supports_breakable_prefill_cuda_graph
     )
     assert defaults["cuda_graph_backend_prefill"] is CudaGraphBackend.BREAKABLE
-    assert defaults["cuda_graph_bs_prefill"] == build_default_prefill_cuda_graph_bs(512)
+    assert defaults["cuda_graph_bs_prefill"] == list(QWEN3_TTS_PREFILL_CUDA_GRAPH_BS)
+    # Every 1-3 token prefill must have an exact bucket: the generic ladder
+    # starts at 4 and sends them over the padding factor back to eager.
+    assert defaults["cuda_graph_bs_prefill"][:4] == [1, 2, 3, 4]
     assert defaults["disable_cuda_graph"] is False
 
 

--- a/tests/unit_test/qwen3_tts/test_pipeline.py
+++ b/tests/unit_test/qwen3_tts/test_pipeline.py
@@ -4,11 +4,13 @@ from __future__ import annotations
 
 import asyncio
 import inspect
+import json
 import sys
 import threading
 import time
 import types
 from collections import deque
+from pathlib import Path
 from queue import Empty, Queue
 from types import SimpleNamespace
 
@@ -299,16 +301,19 @@ def test_qwen3_tts_deterministic_inference_configures_pipeline() -> None:
     assert vocoder["followup_cuda_graph"] is False
 
 
-def test_qwen3_tts_breakable_prefill_enabled_by_default() -> None:
+def test_qwen3_tts_breakable_prefill_enabled_by_default(tmp_path: Path) -> None:
     from sglang_omni.models.qwen3_tts import CAPABILITIES
     from sglang_omni.models.qwen3_tts.engine_builder import (
         QWEN3_TTS_PREFILL_CUDA_GRAPH_BS,
         Qwen3TtsEngineBuilder,
     )
-    from sglang_omni.scheduling.generation_batch_policy import CudaGraphBackend
+    from sglang_omni.scheduling.generation_batch_policy import (
+        CudaGraphBackend,
+        build_default_prefill_cuda_graph_bs,
+    )
 
     builder = Qwen3TtsEngineBuilder()
-    builder.checkpoint_dir = "/models/Qwen3-TTS-12Hz-1.7B-CustomVoice"
+    builder.checkpoint_dir = _qwen3_tts_checkpoint(tmp_path, "custom_voice")
     defaults = builder.generation_defaults(dtype="bfloat16")
 
     assert CAPABILITIES.supports_breakable_prefill_cuda_graph is True
@@ -318,30 +323,52 @@ def test_qwen3_tts_breakable_prefill_enabled_by_default() -> None:
     )
     assert defaults["cuda_graph_backend_prefill"] is CudaGraphBackend.BREAKABLE
     assert defaults["cuda_graph_bs_prefill"] == list(QWEN3_TTS_PREFILL_CUDA_GRAPH_BS)
-    # Every 1-3 token prefill must have an exact bucket: the generic ladder
-    # starts at 4 and sends them over the padding factor back to eager.
-    assert defaults["cuda_graph_bs_prefill"][:4] == [1, 2, 3, 4]
+    # A 1-token prefill is the only shape the shared ladder sends back to eager,
+    # so the 1 bucket is what this default adds; 2 and 3 replay inside bucket 4.
+    ladder = defaults["cuda_graph_bs_prefill"]
+    assert ladder[0] == 1
+    assert ladder[1:] == build_default_prefill_cuda_graph_bs(512)
+    assert all(
+        next(b for b in ladder if b >= tokens) <= 2 * tokens for tokens in (1, 2, 3, 4)
+    )
     assert defaults["disable_cuda_graph"] is False
 
 
-def test_qwen3_tts_breakable_prefill_is_scoped_to_measured_checkpoints() -> None:
-    """Base prefills carry reference audio, so they keep the eager path."""
+def _qwen3_tts_checkpoint(tmp_path: Path, model_type: str | None) -> str:
+    """A checkpoint dir carrying only what the builder reads."""
+    directory = tmp_path / (model_type or "unmarked")
+    directory.mkdir(parents=True, exist_ok=True)
+    config = {} if model_type is None else {"tts_model_type": model_type}
+    (directory / "config.json").write_text(json.dumps(config), encoding="utf-8")
+    return str(directory)
+
+
+def test_qwen3_tts_breakable_prefill_is_scoped_to_the_measured_checkpoint(
+    tmp_path: Path,
+) -> None:
+    """Only CustomVoice was measured, and the signal is the config not the path."""
     from sglang_omni.models.qwen3_tts.engine_builder import Qwen3TtsEngineBuilder
 
-    base = Qwen3TtsEngineBuilder()
-    base.checkpoint_dir = "/models/Qwen3-TTS-12Hz-1.7B-Base"
-    base_defaults = base.generation_defaults(dtype="bfloat16")
-    assert "cuda_graph_backend_prefill" not in base_defaults
-    assert "cuda_graph_bs_prefill" not in base_defaults
+    def _defaults(model_type: str | None) -> dict:
+        builder = Qwen3TtsEngineBuilder()
+        builder.checkpoint_dir = _qwen3_tts_checkpoint(tmp_path, model_type)
+        return builder.generation_defaults(dtype="bfloat16")
+
+    assert "cuda_graph_backend_prefill" in _defaults("custom_voice")
+    for model_type in ("base", "voice_design", None):
+        assert "cuda_graph_backend_prefill" not in _defaults(model_type), model_type
+
+    # A directory name carries no signal: this Base checkpoint has none.
+    unnamed = Qwen3TtsEngineBuilder()
+    unnamed.checkpoint_dir = _qwen3_tts_checkpoint(tmp_path / "srv", "base")
+    assert "cuda_graph_backend_prefill" not in unnamed.generation_defaults(
+        dtype="bfloat16"
+    )
 
     # The admission-defaults path builds a bare builder with no checkpoint.
     bare = Qwen3TtsEngineBuilder().generation_defaults(dtype="bfloat16")
     assert "cuda_graph_backend_prefill" not in bare
     assert bare["max_running_requests"] == 16
-
-    design = Qwen3TtsEngineBuilder()
-    design.checkpoint_dir = "/models/Qwen3-TTS-12Hz-1.7B-VoiceDesign"
-    assert "cuda_graph_backend_prefill" in design.generation_defaults(dtype="bfloat16")
 
 
 def test_qwen3_tts_breakable_prefill_breaks_around_qk_norm_rope(

--- a/tests/unit_test/qwen3_tts/test_pipeline.py
+++ b/tests/unit_test/qwen3_tts/test_pipeline.py
@@ -308,6 +308,7 @@ def test_qwen3_tts_breakable_prefill_enabled_by_default() -> None:
     )
 
     builder = Qwen3TtsEngineBuilder()
+    builder.checkpoint_dir = "/models/Qwen3-TTS-12Hz-1.7B-CustomVoice"
     defaults = builder.generation_defaults(dtype="bfloat16")
 
     assert CAPABILITIES.supports_breakable_prefill_cuda_graph is True
@@ -318,6 +319,26 @@ def test_qwen3_tts_breakable_prefill_enabled_by_default() -> None:
     assert defaults["cuda_graph_backend_prefill"] is CudaGraphBackend.BREAKABLE
     assert defaults["cuda_graph_bs_prefill"] == build_default_prefill_cuda_graph_bs(512)
     assert defaults["disable_cuda_graph"] is False
+
+
+def test_qwen3_tts_breakable_prefill_is_scoped_to_measured_checkpoints() -> None:
+    """Base prefills carry reference audio, so they keep the eager path."""
+    from sglang_omni.models.qwen3_tts.engine_builder import Qwen3TtsEngineBuilder
+
+    base = Qwen3TtsEngineBuilder()
+    base.checkpoint_dir = "/models/Qwen3-TTS-12Hz-1.7B-Base"
+    base_defaults = base.generation_defaults(dtype="bfloat16")
+    assert "cuda_graph_backend_prefill" not in base_defaults
+    assert "cuda_graph_bs_prefill" not in base_defaults
+
+    # The admission-defaults path builds a bare builder with no checkpoint.
+    bare = Qwen3TtsEngineBuilder().generation_defaults(dtype="bfloat16")
+    assert "cuda_graph_backend_prefill" not in bare
+    assert bare["max_running_requests"] == 16
+
+    design = Qwen3TtsEngineBuilder()
+    design.checkpoint_dir = "/models/Qwen3-TTS-12Hz-1.7B-VoiceDesign"
+    assert "cuda_graph_backend_prefill" in design.generation_defaults(dtype="bfloat16")
 
 
 def test_qwen3_tts_breakable_prefill_breaks_around_qk_norm_rope(

--- a/tests/unit_test/scheduling/test_prefill_graph_policy.py
+++ b/tests/unit_test/scheduling/test_prefill_graph_policy.py
@@ -691,3 +691,33 @@ def test_builder_rejects_breakable_without_model_opt_in(monkeypatch) -> None:
                 "cuda_graph_bs_prefill": [128, 256],
             },
         )
+
+
+def test_raised_operator_cap_regrows_a_stage_supplied_ladder() -> None:
+    """A builder default must not silently bound a raised operator cap."""
+    overrides = build_generation_batch_overrides(
+        max_running_requests=4,
+        cuda_graph_backend_prefill="breakable",
+        cuda_graph_bs_prefill=build_default_prefill_cuda_graph_bs(512),
+        server_args_overrides={"cuda_graph_max_bs_prefill": 1024},
+    )
+
+    assert overrides["cuda_graph_max_bs_prefill"] == 1024
+    assert overrides["cuda_graph_bs_prefill"] == build_default_prefill_cuda_graph_bs(
+        1024
+    )
+
+
+def test_raised_operator_cap_leaves_an_operator_declared_ladder_alone() -> None:
+    """When the operator declares both, they own the pair."""
+    overrides = build_generation_batch_overrides(
+        max_running_requests=4,
+        server_args_overrides={
+            "cuda_graph_backend_prefill": "breakable",
+            "cuda_graph_bs_prefill": [128, 256],
+            "cuda_graph_max_bs_prefill": 1024,
+        },
+    )
+
+    assert overrides["cuda_graph_bs_prefill"] == [128, 256]
+    assert overrides["cuda_graph_max_bs_prefill"] == 1024

--- a/tests/unit_test/scheduling/test_prefill_graph_policy.py
+++ b/tests/unit_test/scheduling/test_prefill_graph_policy.py
@@ -693,19 +693,28 @@ def test_builder_rejects_breakable_without_model_opt_in(monkeypatch) -> None:
         )
 
 
-def test_raised_operator_cap_regrows_a_stage_supplied_ladder() -> None:
-    """A builder default must not silently bound a raised operator cap."""
+def test_raised_operator_cap_extends_a_stage_ladder_without_dropping_buckets() -> None:
+    """A raised cap must grow a stage ladder, not replace it with the shared one.
+
+    The stage ladders carry buckets the shared one does not, such as the
+    Qwen3-TTS 1-token bucket, and losing them sends those shapes back to eager.
+    """
+    stage_ladder = [1, 2] + build_default_prefill_cuda_graph_bs(512)
     overrides = build_generation_batch_overrides(
         max_running_requests=4,
         cuda_graph_backend_prefill="breakable",
-        cuda_graph_bs_prefill=build_default_prefill_cuda_graph_bs(512),
+        cuda_graph_bs_prefill=list(stage_ladder),
         server_args_overrides={"cuda_graph_max_bs_prefill": 1024},
     )
 
+    result = overrides["cuda_graph_bs_prefill"]
     assert overrides["cuda_graph_max_bs_prefill"] == 1024
-    assert overrides["cuda_graph_bs_prefill"] == build_default_prefill_cuda_graph_bs(
-        1024
-    )
+    # Every stage bucket survives, including the ones the shared ladder lacks.
+    assert set(stage_ladder) <= set(result)
+    assert 1 in result and 2 in result
+    assert max(result) == 1024
+    assert result == sorted(result)
+    assert len(result) == len(set(result))
 
 
 def test_raised_operator_cap_leaves_an_operator_declared_ladder_alone() -> None:


### PR DESCRIPTION
Implements the default-enable half of **T-PR15 in #1754**.

## Motivation

#1581 made Qwen3-TTS satisfy the breakable-prefill contract end to end, but left the backend default-off: every Talker prefill still runs eager, while Higgs TTS and Qwen3-ASR already ship `CudaGraphBackend.BREAKABLE` in their generation defaults. Qwen3-TTS prompts sit exactly in the range where per-launch overhead is visible — a CustomVoice prompt is `N_text + 10/11` tokens, and the streaming Base prompt is a fixed 9–10 tokens.

## Change

`generation_defaults()` now sets `cuda_graph_backend_prefill: breakable` with `cuda_graph_bs_prefill: build_default_prefill_cuda_graph_bs(512)`, the same shape Higgs TTS uses. The 512 cap matters: under load, prefills coalesce several requests into one extend batch, so a short ladder loses exactly the loaded case (measured below). Explicit operator overrides keep working; `--tts_engine.engine.cuda_graph_backend_prefill disabled` restores eager prefill; the runner's 2x padding guard and eager fallback are unchanged.

## Measured on one H100 80GB, 1.7B CustomVoice, Seed-TTS EN, Ryan, open-loop Poisson

Same server config either side (mem_fraction_static 0.60, admission 16+16, decode graph buckets 1/2/4/8/12/16, vocoder ramp 2/4/8) on main d6670de plus #1852; only the prefill graph keys differ. Capture cost with an explicit [4..256] ladder: 2.79 s startup, 0.46 GB.

| metric | eager prefill | breakable prefill |
|---|---|---|
| 1 RPS TTFB p50 | 53.7 ms | 46.1 ms |
| 1 RPS audible TTFA p50 | 139.4 ms | 125.6 ms |
| 10 RPS p95 audible TTFA (median of 3 seeds) | 438.0 ms | 411.5 ms |
| 10 RPS median underrun rate | 1.02% | 0.51% |

`/model_info` counters for the run: 1106 graph replays concentrated in the 12–20-token buckets, but 1449 prefills still eager because coalesced batches overflowed the measurement ladder's 256-token cap — which is why the shipped default carries the ladder to 512.

## Compile warmup cost (on by default)

Prefill graph capture adds ~2.8 s and 0.46 GB at startup on H100. Opt-out is the documented `cuda_graph_backend_prefill: disabled` override.

## Tests

`test_qwen3_tts_breakable_prefill_enabled_by_default` pins the new defaults (backend, ladder, decode graph unaffected); the #1581 graph-break and policy-validation tests are unchanged.