### PR TITLE
[Qwen3-TTS] Pace streaming decode by playback lead

### DIFF
--- a/sglang_omni/models/qwen3_tts/engine_builder.py
+++ b/sglang_omni/models/qwen3_tts/engine_builder.py
@@ -37,7 +37,7 @@ class Qwen3TtsEngineBuilder(TtsEngineBuilder):
         self,
         *,
         attn_implementation: str | None = None,
-        pacing_lead_s: float = 1.0,
+        pacing_lead_s: float = 0.0,
         pacing_resume_lead_s: float = 0.4,
         pacing_max_resume_per_step: int = 4,
     ) -> None:

--- a/sglang_omni/models/qwen3_tts/engine_builder.py
+++ b/sglang_omni/models/qwen3_tts/engine_builder.py
@@ -150,6 +150,12 @@ class Qwen3TtsEngineBuilder(TtsEngineBuilder):
                 pacing_resume_lead_s=float(self.pacing_resume_lead_s),
                 pacing_frame_duration_s=self.pacing_frame_duration_s,
                 pacing_max_resume_per_step=int(self.pacing_max_resume_per_step),
+                # note (luojiaxuan): mirrors the latency-serving vocoder chunk
+                # plan (stream_chunk_ramp [2, 4, 8], steady follow-up stride
+                # 8); operators changing the vocoder ramp must keep these in
+                # sync until serving profiles unify the two.
+                pacing_chunk_frames=(2, 4, 8),
+                pacing_steady_stride_frames=8,
             )
         return kwargs
 

--- a/sglang_omni/models/qwen3_tts/engine_builder.py
+++ b/sglang_omni/models/qwen3_tts/engine_builder.py
@@ -29,8 +29,22 @@ class Qwen3TtsEngineBuilder(TtsEngineBuilder):
         CAPABILITIES.supports_breakable_prefill_cuda_graph
     )
 
-    def __init__(self, *, attn_implementation: str | None = None) -> None:
+    # note (luojiaxuan): one 12.5 Hz codec frame is 80 ms of audio; the
+    # scheduler needs this to turn generation steps into playback lead.
+    pacing_frame_duration_s = 0.08
+
+    def __init__(
+        self,
+        *,
+        attn_implementation: str | None = None,
+        pacing_lead_s: float = 1.0,
+        pacing_resume_lead_s: float = 0.4,
+        pacing_max_resume_per_step: int = 4,
+    ) -> None:
         self.attn_implementation = attn_implementation
+        self.pacing_lead_s = pacing_lead_s
+        self.pacing_resume_lead_s = pacing_resume_lead_s
+        self.pacing_max_resume_per_step = pacing_max_resume_per_step
         self.wrapper: Any | None = None
         self._stream_output_builder: Any | None = None
 
@@ -125,11 +139,19 @@ class Qwen3TtsEngineBuilder(TtsEngineBuilder):
         return request_builder, result_adapter
 
     def extra_scheduler_kwargs(self) -> dict[str, Any]:
-        return {
+        kwargs: dict[str, Any] = {
             "stream_output_builder": self._stream_output_builder,
             "request_build_max_workers": 4,
             "request_build_max_pending": 16,
         }
+        if self.pacing_lead_s and self.pacing_lead_s > 0:
+            kwargs.update(
+                pacing_lead_s=float(self.pacing_lead_s),
+                pacing_resume_lead_s=float(self.pacing_resume_lead_s),
+                pacing_frame_duration_s=self.pacing_frame_duration_s,
+                pacing_max_resume_per_step=int(self.pacing_max_resume_per_step),
+            )
+        return kwargs
 
     def make_abort_callback(self) -> Any | None:
         return request_builders.cleanup_prepared_qwen3_tts_request

--- a/sglang_omni/models/qwen3_tts/stages.py
+++ b/sglang_omni/models/qwen3_tts/stages.py
@@ -127,11 +127,17 @@ def create_sglang_tts_engine_executor(
     dtype: str = "bfloat16",
     attn_implementation: str | None = None,
     server_args_overrides: dict[str, Any] | None = None,
+    pacing_lead_s: float = 1.0,
+    pacing_resume_lead_s: float = 0.4,
+    pacing_max_resume_per_step: int = 4,
 ) -> Any:
     from sglang_omni.models.qwen3_tts.engine_builder import Qwen3TtsEngineBuilder
 
     return Qwen3TtsEngineBuilder(
         attn_implementation=attn_implementation,
+        pacing_lead_s=pacing_lead_s,
+        pacing_resume_lead_s=pacing_resume_lead_s,
+        pacing_max_resume_per_step=pacing_max_resume_per_step,
     ).build(
         model_path,
         device=device,

--- a/sglang_omni/models/qwen3_tts/stages.py
+++ b/sglang_omni/models/qwen3_tts/stages.py
@@ -127,7 +127,7 @@ def create_sglang_tts_engine_executor(
     dtype: str = "bfloat16",
     attn_implementation: str | None = None,
     server_args_overrides: dict[str, Any] | None = None,
-    pacing_lead_s: float = 1.0,
+    pacing_lead_s: float = 0.0,
     pacing_resume_lead_s: float = 0.4,
     pacing_max_resume_per_step: int = 4,
 ) -> Any:

--- a/sglang_omni/scheduling/omni_scheduler.py
+++ b/sglang_omni/scheduling/omni_scheduler.py
@@ -1426,18 +1426,14 @@ class OmniScheduler:
         batch.forward_mode = ForwardMode.DECODE
         device = batch.device
         pool_indices = [req.req_pool_idx for req in reqs]
-        seq_lens = [
-            len(req.origin_input_ids) + len(req.output_ids) for req in reqs
-        ]
+        seq_lens = [len(req.origin_input_ids) + len(req.output_ids) for req in reqs]
         batch.req_pool_indices = torch.tensor(
             pool_indices, dtype=torch.int64, device=device
         )
         batch.req_pool_indices_cpu = torch.tensor(pool_indices, dtype=torch.int64)
         batch.seq_lens = torch.tensor(seq_lens, dtype=torch.int64, device=device)
         batch.seq_lens_cpu = torch.tensor(seq_lens, dtype=torch.int64)
-        batch.orig_seq_lens = torch.tensor(
-            seq_lens, dtype=torch.int32, device=device
-        )
+        batch.orig_seq_lens = torch.tensor(seq_lens, dtype=torch.int32, device=device)
         batch.seq_lens_sum = sum(seq_lens)
         batch.input_ids = None
         batch.multimodal_inputs = [req.multimodal_inputs for req in reqs]
@@ -2303,9 +2299,7 @@ class OmniScheduler:
         batch = self.running_batch
         parked_reqs: list[Any] = []
         if self._pacer is not None:
-            parked_reqs = [
-                req for req in self._pacer.drain() if not req.finished()
-            ]
+            parked_reqs = [req for req in self._pacer.drain() if not req.finished()]
         if batch is None or batch.is_empty():
             if not parked_reqs:
                 return 0

--- a/sglang_omni/scheduling/omni_scheduler.py
+++ b/sglang_omni/scheduling/omni_scheduler.py
@@ -1392,7 +1392,23 @@ class OmniScheduler:
             self._pacer.hold(req, lead, now)
 
     def _resume_paced_requests(self, now: float) -> None:
-        resumable, dropped = self._pacer.pop_resumable(now)
+        budget: int | None = None
+        reserve = self._pacer.config.startup_reserve_slots
+        if reserve and self.waiting_queue:
+            running_len = (
+                0 if self.running_batch is None else len(self.running_batch.reqs)
+            )
+            budget = self.max_running_requests - reserve - running_len
+            if budget < 1:
+                # note (luojiaxuan): starving parked streams indefinitely
+                # trades queue wait for underruns; once the most pressing
+                # parked stream is overdue past its grace, it outranks
+                # startup work.
+                overdue_at = self._pacer.next_wake_at()
+                if overdue_at is not None and now - overdue_at > 0.2:
+                    budget = 1
+        resumable, dropped = self._pacer.pop_resumable(now, max_resume=budget)
+        dropped.extend(self._pacer.take_orphaned_drops())
         for req in dropped:
             # A parked request has no batch row, so the abort path could not
             # release its KV; a request that finished normally had its KV

--- a/sglang_omni/scheduling/omni_scheduler.py
+++ b/sglang_omni/scheduling/omni_scheduler.py
@@ -205,6 +205,8 @@ class OmniScheduler:
         pacing_resume_lead_s: float = 0.4,
         pacing_frame_duration_s: float | None = None,
         pacing_max_resume_per_step: int = 4,
+        pacing_chunk_frames: tuple[int, ...] | list[int] = (),
+        pacing_steady_stride_frames: int = 0,
         shutdown_callback: Callable[[], None] | None = None,
     ):
         self.inbox: _queue_mod.Queue[IncomingMessage] = _queue_mod.Queue()
@@ -332,6 +334,8 @@ class OmniScheduler:
                     resume_lead_s=float(pacing_resume_lead_s),
                     frame_duration_s=float(pacing_frame_duration_s),
                     max_resume_per_step=int(pacing_max_resume_per_step),
+                    chunk_frames=tuple(int(f) for f in (pacing_chunk_frames or ())),
+                    steady_stride_frames=int(pacing_steady_stride_frames),
                 )
             )
 

--- a/sglang_omni/scheduling/omni_scheduler.py
+++ b/sglang_omni/scheduling/omni_scheduler.py
@@ -41,6 +41,7 @@ from sglang.srt.runtime_context import get_model, get_serving
 from sglang.srt.utils import broadcast_pyobj
 
 from sglang_omni.admission import QueueFullError
+from sglang_omni.scheduling.pacing import PacingConfig, PlaybackLeadPacer
 from sglang_omni.profiler.event_recorder import emit as _emit_event
 from sglang_omni.profiler.event_recorder import (
     emit_model_path_end as _emit_model_path_end,
@@ -195,6 +196,10 @@ class OmniScheduler:
         prefill_coalesce_after_builds_during_decode: bool = False,
         request_build_max_workers: int = 1,
         request_build_max_pending: int | None = None,
+        pacing_lead_s: float | None = None,
+        pacing_resume_lead_s: float = 0.4,
+        pacing_frame_duration_s: float | None = None,
+        pacing_max_resume_per_step: int = 4,
         shutdown_callback: Callable[[], None] | None = None,
     ):
         self.inbox: _queue_mod.Queue[IncomingMessage] = _queue_mod.Queue()
@@ -308,6 +313,22 @@ class OmniScheduler:
         self.prefill_coalesce_after_builds_during_decode = bool(
             prefill_coalesce_after_builds_during_decode
         )
+
+        self._pacer: PlaybackLeadPacer | None = None
+        if pacing_lead_s is not None:
+            if pacing_frame_duration_s is None:
+                raise ValueError(
+                    "pacing_lead_s requires pacing_frame_duration_s so leads "
+                    "can be computed from generation steps"
+                )
+            self._pacer = PlaybackLeadPacer(
+                PacingConfig(
+                    lead_s=float(pacing_lead_s),
+                    resume_lead_s=float(pacing_resume_lead_s),
+                    frame_duration_s=float(pacing_frame_duration_s),
+                    max_resume_per_step=int(pacing_max_resume_per_step),
+                )
+            )
 
         # Token / memory info (upstream reads from tp_worker.get_worker_info)
         mr = tp_worker.model_runner
@@ -1322,11 +1343,108 @@ class OmniScheduler:
         own that state, so feed it in and write the (possibly rebuilt) running
         batch back before handing the runnable batch to the caller.
         """
+        if self._pacer is not None:
+            self._apply_playback_pacing()
         plan = _Upstream.get_next_batch_to_run(
             self, self.running_batch, self.last_batch
         )
         self.running_batch = plan.running_batch
         return plan.batch_to_run
+
+    def _apply_playback_pacing(self) -> None:
+        """Park comfortable streams and wake pressing ones between steps.
+
+        Runs before the upstream batch plan, on the same between-step boundary
+        upstream retraction uses: the in-flight async batch snapshots its
+        request list, so resizing ``running_batch`` here never desyncs a
+        launched step.
+        """
+        now = time.perf_counter()
+        self._resume_paced_requests(now)
+        batch = self.running_batch
+        if batch is None or batch.is_empty():
+            return
+        keep_indices: list[int] = []
+        parked: list[tuple[Any, float]] = []
+        for i, req in enumerate(batch.reqs):
+            lead = None
+            if not req.finished() and req.rid not in self._aborted_request_ids:
+                lead = self._pacer.should_pace(req._omni_data, now)
+            if lead is None:
+                keep_indices.append(i)
+            else:
+                parked.append((req, lead))
+        if not parked:
+            return
+        batch.filter_batch(keep_indices=keep_indices)
+        if not batch.reqs:
+            batch.batch_is_full = False
+        for req, lead in parked:
+            self._pacer.hold(req, lead, now)
+
+    def _resume_paced_requests(self, now: float) -> None:
+        resumable, dropped = self._pacer.pop_resumable(now)
+        for req in dropped:
+            # A parked request has no batch row, so the abort path could not
+            # release its KV; a request that finished normally had its KV
+            # released by process_batch_result already.
+            if not req.finished():
+                self._release_request_kv_cache(req)
+            _detach_request_data(req)
+        alive: list[Any] = []
+        for req in resumable:
+            if req.finished():
+                continue
+            if req.rid in self._aborted_request_ids:
+                self._release_request_kv_cache(req)
+                _detach_request_data(req)
+                continue
+            alive.append(req)
+        if not alive:
+            return
+        mini = self._build_resident_decode_batch(alive)
+        if self.running_batch is None or self.running_batch.is_empty():
+            self.running_batch = mini
+        else:
+            self.running_batch.merge_batch(mini)
+
+    def _build_resident_decode_batch(self, reqs: list[Any]) -> Any:
+        """Rebuild a decode-mode ScheduleBatch for requests whose KV stayed
+        resident while they were parked."""
+        from sglang.srt.model_executor.forward_batch_info import ForwardMode
+        from sglang.srt.sampling.sampling_batch_info import SamplingBatchInfo
+
+        batch = ScheduleBatch.init_new(
+            reqs,
+            self.req_to_token_pool,
+            self.token_to_kv_pool_allocator,
+            self.tree_cache,
+            self.model_config,
+            self.enable_overlap,
+            self.spec_algorithm,
+        )
+        batch.forward_mode = ForwardMode.DECODE
+        device = batch.device
+        pool_indices = [req.req_pool_idx for req in reqs]
+        seq_lens = [
+            len(req.origin_input_ids) + len(req.output_ids) for req in reqs
+        ]
+        batch.req_pool_indices = torch.tensor(
+            pool_indices, dtype=torch.int64, device=device
+        )
+        batch.req_pool_indices_cpu = torch.tensor(pool_indices, dtype=torch.int64)
+        batch.seq_lens = torch.tensor(seq_lens, dtype=torch.int64, device=device)
+        batch.seq_lens_cpu = torch.tensor(seq_lens, dtype=torch.int64)
+        batch.orig_seq_lens = torch.tensor(
+            seq_lens, dtype=torch.int32, device=device
+        )
+        batch.seq_lens_sum = sum(seq_lens)
+        batch.input_ids = None
+        batch.multimodal_inputs = [req.multimodal_inputs for req in reqs]
+        batch.sampling_info = SamplingBatchInfo.from_schedule_batch(
+            batch, self.model_config.vocab_size
+        )
+        return batch
 
     def get_new_batch_prefill(self, running_batch):
         # Note: (maydomine) batch prefill admissions to amortize the fixed step
@@ -1429,10 +1547,10 @@ class OmniScheduler:
             if rid in skip_rids or rid in self._aborted_request_ids:
                 continue
             req_output = mr_output.outputs[rid]
-            self._put_stream_messages(
-                rid,
-                self._stream_output_builder(rid, sched_req.data, req_output),
-            )
+            messages = self._stream_output_builder(rid, sched_req.data, req_output)
+            if messages and not sched_req.data.first_emit_s:
+                sched_req.data.first_emit_s = time.perf_counter()
+            self._put_stream_messages(rid, messages)
 
     def _put_stream_messages(self, request_id: str, messages: Any) -> None:
         emitted_any = False
@@ -1809,6 +1927,8 @@ class OmniScheduler:
         self._deferred_request_payloads.pop(request_id, None)
         self._dirty_deferred_request_ids.discard(request_id)
         self._first_emit_done.discard(request_id)
+        if self._pacer is not None:
+            self._pacer.drop(request_id)
         # Note: (Jiaxin Deng) emit before discarding, and discard whether or
         # not the request is still in a running batch. A running abort that
         # never reaches stream_output used to leave its rid here forever,
@@ -2181,16 +2301,33 @@ class OmniScheduler:
 
     def _retract_running_requests(self) -> int:
         batch = self.running_batch
+        parked_reqs: list[Any] = []
+        if self._pacer is not None:
+            parked_reqs = [
+                req for req in self._pacer.drain() if not req.finished()
+            ]
         if batch is None or batch.is_empty():
-            return 0
+            if not parked_reqs:
+                return 0
+            retract_all(
+                reqs=parked_reqs,
+                server_args=self.server_args,
+                req_to_token_pool=self.req_to_token_pool,
+                token_to_kv_pool_allocator=self.token_to_kv_pool_allocator,
+                tree_cache=self.tree_cache,
+                hisparse_coordinator=self.hisparse_coordinator,
+            )
+            for req in parked_reqs:
+                self._add_request_to_queue(req)
+            return len(parked_reqs)
         batch.filter_batch()
-        if len(batch.reqs) == 0:
+        if len(batch.reqs) == 0 and not parked_reqs:
             return 0
         # ScheduleBatch has no retract_all; the module-level function leaves
         # batch.reqs in place, so snapshot the requests and clear the batch here.
-        retracted_reqs = list(batch.reqs)
+        retracted_reqs = list(batch.reqs) + parked_reqs
         retract_all(
-            reqs=batch.reqs,
+            reqs=retracted_reqs,
             server_args=self.server_args,
             req_to_token_pool=batch.req_to_token_pool,
             token_to_kv_pool_allocator=batch.token_to_kv_pool_allocator,

--- a/sglang_omni/scheduling/omni_scheduler.py
+++ b/sglang_omni/scheduling/omni_scheduler.py
@@ -169,6 +169,11 @@ class OmniScheduler:
         are defined directly on this class and take precedence.
     """
 
+    # note (luojiaxuan): class-level default so partially constructed
+    # schedulers (tests build instances without running __init__) still
+    # read as pacing-disabled.
+    _pacer: PlaybackLeadPacer | None = None
+
     def __init__(
         self,
         tp_worker: Any,

--- a/sglang_omni/scheduling/omni_scheduler.py
+++ b/sglang_omni/scheduling/omni_scheduler.py
@@ -41,7 +41,6 @@ from sglang.srt.runtime_context import get_model, get_serving
 from sglang.srt.utils import broadcast_pyobj
 
 from sglang_omni.admission import QueueFullError
-from sglang_omni.scheduling.pacing import PacingConfig, PlaybackLeadPacer
 from sglang_omni.profiler.event_recorder import emit as _emit_event
 from sglang_omni.profiler.event_recorder import (
     emit_model_path_end as _emit_model_path_end,
@@ -62,6 +61,7 @@ from sglang_omni.proto.admin import (
     ADMIN_WEIGHTS_CHECKER,
 )
 from sglang_omni.scheduling.messages import IncomingMessage, OutgoingMessage
+from sglang_omni.scheduling.pacing import PacingConfig, PlaybackLeadPacer
 from sglang_omni.scheduling.types import DeferredAdmission
 
 logger = logging.getLogger(__name__)

--- a/sglang_omni/scheduling/pacing.py
+++ b/sglang_omni/scheduling/pacing.py
@@ -43,6 +43,7 @@ class PacingConfig:
     max_resume_per_step: int = 4
     chunk_frames: tuple[int, ...] = ()
     steady_stride_frames: int = 0
+    startup_reserve_slots: int = 4
 
     def __post_init__(self) -> None:
         if self.lead_s <= 0:
@@ -59,6 +60,8 @@ class PacingConfig:
             raise ValueError(
                 "pacing steady_stride_frames must be > 0 when chunk_frames is set"
             )
+        if self.startup_reserve_slots < 0:
+            raise ValueError("pacing startup_reserve_slots must be >= 0")
 
 
 class PlaybackLeadPacer:
@@ -69,6 +72,7 @@ class PlaybackLeadPacer:
         self._heap: list[tuple[float, int, Any]] = []
         self._held_rids: set[str] = set()
         self._dropped_rids: set[str] = set()
+        self._orphaned_drops: list[Any] = []
         self._tiebreak = count()
         self.paced_total = 0
         self.resumed_total = 0
@@ -153,18 +157,29 @@ class PlaybackLeadPacer:
     def held_rids(self) -> frozenset[str]:
         return frozenset(self._held_rids)
 
-    def pop_resumable(self, now: float | None = None) -> tuple[list[Any], list[Any]]:
+    def pop_resumable(
+        self,
+        now: float | None = None,
+        *,
+        max_resume: int | None = None,
+    ) -> tuple[list[Any], list[Any]]:
         """Pop requests due to wake, capped per step.
 
-        Returns ``(resumable, dropped)``: requests to put back into the decode
+        ``max_resume`` lowers this step's cap below the configured one —
+        the scheduler passes the decode slots it can spare after reserving
+        room for requests still waiting for first audio. Returns
+        ``(resumable, dropped)``: requests to put back into the decode
         batch, and parked requests that were dropped (aborted) while held —
         the caller owns releasing their resources.
         """
         if now is None:
             now = time.perf_counter()
+        cap = self.config.max_resume_per_step
+        if max_resume is not None:
+            cap = min(cap, max(0, max_resume))
         resumable: list[Any] = []
         dropped: list[Any] = []
-        while self._heap and len(resumable) < self.config.max_resume_per_step:
+        while self._heap and len(resumable) < cap:
             wake_at, _, req = self._heap[0]
             rid = req.rid
             if rid in self._dropped_rids:
@@ -180,6 +195,25 @@ class PlaybackLeadPacer:
             resumable.append(req)
         self.resumed_total += len(resumable)
         return resumable, dropped
+
+    def next_wake_at(self) -> float | None:
+        """Earliest pending wake time, skipping dropped entries."""
+        while self._heap:
+            wake_at, _, req = self._heap[0]
+            if req.rid in self._dropped_rids:
+                heapq.heappop(self._heap)
+                self._held_rids.discard(req.rid)
+                self._dropped_rids.discard(req.rid)
+                self._orphaned_drops.append(req)
+                continue
+            return wake_at
+        return None
+
+    def take_orphaned_drops(self) -> list[Any]:
+        """Dropped entries surfaced by ``next_wake_at`` peeks."""
+        drops = self._orphaned_drops
+        self._orphaned_drops = []
+        return drops
 
     def drain(self) -> list[Any]:
         """Remove and return every parked request, dropped ones included."""

--- a/sglang_omni/scheduling/pacing.py
+++ b/sglang_omni/scheduling/pacing.py
@@ -28,12 +28,21 @@ class PacingConfig:
     eligible to decode again. Parked requests wake by ascending deadline, at
     most ``max_resume_per_step`` per scheduling step, so a burst that parked
     together does not rejoin as one oversized batch.
+
+    ``chunk_frames`` and ``steady_stride_frames`` describe the vocoder's
+    emission plan (first chunk, ramp entries, then the steady stride). The
+    client only holds audio up to the last completed chunk boundary, so the
+    lead is computed from *routed* frames, not generated frames — generated
+    frames still parked inside the vocoder's next chunk are no cushion at
+    all. Keep these in sync with the vocoder factory's chunk configuration.
     """
 
     lead_s: float
     resume_lead_s: float
     frame_duration_s: float
     max_resume_per_step: int = 4
+    chunk_frames: tuple[int, ...] = ()
+    steady_stride_frames: int = 0
 
     def __post_init__(self) -> None:
         if self.lead_s <= 0:
@@ -44,6 +53,12 @@ class PacingConfig:
             raise ValueError("pacing frame_duration_s must be > 0")
         if self.max_resume_per_step <= 0:
             raise ValueError("pacing max_resume_per_step must be > 0")
+        if any(f <= 0 for f in self.chunk_frames):
+            raise ValueError("pacing chunk_frames entries must be > 0")
+        if self.chunk_frames and self.steady_stride_frames <= 0:
+            raise ValueError(
+                "pacing steady_stride_frames must be > 0 when chunk_frames is set"
+            )
 
 
 class PlaybackLeadPacer:
@@ -78,8 +93,38 @@ class PlaybackLeadPacer:
             return None
         if now is None:
             now = time.perf_counter()
-        generated_s = data.generation_steps * self.config.frame_duration_s
-        return generated_s - (now - data.first_emit_s)
+        routed = self._routed_audio_frames(
+            data.generation_steps,
+            suppressed=bool(getattr(data, "suppress_bootstrap_silence", False)),
+        )
+        if routed <= 0:
+            return None
+        routed_s = routed * self.config.frame_duration_s
+        return routed_s - (now - data.first_emit_s)
+
+    def _routed_audio_frames(self, generated: int, *, suppressed: bool) -> int:
+        """Audio frames the vocoder has released for ``generated`` frames.
+
+        Chunks flush at cumulative boundaries; a suppressed stream decodes
+        one extra frame into its first chunk and withholds one frame of
+        audio from it.
+        """
+        chunk_frames = self.config.chunk_frames
+        if not chunk_frames:
+            return generated
+        bump = 1 if suppressed else 0
+        boundary = chunk_frames[0] + bump
+        if generated < boundary:
+            return 0
+        routed = boundary - bump
+        for stride in chunk_frames[1:]:
+            if generated < boundary + stride:
+                return routed
+            boundary += stride
+            routed += stride
+        stride = self.config.steady_stride_frames
+        routed += ((generated - boundary) // stride) * stride
+        return routed
 
     def should_pace(self, data: Any, now: float | None = None) -> float | None:
         """Return the lead when the request should be parked, else None."""

--- a/sglang_omni/scheduling/pacing.py
+++ b/sglang_omni/scheduling/pacing.py
@@ -1,0 +1,145 @@
+# SPDX-License-Identifier: Apache-2.0
+"""Playback-lead pacing policy for streaming AR requests.
+
+A streaming TTS request that has already emitted audio far ahead of the
+client's playback position gains nothing from decoding further right now,
+while its decode slot is scarce for streams near their playback deadline and
+for requests still waiting for first audio. The pacer tracks how far ahead of
+playback each emitting request is and parks the comfortable ones — the
+scheduler keeps their KV resident and simply leaves them out of the decode
+batch until their lead drains.
+"""
+
+from __future__ import annotations
+
+import heapq
+import time
+from dataclasses import dataclass
+from itertools import count
+from typing import Any
+
+
+@dataclass(frozen=True)
+class PacingConfig:
+    """Playback-lead pacing thresholds.
+
+    ``lead_s`` parks a request once its emitted audio runs this far ahead of
+    realtime playback; ``resume_lead_s`` is the lead at which it becomes
+    eligible to decode again. Parked requests wake by ascending deadline, at
+    most ``max_resume_per_step`` per scheduling step, so a burst that parked
+    together does not rejoin as one oversized batch.
+    """
+
+    lead_s: float
+    resume_lead_s: float
+    frame_duration_s: float
+    max_resume_per_step: int = 4
+
+    def __post_init__(self) -> None:
+        if self.lead_s <= 0:
+            raise ValueError("pacing lead_s must be > 0")
+        if not 0 < self.resume_lead_s < self.lead_s:
+            raise ValueError("pacing resume_lead_s must be in (0, lead_s)")
+        if self.frame_duration_s <= 0:
+            raise ValueError("pacing frame_duration_s must be > 0")
+        if self.max_resume_per_step <= 0:
+            raise ValueError("pacing max_resume_per_step must be > 0")
+
+
+class PlaybackLeadPacer:
+    """Holds parked requests and decides pace/resume per scheduling step."""
+
+    def __init__(self, config: PacingConfig) -> None:
+        self.config = config
+        self._heap: list[tuple[float, int, Any]] = []
+        self._held_rids: set[str] = set()
+        self._dropped_rids: set[str] = set()
+        self._tiebreak = count()
+        self.paced_total = 0
+        self.resumed_total = 0
+
+    def __len__(self) -> int:
+        return len(self._held_rids)
+
+    def lead_s(self, data: Any, now: float | None = None) -> float | None:
+        """Playback lead of a request, or None when it is not paceable.
+
+        A request is paceable only after its first emitted chunk (protecting
+        time to first audio) and only when it streams codec output — a
+        non-streaming request has no playback clock to pace against.
+        """
+        if data is None:
+            return None
+        if not data.first_emit_s:
+            return None
+        # note (luojiaxuan): only Qwen3-TTS request data carries this field;
+        # other AR models' requests are simply never paceable.
+        if not getattr(data, "stream_codec_output", False):
+            return None
+        if now is None:
+            now = time.perf_counter()
+        generated_s = data.generation_steps * self.config.frame_duration_s
+        return generated_s - (now - data.first_emit_s)
+
+    def should_pace(self, data: Any, now: float | None = None) -> float | None:
+        """Return the lead when the request should be parked, else None."""
+        lead = self.lead_s(data, now)
+        if lead is None or lead <= self.config.lead_s:
+            return None
+        return lead
+
+    def hold(self, req: Any, lead: float, now: float | None = None) -> None:
+        if now is None:
+            now = time.perf_counter()
+        rid = req.rid
+        if rid in self._held_rids:
+            return
+        wake_at = now + max(0.0, lead - self.config.resume_lead_s)
+        heapq.heappush(self._heap, (wake_at, next(self._tiebreak), req))
+        self._held_rids.add(rid)
+        self._dropped_rids.discard(rid)
+        self.paced_total += 1
+
+    def drop(self, rid: str) -> None:
+        """Mark a parked request as gone (abort); it is skipped on wake."""
+        if rid in self._held_rids:
+            self._dropped_rids.add(rid)
+
+    def held_rids(self) -> frozenset[str]:
+        return frozenset(self._held_rids)
+
+    def pop_resumable(self, now: float | None = None) -> tuple[list[Any], list[Any]]:
+        """Pop requests due to wake, capped per step.
+
+        Returns ``(resumable, dropped)``: requests to put back into the decode
+        batch, and parked requests that were dropped (aborted) while held —
+        the caller owns releasing their resources.
+        """
+        if now is None:
+            now = time.perf_counter()
+        resumable: list[Any] = []
+        dropped: list[Any] = []
+        while self._heap and len(resumable) < self.config.max_resume_per_step:
+            wake_at, _, req = self._heap[0]
+            rid = req.rid
+            if rid in self._dropped_rids:
+                heapq.heappop(self._heap)
+                self._held_rids.discard(rid)
+                self._dropped_rids.discard(rid)
+                dropped.append(req)
+                continue
+            if wake_at > now:
+                break
+            heapq.heappop(self._heap)
+            self._held_rids.discard(rid)
+            resumable.append(req)
+        self.resumed_total += len(resumable)
+        return resumable, dropped
+
+    def drain(self) -> list[Any]:
+        """Remove and return every parked request, dropped ones included."""
+        reqs = [req for _, _, req in self._heap]
+        self._heap.clear()
+        self._held_rids.clear()
+        self._dropped_rids.clear()
+        return reqs

--- a/sglang_omni/scheduling/sglang_backend/request_data.py
+++ b/sglang_omni/scheduling/sglang_backend/request_data.py
@@ -17,6 +17,7 @@ class SGLangARRequestData(ARRequestData):
     req: Any = None
     synced: bool = False
     generation_steps: int = 0
+    first_emit_s: float = 0.0
     suppress_tokens: list[int] | None = None
     top_p: float = 1.0
     top_k: int = -1

--- a/tests/unit_test/scheduling/test_pacing.py
+++ b/tests/unit_test/scheduling/test_pacing.py
@@ -149,14 +149,14 @@ def test_drain_returns_everything() -> None:
     assert pacer.pop_resumable(now=999.0) == ([], [])
 
 
-def test_qwen3_tts_builder_enables_pacing_by_default() -> None:
+def test_qwen3_tts_builder_keeps_pacing_opt_in() -> None:
     from sglang_omni.models.qwen3_tts.engine_builder import Qwen3TtsEngineBuilder
 
-    kwargs = Qwen3TtsEngineBuilder().extra_scheduler_kwargs()
-    assert kwargs["pacing_lead_s"] == 1.0
-    assert kwargs["pacing_resume_lead_s"] == 0.4
-    assert kwargs["pacing_frame_duration_s"] == 0.08
-    assert kwargs["pacing_max_resume_per_step"] == 4
+    default = Qwen3TtsEngineBuilder().extra_scheduler_kwargs()
+    assert "pacing_lead_s" not in default
 
-    disabled = Qwen3TtsEngineBuilder(pacing_lead_s=0.0).extra_scheduler_kwargs()
-    assert "pacing_lead_s" not in disabled
+    enabled = Qwen3TtsEngineBuilder(pacing_lead_s=1.0).extra_scheduler_kwargs()
+    assert enabled["pacing_lead_s"] == 1.0
+    assert enabled["pacing_resume_lead_s"] == 0.4
+    assert enabled["pacing_frame_duration_s"] == 0.08
+    assert enabled["pacing_max_resume_per_step"] == 4

--- a/tests/unit_test/scheduling/test_pacing.py
+++ b/tests/unit_test/scheduling/test_pacing.py
@@ -149,6 +149,36 @@ def test_drain_returns_everything() -> None:
     assert pacer.pop_resumable(now=999.0) == ([], [])
 
 
+def test_routed_audio_frames_follow_chunk_boundaries() -> None:
+    pacer = _pacer(chunk_frames=(2, 4, 8), steady_stride_frames=8)
+
+    expect = {1: 0, 2: 2, 5: 2, 6: 6, 13: 6, 14: 14, 21: 14, 22: 22, 30: 30}
+    for generated, routed in expect.items():
+        assert (
+            pacer._routed_audio_frames(generated, suppressed=False) == routed
+        ), generated
+
+    suppressed_expect = {2: 0, 3: 2, 6: 2, 7: 6, 14: 6, 15: 14}
+    for generated, routed in suppressed_expect.items():
+        assert (
+            pacer._routed_audio_frames(generated, suppressed=True) == routed
+        ), generated
+
+
+def test_lead_uses_routed_frames_not_generated() -> None:
+    pacer = _pacer(chunk_frames=(2, 4, 8), steady_stride_frames=8)
+    now = 100.0
+
+    # 13 generated frames, but only 6 released to the client: the five
+    # frames parked inside the vocoder's next chunk are no cushion.
+    data = _Data(generation_steps=13, first_emit_s=99.9)
+    assert pacer.lead_s(data, now) == pytest.approx(6 * 0.08 - 0.1)
+
+    # Below the first chunk boundary nothing has been released.
+    early = _Data(generation_steps=1, first_emit_s=99.9)
+    assert pacer.lead_s(early, now) is None
+
+
 def test_qwen3_tts_builder_keeps_pacing_opt_in() -> None:
     from sglang_omni.models.qwen3_tts.engine_builder import Qwen3TtsEngineBuilder
 
@@ -160,3 +190,5 @@ def test_qwen3_tts_builder_keeps_pacing_opt_in() -> None:
     assert enabled["pacing_resume_lead_s"] == 0.4
     assert enabled["pacing_frame_duration_s"] == 0.08
     assert enabled["pacing_max_resume_per_step"] == 4
+    assert enabled["pacing_chunk_frames"] == (2, 4, 8)
+    assert enabled["pacing_steady_stride_frames"] == 8

--- a/tests/unit_test/scheduling/test_pacing.py
+++ b/tests/unit_test/scheduling/test_pacing.py
@@ -135,6 +135,35 @@ def test_double_hold_is_idempotent() -> None:
     assert len(woken) == 1
 
 
+def test_pop_resumable_honors_step_budget() -> None:
+    pacer = _pacer(max_resume_per_step=4)
+    now = 100.0
+    for i in range(3):
+        pacer.hold(_Req(rid=f"r{i}"), lead=1.1, now=now)
+
+    none_allowed, _ = pacer.pop_resumable(now=now + 5.0, max_resume=0)
+    assert none_allowed == []
+
+    one, _ = pacer.pop_resumable(now=now + 5.0, max_resume=1)
+    assert len(one) == 1
+    assert len(pacer) == 2
+
+
+def test_next_wake_at_skips_dropped_and_surfaces_them() -> None:
+    pacer = _pacer()
+    now = 100.0
+    gone = _Req(rid="gone")
+    keep = _Req(rid="keep")
+    pacer.hold(gone, lead=1.1, now=now)
+    pacer.hold(keep, lead=1.5, now=now)
+    pacer.drop("gone")
+
+    wake_at = pacer.next_wake_at()
+    assert wake_at == pytest.approx(now + 1.1)
+    assert [r.rid for r in pacer.take_orphaned_drops()] == ["gone"]
+    assert len(pacer) == 1
+
+
 def test_drain_returns_everything() -> None:
     pacer = _pacer()
     reqs = [_Req(rid=f"r{i}") for i in range(3)]

--- a/tests/unit_test/scheduling/test_pacing.py
+++ b/tests/unit_test/scheduling/test_pacing.py
@@ -1,0 +1,162 @@
+# SPDX-License-Identifier: Apache-2.0
+"""Unit tests for playback-lead pacing policy."""
+
+from dataclasses import dataclass, field
+
+import pytest
+
+from sglang_omni.scheduling.pacing import PacingConfig, PlaybackLeadPacer
+
+
+@dataclass
+class _Data:
+    generation_steps: int = 0
+    first_emit_s: float = 0.0
+    stream_codec_output: bool = True
+
+
+@dataclass
+class _Req:
+    rid: str
+    _finished: bool = False
+    _omni_data: _Data = field(default_factory=_Data)
+
+    def finished(self) -> bool:
+        return self._finished
+
+
+def _pacer(**overrides) -> PlaybackLeadPacer:
+    config = dict(
+        lead_s=1.0,
+        resume_lead_s=0.4,
+        frame_duration_s=0.08,
+        max_resume_per_step=2,
+    )
+    config.update(overrides)
+    return PlaybackLeadPacer(PacingConfig(**config))
+
+
+def test_pacing_config_validation() -> None:
+    with pytest.raises(ValueError):
+        PacingConfig(lead_s=0.0, resume_lead_s=0.4, frame_duration_s=0.08)
+    with pytest.raises(ValueError):
+        PacingConfig(lead_s=1.0, resume_lead_s=1.5, frame_duration_s=0.08)
+    with pytest.raises(ValueError):
+        PacingConfig(lead_s=1.0, resume_lead_s=0.4, frame_duration_s=0.0)
+
+
+def test_lead_requires_first_emit_and_streaming() -> None:
+    pacer = _pacer()
+    now = 100.0
+
+    assert pacer.lead_s(None, now) is None
+    assert pacer.lead_s(_Data(generation_steps=50), now) is None
+
+    silent = _Data(generation_steps=50, first_emit_s=99.0, stream_codec_output=False)
+    assert pacer.lead_s(silent, now) is None
+
+    emitting = _Data(generation_steps=50, first_emit_s=99.0)
+    assert pacer.lead_s(emitting, now) == pytest.approx(50 * 0.08 - 1.0)
+
+
+def test_should_pace_only_above_threshold() -> None:
+    pacer = _pacer()
+    now = 100.0
+
+    behind = _Data(generation_steps=10, first_emit_s=99.5)
+    assert pacer.should_pace(behind, now) is None
+
+    ahead = _Data(generation_steps=30, first_emit_s=99.9)
+    lead = pacer.should_pace(ahead, now)
+    assert lead == pytest.approx(30 * 0.08 - 0.1)
+
+
+def test_hold_and_resume_by_deadline_with_step_cap() -> None:
+    pacer = _pacer(max_resume_per_step=2)
+    now = 100.0
+    reqs = [_Req(rid=f"r{i}") for i in range(3)]
+    for i, req in enumerate(reqs):
+        pacer.hold(req, lead=1.2 + 0.1 * i, now=now)
+
+    assert len(pacer) == 3
+
+    early, dropped = pacer.pop_resumable(now=now + 0.1)
+    assert early == [] and dropped == []
+
+    first, dropped = pacer.pop_resumable(now=now + 2.0)
+    assert dropped == []
+    assert [req.rid for req in first] == ["r0", "r1"]
+
+    rest, _ = pacer.pop_resumable(now=now + 2.0)
+    assert [req.rid for req in rest] == ["r2"]
+    assert len(pacer) == 0
+    assert pacer.paced_total == 3
+    assert pacer.resumed_total == 3
+
+
+def test_wake_time_tracks_lead_over_resume_threshold() -> None:
+    pacer = _pacer()
+    now = 100.0
+    req = _Req(rid="r")
+    pacer.hold(req, lead=1.5, now=now)
+
+    not_yet, _ = pacer.pop_resumable(now=now + 1.0)
+    assert not_yet == []
+
+    woken, _ = pacer.pop_resumable(now=now + 1.11)
+    assert [r.rid for r in woken] == ["r"]
+
+
+def test_dropped_requests_skip_resume_and_are_returned() -> None:
+    pacer = _pacer()
+    now = 100.0
+    keep = _Req(rid="keep")
+    gone = _Req(rid="gone")
+    pacer.hold(gone, lead=1.1, now=now)
+    pacer.hold(keep, lead=1.2, now=now)
+    pacer.drop("gone")
+    pacer.drop("never-held")
+
+    woken, dropped = pacer.pop_resumable(now=now + 5.0)
+
+    assert [r.rid for r in woken] == ["keep"]
+    assert [r.rid for r in dropped] == ["gone"]
+    assert len(pacer) == 0
+
+
+def test_double_hold_is_idempotent() -> None:
+    pacer = _pacer()
+    req = _Req(rid="r")
+    pacer.hold(req, lead=1.5, now=100.0)
+    pacer.hold(req, lead=2.0, now=100.0)
+
+    assert len(pacer) == 1
+    woken, _ = pacer.pop_resumable(now=200.0)
+    assert len(woken) == 1
+
+
+def test_drain_returns_everything() -> None:
+    pacer = _pacer()
+    reqs = [_Req(rid=f"r{i}") for i in range(3)]
+    for req in reqs:
+        pacer.hold(req, lead=1.5, now=100.0)
+    pacer.drop("r1")
+
+    drained = pacer.drain()
+
+    assert {r.rid for r in drained} == {"r0", "r1", "r2"}
+    assert len(pacer) == 0
+    assert pacer.pop_resumable(now=999.0) == ([], [])
+
+
+def test_qwen3_tts_builder_enables_pacing_by_default() -> None:
+    from sglang_omni.models.qwen3_tts.engine_builder import Qwen3TtsEngineBuilder
+
+    kwargs = Qwen3TtsEngineBuilder().extra_scheduler_kwargs()
+    assert kwargs["pacing_lead_s"] == 1.0
+    assert kwargs["pacing_resume_lead_s"] == 0.4
+    assert kwargs["pacing_frame_duration_s"] == 0.08
+    assert kwargs["pacing_max_resume_per_step"] == 4
+
+    disabled = Qwen3TtsEngineBuilder(pacing_lead_s=0.0).extra_scheduler_kwargs()
+    assert "pacing_lead_s" not in disabled


### PR DESCRIPTION
First slice of **T-PR11 in #1754**: stop spending decode steps on streams that are already far ahead of their client's playback, so the same GPU serves new requests and pressing streams instead.

## Motivation (measured, recorded in #1754)

A streamed 1.7B CustomVoice request generates at ~2.9x realtime and runs to completion, holding a decode slot while seconds ahead of playback. At 20 RPS open-loop on one GPU, admission 16+16 rejects 37% of requests; raising admission to 32+32 without pacing collapses success to 5.5% — 79 concurrent streams all decode, none keeps realtime, and continuity failures kill nearly everything. Scheduling allocation, not kernel speed, is the binding constraint.

## Design

- Between scheduling steps (the same boundary upstream retraction uses), `OmniScheduler` computes each running stream's **playback lead** — `generation_steps x 80 ms` minus wall time since its first emitted chunk — and **parks** streams more than `pacing_lead_s` (default 1.0 s) ahead: their rows leave the running batch via `filter_batch(keep_indices=...)`, while **KV stays resident** (a paced TTS stream pins only a few hundred tokens).
- Parked streams sit in a wake-at min-heap (`sglang_omni/scheduling/pacing.py`) and become eligible again once their lead drains to `pacing_resume_lead_s` (default 0.4 s). Eligibility is not entitlement: at most `pacing_max_resume_per_step` (default 4) rejoin per step, in deadline order, so a burst that parked together does not rejoin as one oversized batch.
- Rejoin rebuilds a decode-mode `ScheduleBatch` directly from the parked requests (`req_pool_idx`, sequence lengths, `SamplingBatchInfo.from_schedule_batch`) and merges it into the running batch — **no retraction and no re-prefill of the generated history**, avoiding the quadratic re-extend cost of pacing via the KV-pressure retract path.
- Requests that have not yet emitted first audio are never paced. Non-streaming requests have no playback clock and are never paced. Aborts drop parked entries (KV released on wake); the admin retract path drains and retracts parked requests along with running ones.

## Scope and defaults

Scheduler support is generic and inert unless enabled. Pacing is **opt-in**: `--tts_engine.factory.pacing_lead_s 1.0` enables it for Qwen3-TTS (0, the default, disables). The first H200 validation round (see comments) confirmed the mechanism but surfaced two behavior gaps — the Talker-side lead clock vs vocoder chunk quantization, and resident-session caps — that must land before this can default on.

Known v1 limitation, by design: the lead clock is Talker-side and does not see vocoder backlog; the deadline-aware end state in #1754 (T-PR10/13) anchors deadlines to routed PCM and adds an execution reserve. The 1.0 s lead window absorbs the constant part of that offset; the follow-up moves the clock downstream.

## Validation

- Unit tests cover the pacing policy (thresholds, deadline-ordered capped wake, abort drops, drain) and the builder defaults.
- Open-loop 10/20 RPS grids on the #1754 harness are running next and will be posted here before this merges; the merge decision on default-on follows those numbers.
