### PR TITLE
[Qwen3-TTS] Capture QK norm and RoPE in the prefill graph

### DIFF
--- a/sglang_omni/models/qwen3_tts/model_runner.py
+++ b/sglang_omni/models/qwen3_tts/model_runner.py
@@ -17,6 +17,22 @@ from sglang_omni.models.qwen3_omni.talker_model_runner import QwenTalkerModelRun
 from sglang_omni.scheduling.types import RequestOutput
 
 
+def _ensure_mrope_positions(forward_batch: Any) -> None:
+    """Give the batch MRoPE positions mirroring its plain positions.
+
+    The Talker declares ``is_mrope_enabled``, so a captured prefill graph
+    binds the runner's ``mrope_positions`` slot — but that slot is only
+    refreshed at replay when the live batch carries mrope positions, and a
+    TTS request has no multimodal inputs to provide them. All three MRoPE
+    rows are equal for the Talker, so the plain positions expanded to
+    ``[3, T]`` are the exact values the layer collapses back to.
+    """
+    if forward_batch.mrope_positions is None:
+        forward_batch.mrope_positions = (
+            forward_batch.positions.unsqueeze(0).expand(3, -1).contiguous()
+        )
+
+
 class Qwen3TTSModelRunner(ModelRunner):
     """Runs Qwen3-TTS AR steps and stores generated codec frames per request."""
 
@@ -45,6 +61,7 @@ class Qwen3TTSModelRunner(ModelRunner):
         requests: list,
     ) -> None:
         del schedule_batch
+        _ensure_mrope_positions(forward_batch)
         self.model.prepare_decode_buffers(requests)
         attach_omni_prefill_inputs(
             forward_batch,

--- a/sglang_omni/models/qwen3_tts/model_runner.py
+++ b/sglang_omni/models/qwen3_tts/model_runner.py
@@ -17,16 +17,24 @@ from sglang_omni.models.qwen3_omni.talker_model_runner import QwenTalkerModelRun
 from sglang_omni.scheduling.types import RequestOutput
 
 
-def _ensure_mrope_positions(forward_batch: Any) -> None:
-    """Give the batch MRoPE positions mirroring its plain positions.
+def _ensure_mrope_positions(forward_batch: Any, *, prefill_graph_runner: Any) -> None:
+    """Give a graph-replayed batch MRoPE positions mirroring its plain ones.
 
-    The Talker declares ``is_mrope_enabled``, so a captured prefill graph
-    binds the runner's ``mrope_positions`` slot — but that slot is only
-    refreshed at replay when the live batch carries mrope positions, and a
-    TTS request has no multimodal inputs to provide them. All three MRoPE
-    rows are equal for the Talker, so the plain positions expanded to
-    ``[3, T]`` are the exact values the layer collapses back to.
+    The Talker declares ``is_mrope_enabled``, so a captured prefill graph binds
+    the runner's ``mrope_positions`` slot, and that slot is only refreshed at
+    replay when the live batch carries mrope positions. A TTS request has no
+    multimodal inputs to provide them, so a replay would otherwise rotate on
+    whatever positions capture happened to leave behind.
+
+    All three MRoPE rows are equal for the Talker, and ``MRotaryEmbedding``
+    selects row ``i`` of each mrope section, so a mirrored ``[3, T]`` collapses
+    to exactly the 1-D result. It is not the same kernel though: on CUDA a 1-D
+    positions tensor runs ``forward_native`` while a 2-D one runs the fused
+    ``forward_triton``. Mirroring only where a graph will replay keeps every
+    other prefill on the kernel it already used.
     """
+    if prefill_graph_runner is None:
+        return
     if forward_batch.mrope_positions is None:
         forward_batch.mrope_positions = (
             forward_batch.positions.unsqueeze(0).expand(3, -1).contiguous()
@@ -61,7 +69,10 @@ class Qwen3TTSModelRunner(ModelRunner):
         requests: list,
     ) -> None:
         del schedule_batch
-        _ensure_mrope_positions(forward_batch)
+        _ensure_mrope_positions(
+            forward_batch,
+            prefill_graph_runner=self.tp_worker.model_runner.prefill_cuda_graph_runner,
+        )
         self.model.prepare_decode_buffers(requests)
         attach_omni_prefill_inputs(
             forward_batch,

--- a/sglang_omni/models/qwen3_tts/model_runner.py
+++ b/sglang_omni/models/qwen3_tts/model_runner.py
@@ -30,10 +30,14 @@ def _ensure_mrope_positions(forward_batch: Any, *, prefill_graph_runner: Any) ->
     selects row ``i`` of each mrope section, so a mirrored ``[3, T]`` collapses
     to exactly the 1-D result. It is not the same kernel though: on CUDA a 1-D
     positions tensor runs ``forward_native`` while a 2-D one runs the fused
-    ``forward_triton``. Mirroring only where a graph will replay keeps every
-    other prefill on the kernel it already used.
+    ``forward_triton``. Mirroring only the batches that replay keeps every
+    other prefill on the kernel it already used: SGLang hands out an
+    ``EagerRunner`` when prefill graphs are off, and a runner that holds graphs
+    still declines batches outside its captured shapes.
     """
-    if prefill_graph_runner is None:
+    if prefill_graph_runner is None or not prefill_graph_runner.can_run_graph(
+        forward_batch
+    ):
         return
     if forward_batch.mrope_positions is None:
         forward_batch.mrope_positions = (

--- a/sglang_omni/models/qwen3_tts/sglang_model.py
+++ b/sglang_omni/models/qwen3_tts/sglang_model.py
@@ -18,9 +18,6 @@ from sglang.srt.layers.quantization.unquant import (
     get_bf16_gemm_backend,
 )
 from sglang.srt.layers.sampler import multinomial_with_seed
-from sglang.srt.model_executor.runner_backend_utils.breakable_cuda_graph import (
-    eager_on_graph,
-)
 from sglang.srt.utils import add_prefix
 from torch import nn
 
@@ -56,11 +53,6 @@ _PREDICTOR_GRAPH_WARMUP_PASSES = 2
 # Note: (Jiaxin Deng) 50 is on the ladder because it is the family checkpoint
 # default, keeping the dominant signature's kernel width exactly as before.
 _PREDICTOR_TOP_K_LADDER = (4, 8, 16, 32, 50, 64, 128, 256, 512, 1024)
-
-
-def _install_breakable_prefill_qk_norm_rope_graph_break(attention: Any) -> None:
-    """Keep Qwen3-TTS QK norm and RoPE outside breakable graph segments."""
-    attention.apply_qk_norm_rope = eager_on_graph(True)(attention.apply_qk_norm_rope)
 
 
 def _predictor_graph_env_enabled() -> bool:
@@ -192,11 +184,6 @@ class Qwen3TTSTalkerDecoderLayer(nn.Module):
             dual_chunk_attention_config=None,
             alt_stream=None,
         )
-        # Capturing the packed QKV normalization and RoPE block corrupts
-        # Qwen3-TTS prefill replay. Keep this narrow block eager while the
-        # surrounding projections and MLP remain captured. Decode execution
-        # runs outside the breakable-prefill context and is unchanged.
-        _install_breakable_prefill_qk_norm_rope_graph_break(self.self_attn)
         self.mlp = Qwen3OmniMoeTalkerDenseMLP(
             config.hidden_size,
             config.intermediate_size,

--- a/tests/unit_test/qwen3_tts/test_pipeline.py
+++ b/tests/unit_test/qwen3_tts/test_pipeline.py
@@ -4724,11 +4724,14 @@ def test_qwen3_tts_prefill_attaches_runner_composed_embeddings_to_sidecar(
         lambda forward_batch, requests: calls.append("embeds") or input_embeds
     )
     mm_inputs = [object()]
+    positions = torch.arange(3)
     forward_batch = SimpleNamespace(
         input_ids=torch.zeros(3, dtype=torch.long),
         input_embeds=None,
         replace_embeds=None,
         mm_inputs=mm_inputs,
+        positions=positions,
+        mrope_positions=None,
     )
 
     runner.before_prefill(forward_batch, object(), [object()])
@@ -4739,6 +4742,9 @@ def test_qwen3_tts_prefill_attaches_runner_composed_embeddings_to_sidecar(
     assert forward_batch.input_embeds is None
     assert forward_batch.mm_inputs is mm_inputs
     assert calls == ["prepare", "embeds"]
+    assert forward_batch.mrope_positions.shape == (3, 3)
+    for row in forward_batch.mrope_positions:
+        assert torch.equal(row, positions)
 
 
 def test_qwen3_tts_prefill_uses_shared_late_bound_forward_transport(

--- a/tests/unit_test/qwen3_tts/test_pipeline.py
+++ b/tests/unit_test/qwen3_tts/test_pipeline.py
@@ -378,12 +378,44 @@ def test_qwen3_tts_before_prefill_mirrors_positions_into_mrope() -> None:
         positions=torch.arange(7, dtype=torch.int64),
         mrope_positions=None,
     )
-    _ensure_mrope_positions(batch)
+    _ensure_mrope_positions(batch, prefill_graph_runner=object())
 
     assert batch.mrope_positions.shape == (3, 7)
     assert torch.equal(batch.mrope_positions[0], batch.positions)
     assert torch.equal(batch.mrope_positions[1], batch.positions)
     assert torch.equal(batch.mrope_positions[2], batch.positions)
+
+
+def test_qwen3_tts_mrope_mirror_is_scoped_to_the_graphed_path() -> None:
+    """A 2-D positions tensor picks a different CUDA kernel.
+
+    ``MRotaryEmbedding.forward_cuda`` dispatches 1-D positions to
+    ``forward_native`` and 2-D positions to the fused ``forward_triton``, so
+    mirroring an eager prefill would move it to another kernel for no reason.
+    """
+    from sglang_omni.models.qwen3_tts.model_runner import _ensure_mrope_positions
+
+    batch = SimpleNamespace(
+        positions=torch.arange(7, dtype=torch.int64),
+        mrope_positions=None,
+    )
+    _ensure_mrope_positions(batch, prefill_graph_runner=None)
+
+    assert batch.mrope_positions is None
+
+
+def test_qwen3_tts_mrope_mirror_leaves_real_positions_alone() -> None:
+    """A batch that already carries mrope positions owns them."""
+    from sglang_omni.models.qwen3_tts.model_runner import _ensure_mrope_positions
+
+    supplied = torch.arange(21, dtype=torch.int64).reshape(3, 7)
+    batch = SimpleNamespace(
+        positions=torch.zeros(7, dtype=torch.int64),
+        mrope_positions=supplied,
+    )
+    _ensure_mrope_positions(batch, prefill_graph_runner=object())
+
+    assert batch.mrope_positions is supplied
 
     existing = torch.zeros((3, 7), dtype=torch.int64)
     batch = SimpleNamespace(

--- a/tests/unit_test/qwen3_tts/test_pipeline.py
+++ b/tests/unit_test/qwen3_tts/test_pipeline.py
@@ -417,15 +417,6 @@ def test_qwen3_tts_mrope_mirror_leaves_real_positions_alone() -> None:
 
     assert batch.mrope_positions is supplied
 
-    existing = torch.zeros((3, 7), dtype=torch.int64)
-    batch = SimpleNamespace(
-        positions=torch.arange(7, dtype=torch.int64),
-        mrope_positions=existing,
-    )
-    _ensure_mrope_positions(batch)
-
-    assert batch.mrope_positions is existing
-
 
 def test_qwen3_tts_prefill_coalescing_is_opt_in() -> None:
     signature = inspect.signature(qwen3_stages.create_sglang_tts_engine_executor)

--- a/tests/unit_test/qwen3_tts/test_pipeline.py
+++ b/tests/unit_test/qwen3_tts/test_pipeline.py
@@ -371,68 +371,28 @@ def test_qwen3_tts_breakable_prefill_is_scoped_to_the_measured_checkpoint(
     assert bare["max_running_requests"] == 16
 
 
-def test_qwen3_tts_breakable_prefill_breaks_around_qk_norm_rope(
-    monkeypatch: pytest.MonkeyPatch,
-) -> None:
-    install_fake_sglang(monkeypatch)
-    from sglang_omni.models.qwen3_tts import sglang_model
+def test_qwen3_tts_before_prefill_mirrors_positions_into_mrope() -> None:
+    from sglang_omni.models.qwen3_tts.model_runner import _ensure_mrope_positions
 
-    events: list[tuple[str, object]] = []
-
-    def fake_eager_on_graph(enabled: bool):
-        events.append(("enabled", enabled))
-
-        def decorate(function):
-            def wrapped(*args, **kwargs):
-                events.append(("wrapped", (args, kwargs)))
-                return function(*args, **kwargs)
-
-            return wrapped
-
-        return decorate
-
-    class FakeAttention(torch.nn.Module):
-        def __init__(self, **kwargs) -> None:
-            super().__init__()
-
-        def apply_qk_norm_rope(self, qkv, positions, forward_batch):
-            events.append(("inner", (qkv, positions, forward_batch)))
-            return qkv, positions, forward_batch
-
-    class FakeModule(torch.nn.Module):
-        def __init__(self, *args, **kwargs) -> None:
-            super().__init__()
-
-    monkeypatch.setattr(sglang_model, "eager_on_graph", fake_eager_on_graph)
-    monkeypatch.setattr(
-        sglang_model,
-        "Qwen3OmniMoeThinkerTextAttention",
-        FakeAttention,
+    batch = SimpleNamespace(
+        positions=torch.arange(7, dtype=torch.int64),
+        mrope_positions=None,
     )
-    monkeypatch.setattr(sglang_model, "Qwen3OmniMoeTalkerDenseMLP", FakeModule)
-    monkeypatch.setattr(sglang_model, "RMSNorm", FakeModule)
+    _ensure_mrope_positions(batch)
 
-    config = SimpleNamespace(
-        hidden_size=1024,
-        num_attention_heads=16,
-        num_key_value_heads=8,
-        rope_theta=1_000_000,
-        rope_scaling=None,
-        max_position_embeddings=32_768,
-        head_dim=128,
-        rms_norm_eps=1e-6,
-        attention_bias=False,
-        intermediate_size=3072,
+    assert batch.mrope_positions.shape == (3, 7)
+    assert torch.equal(batch.mrope_positions[0], batch.positions)
+    assert torch.equal(batch.mrope_positions[1], batch.positions)
+    assert torch.equal(batch.mrope_positions[2], batch.positions)
+
+    existing = torch.zeros((3, 7), dtype=torch.int64)
+    batch = SimpleNamespace(
+        positions=torch.arange(7, dtype=torch.int64),
+        mrope_positions=existing,
     )
-    layer = sglang_model.Qwen3TTSTalkerDecoderLayer(config, layer_id=0)
+    _ensure_mrope_positions(batch)
 
-    expected = (object(), object(), object())
-    assert layer.self_attn.apply_qk_norm_rope(*expected) == expected
-    assert events == [
-        ("enabled", True),
-        ("wrapped", (expected, {})),
-        ("inner", expected),
-    ]
+    assert batch.mrope_positions is existing
 
 
 def test_qwen3_tts_prefill_coalescing_is_opt_in() -> None:

--- a/tests/unit_test/qwen3_tts/test_pipeline.py
+++ b/tests/unit_test/qwen3_tts/test_pipeline.py
@@ -4813,7 +4813,8 @@ def test_qwen3_tts_prefill_uses_shared_late_bound_forward_transport(
         return SimpleNamespace(logits_output=logits_output, next_token_ids=None)
 
     runner.tp_worker = SimpleNamespace(
-        forward_batch_generation=forward_batch_generation
+        forward_batch_generation=forward_batch_generation,
+        model_runner=SimpleNamespace(prefill_cuda_graph_runner=None),
     )
     requests = [SimpleNamespace(request_id="request-a")]
     forward_batch = SimpleNamespace(

--- a/tests/unit_test/qwen3_tts/test_pipeline.py
+++ b/tests/unit_test/qwen3_tts/test_pipeline.py
@@ -4743,6 +4743,10 @@ def test_qwen3_tts_prefill_attaches_runner_composed_embeddings_to_sidecar(
     runner.model = SimpleNamespace(
         prepare_decode_buffers=lambda requests: calls.append("prepare")
     )
+    # A prefill graph runner is present, so the MRoPE mirror applies here.
+    runner.tp_worker = SimpleNamespace(
+        model_runner=SimpleNamespace(prefill_cuda_graph_runner=object())
+    )
     runner._build_prefill_input_embeds = (
         lambda forward_batch, requests: calls.append("embeds") or input_embeds
     )

--- a/tests/unit_test/qwen3_tts/test_pipeline.py
+++ b/tests/unit_test/qwen3_tts/test_pipeline.py
@@ -378,7 +378,9 @@ def test_qwen3_tts_before_prefill_mirrors_positions_into_mrope() -> None:
         positions=torch.arange(7, dtype=torch.int64),
         mrope_positions=None,
     )
-    _ensure_mrope_positions(batch, prefill_graph_runner=object())
+    _ensure_mrope_positions(
+        batch, prefill_graph_runner=SimpleNamespace(can_run_graph=lambda _: True)
+    )
 
     assert batch.mrope_positions.shape == (3, 7)
     assert torch.equal(batch.mrope_positions[0], batch.positions)
@@ -395,13 +397,32 @@ def test_qwen3_tts_mrope_mirror_is_scoped_to_the_graphed_path() -> None:
     """
     from sglang_omni.models.qwen3_tts.model_runner import _ensure_mrope_positions
 
-    batch = SimpleNamespace(
-        positions=torch.arange(7, dtype=torch.int64),
-        mrope_positions=None,
-    )
-    _ensure_mrope_positions(batch, prefill_graph_runner=None)
+    def _batch():
+        return SimpleNamespace(
+            positions=torch.arange(7, dtype=torch.int64),
+            mrope_positions=None,
+        )
 
+    # note (luojiaxuan): SGLang hands out an EagerRunner rather than None when
+    # prefill graphs are disabled, so the runner's own verdict is what scopes
+    # the mirror.
+    batch = _batch()
+    _ensure_mrope_positions(
+        batch, prefill_graph_runner=SimpleNamespace(can_run_graph=lambda _: False)
+    )
     assert batch.mrope_positions is None
+
+    batch = _batch()
+    _ensure_mrope_positions(batch, prefill_graph_runner=None)
+    assert batch.mrope_positions is None
+
+    batch = _batch()
+    _ensure_mrope_positions(
+        batch, prefill_graph_runner=SimpleNamespace(can_run_graph=lambda _: True)
+    )
+    assert batch.mrope_positions is not None
+    assert batch.mrope_positions.shape == (3, 7)
+    assert torch.equal(batch.mrope_positions[0], batch.positions)
 
 
 def test_qwen3_tts_mrope_mirror_leaves_real_positions_alone() -> None:
@@ -413,7 +434,9 @@ def test_qwen3_tts_mrope_mirror_leaves_real_positions_alone() -> None:
         positions=torch.zeros(7, dtype=torch.int64),
         mrope_positions=supplied,
     )
-    _ensure_mrope_positions(batch, prefill_graph_runner=object())
+    _ensure_mrope_positions(
+        batch, prefill_graph_runner=SimpleNamespace(can_run_graph=lambda _: True)
+    )
 
     assert batch.mrope_positions is supplied
 
@@ -4743,9 +4766,11 @@ def test_qwen3_tts_prefill_attaches_runner_composed_embeddings_to_sidecar(
     runner.model = SimpleNamespace(
         prepare_decode_buffers=lambda requests: calls.append("prepare")
     )
-    # A prefill graph runner is present, so the MRoPE mirror applies here.
+    # note (luojiaxuan): the runner accepts this batch, so the mirror applies.
     runner.tp_worker = SimpleNamespace(
-        model_runner=SimpleNamespace(prefill_cuda_graph_runner=object())
+        model_runner=SimpleNamespace(
+            prefill_cuda_graph_runner=SimpleNamespace(can_run_graph=lambda _: True)
+        )
     )
     runner._build_prefill_input_embeds = (
         lambda forward_batch, requests: calls.append("embeds") or input_embeds


### PR DESCRIPTION
Removes the QK-norm/RoPE graph break that #1581 installed around every Talker layer, and fixes what the evidence says the break was papering over: the captured prefill binds the runner's `mrope_positions` slot (the Talker declares `is_mrope_enabled`), but a TTS batch never populates mrope positions, so the replay-side slot refresh, which is conditional on the live batch carrying them, never ran. `before_prefill` now mirrors the plain positions into `[3, T]` mrope positions (all three rows are equal for the Talker; its attention collapses to row 0). Qwen3-ASR mirrors the same degenerate MRoPE, though on the request-building side (`request_builders.py:353` fills `mm_inputs.mrope_positions` with `positions.unsqueeze(0).expand(3, -1)`); its `mrope_fast_path.py` is a decode fast path, not a breakable-prefill precedent.

## Why

Measured at 1 RPS on the current full stack (T-PR19 decomposition in #1754): the extend forward runs **9.4 to 17.5 ms** with the break (dozens of graph segments with per-layer eager QK-norm/RoPE between them, CPU-launch-bound with a heavy jitter tail) versus **5.1 to 8.1 ms** captured whole. That is ~6 ms p50 and ~10 ms p95 of first-audio latency at c1, on the critical path of every request.

## Correctness evidence

The #1581 corruption does not reproduce on current main with the break removed (H200, 1.7B CustomVoice):

- fixed-seed fresh request: byte-identical to the broken-path reference, first codec frame at -104 dBFS (the Ryan/English silent-bootstrap invariant from #1754, a deterministic corruption detector);
- repeated identical requests (radix-warm): byte-identical across repeats;
- fused vs non-fused QK-norm/RoPE under capture: byte-identical;
- 381-request open-loop burst at 6 RPS: 100% success, leading-silence p50/p95 = 0/10 ms, no acoustic anomalies.

One earlier observation of "corruption" during this investigation turned out to be a measurement artifact (160 ms analysis window straddling the silence/speech boundary) and is corrected in #1754. If the original #1581 failure had a more specific trigger (shape, mode, or runner state), review input from that context is very welcome, the silence invariant plus fixed-seed byte-compare makes any counterexample cheap to demonstrate.

## Changes

- `before_prefill` fills `mrope_positions` from plain positions when absent (unit-tested).
- The per-layer `eager_on_graph` wrap and its installer are removed; the layer captures whole.
- The graph-break unit test is replaced by the mrope-mirroring test, which now scopes the mirror by the runner's own `can_run_graph` verdict: SGLang hands out an `EagerRunner` rather than `None` when prefill graphs are disabled, so a `None` check would have mirrored every eager prefill too.
