### PR TITLE
[Qwen3-TTS] Suppress the silent bootstrap frame for streamed CustomVoice

### DIFF
--- a/docs/basic_usage/tts.md
+++ b/docs/basic_usage/tts.md
@@ -595,6 +595,7 @@ The table below lists all parameters accepted by the `/v1/audio/speech` endpoint
 | `stream` | bool | `false` | Enable raw PCM streaming. When true, `response_format` must be `pcm` |
 | `initial_codec_chunk_frames` | int | `null` | Optional first codec chunk size for streaming TTFA / playback-continuity tuning. When omitted, each model applies its own default: Qwen3-TTS ramps `1 -> 2 -> 4` into the steady stride, Higgs TTS uses `20`, MOSS-TTS Local uses `5`, and ZONOS2 uses `40`. An explicit `0` uses the model's steady chunk size from the start. Ming-Omni-TTS rejects the field entirely |
 | `stream_codec_output` | bool | `true` | Qwen3-TTS only. Forward codec frames to the vocoder as they are generated. Set `false` to restore whole-utterance decoding for CustomVoice / VoiceDesign |
+| `suppress_bootstrap_silence` | bool | `true` | Qwen3-TTS only. Withhold the silent bootstrap codec frame's audio from streamed CustomVoice output on validated voice/language pairs; an audible first frame is always emitted unchanged. Set `false` to keep the leading silence |
 | `references` | list | `null` | Reference audio for voice cloning. Each item has `audio_path` (local path / file URL / data URL / remote URL) and `text` |
 | `ref_audio` | string | `null` | Reference audio path / URL / base64 string. Equivalent to `references[0].audio_path` |
 | `ref_text` | string | `null` | Transcript for `ref_audio`. Equivalent to `references[0].text` |

--- a/docs/cookbook/qwen3_tts.md
+++ b/docs/cookbook/qwen3_tts.md
@@ -371,6 +371,15 @@ true incremental codec and vocoder streaming, for both this HTTP endpoint and
 `--preprocessing.factory.stream_codec_output false`, to restore whole-utterance
 decoding.
 
+Streamed CustomVoice output on validated voice/language pairs (currently
+Ryan/English with default sampling) withholds the model's silent bootstrap
+codec frame, removing about 80 ms of leading silence from the first chunk. The
+frame still feeds the vocoder, so every later sample is unchanged, and a
+runtime silence check emits the audio unmodified whenever the first frame is
+not actually silent. Opt out per request with
+`"suppress_bootstrap_silence": false` or per deployment with
+`--vocoder.factory.suppress_bootstrap_silence false`.
+
 When `initial_codec_chunk_frames` is omitted, Qwen3-TTS ramps its first chunks
 `1 -> 2 -> 4` codec frames before the steady stride, so first audio leaves after a
 single AR step while the playback cushion is rebuilt within four chunks. Pass an
@@ -428,6 +437,7 @@ only the first chunk.
 | `stream` | `false` | Stream raw PCM audio chunks |
 | `initial_codec_chunk_frames` | ramp `1 -> 2 -> 4` when omitted | First streaming vocoder chunk size in codec frames. An explicit value replaces the ramp's first chunk only. Smaller values lower TTFA but underrun more easily; `0` uses the steady stride from the start |
 | `stream_codec_output` | `true` | Forward codec frames to the vocoder as they are generated. Set `false` to restore whole-utterance decoding for CustomVoice/VoiceDesign |
+| `suppress_bootstrap_silence` | `true` | Withhold the silent bootstrap codec frame's audio from streamed CustomVoice output (validated voice/language pairs only, guarded by a runtime silence check). Set `false` to keep the leading silence |
 
 ## Model Variants
 

--- a/sglang_omni/models/qwen3_tts/payload_types.py
+++ b/sglang_omni/models/qwen3_tts/payload_types.py
@@ -28,6 +28,7 @@ class Qwen3TTSState(DeclarativeStateBase):
     x_vector_only_mode: bool = wire(False, codec="bool")
     non_streaming_mode: bool = wire(False, codec="bool")
     stream_codec_output: bool = wire(True, codec="bool")
+    suppress_bootstrap_silence: bool = wire(False, codec="bool")
     generation_kwargs: dict[str, Any] = wire(default_factory=dict, codec="dict")
     seed: int | None = None
     audio_codes: Any | None = wire(None, codec="tensor_list")

--- a/sglang_omni/models/qwen3_tts/request_builders.py
+++ b/sglang_omni/models/qwen3_tts/request_builders.py
@@ -129,6 +129,7 @@ class Qwen3TTSSGLangRequestData(SGLangARRequestData):
     latest_stream_code_chunk: torch.Tensor | None = None
     stream_ref_sent: bool = False
     stream_codec_output: bool = False
+    suppress_bootstrap_silence: bool = False
     ref_code: torch.Tensor | None = None
     ref_code_len: int = 0
     prompt_input_embeds: torch.Tensor | None = None
@@ -330,6 +331,16 @@ def build_qwen3_tts_state(
     seed = tts_params["seed"] if "seed" in tts_params else params.get("seed")
     normalized_seed = _normalize_qwen3_tts_seed(seed) if seed is not None else None
 
+    suppress_bootstrap_silence = resolve_bootstrap_silence_suppression(
+        task_type=task_type,
+        voice=voice,
+        language=language,
+        instructions=instructions,
+        stream_codec_output=stream_codec_output,
+        params=params,
+        tts_params=tts_params,
+    )
+
     return Qwen3TTSState(
         text=text,
         task_type=task_type,
@@ -350,6 +361,7 @@ def build_qwen3_tts_state(
         x_vector_only_mode=x_vector_only_mode,
         non_streaming_mode=non_streaming_mode,
         stream_codec_output=stream_codec_output,
+        suppress_bootstrap_silence=suppress_bootstrap_silence,
         generation_kwargs=build_generation_kwargs(
             params,
             tts_params=tts_params,
@@ -487,6 +499,50 @@ def resolve_stream_codec_output(
         if "non_streaming_mode" in source:
             return not bool(source["non_streaming_mode"])
     return default
+
+
+# note (luojiaxuan): the model deterministically emits one silent bootstrap
+# codec frame for these voice/language pairs under shipped-default sampling
+# (measured n=2229, Ryan/English 1.7B: first-80ms RMS never above -103 dBFS).
+# Extending either set requires an equivalent corpus measurement first.
+QWEN3_TTS_BOOTSTRAP_SILENCE_VOICES = frozenset({"ryan"})
+QWEN3_TTS_BOOTSTRAP_SILENCE_LANGUAGES = frozenset({"english"})
+# note (luojiaxuan): max_new_tokens caps length without touching the first
+# frame's sampling distribution, so it stays out of the eligibility gate.
+_BOOTSTRAP_SILENCE_SAMPLING_FIELDS = tuple(
+    name for name in _GENERATION_FIELDS if name != "max_new_tokens"
+)
+
+
+def resolve_bootstrap_silence_suppression(
+    *,
+    task_type: str,
+    voice: str | None,
+    language: str,
+    instructions: str | None,
+    stream_codec_output: bool,
+    params: dict[str, Any],
+    tts_params: dict[str, Any],
+) -> bool:
+    for source in (params, tts_params):
+        if "suppress_bootstrap_silence" in source:
+            if not bool(source["suppress_bootstrap_silence"]):
+                return False
+            break
+    if task_type != QWEN3_TTS_TASK_CUSTOM_VOICE:
+        return False
+    if not stream_codec_output:
+        return False
+    if instructions:
+        return False
+    if (voice or "").lower() not in QWEN3_TTS_BOOTSTRAP_SILENCE_VOICES:
+        return False
+    if language.lower() not in QWEN3_TTS_BOOTSTRAP_SILENCE_LANGUAGES:
+        return False
+    return not any(
+        has_param(tts_params, params, name)
+        for name in _BOOTSTRAP_SILENCE_SAMPLING_FIELDS
+    )
 
 
 def normalize_language(language: Any) -> str:
@@ -1379,6 +1435,7 @@ def build_sglang_qwen3_tts_request(
         subtalker_top_k=subtalker.top_k,
         subtalker_sampling_seed=subtalker_sampling_seed,
         stream_codec_output=state.stream_codec_output,
+        suppress_bootstrap_silence=state.suppress_bootstrap_silence,
         engine_start_s=time.perf_counter(),
     )
     data.pending_text_queue = PendingTextTensorQueue.from_tensor(
@@ -1516,6 +1573,8 @@ def make_qwen3_tts_scheduler_adapters(*, model: Any, wrapper: Any):
                 metadata[INITIAL_CODEC_CHUNK_FRAMES_PARAM] = params[
                     INITIAL_CODEC_CHUNK_FRAMES_PARAM
                 ]
+            if data.suppress_bootstrap_silence:
+                metadata["bootstrap_silence_suppression"] = True
             data.stream_ref_sent = True
 
         codes = codes.detach().to(dtype=torch.long)

--- a/sglang_omni/models/qwen3_tts/request_builders.py
+++ b/sglang_omni/models/qwen3_tts/request_builders.py
@@ -512,6 +512,17 @@ QWEN3_TTS_BOOTSTRAP_SILENCE_LANGUAGES = frozenset({"english"})
 _BOOTSTRAP_SILENCE_SAMPLING_FIELDS = tuple(
     name for name in _GENERATION_FIELDS if name != "max_new_tokens"
 )
+# note (luojiaxuan): the serving layer materializes these exact values on
+# every request (speech_service._build_sampling_params), so key presence
+# alone cannot distinguish an operator override; the silence corpus was
+# measured under precisely these values, so they and only they stay
+# eligible.
+_BOOTSTRAP_SILENCE_SAMPLING_DEFAULTS = {
+    "temperature": 0.8,
+    "top_p": 0.8,
+    "top_k": 30,
+    "repetition_penalty": 1.1,
+}
 
 
 def resolve_bootstrap_silence_suppression(
@@ -539,10 +550,12 @@ def resolve_bootstrap_silence_suppression(
         return False
     if language.lower() not in QWEN3_TTS_BOOTSTRAP_SILENCE_LANGUAGES:
         return False
-    return not any(
-        has_param(tts_params, params, name)
-        for name in _BOOTSTRAP_SILENCE_SAMPLING_FIELDS
-    )
+    for name in _BOOTSTRAP_SILENCE_SAMPLING_FIELDS:
+        expected = _BOOTSTRAP_SILENCE_SAMPLING_DEFAULTS.get(name)
+        for source in (tts_params, params):
+            if name in source and source[name] != expected:
+                return False
+    return True
 
 
 def normalize_language(language: Any) -> str:

--- a/sglang_omni/models/qwen3_tts/request_builders.py
+++ b/sglang_omni/models/qwen3_tts/request_builders.py
@@ -509,20 +509,14 @@ QWEN3_TTS_BOOTSTRAP_SILENCE_VOICES = frozenset({"ryan"})
 QWEN3_TTS_BOOTSTRAP_SILENCE_LANGUAGES = frozenset({"english"})
 # note (luojiaxuan): max_new_tokens caps length without touching the first
 # frame's sampling distribution, so it stays out of the eligibility gate.
-_BOOTSTRAP_SILENCE_SAMPLING_FIELDS = tuple(
+_BOOTSTRAP_SILENCE_SAMPLING_FIELDS = frozenset(
     name for name in _GENERATION_FIELDS if name != "max_new_tokens"
 )
-# note (luojiaxuan): the serving layer materializes these exact values on
-# every request (speech_service._build_sampling_params), so key presence
-# alone cannot distinguish an operator override; the silence corpus was
-# measured under precisely these values, so they and only they stay
-# eligible.
-_BOOTSTRAP_SILENCE_SAMPLING_DEFAULTS = {
-    "temperature": 0.8,
-    "top_p": 0.8,
-    "top_k": 30,
-    "repetition_penalty": 1.1,
-}
+# note (luojiaxuan): the serving layer materializes a sampling value on every
+# request, so key presence cannot distinguish an operator override. The request
+# already carries explicit_generation_params, which names the fields the caller
+# actually set, so that is the discriminator rather than a second copy of the
+# defaults.
 
 
 def resolve_bootstrap_silence_suppression(
@@ -550,11 +544,14 @@ def resolve_bootstrap_silence_suppression(
         return False
     if language.lower() not in QWEN3_TTS_BOOTSTRAP_SILENCE_LANGUAGES:
         return False
-    for name in _BOOTSTRAP_SILENCE_SAMPLING_FIELDS:
-        expected = _BOOTSTRAP_SILENCE_SAMPLING_DEFAULTS.get(name)
-        for source in (tts_params, params):
-            if name in source and source[name] != expected:
-                return False
+    explicit = tts_params.get("explicit_generation_params")
+    explicit_fields = (
+        {str(field) for field in explicit}
+        if isinstance(explicit, (list, tuple, set))
+        else set()
+    )
+    if explicit_fields & _BOOTSTRAP_SILENCE_SAMPLING_FIELDS:
+        return False
     return True
 
 

--- a/sglang_omni/models/qwen3_tts/stages.py
+++ b/sglang_omni/models/qwen3_tts/stages.py
@@ -239,6 +239,7 @@ def create_vocoder_executor(
     fused_snake_activation: bool = False,
     enable_stateful_codec_decoder: bool = False,
     suppress_bootstrap_silence: bool = True,
+    suppress_bootstrap_max_streams: int = 24,
 ) -> SimpleScheduler:
     device = resolve_device_spec(device, gpu_id)
     tokenizer = _load_qwen3_tts_tokenizer(
@@ -270,6 +271,7 @@ def create_vocoder_executor(
         fused_snake_activation=fused_snake_activation,
         enable_stateful_codec_decoder=enable_stateful_codec_decoder,
         suppress_bootstrap_silence=suppress_bootstrap_silence,
+        suppress_bootstrap_max_streams=suppress_bootstrap_max_streams,
     )
     # note (ratish): Factory construction completes before the stage process
     # publishes readiness, so CUDA capture cannot overlap request-time GPU work

--- a/sglang_omni/models/qwen3_tts/stages.py
+++ b/sglang_omni/models/qwen3_tts/stages.py
@@ -238,6 +238,7 @@ def create_vocoder_executor(
     followup_cuda_graph: bool = True,
     fused_snake_activation: bool = False,
     enable_stateful_codec_decoder: bool = False,
+    suppress_bootstrap_silence: bool = True,
 ) -> SimpleScheduler:
     device = resolve_device_spec(device, gpu_id)
     tokenizer = _load_qwen3_tts_tokenizer(
@@ -268,6 +269,7 @@ def create_vocoder_executor(
         followup_cuda_graph=followup_cuda_graph,
         fused_snake_activation=fused_snake_activation,
         enable_stateful_codec_decoder=enable_stateful_codec_decoder,
+        suppress_bootstrap_silence=suppress_bootstrap_silence,
     )
     # note (ratish): Factory construction completes before the stage process
     # publishes readiness, so CUDA capture cannot overlap request-time GPU work

--- a/sglang_omni/models/qwen3_tts/streaming_vocoder.py
+++ b/sglang_omni/models/qwen3_tts/streaming_vocoder.py
@@ -426,6 +426,7 @@ class Qwen3TTSStreamingVocoderScheduler(
         fused_snake_activation: bool = False,
         enable_stateful_codec_decoder: bool = False,
         suppress_bootstrap_silence: bool = True,
+        suppress_bootstrap_max_streams: int = 24,
     ) -> None:
         if stream_stride <= 0 or stream_followup_stride <= 0:
             raise ValueError("stream strides must be > 0")
@@ -520,6 +521,12 @@ class Qwen3TTSStreamingVocoderScheduler(
         )
         self._enable_stateful_codec_decoder = bool(enable_stateful_codec_decoder)
         self._suppress_bootstrap_silence = bool(suppress_bootstrap_silence)
+        # note (luojiaxuan): the compensation below decodes one extra frame
+        # into a suppressed stream's first chunk. Near capacity that extra
+        # per-stream startup work is what the pipeline cannot spare, so the
+        # suppression is skipped once this many streams are already live
+        # (measured: a win to 10 RPS, a regression at 20 RPS).
+        self._suppress_bootstrap_max_streams = int(suppress_bootstrap_max_streams)
         self._incremental_decoder = (
             Qwen3TTSIncrementalDecoder(self._decoder)
             if self._enable_stateful_codec_decoder
@@ -545,11 +552,7 @@ class Qwen3TTSStreamingVocoderScheduler(
             graph_frames = tuple(
                 sorted(
                     set(graph_frames)
-                    | {
-                        int(stream_left_context_frames)
-                        + int(initial_chunk_frames)
-                        + 1
-                    }
+                    | {int(stream_left_context_frames) + int(initial_chunk_frames) + 1}
                 )
             )
         self._initial_decode_graphs = _Qwen3TTSInitialDecodeGraphs(
@@ -797,7 +800,10 @@ class Qwen3TTSStreamingVocoderScheduler(
                 default_frames=self._default_initial_chunk_frames,
             )
         if metadata.get("bootstrap_silence_suppression"):
-            state.suppress_bootstrap = self._suppress_bootstrap_silence
+            state.suppress_bootstrap = (
+                self._suppress_bootstrap_silence
+                and len(self._stream_states) <= self._suppress_bootstrap_max_streams
+            )
             if state.suppress_bootstrap and state.initial_chunk_frames > 0:
                 # note (luojiaxuan): the withheld frame is also withheld from
                 # the client's playback buffer, so decode one extra frame into

--- a/sglang_omni/models/qwen3_tts/streaming_vocoder.py
+++ b/sglang_omni/models/qwen3_tts/streaming_vocoder.py
@@ -41,6 +41,14 @@ DEFAULT_QWEN3_TTS_INITIAL_CHUNK_FRAMES = 8
 DEFAULT_QWEN3_TTS_STREAM_CHUNK_RAMP = (1, 2, 4)
 DEFAULT_QWEN3_TTS_LEFT_CONTEXT_FRAMES = 16
 _QWEN3_TTS_CODEBOOK_SIZE = 2048
+# note (luojiaxuan): fail-closed acoustic guard for bootstrap-frame
+# suppression, in linear amplitude: RMS cap 1e-3 is -60 dBFS, peak cap
+# 3.2e-3 is -50 dBFS. Calibrated against the Ryan/English corpus, whose
+# loudest first frame measured -103.7 dBFS RMS; real speech onsets sit far
+# above -40 dBFS, so these thresholds separate the two by orders of
+# magnitude.
+_BOOTSTRAP_SILENCE_MAX_RMS = 1e-3
+_BOOTSTRAP_SILENCE_MAX_PEAK = 3.2e-3
 
 
 def _decode_graph_frame_counts(
@@ -100,6 +108,7 @@ class _Qwen3TTSStreamState:
     playback_deadline_s: float = 0.0
     incremental_codec_state: Qwen3TTSIncrementalCodecState | None = None
     incremental_codec_fallback: bool = False
+    suppress_bootstrap: bool = False
 
 
 class _Qwen3TTSInvalidCodeRows(ValueError):
@@ -416,6 +425,7 @@ class Qwen3TTSStreamingVocoderScheduler(
         followup_cuda_graph: bool = True,
         fused_snake_activation: bool = False,
         enable_stateful_codec_decoder: bool = False,
+        suppress_bootstrap_silence: bool = True,
     ) -> None:
         if stream_stride <= 0 or stream_followup_stride <= 0:
             raise ValueError("stream strides must be > 0")
@@ -509,6 +519,7 @@ class Qwen3TTSStreamingVocoderScheduler(
             1 if self._deterministic_inference else int(followup_worker_count)
         )
         self._enable_stateful_codec_decoder = bool(enable_stateful_codec_decoder)
+        self._suppress_bootstrap_silence = bool(suppress_bootstrap_silence)
         self._incremental_decoder = (
             Qwen3TTSIncrementalDecoder(self._decoder)
             if self._enable_stateful_codec_decoder
@@ -772,6 +783,8 @@ class Qwen3TTSStreamingVocoderScheduler(
                 steady_chunk_frames=self._stream_stride,
                 default_frames=self._default_initial_chunk_frames,
             )
+        if metadata.get("bootstrap_silence_suppression"):
+            state.suppress_bootstrap = self._suppress_bootstrap_silence
 
     def validate_chunk(
         self,
@@ -865,6 +878,8 @@ class Qwen3TTSStreamingVocoderScheduler(
                 delta = self._commit_decode_plan(state, plan, delta)
                 state.incremental_codec_state = candidate_state
                 self._prune_incremental_codes(state)
+                if state.decoded_chunks == 1:
+                    delta = self._apply_bootstrap_suppression(state, delta)
                 return delta
 
         plan = self._build_decode_plan(state, is_final=is_final or force_legacy_decode)
@@ -872,7 +887,10 @@ class Qwen3TTSStreamingVocoderScheduler(
             return None
         handle = self._launch_decode_plans([plan], stream=self._decode_stream)
         deltas = handle.resolve()
-        return self._commit_decode_plan(state, plan, deltas[0])
+        delta = self._commit_decode_plan(state, plan, deltas[0])
+        if state.decoded_chunks == 1:
+            delta = self._apply_bootstrap_suppression(state, delta)
+        return delta
 
     def _decode_incremental_eager(
         self,
@@ -1339,6 +1357,29 @@ class Qwen3TTSStreamingVocoderScheduler(
         state.playback_deadline_s = max(state.playback_deadline_s, now) + duration_s
         return delta
 
+    def _apply_bootstrap_suppression(
+        self, state: _Qwen3TTSStreamState, delta: torch.Tensor
+    ) -> torch.Tensor:
+        """Withhold the bootstrap frame's samples from the first emitted chunk.
+
+        The frame stays in decoder history — only its emitted audio is
+        suppressed — so every later sample is identical to the unsuppressed
+        stream. The acoustic guard fails closed: a first frame that is not
+        actually silent is emitted unchanged.
+        """
+        if not state.suppress_bootstrap:
+            return delta
+        state.suppress_bootstrap = False
+        frame_samples = self._samples_per_frame
+        if int(delta.shape[-1]) <= frame_samples:
+            return delta
+        head = delta[..., :frame_samples].float()
+        rms = float(head.pow(2).mean().sqrt())
+        peak = float(head.abs().max())
+        if rms > _BOOTSTRAP_SILENCE_MAX_RMS or peak > _BOOTSTRAP_SILENCE_MAX_PEAK:
+            return delta
+        return delta[..., frame_samples:]
+
     def _next_followup_stride(self, state: _Qwen3TTSStreamState) -> int:
         """Stride of the next decode chunk after a commit.
 
@@ -1567,6 +1608,7 @@ class Qwen3TTSStreamingVocoderScheduler(
             else:
                 state.initial_pending = False
                 if not self._is_aborted(request_id):
+                    delta = self._apply_bootstrap_suppression(state, delta)
                     self._mark_stream_emitted(request_id)
                     self.outbox.put(self._stream_chunk_message(request_id, delta))
                 has_remainder = (

--- a/sglang_omni/models/qwen3_tts/streaming_vocoder.py
+++ b/sglang_omni/models/qwen3_tts/streaming_vocoder.py
@@ -539,6 +539,19 @@ class Qwen3TTSStreamingVocoderScheduler(
             followup_stride_ramp=followup_stride_ramp,
             steady_stride=int(stream_followup_stride),
         )
+        if self._suppress_bootstrap_silence and initial_chunk_frames < stream_stride:
+            # note (luojiaxuan): suppressed streams decode one extra bootstrap
+            # frame into their first chunk, so capture that shape too.
+            graph_frames = tuple(
+                sorted(
+                    set(graph_frames)
+                    | {
+                        int(stream_left_context_frames)
+                        + int(initial_chunk_frames)
+                        + 1
+                    }
+                )
+            )
         self._initial_decode_graphs = _Qwen3TTSInitialDecodeGraphs(
             self._decoder,
             device=self._device,
@@ -785,6 +798,13 @@ class Qwen3TTSStreamingVocoderScheduler(
             )
         if metadata.get("bootstrap_silence_suppression"):
             state.suppress_bootstrap = self._suppress_bootstrap_silence
+            if state.suppress_bootstrap and state.initial_chunk_frames > 0:
+                # note (luojiaxuan): the withheld frame is also withheld from
+                # the client's playback buffer, so decode one extra frame into
+                # the first chunk to keep the audible lead unchanged.
+                state.initial_chunk_frames = min(
+                    state.initial_chunk_frames + 1, self._stream_stride
+                )
 
     def validate_chunk(
         self,

--- a/sglang_omni/models/qwen3_tts/streaming_vocoder.py
+++ b/sglang_omni/models/qwen3_tts/streaming_vocoder.py
@@ -547,12 +547,22 @@ class Qwen3TTSStreamingVocoderScheduler(
             steady_stride=int(stream_followup_stride),
         )
         if self._suppress_bootstrap_silence and initial_chunk_frames < stream_stride:
-            # note (luojiaxuan): suppressed streams decode one extra bootstrap
-            # frame into their first chunk, so capture that shape too.
+            # note (luojiaxuan): a suppressed stream decodes one extra bootstrap
+            # frame into its first chunk, which shifts every startup window, not
+            # just the first. CustomVoice carries no reference codes, so those
+            # windows are the running sums of the bumped schedule rather than
+            # left_context + stride. Capture the whole bumped schedule.
             graph_frames = tuple(
                 sorted(
                     set(graph_frames)
-                    | {int(stream_left_context_frames) + int(initial_chunk_frames) + 1}
+                    | set(
+                        _decode_graph_frame_counts(
+                            left_context=int(stream_left_context_frames),
+                            initial_chunk_frames=int(initial_chunk_frames) + 1,
+                            followup_stride_ramp=followup_stride_ramp,
+                            steady_stride=int(stream_followup_stride),
+                        )
+                    )
                 )
             )
         self._initial_decode_graphs = _Qwen3TTSInitialDecodeGraphs(
@@ -804,13 +814,21 @@ class Qwen3TTSStreamingVocoderScheduler(
                 self._suppress_bootstrap_silence
                 and len(self._stream_states) <= self._suppress_bootstrap_max_streams
             )
-            if state.suppress_bootstrap and state.initial_chunk_frames > 0:
+            if state.suppress_bootstrap:
                 # note (luojiaxuan): the withheld frame is also withheld from
                 # the client's playback buffer, so decode one extra frame into
-                # the first chunk to keep the audible lead unchanged.
-                state.initial_chunk_frames = min(
-                    state.initial_chunk_frames + 1, self._stream_stride
-                )
+                # the first chunk to keep the audible lead unchanged. Without
+                # that compensation the stream would emit a shorter lead than
+                # an unsuppressed one, so suppression only stays on when the
+                # bump actually applies.
+                bumped = min(state.initial_chunk_frames + 1, self._stream_stride)
+                if (
+                    state.initial_chunk_frames > 0
+                    and bumped > state.initial_chunk_frames
+                ):
+                    state.initial_chunk_frames = bumped
+                else:
+                    state.suppress_bootstrap = False
 
     def validate_chunk(
         self,
@@ -904,8 +922,6 @@ class Qwen3TTSStreamingVocoderScheduler(
                 delta = self._commit_decode_plan(state, plan, delta)
                 state.incremental_codec_state = candidate_state
                 self._prune_incremental_codes(state)
-                if state.decoded_chunks == 1:
-                    delta = self._apply_bootstrap_suppression(state, delta)
                 return delta
 
         plan = self._build_decode_plan(state, is_final=is_final or force_legacy_decode)
@@ -913,10 +929,7 @@ class Qwen3TTSStreamingVocoderScheduler(
             return None
         handle = self._launch_decode_plans([plan], stream=self._decode_stream)
         deltas = handle.resolve()
-        delta = self._commit_decode_plan(state, plan, deltas[0])
-        if state.decoded_chunks == 1:
-            delta = self._apply_bootstrap_suppression(state, delta)
-        return delta
+        return self._commit_decode_plan(state, plan, deltas[0])
 
     def _decode_incremental_eager(
         self,
@@ -1373,6 +1386,11 @@ class Qwen3TTSStreamingVocoderScheduler(
         if delta.numel() == 0:
             raise RuntimeError("Qwen3-TTS streaming decoder returned an empty delta")
 
+        # note (luojiaxuan): trim before the deadline is credited, otherwise the
+        # stream is charged for the withheld frame it never emits and sorts late
+        # in the follow-up queue. The call is one-shot and self-gating.
+        delta = self._apply_bootstrap_suppression(state, delta)
+
         state.emitted_generated_frames = plan.generated_frames
         state.decoded_chunks += 1
         state.next_decode_generated_frames = (
@@ -1634,7 +1652,6 @@ class Qwen3TTSStreamingVocoderScheduler(
             else:
                 state.initial_pending = False
                 if not self._is_aborted(request_id):
-                    delta = self._apply_bootstrap_suppression(state, delta)
                     self._mark_stream_emitted(request_id)
                     self.outbox.put(self._stream_chunk_message(request_id, delta))
                 has_remainder = (

--- a/sglang_omni/serve/protocol.py
+++ b/sglang_omni/serve/protocol.py
@@ -353,6 +353,7 @@ class CreateSpeechRequest(BaseModel):
     references: list[SpeechReference] | None = None  # S2-Pro-style refs
     x_vector_only_mode: bool | None = None
     stream_codec_output: bool | None = None
+    suppress_bootstrap_silence: bool | None = None
     token_count: int | None = None  # MOSS-TTS duration token target
     duration_tokens: int | None = None  # alias for token_count
     initial_codec_chunk_frames: int | None = Field(default=None, ge=0)
@@ -391,6 +392,7 @@ class SpeechBatchItem(BaseModel):
     references: Any = None
     x_vector_only_mode: Any = None
     stream_codec_output: Any = None
+    suppress_bootstrap_silence: Any = None
     token_count: Any = None
     duration_tokens: Any = None
     max_new_tokens: Any = None
@@ -425,6 +427,7 @@ class CreateSpeechBatchRequest(BaseModel):
     references: list[SpeechReference] | None = None
     x_vector_only_mode: bool | None = None
     stream_codec_output: bool | None = None
+    suppress_bootstrap_silence: bool | None = None
     token_count: int | None = None
     duration_tokens: int | None = None
     max_new_tokens: int | None = None
@@ -481,6 +484,7 @@ class SpeechStreamSessionConfig(BaseModel):
     references: list[SpeechReference] | None = None
     x_vector_only_mode: bool | None = None
     stream_codec_output: bool | None = None
+    suppress_bootstrap_silence: bool | None = None
     token_count: int | None = None
     duration_tokens: int | None = None
     max_new_tokens: int | None = None

--- a/sglang_omni/serve/speech_service.py
+++ b/sglang_omni/serve/speech_service.py
@@ -687,7 +687,12 @@ class SpeechRequestValidator:
                     raise bad_request(
                         f"{field_name} must be a number", param=field_name
                     )
-        for field_name in ("stream", "x_vector_only_mode", "stream_codec_output"):
+        for field_name in (
+            "stream",
+            "x_vector_only_mode",
+            "stream_codec_output",
+            "suppress_bootstrap_silence",
+        ):
             if field_name in payload and payload[field_name] is not None:
                 if not isinstance(payload[field_name], bool):
                     raise bad_request(
@@ -803,6 +808,8 @@ def _build_tts_params(
         tts_params["x_vector_only_mode"] = request.x_vector_only_mode
     if request.stream_codec_output is not None:
         tts_params["stream_codec_output"] = request.stream_codec_output
+    if request.suppress_bootstrap_silence is not None:
+        tts_params["suppress_bootstrap_silence"] = request.suppress_bootstrap_silence
     if request.initial_codec_chunk_frames is not None:
         tts_params[INITIAL_CODEC_CHUNK_FRAMES_PARAM] = (
             request.initial_codec_chunk_frames

--- a/tests/unit_test/qwen3_tts/test_pipeline.py
+++ b/tests/unit_test/qwen3_tts/test_pipeline.py
@@ -2407,8 +2407,9 @@ def test_qwen3_tts_explicit_initial_chunk_frames_keeps_legacy_ramp() -> None:
     )
 
     left = scheduler._stream_left_context_frames
-    # Startup prefix sums plus the steady jitter band left+1..left+stride.
-    expected = tuple(sorted({8} | {left + f for f in range(0, 9)}))
+    # Startup prefix sums, the steady jitter band left+1..left+stride, and
+    # left+9 for the extra frame a bootstrap-suppressed first chunk decodes.
+    expected = tuple(sorted({8} | {left + f for f in range(0, 10)}))
     assert scheduler.create_stream_state("request").initial_chunk_frames == 8
     assert scheduler._followup_stride_ramp == (8,)
     assert scheduler._initial_decode_graphs._input_frames == expected

--- a/tests/unit_test/qwen3_tts/test_pipeline.py
+++ b/tests/unit_test/qwen3_tts/test_pipeline.py
@@ -3768,6 +3768,55 @@ def test_qwen3_tts_vocoder_latches_bootstrap_suppression_contract() -> None:
     assert state.suppress_bootstrap is False
 
 
+def test_qwen3_tts_bootstrap_suppression_extends_first_chunk_by_one_frame() -> None:
+    scheduler = Qwen3TTSStreamingVocoderScheduler(
+        _FakeQwen3TTSTokenizer(),
+        device="cpu",
+    )
+    assert scheduler._initial_decode_graphs._input_frames == (24, 25)
+    state = scheduler.create_stream_state("request")
+    assert state.initial_chunk_frames == 8
+    scheduler.latch_stream_contract(
+        "request",
+        state,
+        {"num_quantizers": 2, "bootstrap_silence_suppression": True},
+        origin="metadata",
+    )
+    assert state.initial_chunk_frames == 9
+
+    disabled = Qwen3TTSStreamingVocoderScheduler(
+        _FakeQwen3TTSTokenizer(),
+        device="cpu",
+        suppress_bootstrap_silence=False,
+    )
+    assert disabled._initial_decode_graphs._input_frames == (24,)
+    state = disabled.create_stream_state("request")
+    disabled.latch_stream_contract(
+        "request",
+        state,
+        {"num_quantizers": 2, "bootstrap_silence_suppression": True},
+        origin="metadata",
+    )
+    assert state.initial_chunk_frames == 8
+
+
+def test_qwen3_tts_bootstrap_suppression_first_chunk_clamps_to_stride() -> None:
+    scheduler = Qwen3TTSStreamingVocoderScheduler(
+        _FakeQwen3TTSTokenizer(),
+        device="cpu",
+        stream_chunk_ramp=[16, 8],
+    )
+    state = scheduler.create_stream_state("request")
+    assert state.initial_chunk_frames == 16
+    scheduler.latch_stream_contract(
+        "request",
+        state,
+        {"num_quantizers": 2, "bootstrap_silence_suppression": True},
+        origin="metadata",
+    )
+    assert state.initial_chunk_frames == 16
+
+
 def test_qwen3_tts_bootstrap_suppression_trims_one_silent_frame_once() -> None:
     scheduler = Qwen3TTSStreamingVocoderScheduler(
         _FakeQwen3TTSTokenizer(),

--- a/tests/unit_test/qwen3_tts/test_pipeline.py
+++ b/tests/unit_test/qwen3_tts/test_pipeline.py
@@ -1457,8 +1457,8 @@ def test_qwen3_tts_bootstrap_silence_eligible_on_allowlisted_custom_voice() -> N
         {"voice": "Vivian"},
         {"language": "Chinese"},
         {"instructions": "Whisper softly."},
-        {"temperature": 0.9},
-        {"top_p": 0.7},
+        {"temperature": 0.9, "explicit_generation_params": ["temperature"]},
+        {"top_p": 0.7, "explicit_generation_params": ["top_p"]},
         {"stream_codec_output": False},
         {"suppress_bootstrap_silence": False},
     ],
@@ -1469,6 +1469,27 @@ def test_qwen3_tts_bootstrap_silence_ineligible_variants(
     state = build_qwen3_tts_state(_bootstrap_eligible_payload(tts_params=tts_params))
 
     assert state.suppress_bootstrap_silence is False
+
+
+@pytest.mark.parametrize(
+    "tts_params",
+    [
+        {"temperature": 0.9},
+        {"top_p": 0.7},
+        {"top_k": 50, "repetition_penalty": 1.05},
+    ],
+)
+def test_qwen3_tts_bootstrap_silence_ignores_materialized_sampling(
+    tts_params: dict[str, Any],
+) -> None:
+    """The serving layer materializes a sampling value on every request.
+
+    Only explicit_generation_params distinguishes a caller override, so a
+    materialized value must not disqualify the stream on its own.
+    """
+    state = build_qwen3_tts_state(_bootstrap_eligible_payload(tts_params=tts_params))
+
+    assert state.suppress_bootstrap_silence is True
 
 
 def test_qwen3_tts_bootstrap_silence_ignores_max_new_tokens() -> None:

--- a/tests/unit_test/qwen3_tts/test_pipeline.py
+++ b/tests/unit_test/qwen3_tts/test_pipeline.py
@@ -1479,6 +1479,22 @@ def test_qwen3_tts_bootstrap_silence_ignores_max_new_tokens() -> None:
     assert state.suppress_bootstrap_silence is True
 
 
+def test_qwen3_tts_bootstrap_silence_accepts_materialized_sampling_defaults() -> None:
+    state = build_qwen3_tts_state(
+        _bootstrap_eligible_payload(
+            params={
+                "temperature": 0.8,
+                "top_p": 0.8,
+                "top_k": 30,
+                "repetition_penalty": 1.1,
+                "seed": 7,
+            }
+        )
+    )
+
+    assert state.suppress_bootstrap_silence is True
+
+
 def test_qwen3_tts_bootstrap_silence_not_offered_on_base() -> None:
     payload = make_payload(
         inputs={"text": "target", "references": [{"audio_path": "v.wav", "text": "r"}]},

--- a/tests/unit_test/qwen3_tts/test_pipeline.py
+++ b/tests/unit_test/qwen3_tts/test_pipeline.py
@@ -1429,6 +1429,67 @@ def test_qwen3_tts_stream_codec_output_factory_default_disables_streaming() -> N
     )
 
 
+def _bootstrap_eligible_payload(**overrides: Any):
+    tts_params = {
+        "task_type": "CustomVoice",
+        "voice": "Ryan",
+        "language": "English",
+    }
+    tts_params.update(overrides.pop("tts_params", {}))
+    return make_payload(
+        inputs="target",
+        params=overrides.pop("params", None),
+        tts_params=tts_params,
+    )
+
+
+def test_qwen3_tts_bootstrap_silence_eligible_on_allowlisted_custom_voice() -> None:
+    state = build_qwen3_tts_state(_bootstrap_eligible_payload())
+
+    assert state.task_type == "CustomVoice"
+    assert state.stream_codec_output is True
+    assert state.suppress_bootstrap_silence is True
+
+
+@pytest.mark.parametrize(
+    "tts_params",
+    [
+        {"voice": "Vivian"},
+        {"language": "Chinese"},
+        {"instructions": "Whisper softly."},
+        {"temperature": 0.9},
+        {"top_p": 0.7},
+        {"stream_codec_output": False},
+        {"suppress_bootstrap_silence": False},
+    ],
+)
+def test_qwen3_tts_bootstrap_silence_ineligible_variants(
+    tts_params: dict[str, Any],
+) -> None:
+    state = build_qwen3_tts_state(_bootstrap_eligible_payload(tts_params=tts_params))
+
+    assert state.suppress_bootstrap_silence is False
+
+
+def test_qwen3_tts_bootstrap_silence_ignores_max_new_tokens() -> None:
+    state = build_qwen3_tts_state(
+        _bootstrap_eligible_payload(tts_params={"max_new_tokens": 512})
+    )
+
+    assert state.suppress_bootstrap_silence is True
+
+
+def test_qwen3_tts_bootstrap_silence_not_offered_on_base() -> None:
+    payload = make_payload(
+        inputs={"text": "target", "references": [{"audio_path": "v.wav", "text": "r"}]},
+    )
+
+    state = build_qwen3_tts_state(payload)
+
+    assert state.task_type == "Base"
+    assert state.suppress_bootstrap_silence is False
+
+
 def test_qwen3_tts_custom_voice_rejects_base_only_fields() -> None:
     payload = make_payload(
         inputs="target",
@@ -3635,6 +3696,128 @@ def test_qwen3_tts_stream_output_prepends_reference_once() -> None:
     second = stream_output_builder(payload.request_id, data, None)
     assert second[0].data.tolist() == [[3, 4]]
     assert "ref_code_len" not in second[0].metadata
+
+
+def test_qwen3_tts_stream_output_marks_bootstrap_silence_suppression() -> None:
+    from sglang_omni.models.qwen3_tts.request_builders import (
+        make_qwen3_tts_scheduler_adapters,
+    )
+
+    payload = make_payload(inputs="target", params={"stream": True})
+    _, _, stream_output_builder = make_qwen3_tts_scheduler_adapters(
+        model=None,
+        wrapper=None,
+    )
+    data = Qwen3TTSSGLangRequestData(
+        latest_stream_code_chunk=torch.tensor([1, 2]),
+        stream_codec_output=True,
+        suppress_bootstrap_silence=True,
+        stage_payload=payload,
+    )
+
+    first = stream_output_builder(payload.request_id, data, None)
+    assert first[0].metadata["bootstrap_silence_suppression"] is True
+
+    data.latest_stream_code_chunk = torch.tensor([3, 4])
+    second = stream_output_builder(payload.request_id, data, None)
+    assert "bootstrap_silence_suppression" not in second[0].metadata
+
+
+def test_qwen3_tts_vocoder_latches_bootstrap_suppression_contract() -> None:
+    scheduler = Qwen3TTSStreamingVocoderScheduler(
+        _FakeQwen3TTSTokenizer(),
+        device="cpu",
+    )
+    state = scheduler.create_stream_state("request")
+    scheduler.latch_stream_contract(
+        "request",
+        state,
+        {"num_quantizers": 2, "bootstrap_silence_suppression": True},
+        origin="metadata",
+    )
+    assert state.suppress_bootstrap is True
+
+    disabled = Qwen3TTSStreamingVocoderScheduler(
+        _FakeQwen3TTSTokenizer(),
+        device="cpu",
+        suppress_bootstrap_silence=False,
+    )
+    state = disabled.create_stream_state("request")
+    disabled.latch_stream_contract(
+        "request",
+        state,
+        {"num_quantizers": 2, "bootstrap_silence_suppression": True},
+        origin="metadata",
+    )
+    assert state.suppress_bootstrap is False
+
+
+def test_qwen3_tts_bootstrap_suppression_trims_one_silent_frame_once() -> None:
+    scheduler = Qwen3TTSStreamingVocoderScheduler(
+        _FakeQwen3TTSTokenizer(),
+        device="cpu",
+    )
+    state = scheduler.create_stream_state("request")
+    frame = scheduler._samples_per_frame
+    silent_head = torch.zeros(frame)
+    speech = torch.full((2 * frame,), 0.5)
+    delta = torch.cat((silent_head, speech))
+
+    state.suppress_bootstrap = True
+    trimmed = scheduler._apply_bootstrap_suppression(state, delta)
+
+    assert state.suppress_bootstrap is False
+    assert torch.equal(trimmed, delta[frame:])
+
+    untouched = scheduler._apply_bootstrap_suppression(state, delta)
+    assert torch.equal(untouched, delta)
+
+
+def test_qwen3_tts_bootstrap_suppression_fails_closed_on_audible_frame() -> None:
+    scheduler = Qwen3TTSStreamingVocoderScheduler(
+        _FakeQwen3TTSTokenizer(),
+        device="cpu",
+    )
+    state = scheduler.create_stream_state("request")
+    frame = scheduler._samples_per_frame
+    delta = torch.full((3 * frame,), 0.5)
+
+    state.suppress_bootstrap = True
+    kept = scheduler._apply_bootstrap_suppression(state, delta)
+
+    assert state.suppress_bootstrap is False
+    assert torch.equal(kept, delta)
+
+
+def test_qwen3_tts_bootstrap_suppression_keeps_single_frame_delta() -> None:
+    scheduler = Qwen3TTSStreamingVocoderScheduler(
+        _FakeQwen3TTSTokenizer(),
+        device="cpu",
+    )
+    state = scheduler.create_stream_state("request")
+    frame = scheduler._samples_per_frame
+    delta = torch.zeros(frame)
+
+    state.suppress_bootstrap = True
+    kept = scheduler._apply_bootstrap_suppression(state, delta)
+
+    assert torch.equal(kept, delta)
+
+
+def test_qwen3_tts_bootstrap_suppression_applies_through_decode_delta(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    scheduler, _ = _stateful_qwen3_tts_scheduler(monkeypatch)
+    state = scheduler.create_stream_state("request")
+    state.suppress_bootstrap = True
+    state.code_chunks.append(torch.tensor([[0, 0], [10, 1], [20, 2]], dtype=torch.long))
+    state.total_frames = 3
+
+    first = scheduler.decode_delta("request", state, is_final=False)
+
+    assert first is not None
+    assert first.tolist() == [10.0] * 4 + [20.0] * 4
+    assert state.suppress_bootstrap is False
 
 
 def test_qwen3_tts_stream_output_skips_when_codec_streaming_is_disabled() -> None:

--- a/tests/unit_test/qwen3_tts/test_pipeline.py
+++ b/tests/unit_test/qwen3_tts/test_pipeline.py
@@ -3839,38 +3839,49 @@ def test_qwen3_tts_bootstrap_suppression_extends_first_chunk_by_one_frame() -> N
     left = scheduler._stream_left_context_frames
     captured = set(scheduler._initial_decode_graphs._input_frames)
 
+    # Derived from the scheduler, not hardcoded: the shipped first chunk moves
+    # with the chunk-ramp default, and only the bump of one frame is fixed.
+    plain = scheduler.create_stream_state("request").initial_chunk_frames
+    bumped = plain + 1
+    ramp = (*scheduler._followup_stride_ramp, scheduler._stream_followup_stride)
+
     def _windows(ref_frames: int, first_chunk: int) -> list[int]:
         emitted, out = 0, []
         for index in range(6):
-            stride = first_chunk if index == 0 else 8
+            stride = first_chunk if index == 0 else ramp[min(index - 1, len(ramp) - 1)]
             generated = emitted + stride
             out.append((ref_frames + generated) - max(0, ref_frames + emitted - left))
             emitted = generated
         return out
 
-    for ref_frames, first_chunk in ((0, 9), (0, 8), (120, 9), (120, 8)):
+    for ref_frames, first_chunk in (
+        (0, bumped),
+        (0, plain),
+        (120, bumped),
+        (120, plain),
+    ):
         produced = _windows(ref_frames, first_chunk)
         assert not set(produced) - captured, (
             f"uncaptured decode windows for ref={ref_frames} "
             f"first_chunk={first_chunk}: {sorted(set(produced) - captured)}"
         )
-    assert 9 in captured
+    assert bumped in captured
+
     state = scheduler.create_stream_state("request")
-    assert state.initial_chunk_frames == 8
     scheduler.latch_stream_contract(
         "request",
         state,
         {"num_quantizers": 2, "bootstrap_silence_suppression": True},
         origin="metadata",
     )
-    assert state.initial_chunk_frames == 9
+    assert state.initial_chunk_frames == bumped
 
     disabled = Qwen3TTSStreamingVocoderScheduler(
         _FakeQwen3TTSTokenizer(),
         device="cpu",
         suppress_bootstrap_silence=False,
     )
-    assert 9 not in disabled._initial_decode_graphs._input_frames
+    assert bumped not in disabled._initial_decode_graphs._input_frames
     state = disabled.create_stream_state("request")
     disabled.latch_stream_contract(
         "request",
@@ -3878,7 +3889,7 @@ def test_qwen3_tts_bootstrap_suppression_extends_first_chunk_by_one_frame() -> N
         {"num_quantizers": 2, "bootstrap_silence_suppression": True},
         origin="metadata",
     )
-    assert state.initial_chunk_frames == 8
+    assert state.initial_chunk_frames == plain
 
 
 def test_qwen3_tts_bootstrap_suppression_first_chunk_clamps_to_stride() -> None:
@@ -3971,7 +3982,10 @@ def test_qwen3_tts_bootstrap_suppression_skips_at_high_concurrency() -> None:
     scheduler._stream_states["d"] = over
     scheduler.latch_stream_contract("d", over, metadata, origin="metadata")
     assert over.suppress_bootstrap is False
-    assert over.initial_chunk_frames == 8
+    assert (
+        over.initial_chunk_frames
+        == scheduler.create_stream_state("probe").initial_chunk_frames
+    )
 
 
 def test_qwen3_tts_bootstrap_suppression_trims_one_silent_frame_once() -> None:

--- a/tests/unit_test/qwen3_tts/test_pipeline.py
+++ b/tests/unit_test/qwen3_tts/test_pipeline.py
@@ -2428,13 +2428,33 @@ def test_qwen3_tts_explicit_initial_chunk_frames_keeps_legacy_ramp() -> None:
     )
 
     left = scheduler._stream_left_context_frames
-    # Startup prefix sums, the steady jitter band left+1..left+stride, and
-    # left+9 for the extra frame a bootstrap-suppressed first chunk decodes.
-    expected = tuple(sorted({8} | {left + f for f in range(0, 10)}))
     assert scheduler.create_stream_state("request").initial_chunk_frames == 8
     assert scheduler._followup_stride_ramp == (8,)
-    assert scheduler._initial_decode_graphs._input_frames == expected
-    assert scheduler._followup_decode_graphs._input_frames == expected
+
+    # Replay the real window arithmetic rather than restating the formula. A
+    # suppressed stream runs a 9-frame first chunk, and CustomVoice carries no
+    # reference codes, so its first window is 9 rather than left + 9.
+    captured = set(scheduler._initial_decode_graphs._input_frames)
+
+    def _windows(ref_frames: int, first_chunk: int) -> list[int]:
+        emitted, out = 0, []
+        for index in range(6):
+            stride = first_chunk if index == 0 else 8
+            generated = emitted + stride
+            out.append((ref_frames + generated) - max(0, ref_frames + emitted - left))
+            emitted = generated
+        return out
+
+    for ref_frames, first_chunk in ((0, 8), (0, 9), (120, 8), (120, 9)):
+        produced = _windows(ref_frames, first_chunk)
+        assert not set(produced) - captured, (
+            f"uncaptured windows for ref={ref_frames} first={first_chunk}: "
+            f"{sorted(set(produced) - captured)}"
+        )
+    assert 9 in captured
+    assert scheduler._followup_decode_graphs._input_frames == (
+        scheduler._initial_decode_graphs._input_frames
+    )
 
 
 def _qwen3_tts_stream_item(

--- a/tests/unit_test/qwen3_tts/test_pipeline.py
+++ b/tests/unit_test/qwen3_tts/test_pipeline.py
@@ -3377,6 +3377,7 @@ def test_qwen3_tts_streaming_vocoder_chunk_ramp_covers_graph_shapes() -> None:
     )
     left = scheduler._stream_left_context_frames
     # Startup prefix sums {2, 6, 14} plus the steady jitter band left+1..left+8.
+    # Suppression's extra frame lands on left+3, already inside that band.
     expected = tuple(sorted({2, 6, 14} | {left + f for f in range(1, 9)}))
     assert scheduler._initial_decode_graphs._input_frames == expected
     assert scheduler._followup_decode_graphs._input_frames == expected

--- a/tests/unit_test/qwen3_tts/test_pipeline.py
+++ b/tests/unit_test/qwen3_tts/test_pipeline.py
@@ -3775,7 +3775,9 @@ def test_qwen3_tts_bootstrap_suppression_extends_first_chunk_by_one_frame() -> N
         _FakeQwen3TTSTokenizer(),
         device="cpu",
     )
-    assert scheduler._initial_decode_graphs._input_frames == (24, 25)
+    # The suppressed first chunk decodes one extra frame, so 25 joins the
+    # captured shapes; without suppression it is absent (asserted below).
+    assert 25 in scheduler._initial_decode_graphs._input_frames
     state = scheduler.create_stream_state("request")
     assert state.initial_chunk_frames == 8
     scheduler.latch_stream_contract(
@@ -3791,7 +3793,7 @@ def test_qwen3_tts_bootstrap_suppression_extends_first_chunk_by_one_frame() -> N
         device="cpu",
         suppress_bootstrap_silence=False,
     )
-    assert disabled._initial_decode_graphs._input_frames == (24,)
+    assert 25 not in disabled._initial_decode_graphs._input_frames
     state = disabled.create_stream_state("request")
     disabled.latch_stream_contract(
         "request",

--- a/tests/unit_test/qwen3_tts/test_pipeline.py
+++ b/tests/unit_test/qwen3_tts/test_pipeline.py
@@ -3417,11 +3417,28 @@ def test_qwen3_tts_streaming_vocoder_chunk_ramp_covers_graph_shapes() -> None:
         stream_chunk_ramp=(2, 4, 8),
     )
     left = scheduler._stream_left_context_frames
-    # Startup prefix sums {2, 6, 14} plus the steady jitter band left+1..left+8.
-    # Suppression's extra frame lands on left+3, already inside that band.
-    expected = tuple(sorted({2, 6, 14} | {left + f for f in range(1, 9)}))
-    assert scheduler._initial_decode_graphs._input_frames == expected
-    assert scheduler._followup_decode_graphs._input_frames == expected
+    # A suppressed stream runs the bumped ramp 3 -> 4 -> 8, and CustomVoice has
+    # no reference codes, so its startup windows are that schedule's running
+    # sums. Replay the real arithmetic instead of restating the formula.
+    captured = set(scheduler._initial_decode_graphs._input_frames)
+
+    def _windows(ref_frames: int, first_chunk: int) -> list[int]:
+        emitted, out = 0, []
+        for index, stride in enumerate((first_chunk, 4, 8, 8, 8, 8)):
+            generated = emitted + stride
+            out.append((ref_frames + generated) - max(0, ref_frames + emitted - left))
+            emitted = generated
+        return out
+
+    for ref_frames, first_chunk in ((0, 2), (0, 3), (120, 2), (120, 3)):
+        produced = _windows(ref_frames, first_chunk)
+        assert not set(produced) - captured, (
+            f"uncaptured windows for ref={ref_frames} first={first_chunk}: "
+            f"{sorted(set(produced) - captured)}"
+        )
+    assert scheduler._followup_decode_graphs._input_frames == (
+        scheduler._initial_decode_graphs._input_frames
+    )
 
     payload = make_payload(inputs="target", params={"stream": True})
     scheduler._on_streaming_new_request(payload.request_id, payload)

--- a/tests/unit_test/qwen3_tts/test_pipeline.py
+++ b/tests/unit_test/qwen3_tts/test_pipeline.py
@@ -3819,6 +3819,30 @@ def test_qwen3_tts_bootstrap_suppression_first_chunk_clamps_to_stride() -> None:
     assert state.initial_chunk_frames == 16
 
 
+def test_qwen3_tts_bootstrap_suppression_skips_at_high_concurrency() -> None:
+    scheduler = Qwen3TTSStreamingVocoderScheduler(
+        _FakeQwen3TTSTokenizer(),
+        device="cpu",
+        suppress_bootstrap_max_streams=2,
+    )
+    metadata = {"num_quantizers": 2, "bootstrap_silence_suppression": True}
+
+    under = scheduler.create_stream_state("a")
+    scheduler._stream_states["a"] = under
+    scheduler.latch_stream_contract("a", under, metadata, origin="metadata")
+    assert under.suppress_bootstrap is True
+
+    # A third live stream puts the vocoder past the gate, so the extra
+    # first-chunk frame is not spent and the silence is left in place.
+    for rid in ("b", "c"):
+        scheduler._stream_states[rid] = scheduler.create_stream_state(rid)
+    over = scheduler.create_stream_state("d")
+    scheduler._stream_states["d"] = over
+    scheduler.latch_stream_contract("d", over, metadata, origin="metadata")
+    assert over.suppress_bootstrap is False
+    assert over.initial_chunk_frames == 8
+
+
 def test_qwen3_tts_bootstrap_suppression_trims_one_silent_frame_once() -> None:
     scheduler = Qwen3TTSStreamingVocoderScheduler(
         _FakeQwen3TTSTokenizer(),

--- a/tests/unit_test/qwen3_tts/test_pipeline.py
+++ b/tests/unit_test/qwen3_tts/test_pipeline.py
@@ -3775,9 +3775,28 @@ def test_qwen3_tts_bootstrap_suppression_extends_first_chunk_by_one_frame() -> N
         _FakeQwen3TTSTokenizer(),
         device="cpu",
     )
-    # The suppressed first chunk decodes one extra frame, so 25 joins the
-    # captured shapes; without suppression it is absent (asserted below).
-    assert 25 in scheduler._initial_decode_graphs._input_frames
+    # CustomVoice carries no reference codes, so the suppressed first window is
+    # the bumped chunk itself, not left_context + chunk. Replay the real window
+    # arithmetic from _build_decode_plan rather than re-deriving it.
+    left = scheduler._stream_left_context_frames
+    captured = set(scheduler._initial_decode_graphs._input_frames)
+
+    def _windows(ref_frames: int, first_chunk: int) -> list[int]:
+        emitted, out = 0, []
+        for index in range(6):
+            stride = first_chunk if index == 0 else 8
+            generated = emitted + stride
+            out.append((ref_frames + generated) - max(0, ref_frames + emitted - left))
+            emitted = generated
+        return out
+
+    for ref_frames, first_chunk in ((0, 9), (0, 8), (120, 9), (120, 8)):
+        produced = _windows(ref_frames, first_chunk)
+        assert not set(produced) - captured, (
+            f"uncaptured decode windows for ref={ref_frames} "
+            f"first_chunk={first_chunk}: {sorted(set(produced) - captured)}"
+        )
+    assert 9 in captured
     state = scheduler.create_stream_state("request")
     assert state.initial_chunk_frames == 8
     scheduler.latch_stream_contract(
@@ -3793,7 +3812,7 @@ def test_qwen3_tts_bootstrap_suppression_extends_first_chunk_by_one_frame() -> N
         device="cpu",
         suppress_bootstrap_silence=False,
     )
-    assert 25 not in disabled._initial_decode_graphs._input_frames
+    assert 9 not in disabled._initial_decode_graphs._input_frames
     state = disabled.create_stream_state("request")
     disabled.latch_stream_contract(
         "request",
@@ -3819,6 +3838,58 @@ def test_qwen3_tts_bootstrap_suppression_first_chunk_clamps_to_stride() -> None:
         origin="metadata",
     )
     assert state.initial_chunk_frames == 16
+    # The lead compensation could not apply, so nothing may be stripped either.
+    assert state.suppress_bootstrap is False
+
+
+def test_qwen3_tts_bootstrap_suppression_off_when_first_chunk_is_zero() -> None:
+    """A stream that cannot take the compensating frame keeps its full lead."""
+    scheduler = Qwen3TTSStreamingVocoderScheduler(
+        _FakeQwen3TTSTokenizer(),
+        device="cpu",
+        initial_chunk_frames=0,
+    )
+    state = scheduler.create_stream_state("request")
+    scheduler.latch_stream_contract(
+        "request",
+        state,
+        {"num_quantizers": 2, "bootstrap_silence_suppression": True},
+        origin="metadata",
+    )
+    assert state.suppress_bootstrap is False
+
+
+def test_qwen3_tts_bootstrap_suppression_credits_only_emitted_audio() -> None:
+    """The withheld frame must not be charged to the playback deadline."""
+    scheduler = Qwen3TTSStreamingVocoderScheduler(
+        _FakeQwen3TTSTokenizer(),
+        device="cpu",
+    )
+    state = scheduler.create_stream_state("request")
+    scheduler.latch_stream_contract(
+        "request",
+        state,
+        {"num_quantizers": 2, "bootstrap_silence_suppression": True},
+        origin="metadata",
+    )
+    assert state.suppress_bootstrap is True
+
+    frame = scheduler._samples_per_frame
+    plan = _Qwen3TTSDecodePlan(
+        decoder_input=torch.zeros(1, 2, state.initial_chunk_frames),
+        absolute_emitted_frames=0,
+        generated_frames=state.initial_chunk_frames,
+        window_start=0,
+        emitted_generated_frames=0,
+    )
+    delta = torch.zeros(1, frame * state.initial_chunk_frames)
+    emitted = scheduler._commit_decode_plan(state, plan, delta)
+
+    assert int(emitted.shape[-1]) == frame * (state.initial_chunk_frames - 1)
+    credited = state.playback_deadline_s - time.monotonic()
+    assert credited == pytest.approx(
+        float(emitted.numel()) / scheduler._sample_rate, abs=0.05
+    )
 
 
 def test_qwen3_tts_bootstrap_suppression_skips_at_high_concurrency() -> None:


### PR DESCRIPTION
Stacked on #1852 (its commits appear in this diff until it merges). Re-opens the T-PR16 idea from #1754 in the narrow form the original probe never tested: streamed CustomVoice only, per-voice allowlisted, and guarded at runtime.

## Evidence

Per-request analysis of every successful measurement request from the H100 A/B corpus (n=2229; 1.7B CustomVoice, Ryan, English, shipped-default sampling): the audible-onset offset is min 70 ms / p50 80 ms, and the first 80 ms of decoded PCM never exceeds **-103.7 dBFS RMS** — one 12.5 Hz codec frame (80 ms) of digital silence at the head of every utterance. The apparent 70 ms onsets are artifacts of the 20 ms/10 ms audibility detector window reaching into frame 2. Details in #1754.

This is worth ~80 ms of audible TTFA at every load level: at 1 RPS our audible-TTFA p50 splits into 54 ms TTFB + 80 ms leading silence.

## Design

The bootstrap frame is **not** removed from the codec sequence: it still feeds the vocoder, so decoder state (causal attention, conv history, ConvTranspose overlap) and every later sample are unchanged. Only the first frame's samples are withheld from the first emitted chunk.

Two gates, both required:

- **Static eligibility** (resolved with the request state, transported to the vocoder in the first stream chunk's metadata): CustomVoice, streamed codec output, voice in `QWEN3_TTS_BOOTSTRAP_SILENCE_VOICES` (Ryan), language in `QWEN3_TTS_BOOTSTRAP_SILENCE_LANGUAGES` (English), no instructions, and no explicit sampling overrides (`max_new_tokens` stays out of the gate — it does not touch the first frame's sampling distribution). Extending either allowlist requires an equivalent corpus measurement first.
- **Runtime acoustic guard, fail closed**: before withholding, the vocoder checks the actual first-frame PCM (RMS <= -60 dBFS and peak <= -50 dBFS, orders of magnitude above the measured -103.7 dBFS corpus maximum and far below any real onset). A first frame that is not silent is emitted unchanged, so the failure direction is "80 ms slower", never a clipped phoneme.

Suppression engages once per stream on the first committed chunk, covering the sync path, the async initial lane, and the single-final-flush path for short utterances; a first delta of one frame or less is never emptied.

Because the withheld frame is also withheld from the client's playback buffer, a suppressed stream decodes **one extra frame into its first chunk** (`initial_chunk_frames + 1`, clamped to the steady stride) so the audible lead is unchanged, and the initial-decode CUDA graph captures both shapes. Without this, 10 RPS underruns doubled; with it they drop below the no-suppression baseline (measured tables in the PR comments).

Opt-outs: per request `"suppress_bootstrap_silence": false` (HTTP, batch, WebSocket surfaces), per deployment `--vocoder.factory.suppress_bootstrap_silence false`.

## Concurrency gate

A third gate was added after benchmarking: suppression is skipped once more than `suppress_bootstrap_max_streams` (default **24**) streams are live in the vocoder.

The reason is that the win and the cost scale in opposite directions. The extra frame a suppressed stream decodes into its first chunk (see above) is what keeps the audible lead intact, but it is also extra vocoder work at exactly the moment the follow-up workers are the binding constraint. At low concurrency that trade is free and buys the full ~80 ms; at 20 RPS it measurably worsened continuity. Rather than ship a latency win that regresses under load, suppression now engages only while the vocoder is below the threshold and silently stops above it — the stream simply keeps its 80 ms of leading silence, which is today's shipped behaviour.

The gate reads `len(self._stream_states)` at contract-latch time, so it is per-stream and needs no extra bookkeeping. It is exposed as `--vocoder.factory.suppress_bootstrap_max_streams` for hosts that measure differently.

## Why not the alternatives

- Deleting the frame before the vocoder changes the representation the causal decoder sees and risks altering frame-2+ onset/prosody, for no latency gain (the 80 ms is audio time, not compute time).
- A generic RMS trim was already rejected by the Base-model probe in #1754 (first frames there are content-dependent); this path never engages outside the allowlist.

## Validation

- Unit tests: eligibility matrix (voice/language/instructions/sampling/opt-out/Base), metadata propagation, factory kill-switch, one-shot trim, fail-closed on audible first frame, single-frame delta untouched, and end-to-end through `decode_delta`.
- Correctness invariant by construction: with suppression active, emitted audio equals the unsuppressed stream minus its first 1920 samples.
- WER + TTFA A/B on H100 with the #1754 harness: attached in the comments. TTS CI stage 1 selected `qwen3-tts` and passed at wer_corpus 1.0299% and speaker similarity 71.09.


