### PR TITLE
[CI][XPU] Build-vs-pull CI, release workflow, ZE_AFFINITY_MASK, pip timeout

### DIFF
--- a/.github/workflows/omni-xpu-ci.yaml
+++ b/.github/workflows/omni-xpu-ci.yaml
@@ -3,31 +3,51 @@ name: XPU CI
 # Per-PR XPU CI for sglang-omni.
 #
 # DAG:
-#   preflight -> xpu-ci
+#   check-changes -> preflight -> xpu-ci
+#
+# check-changes (ubuntu-latest) runs dorny/paths-filter and emits two
+# booleans: `xpu` gates the whole pipeline so PRs that touch no XPU path
+# skip cleanly (skip = pass, so this workflow can safely become a required
+# status check), and `image` distinguishes source-only PRs from PRs that
+# change image inputs (docker/xpu.Dockerfile or pyproject_xpu.toml).
 #
 # preflight (ubuntu-latest) enforces the PR gate: fetches live label/draft
 # state, blocks draft PRs, requires the `run-ci` label, and runs
-# .github/scripts/pr_ci_gate.py for lint + mergeability. It also pins the
-# exact SHA that xpu-ci checks out, so a force-push mid-run cannot split
+# .github/scripts/pr_ci_gate.py for lint + mergeability. It pins the exact
+# SHA that xpu-ci checks out, so a force-push mid-run cannot split
 # preflight and test across two commits.
 #
-# xpu-ci (self-hosted intel-omni-bmg) builds the XPU docker image from the
-# PR checkout using docker/xpu.Dockerfile, starts a long-lived container
-# with /dev/dri exposed, runs the XPU unit tests inside it, and removes
-# both the container and the image on completion so nothing is retained
-# across runs. GHA's `container:` block is intentionally NOT used -- it
-# would try to pull the image before any step runs, and we want to build
-# it here instead.
-#
-# Trade-offs vs a prebuilt image: every push pays the docker build cost
-# (torch+xpu wheels, sglang clone + install, sglang-omni install). In
-# exchange there is no dependency on a companion release workflow, and
-# every test run exercises the Dockerfile itself.
+# xpu-ci (self-hosted intel-omni-bmg) sudo-cleans the workspace first to
+# reap root-owned droppings from prior bind-mount runs that would otherwise
+# fail actions/checkout, then builds locally when image inputs changed,
+# otherwise pulls intel/sglang-omni-xpu-dev:img-<fp>, where <fp> is a
+# 12-char sha256 of docker/xpu.Dockerfile + pyproject_xpu.toml -- so the
+# pulled image is content-bound to the PR's own inputs and cannot drift
+# from a stale :latest. Falls back to a local build if the fingerprint is
+# not yet published (registry outage, or a source-only PR racing ahead of
+# the release workflow after an image-input merge). It bind-mounts the
+# PR source at /workspace/sglang-omni-pr
+# and refreshes the editable install so tests always exercise PR code, runs
+# the container with ZE_AFFINITY_MASK resolved from the runner-scoped env
+# $XPU_CI_MASK (defaults to "6,7" if unset), then runs the XPU unit tests
+# and unconditionally removes the container and the run-owned image tag on completion.
+# Baking a distinct $XPU_CI_MASK into each runner process on a multi-card
+# host lets several runners share the machine and claim disjoint L0 card
+# pairs, so multiple PRs can run in parallel there; hosts that share cards
+# with other workloads (like the intel-omni-bmg node that leaves 0-5 free
+# for co-tenants) simply omit the env and inherit the "6,7" default. The
+# image consumed on the pull path is published by omni-xpu-docker-release.yaml on
+# merges that change the same image inputs.
 #
 # Runtime prerequisites (fleet-side, not enforced by this workflow):
 #   * self-hosted runner labeled [self-hosted, intel-omni-bmg] with /dev/dri
 #     exposed, docker daemon reachable to the runner user, and the runner
-#     user in the render/video groups.
+#     user in the render/video groups;
+#   * (optional) $XPU_CI_MASK in the runner process's env-file set to the
+#     L0 card pair that runner should claim (e.g. "0,1"); unset -> "6,7";
+#   * intel/sglang-omni-xpu-dev:img-<fp> published on Docker Hub for the
+#     current main's <fp> (or the pull path falls back to a local build --
+#     see omni-xpu-docker-release.yaml).
 
 on:
   pull_request:
@@ -50,11 +70,8 @@ jobs:
     runs-on: ubuntu-latest
     timeout-minutes: 5
     outputs:
-      # workflow_dispatch on main lets dorny/paths-filter inspect only the
-      # tip commit, so a manual run against a non-XPU tip would skip the
-      # heavy job. Force `true` on manual dispatch; keep path filtering for
-      # pull requests.
       xpu: ${{ github.event_name == 'workflow_dispatch' && 'true' || steps.filter.outputs.xpu }}
+      image: ${{ github.event_name == 'workflow_dispatch' && 'true' || steps.filter.outputs.image }}
     steps:
       - uses: actions/checkout@v4
       - uses: dorny/paths-filter@v3
@@ -69,6 +86,9 @@ jobs:
               - 'scripts/xpu/**'
               - 'docker/xpu.Dockerfile'
               - '.github/workflows/omni-xpu-ci.yaml'
+            image:
+              - 'docker/xpu.Dockerfile'
+              - 'pyproject_xpu.toml'
 
   preflight:
     name: xpu-ci-gate
@@ -87,8 +107,6 @@ jobs:
         with:
           github-token: ${{ github.token }}
           script: |
-            // Reruns reuse the original pull_request event payload, so fetch
-            // live labels/draft state after /tag-and-rerun-ci adds run-ci.
             const pr = await github.rest.pulls.get({
               owner: context.repo.owner,
               repo: context.repo.repo,
@@ -152,12 +170,14 @@ jobs:
     runs-on: [self-hosted, intel-omni-bmg]
     timeout-minutes: 120
     env:
-      # Unique per push + attempt so parallel PRs / reruns cannot collide on
-      # the local docker daemon. Full SHA (not short) so image tags are
-      # trivially traceable back to the tested commit.
       IMAGE_TAG: sglang-omni-xpu-ci:${{ github.event.pull_request.number || github.run_id }}-${{ needs.preflight.outputs.exact_sha }}
       CONTAINER_NAME: ci_omni_xpu_${{ github.event.pull_request.number || github.run_id }}_${{ github.run_attempt }}
+      PUBLISHED_IMAGE_REPO: intel/sglang-omni-xpu-dev
     steps:
+      - name: Force-clean workspace (root-owned files from prior runs)
+        shell: bash
+        run: sudo rm -rf "$GITHUB_WORKSPACE"/* "$GITHUB_WORKSPACE"/.[!.]* 2>/dev/null || true
+
       - name: Checkout PR code
         uses: actions/checkout@v4
         with:
@@ -165,21 +185,48 @@ jobs:
           fetch-depth: 0
 
       - name: Build XPU docker image
-        # In-place build of docker/xpu.Dockerfile on the runner (no registry
-        # pull). Heaviest step: torch+xpu wheels, sglang clone + build,
-        # sglang-omni editable install. Doubles as Dockerfile CI.
+        if: needs.check-changes.outputs.image == 'true'
         timeout-minutes: 90
         shell: bash
         run: |
           set -euxo pipefail
           docker build -f docker/xpu.Dockerfile -t "${IMAGE_TAG}" .
 
+      - name: Compute image fingerprint
+        if: needs.check-changes.outputs.image != 'true'
+        shell: bash
+        run: |
+          set -euxo pipefail
+          fp=$(sha256sum docker/xpu.Dockerfile pyproject_xpu.toml | sha256sum | cut -c1-12)
+          echo "PUBLISHED_IMAGE=${PUBLISHED_IMAGE_REPO}:img-${fp}" >> "$GITHUB_ENV"
+
+      - name: Pull XPU docker image
+        id: pull
+        if: needs.check-changes.outputs.image != 'true'
+        continue-on-error: true
+        timeout-minutes: 30
+        shell: bash
+        run: |
+          set -euxo pipefail
+          docker pull "${PUBLISHED_IMAGE}"
+          docker tag "${PUBLISHED_IMAGE}" "${IMAGE_TAG}"
+
+      - name: Fallback local build (pull failed or timed out)
+        if: needs.check-changes.outputs.image != 'true' && steps.pull.outcome == 'failure'
+        timeout-minutes: 90
+        shell: bash
+        run: |
+          set -euxo pipefail
+          docker build -f docker/xpu.Dockerfile -t "${IMAGE_TAG}" .
+
+      - name: Resolve XPU affinity mask
+        shell: bash
+        run: echo "ZE_AFFINITY_MASK=${XPU_CI_MASK:-6,7}" >> "$GITHUB_ENV"
+
       - name: Start CI container
         shell: bash
         run: |
           set -euxo pipefail
-          # Idempotent: leftover container from a killed prior attempt would
-          # block `docker run --name` here.
           docker rm -f "${CONTAINER_NAME}" 2>/dev/null || true
           docker run -dt \
             --name "${CONTAINER_NAME}" \
@@ -187,14 +234,19 @@ jobs:
             --group-add video \
             --group-add render \
             --shm-size 32g \
-            -v /dev/shm:/dev/shm \
+            -v "${GITHUB_WORKSPACE}:/workspace/sglang-omni-pr" \
+            -e ZE_AFFINITY_MASK="${ZE_AFFINITY_MASK}" \
             "${IMAGE_TAG}" \
             sleep infinity
 
+      - name: Refresh sglang-omni editable install from PR source
+        shell: bash
+        run: |
+          set -euxo pipefail
+          docker exec -w /workspace/sglang-omni-pr "${CONTAINER_NAME}" \
+            bash -c "cp pyproject_xpu.toml pyproject.toml && pip install --no-cache-dir --no-deps --no-build-isolation -e ."
+
       - name: Verify XPU state
-        # Fail the job if torch.xpu is unavailable: a broken XPU stack lets
-        # device-agnostic tests silently fall back to CPU and pass, keeping
-        # CI green on a regressed image. sycl-ls is diagnostic only.
         shell: bash
         run: |
           docker exec "${CONTAINER_NAME}" python -c "
@@ -210,9 +262,9 @@ jobs:
         shell: bash
         run: |
           set -euxo pipefail
-          docker exec -w /workspace/sglang-omni "${CONTAINER_NAME}" \
+          docker exec -w /workspace/sglang-omni-pr "${CONTAINER_NAME}" \
             pip install --no-cache-dir pytest pytest-asyncio
-          docker exec -w /workspace/sglang-omni "${CONTAINER_NAME}" \
+          docker exec -w /workspace/sglang-omni-pr "${CONTAINER_NAME}" \
             pytest tests/unit_test/xpu/test_device_layer.py -v -x
 
       - name: Cleanup container and image
@@ -220,12 +272,6 @@ jobs:
         shell: bash
         run: |
           set -eux
-          # SIGTERM sglang before docker rm -f to drain GPU context and
-          # avoid a GT reset on Battlemage (learned from upstream sglang's
-          # pr-test-xpu.yml cleanup step). Patterns use character classes
-          # (e.g. [s]glang) so pkill/pgrep do not match their own argv, which
-          # would otherwise send SIGTERM to the enclosing bash -c and stop
-          # the drain loop before it runs.
           if docker ps -a --format '{{.Names}}' | grep -qx "${CONTAINER_NAME}"; then
             docker exec "${CONTAINER_NAME}" bash -c '
               pkill -TERM -f "[s]glang|[r]un_suite|[p]ython3.*[t]est_" 2>/dev/null || true
@@ -238,8 +284,3 @@ jobs:
           fi
           docker rm -f "${CONTAINER_NAME}" || true
           docker rmi -f "${IMAGE_TAG}" || true
-          # Reap dangling images left behind when a prior push was cancelled
-          # mid-build. NOT builder prune -f -- that evicts the shared
-          # BuildKit cache (25-64 GB observed) and forces a 20+ min rebuild
-          # on the next run.
-          docker image prune -f || true

--- a/.github/workflows/omni-xpu-docker-release.yaml
+++ b/.github/workflows/omni-xpu-docker-release.yaml
@@ -1,0 +1,146 @@
+name: XPU Docker Release
+
+# Publishes the XPU docker image to Docker Hub after every merge to main
+# that changes docker/xpu.Dockerfile or pyproject_xpu.toml -- the same
+# inputs that force omni-xpu-ci.yaml onto its build path, so the published
+# image tracks whatever PR CI just verified.
+#
+# Design:
+#   * Trigger on push to main, paths scoped to the two files that go into
+#     the image. workflow_dispatch is available as a manual escape hatch
+#     (also used to seed the first image before any inputs change).
+#   * Build on the same self-hosted runner PR CI uses. BuildKit's persistent
+#     cache from PR CI's pre-merge build is expected to hit for every layer,
+#     keeping the "rebuild" in seconds-to-minutes. Reproducibility comes
+#     from the pinned base image / pinned SGLang / pinned sgl-kernel-xpu
+#     ref inside the Dockerfile, not from --no-cache.
+#   * Sudo-clean the workspace before checkout so root-owned droppings left
+#     by any prior PR container's bind-mount don't fail actions/checkout on
+#     this shared runner. Mirrors the same step in omni-xpu-ci.yaml.
+#   * Build and push only the immutable content tag ":img-<fp>", where
+#     <fp> is a 12-char sha256 of docker/xpu.Dockerfile +
+#     pyproject_xpu.toml. Then, in a separate step, promote that manifest
+#     to ":latest" and ":dev-xpu-bmg-<YYYYMMDD>-<sha>" via
+#     `docker buildx imagetools create --tag <target> <source>`, which is
+#     a registry-side digest-preserving retag -- no layers re-upload, no
+#     local ":latest" tag ever exists on the runner. PR CI pulls the
+#     fingerprint tag, not ":latest", so an unfinished or failed promote
+#     never leaks stale XPU deps into PR testing, and no concurrent PR
+#     CI pull can retarget the release job's local ":latest" between
+#     build and push (there is nothing to retarget).
+#   * Push and promote with exponential backoff -- registry ops are noisy.
+#   * Repo + branch guard so forks and feature branches cannot publish:
+#     if: github.repository == 'sgl-project/sglang-omni' AND
+#         github.ref == 'refs/heads/main'. Checkout pins
+#     ref: ${{ github.sha }} -- the exact triggering commit -- so
+#     workflow_dispatch can never build a feature branch's Dockerfile
+#     as production ":latest", and a push event that queues while main
+#     advances still builds the commit it was triggered by (content,
+#     fingerprint, and dated tag all bind to the same sha).
+#
+# Prerequisites (fleet-side, not enforced by this workflow):
+#   * self-hosted runner labeled [self-hosted, intel-omni-bmg] with docker
+#     daemon reachable to the runner user;
+#   * `prod` GitHub Environment configured on the repo, with
+#     DOCKERHUB_INTEL_USERNAME and DOCKERHUB_INTEL_TOKEN scoped to it
+#     (ideally gated with a required reviewer). Uses the intel/* scoped
+#     credential pair, matching sglang upstream's release workflows;
+#   * `intel/sglang-omni-xpu-dev` repository on Docker Hub with the token above
+#     granted push access.
+
+on:
+  push:
+    branches: [main]
+    paths:
+      - "docker/xpu.Dockerfile"
+      - "pyproject_xpu.toml"
+  workflow_dispatch:
+
+concurrency:
+  # Never cancel a mid-flight release push -- half-written registry state
+  # is worse than a slightly delayed publish.
+  group: xpu-release-${{ github.ref }}
+  cancel-in-progress: false
+
+permissions:
+  contents: read
+
+jobs:
+  publish:
+    name: publish-xpu
+    if: github.repository == 'sgl-project/sglang-omni' && github.ref == 'refs/heads/main'
+    runs-on: [self-hosted, intel-omni-bmg]
+    environment: prod
+    timeout-minutes: 90
+    env:
+      IMAGE_NAME: intel/sglang-omni-xpu-dev
+    steps:
+      - name: Force-clean workspace (root-owned files from prior PR runs)
+        shell: bash
+        run: sudo rm -rf "$GITHUB_WORKSPACE"/* "$GITHUB_WORKSPACE"/.[!.]* 2>/dev/null || true
+
+      - name: Checkout main at triggering commit
+        uses: actions/checkout@v4
+        with:
+          ref: ${{ github.sha }}
+          fetch-depth: 0
+
+      - name: Compute image tags
+        shell: bash
+        run: |
+          set -euxo pipefail
+          fp=$(sha256sum docker/xpu.Dockerfile pyproject_xpu.toml | sha256sum | cut -c1-12)
+          echo "TAG_FP=img-${fp}" >> "$GITHUB_ENV"
+          echo "TAG_DATED=dev-xpu-bmg-$(date -u +%Y%m%d)-${GITHUB_SHA:0:7}" >> "$GITHUB_ENV"
+
+      - name: Log in to Docker Hub
+        uses: docker/login-action@v3
+        with:
+          username: ${{ secrets.DOCKERHUB_INTEL_USERNAME }}
+          password: ${{ secrets.DOCKERHUB_INTEL_TOKEN }}
+
+      - name: Build XPU image (fingerprint tag only)
+        shell: bash
+        run: |
+          set -euxo pipefail
+          docker build -f docker/xpu.Dockerfile \
+            -t "${IMAGE_NAME}:${TAG_FP}" \
+            .
+
+      - name: Push fingerprint tag to Docker Hub
+        shell: bash
+        run: |
+          set -euxo pipefail
+          push_with_retry() {
+            for i in 1 2 3 4 5; do
+              docker push "$1" && return 0
+              echo "push failed (attempt $i), retrying in $((i*15))s..."
+              sleep $((i*15))
+            done
+            return 1
+          }
+          push_with_retry "${IMAGE_NAME}:${TAG_FP}"
+
+      - name: Promote fingerprint to latest and dated tag
+        shell: bash
+        run: |
+          set -euxo pipefail
+          promote_with_retry() {
+            for i in 1 2 3 4 5; do
+              docker buildx imagetools create \
+                --tag "${IMAGE_NAME}:latest" \
+                --tag "${IMAGE_NAME}:${TAG_DATED}" \
+                "${IMAGE_NAME}:${TAG_FP}" && return 0
+              echo "promote failed (attempt $i), retrying in $((i*15))s..."
+              sleep $((i*15))
+            done
+            return 1
+          }
+          promote_with_retry
+
+      - name: Cleanup local tags
+        if: always()
+        shell: bash
+        run: |
+          set -eux
+          docker rmi -f "${IMAGE_NAME}:${TAG_FP}" || true

--- a/docker/xpu.Dockerfile
+++ b/docker/xpu.Dockerfile
@@ -17,6 +17,12 @@ ARG SGL_KERNEL_XPU_REF=3f3c73216dc978eeda689c5960c61a549fc309c2
 ENV DEBIAN_FRONTEND=noninteractive
 ENV PIP_INDEX_URL=https://pypi.org/simple
 ENV TORCH_XPU_INDEX=https://download.pytorch.org/whl/xpu
+# files.pythonhosted.org occasionally throttles large wheels below pip's
+# default 15s socket-read window; raise the timeout and retry budget so
+# builds ride through transient CDN slowdowns instead of failing. 60s x
+# 5 retries caps worst-case wait at 5 min per stalled file.
+ENV PIP_DEFAULT_TIMEOUT=60
+ENV PIP_RETRIES=5
 
 # Level-Zero UMD + IGC, mirroring SGLang's image, which pins them because the rolling
 # PPA once faulted libze on B580 (sgl-kernel-xpu#296). Keep in lockstep with the host


### PR DESCRIPTION
## Summary

Rework the XPU CI path so most PRs skip the ~15-minute image build, multiple PRs can share a multi-card host, and the `:latest` image consumers pull is produced automatically from main.

## Why

- **Every PR rebuilt the XPU image** even when no image inputs changed, costing ~15 min on the hot path. Split into pull vs. build based on whether `docker/xpu.Dockerfile` or `pyproject_xpu.toml` changed; source-only PRs pull, image PRs build.
- **A single 30-min timeout for pull + fallback build** meant a slow pull ate the rebuild budget. Give each step its own timeout so a pull that fails or hangs still leaves a full window for the local fallback build.
- **`ZE_AFFINITY_MASK` was pinned to `6,7`**, forcing every PR to serialize on the same two cards even on hosts with cards to spare. Resolve it from a runner-scoped `$XPU_CI_MASK` env, defaulting to `6,7`, so a host can register several runners with disjoint pairs and run PRs in parallel. Shared hosts do nothing and keep today's behavior.
- **Prior PR containers ran as root** and left files the runner user cannot delete; `actions/checkout` then failed on `EACCES`. A `sudo` pre-clean of `$GITHUB_WORKSPACE` fixes both CI and the release workflow, which share the same runner pool.
- **Host-wide `docker image prune -f`** in cleanup would sweep intermediate layers a concurrent PR is still using once parallel runs are enabled. Restrict cleanup to the run's own `IMAGE_TAG`.
- **The CI `docker run` bind-mounted `/dev/shm`** from the host into the container, silently overriding Docker's per-container tmpfs from `--shm-size 32g`. With N parallel PR runners on one host, every container ended up in the host's `/dev/shm` namespace — one hot PR could starve or corrupt another's shared memory. Drop the bind; `--shm-size 32g` alone gives each container an isolated 32 GiB tmpfs.
- **Pull is only useful if something publishes the image on main.** Add `omni-xpu-docker-release.yaml` (renamed from the earlier `omni-xpu-release.yaml` stub for clarity) triggered on the same image-input paths, gated to `sgl-project/sglang-omni` + `prod` environment, so what PR CI just verified is what gets published.
- **`workflow_dispatch` on the release workflow could be fired from any branch**, publishing that feature branch's Dockerfile as production `:latest`. Gate the job with `github.ref == 'refs/heads/main'` and pin the checkout to `${{ github.sha }}`, so manual dispatches can only ever build from main's content.
- **The release checkout previously used `ref: refs/heads/main`**, which resolves to main's tip when the runner starts. If the job queued while main advanced, the image was built from a later commit than the one `GITHUB_SHA` (used in `TAG_DATED`) encoded — the dated tag and the fingerprint could describe two different commits. Pin the checkout to `${{ github.sha }}`, the exact triggering commit, so content, fingerprint, and dated tag are all bound to the same sha.
- **CI pulling `intel/sglang-omni-xpu-dev:latest` could not distinguish a current image from a stale one**: if the post-merge release was queued or failed, PR CI would test source against an older image; on shared runners a concurrent PR pull could also overwrite the release job's local `:latest` before it pushed. Compute a 12-char sha256 fingerprint of `docker/xpu.Dockerfile` + `pyproject_xpu.toml`, build and push only the immutable `:img-<fp>` tag, then promote its digest to `:latest` and `:dev-xpu-bmg-<YYYYMMDD>-<sha>` via `docker buildx imagetools create` — a registry-side retag that never materializes `:latest` on the runner, so no local-tag race is possible. PR CI pulls `:img-<fp>`; a fingerprint miss falls back to a local build instead of testing against drift.
- **Opaque `${{ github.sha }}` tags on Docker Hub** are impossible to eyeball. Publish a dated `dev-xpu-bmg-YYYYMMDD-<7-char-sha>` tag alongside `:latest` so humans can find a specific build without cross-referencing git.
- **`files.pythonhosted.org` throttles large XPU wheels** below pip's 15s socket-read window, failing the image build on transient CDN slowdowns. Raise `PIP_DEFAULT_TIMEOUT` to 60 and `PIP_RETRIES` to 5 (5-minute worst-case per stalled file).

## Fleet-side prerequisites

- `prod` GitHub Environment on `sgl-project/sglang-omni` with `DOCKERHUB_INTEL_USERNAME` / `DOCKERHUB_INTEL_TOKEN` scoped to it.
- `intel/sglang-omni-xpu-dev` Docker Hub repo with the token above granted push access.
- *(Optional, for parallelism)* N runners registered per multi-card host, each with a disjoint `XPU_CI_MASK` (e.g. `0,1` / `2,3` / `4,5` / `6,7` / `8,9` on a 10-card node).

## Bootstrap

After merge, run `omni-xpu-docker-release.yaml` once via `workflow_dispatch` to seed `intel/sglang-omni-xpu-dev:img-<fp>` and `:latest`. Until that lands, PR CI's pull path falls back cleanly to a local build.

## Test plan

- [x] `xpu-ci (device_layer)` passes on this PR (build path — this PR touches `docker/xpu.Dockerfile` and `.github/workflows/omni-xpu-ci.yaml`).
- [x] `Verify XPU state` shows only the pair from `ZE_AFFINITY_MASK`.
- [ ] After merge, kick `XPU Docker Release` via `workflow_dispatch` to seed `:img-<fp>`, the dated tag, and `:latest`; confirm push succeeds on `hub.docker.com/r/intel/sglang-omni-xpu-dev`.
- [ ] Follow-up source-only PR should hit the pull path — check logs for `docker pull intel/sglang-omni-xpu-dev:img-<fp>`.
- [ ] Once N > 1 runners are registered with disjoint `XPU_CI_MASK` on a multi-card host, two PRs against different pairs should run concurrently, and each container's `df -h /dev/shm` should show an isolated 32 GiB tmpfs.
- [ ] Attempt `workflow_dispatch` of `XPU Docker Release` from a non-main branch — job should be skipped by the `github.ref == 'refs/heads/main'` guard.
