### PR TITLE
[MiniCPM-o] CUDA-graph the talker decode step: 7.9x talker, 5.8-7.2x E2E speech latency

### DIFF
--- a/sglang_omni/models/minicpm_o/bootstrap.py
+++ b/sglang_omni/models/minicpm_o/bootstrap.py
@@ -15,20 +15,65 @@ def create_thinker_scheduler(
     total_gpu_memory_fraction: float | None = None,
     enable_async_decode: bool = True,
     async_decode_min_batch_size: int = 2,
+    speech_enabled: bool = False,
 ):
-    """Create the MiniCPM-o thinker scheduler (text output only)."""
+    """Create the MiniCPM-o thinker scheduler.
+
+    With ``speech_enabled`` the runner captures per-step last-layer hidden
+    states (CaptureHiddenMode.LAST); the talker consumes them as the TTS
+    condition alongside the generated token ids.
+    """
     from sglang.srt.utils.hf_transformers_utils import get_tokenizer
 
     from sglang_omni.models.minicpm_o.request_builders import (
         make_thinker_scheduler_adapters,
         make_thinker_stream_output_builder,
+        should_generate_audio_output,
     )
     from sglang_omni.models.minicpm_o.thinker_model_runner import (
         MiniCPMOThinkerModelRunner,
     )
-    from sglang_omni.scheduling.bootstrap import create_sglang_infrastructure
+    from sglang_omni.scheduling.bootstrap import (
+        create_sglang_infrastructure,
+        init_sglang_cuda_graphs,
+    )
     from sglang_omni.scheduling.omni_scheduler import OmniScheduler
     from sglang_omni.scheduling.sglang_backend import SGLangOutputProcessor
+    from sglang_omni.vendor.sglang.server_args import override_server_args
+
+    # Hidden-state capture requires return_hidden_states in the runner; defer
+    # cuda-graph capture past infrastructure creation so graphs are built with
+    # the hidden-capture configuration (mirrors qwen3_omni bootstrap).
+    want_cuda_graph = not bool(server_args.disable_cuda_graph)
+    defer_cuda_graph_capture = want_cuda_graph and speech_enabled
+    if defer_cuda_graph_capture:
+        saved_disable_cuda_graph = server_args.disable_cuda_graph
+        saved_return_hidden_states = server_args.enable_return_hidden_states
+        override_server_args(
+            server_args,
+            "sglang_omni.minicpm_o.defer_cuda_graph_capture",
+            enable_return_hidden_states=True,
+            disable_cuda_graph=True,
+        )
+
+    try:
+        infrastructure = create_sglang_infrastructure(
+            server_args,
+            gpu_id,
+            tp_rank=tp_rank,
+            nccl_port=nccl_port,
+            model_arch_override="MiniCPMO",
+            total_gpu_memory_fraction=total_gpu_memory_fraction,
+            defer_cuda_graph_capture=defer_cuda_graph_capture,
+        )
+    finally:
+        if defer_cuda_graph_capture:
+            override_server_args(
+                server_args,
+                "sglang_omni.minicpm_o.restore_cuda_graph_capture",
+                disable_cuda_graph=saved_disable_cuda_graph,
+                enable_return_hidden_states=saved_return_hidden_states,
+            )
 
     (
         model_worker,
@@ -38,19 +83,19 @@ def create_thinker_scheduler(
         prefill_mgr,
         decode_mgr,
         model_config,
-    ) = create_sglang_infrastructure(
-        server_args,
-        gpu_id,
-        tp_rank=tp_rank,
-        nccl_port=nccl_port,
-        model_arch_override="MiniCPMO",
-        total_gpu_memory_fraction=total_gpu_memory_fraction,
-    )
+    ) = infrastructure
+
+    if defer_cuda_graph_capture:
+        init_sglang_cuda_graphs(model_worker)
+
+    def _should_emit_hidden(request: Any) -> bool:
+        return should_generate_audio_output(request.data.stage_payload)
 
     output_proc = SGLangOutputProcessor(
-        capture_hidden=False,
+        capture_hidden=speech_enabled,
         capture_hidden_layers=None,
         model=None,
+        should_emit_hidden=_should_emit_hidden if speech_enabled else None,
     )
     model_runner = MiniCPMOThinkerModelRunner(model_worker, output_proc)
 

--- a/sglang_omni/models/minicpm_o/bootstrap.py
+++ b/sglang_omni/models/minicpm_o/bootstrap.py
@@ -72,7 +72,6 @@ def create_thinker_scheduler(
                 server_args,
                 "sglang_omni.minicpm_o.restore_cuda_graph_capture",
                 disable_cuda_graph=saved_disable_cuda_graph,
-                enable_return_hidden_states=saved_return_hidden_states,
             )
 
     (
@@ -86,7 +85,16 @@ def create_thinker_scheduler(
     ) = infrastructure
 
     if defer_cuda_graph_capture:
+        # Graphs must capture with return_hidden_states still on: the runner
+        # requests CaptureHiddenMode.FULL every decode step, and the graph's
+        # can_run gate requires an exact hidden-mode match — a graph captured
+        # without hidden capture would never replay.
         init_sglang_cuda_graphs(model_worker)
+        override_server_args(
+            server_args,
+            "sglang_omni.minicpm_o.restore_return_hidden_states",
+            enable_return_hidden_states=saved_return_hidden_states,
+        )
 
     def _should_emit_hidden(request: Any) -> bool:
         return should_generate_audio_output(request.data.stage_payload)

--- a/sglang_omni/models/minicpm_o/components/audio_encoder.py
+++ b/sglang_omni/models/minicpm_o/components/audio_encoder.py
@@ -109,9 +109,7 @@ class MiniCPMOAudioEncoder(nn.Module):
         self.audio_chunk_length = float(config.audio_chunk_length)
         self.audio_encoder_layer = -1
 
-    def _feature_lens_after_pooling(
-        self, input_lengths: torch.Tensor
-    ) -> torch.Tensor:
+    def _feature_lens_after_pooling(self, input_lengths: torch.Tensor) -> torch.Tensor:
         after_cnn = (input_lengths - 1) // 2 + 1
         after_pool = (after_cnn - self.audio_pool_step) // self.audio_pool_step + 1
         return after_pool.to(dtype=torch.int32)
@@ -147,9 +145,7 @@ class MiniCPMOAudioEncoder(nn.Module):
             .unsqueeze(0)
             .expand(batch_size, max_seq_len)
         )
-        lengths_expand = audio_feature_lens.unsqueeze(1).expand(
-            batch_size, max_seq_len
-        )
+        lengths_expand = audio_feature_lens.unsqueeze(1).expand(batch_size, max_seq_len)
         padding_mask = seq_range >= lengths_expand
         mask_bool = padding_mask.view(batch_size, 1, 1, max_seq_len).expand(
             batch_size, 1, max_seq_len, max_seq_len
@@ -158,9 +154,7 @@ class MiniCPMOAudioEncoder(nn.Module):
         # Generate path uses chunked attention (audio_chunk_length seconds,
         # 50 frames/sec after the conv downsample).
         chunk_num_frame = int(self.audio_chunk_length * 50)
-        chunk_mask = _subsequent_chunk_mask(
-            max_seq_len, chunk_num_frame, self._device
-        )
+        chunk_mask = _subsequent_chunk_mask(max_seq_len, chunk_num_frame, self._device)
         mask_bool = torch.logical_or(mask_bool, torch.logical_not(chunk_mask))
 
         audio_attention_mask = torch.zeros(

--- a/sglang_omni/models/minicpm_o/components/code2wav.py
+++ b/sglang_omni/models/minicpm_o/components/code2wav.py
@@ -1,0 +1,123 @@
+# SPDX-License-Identifier: Apache-2.0
+"""Code2Wav component for MiniCPM-o.
+
+Wraps stepaudio2's ``Token2wav`` (the remote code's ``init_tts`` dependency)
+to turn s3tokenizer codec tokens into a 24 kHz waveform. The vocoder assets
+live in the checkpoint directory under ``assets/token2wav``; the default
+prompt (speaker reference) wav is ``assets/HT_ref_audio.wav`` when present,
+matching the remote demo's default voice.
+"""
+
+from __future__ import annotations
+
+import logging
+import os
+
+import numpy as np
+import torch
+import torch.nn as nn
+
+from sglang_omni.models.weight_loader import resolve_model_path
+
+logger = logging.getLogger(__name__)
+
+OUTPUT_SAMPLE_RATE = 24000
+
+
+class MiniCPMOCode2Wav(nn.Module):
+    """stepaudio2 Token2wav wrapper: codec tokens → float32 waveform."""
+
+    def __init__(
+        self,
+        model_path: str,
+        *,
+        device: str = "cuda",
+        float16: bool = False,
+        n_timesteps: int = 10,
+        prompt_wav: str | None = None,
+    ) -> None:
+        super().__init__()
+        del device  # Token2wav manages its own device placement (cuda).
+        try:
+            from stepaudio2 import Token2wav
+        except ImportError as exc:
+            raise ImportError(
+                "MiniCPM-o audio output requires stepaudio2; install via "
+                "pip install minicpmo-utils[all]"
+            ) from exc
+
+        model_dir = str(resolve_model_path(model_path))
+        asset_dir = os.path.join(model_dir, "assets", "token2wav")
+        if not os.path.isdir(asset_dir):
+            raise FileNotFoundError(
+                f"token2wav assets not found at {asset_dir}; copy the "
+                "checkpoint's assets/token2wav directory next to the weights"
+            )
+        self.token2wav = Token2wav(asset_dir, float16=float16, n_timesteps=n_timesteps)
+
+        if prompt_wav is None:
+            default_wav = os.path.join(model_dir, "assets", "HT_ref_audio.wav")
+            prompt_wav = default_wav if os.path.isfile(default_wav) else None
+        self._prompt_wav = prompt_wav
+
+    @torch.inference_mode()
+    def forward(
+        self,
+        *,
+        codec_tokens: torch.Tensor,
+        prompt_wav: str | None = None,
+        **_: object,
+    ) -> dict[str, object]:
+        """Vocode one utterance.
+
+        Args:
+            codec_tokens: ``(N,)`` s3tokenizer codes (EOS already stripped).
+            prompt_wav: optional path to a 16 kHz speaker-reference wav;
+                falls back to the component default.
+
+        Returns:
+            ``waveform``: ``(samples,)`` float32 at 24 kHz; ``sample_rate``.
+        """
+        tokens = codec_tokens.reshape(-1).tolist()
+        if not tokens:
+            return {
+                "waveform": np.zeros(0, dtype=np.float32),
+                "sample_rate": OUTPUT_SAMPLE_RATE,
+            }
+        waveform = self._vocode(tokens, prompt_wav or self._prompt_wav)
+        return {"waveform": waveform, "sample_rate": OUTPUT_SAMPLE_RATE}
+
+    def _vocode(self, tokens: list[int], prompt_wav: str | None) -> np.ndarray:
+        """``Token2wav.__call__`` minus its final ``torchaudio.save`` — newer
+        torchaudio (torchcodec backend) cannot encode into ``BytesIO``, and we
+        want the raw waveform anyway."""
+        t2w = self.token2wav
+        if t2w.cache is None:
+            t2w.cache = t2w._prepare_prompt(prompt_wav)
+        (
+            prompt_speech_tokens,
+            prompt_speech_tokens_lens,
+            spk_emb,
+            prompt_mels,
+            prompt_mels_lens,
+        ) = t2w.cache
+
+        speech_tokens = torch.tensor([tokens], dtype=torch.int32, device="cuda")
+        speech_tokens_lens = torch.tensor(
+            [speech_tokens.shape[1]], dtype=torch.int32, device="cuda"
+        )
+        with torch.amp.autocast(
+            "cuda", dtype=torch.float16 if t2w.float16 else torch.float32
+        ):
+            mel = t2w.flow.inference(
+                speech_tokens,
+                speech_tokens_lens,
+                prompt_speech_tokens,
+                prompt_speech_tokens_lens,
+                prompt_mels,
+                prompt_mels_lens,
+                spk_emb,
+                t2w.n_timesteps,
+            )
+        wav, _ = t2w.hift(speech_feat=mel)
+        return wav.reshape(-1).float().cpu().numpy()

--- a/sglang_omni/models/minicpm_o/components/preprocessor.py
+++ b/sglang_omni/models/minicpm_o/components/preprocessor.py
@@ -51,7 +51,13 @@ def _first_batch_item(value: Any) -> Any:
 
 
 class MiniCPMOPreprocessor:
-    def __init__(self, model_path: str, *, max_seq_len: int | None = None):
+    def __init__(
+        self,
+        model_path: str,
+        *,
+        max_seq_len: int | None = None,
+        speech_enabled: bool = False,
+    ):
         local_dir = _resolve_local_model_dir(model_path)
         self.tokenizer = AutoTokenizer.from_pretrained(
             local_dir, trust_remote_code=True
@@ -61,6 +67,18 @@ class MiniCPMOPreprocessor:
         self._local_dir = local_dir
         self._processor = None
         self.max_seq_len = max_seq_len
+        # Speech pipelines render the tts chat template for audio-output
+        # requests so the thinker emits a <|tts_bos|>...<|tts_eos|> span for
+        # the talker; the remote code's chat() does the same via
+        # use_tts_template before generating speech.
+        self._speech_enabled = speech_enabled
+
+    def _use_tts_template(self, payload: StagePayload) -> bool:
+        from sglang_omni.models.minicpm_o.request_builders import (
+            should_generate_audio_output,
+        )
+
+        return self._speech_enabled and should_generate_audio_output(payload)
 
     @property
     def processor(self):
@@ -96,7 +114,9 @@ class MiniCPMOPreprocessor:
             prompt_text = ""
             input_ids = torch.tensor(messages, dtype=torch.long)
         else:
-            prompt_text = self._render_chat_template(messages)
+            prompt_text = self._render_chat_template(
+                messages, use_tts_template=self._use_tts_template(payload)
+            )
             encoded = self.tokenizer(prompt_text, return_tensors="pt")
             input_ids = encoded["input_ids"][0].to(dtype=torch.long)
         attention_mask = torch.ones_like(input_ids)
@@ -172,7 +192,8 @@ class MiniCPMOPreprocessor:
                 messages, num_images=len(images), num_audios=len(audios)
             )
         prompt_text = self._render_chat_template(
-            messages, use_tts_template=bool(audios)
+            messages,
+            use_tts_template=bool(audios) or self._use_tts_template(payload),
         )
 
         processed = self.processor(

--- a/sglang_omni/models/minicpm_o/components/talker.py
+++ b/sglang_omni/models/minicpm_o/components/talker.py
@@ -12,6 +12,7 @@ the ``text_eos`` and ``audio_bos`` embeddings; speaker embeddings are empty.
 from __future__ import annotations
 
 import logging
+import os
 
 import torch
 import torch.nn as nn
@@ -19,6 +20,7 @@ import torch.nn.functional as F
 from transformers import AutoConfig
 from transformers.dynamic_module_utils import get_class_from_dynamic_module
 
+from sglang_omni.models.minicpm_o.components.talker_decode import TalkerDecodeLoop
 from sglang_omni.models.weight_loader import (
     load_module,
     resolve_dtype,
@@ -26,6 +28,13 @@ from sglang_omni.models.weight_loader import (
 )
 
 logger = logging.getLogger(__name__)
+
+MINICPMO_TALKER_FAST_ENV = "SGLANG_OMNI_MINICPMO_TALKER_FAST"
+
+
+def _fast_decode_enabled() -> bool:
+    value = os.environ.get(MINICPMO_TALKER_FAST_ENV, "1").strip().lower()
+    return value not in ("0", "false", "off", "no")
 
 
 class MiniCPMOTalker(nn.Module):
@@ -81,6 +90,13 @@ class MiniCPMOTalker(nn.Module):
         cfg = self.tts.config
         self.codec_eos_id = int(cfg.num_audio_tokens) - 1
 
+        self._decode_loop: TalkerDecodeLoop | None = None
+        if _fast_decode_enabled():
+            gen_logits_fn = get_class_from_dynamic_module(
+                "modeling_minicpmo.gen_logits", model_dir
+            )
+            self._decode_loop = TalkerDecodeLoop(self.tts, gen_logits_fn=gen_logits_fn)
+
     def _build_condition(
         self, tts_token_ids: torch.Tensor, tts_hidden: torch.Tensor
     ) -> torch.Tensor:
@@ -135,17 +151,27 @@ class MiniCPMOTalker(nn.Module):
 
         inputs_embeds = self._build_condition(tts_token_ids, tts_hidden)
         sampling_params = self._sampling_params_cls(**(sampling_overrides or {}))
-        outputs = self.tts.generate(
-            inputs_embeds=inputs_embeds,
-            eos_token=torch.tensor(
-                [self.codec_eos_id], dtype=torch.long, device=self._device
-            ),
-            min_new_token=min_new_token,
-            max_new_token=max_new_token,
-            show_tqdm=False,
-            sampling_params=sampling_params,
+        eos_token = torch.tensor(
+            [self.codec_eos_id], dtype=torch.long, device=self._device
         )
-        # new_ids: (1, N, num_vq=1); the remote generate already excludes the
-        # EOS step from new_ids.
-        codec = outputs.new_ids.squeeze(0).squeeze(-1).to("cpu", dtype=torch.long)
+        if self._decode_loop is not None:
+            new_ids = self._decode_loop.generate(
+                inputs_embeds,
+                eos_token,
+                min_new_token=min_new_token,
+                max_new_token=max_new_token,
+                sampling_params=sampling_params,
+            )
+        else:
+            outputs = self.tts.generate(
+                inputs_embeds=inputs_embeds,
+                eos_token=eos_token,
+                min_new_token=min_new_token,
+                max_new_token=max_new_token,
+                show_tqdm=False,
+                sampling_params=sampling_params,
+            )
+            new_ids = outputs.new_ids
+        # new_ids: (1, N, num_vq=1); both paths exclude the EOS step.
+        codec = new_ids.squeeze(0).squeeze(-1).to("cpu", dtype=torch.long)
         return {"codec_tokens": codec}

--- a/sglang_omni/models/minicpm_o/components/talker.py
+++ b/sglang_omni/models/minicpm_o/components/talker.py
@@ -1,0 +1,151 @@
+# SPDX-License-Identifier: Apache-2.0
+"""Talker (TTS) component for MiniCPM-o.
+
+Wraps the checkpoint's remote-code ``MiniCPMTTS`` (``tts.`` prefix): a small
+llama backbone that autoregressively emits s3tokenizer codec tokens. The
+condition construction mirrors the remote code's non-streaming path
+(``_generate_speech_non_streaming``): per thinker token,
+``emb_text(token) + l2_normalize(projector_semantic(hidden))``, followed by
+the ``text_eos`` and ``audio_bos`` embeddings; speaker embeddings are empty.
+"""
+
+from __future__ import annotations
+
+import logging
+
+import torch
+import torch.nn as nn
+import torch.nn.functional as F
+from transformers import AutoConfig
+from transformers.dynamic_module_utils import get_class_from_dynamic_module
+
+from sglang_omni.models.weight_loader import (
+    load_module,
+    resolve_dtype,
+    resolve_model_path,
+)
+
+logger = logging.getLogger(__name__)
+
+
+class MiniCPMOTalker(nn.Module):
+    """Remote-code MiniCPMTTS wrapper: thinker tokens + hidden → codec tokens."""
+
+    def __init__(
+        self,
+        model_path: str,
+        *,
+        device: str = "cuda",
+        dtype: str | torch.dtype | None = None,
+    ) -> None:
+        super().__init__()
+        torch_dtype = resolve_dtype(dtype)
+        model_dir = str(resolve_model_path(model_path))
+        config = AutoConfig.from_pretrained(model_dir, trust_remote_code=True)
+        self._device = torch.device(device)
+        self._dtype = torch_dtype
+
+        tts_cls = get_class_from_dynamic_module(
+            "modeling_minicpmo.MiniCPMTTS", model_dir
+        )
+        self._sampling_params_cls = get_class_from_dynamic_module(
+            "utils.TTSSamplingParams", model_dir
+        )
+
+        # AutoConfig may resolve to a generic config class that leaves
+        # tts_config as a raw dict; coerce it through the remote config class.
+        tts_config = config.tts_config
+        if isinstance(tts_config, dict):
+            tts_config_cls = get_class_from_dynamic_module(
+                "configuration_minicpmo.MiniCPMTTSConfig", model_dir
+            )
+            tts_config = tts_config_cls(**tts_config)
+        # MiniCPMTTS.__init__ reads generation defaults that transformers v4
+        # provided on every PretrainedConfig and v5 removed; backfill the v4
+        # values (generation is driven by TTSSamplingParams, not these).
+        for attr, default in (
+            ("top_p", 1.0),
+            ("top_k", 50),
+            ("repetition_penalty", 1.0),
+        ):
+            if not hasattr(tts_config, attr):
+                setattr(tts_config, attr, default)
+        # Mirrors the remote code's init_tts_module attention pin.
+        tts_config.attn_implementation = "eager"
+        tts = tts_cls(tts_config, audio_tokenizer=None)
+        self.tts = load_module(
+            tts, model_dir, prefix=("tts.",), dtype=torch_dtype, device=device
+        )
+        self.tts.eval()
+
+        cfg = self.tts.config
+        self.codec_eos_id = int(cfg.num_audio_tokens) - 1
+
+    def _build_condition(
+        self, tts_token_ids: torch.Tensor, tts_hidden: torch.Tensor
+    ) -> torch.Tensor:
+        """Per-token condition + text_eos + audio_bos, shape (1, T+2, hidden)."""
+        tokens = tts_token_ids.to(self._device, dtype=torch.long)
+        hidden = tts_hidden.to(self._device, dtype=self._dtype)
+
+        llm_embeds = self.tts.emb_text(tokens)
+        hidden_embeds = self.tts.projector_semantic(hidden)
+        if self.tts.config.normalize_projected_hidden:
+            hidden_embeds = F.normalize(hidden_embeds, p=2, dim=-1)
+        tts_embeds = llm_embeds + hidden_embeds
+
+        boundary = self.tts.emb_text(
+            torch.tensor(
+                [self.tts.config.text_eos_token_id, self.tts.audio_bos_token_id],
+                device=self._device,
+                dtype=torch.long,
+            )
+        )
+        return torch.cat([tts_embeds, boundary], dim=0).unsqueeze(0)
+
+    @torch.inference_mode()
+    def forward(
+        self,
+        *,
+        tts_token_ids: torch.Tensor,
+        tts_hidden: torch.Tensor,
+        min_new_token: int = 50,
+        max_new_token: int = 2048,
+        sampling_overrides: dict[str, float] | None = None,
+        **_: object,
+    ) -> dict[str, torch.Tensor]:
+        """Generate codec tokens for one utterance.
+
+        Args:
+            tts_token_ids: ``(T,)`` thinker token ids inside the
+                ``<|tts_bos|>``/``<|tts_eos|>`` span.
+            tts_hidden: ``(T, llm_dim)`` last-layer thinker hidden states at
+                the same positions.
+
+        Returns:
+            ``codec_tokens``: ``(N,)`` s3tokenizer codes, EOS stripped.
+        """
+        if tts_token_ids.numel() == 0:
+            return {"codec_tokens": torch.empty(0, dtype=torch.long)}
+        if tts_token_ids.shape[0] != tts_hidden.shape[0]:
+            raise ValueError(
+                f"tts_token_ids ({tts_token_ids.shape[0]}) and tts_hidden "
+                f"({tts_hidden.shape[0]}) must be position-aligned"
+            )
+
+        inputs_embeds = self._build_condition(tts_token_ids, tts_hidden)
+        sampling_params = self._sampling_params_cls(**(sampling_overrides or {}))
+        outputs = self.tts.generate(
+            inputs_embeds=inputs_embeds,
+            eos_token=torch.tensor(
+                [self.codec_eos_id], dtype=torch.long, device=self._device
+            ),
+            min_new_token=min_new_token,
+            max_new_token=max_new_token,
+            show_tqdm=False,
+            sampling_params=sampling_params,
+        )
+        # new_ids: (1, N, num_vq=1); the remote generate already excludes the
+        # EOS step from new_ids.
+        codec = outputs.new_ids.squeeze(0).squeeze(-1).to("cpu", dtype=torch.long)
+        return {"codec_tokens": codec}

--- a/sglang_omni/models/minicpm_o/components/talker_decode.py
+++ b/sglang_omni/models/minicpm_o/components/talker_decode.py
@@ -1,0 +1,379 @@
+# SPDX-License-Identifier: Apache-2.0
+"""Fast decode loop for the MiniCPM-o talker (MiniCPMTTS).
+
+The remote code's non-streaming ``MiniCPMTTS.generate`` runs one eager HF
+llama step per codec token (~97 tok/s on H100; ~85% of the speech path's
+per-request compute). This module reimplements the same loop over the same
+weights with a preallocated ``StaticCache`` and, when available, a CUDA graph
+capturing the per-step backbone chain (code embedding -> llama decode step ->
+code head). Sampling stays eager and reuses the remote code's own
+``gen_logits`` processors/warpers, so sampling semantics are unchanged.
+
+Modes:
+- ``compat``: op-for-op the remote loop (DynamicCache, HF-built masks).
+  Reference for parity tests.
+- ``fast``: StaticCache + an explicitly maintained 4D additive mask (HF mask
+  construction happens on the host and is not capture-safe; a device-resident
+  mask buffer is) + CUDA graph replay. ``SGLANG_OMNI_MINICPMO_TALKER_GRAPH=0``
+  keeps the fast loop but replays nothing (eager static-cache steps).
+"""
+
+from __future__ import annotations
+
+import logging
+import os
+from typing import Any, Callable
+
+import torch
+import torch.nn.functional as F
+
+logger = logging.getLogger(__name__)
+
+MINICPMO_TALKER_GRAPH_ENV = "SGLANG_OMNI_MINICPMO_TALKER_GRAPH"
+
+
+def _graph_env_enabled() -> bool:
+    value = os.environ.get(MINICPMO_TALKER_GRAPH_ENV, "1").strip().lower()
+    return value not in ("0", "false", "off", "no")
+
+
+def _mask_min(dtype: torch.dtype) -> float:
+    return torch.finfo(dtype).min
+
+
+class _SamplingState:
+    """Per-generate sampling state mirroring the remote loop's semantics."""
+
+    def __init__(
+        self,
+        *,
+        num_vq: int,
+        num_audio_tokens: int,
+        temperature: float,
+        gen_logits_fn: Callable[..., tuple],
+        repetition_penalty: float,
+        top_p: float,
+        top_k: int,
+        device: torch.device,
+    ) -> None:
+        self.temperature = torch.tensor(
+            [temperature] * num_vq, dtype=torch.float, device=device
+        ).view(-1, 1)
+        self.logits_warpers, self.logits_processors = gen_logits_fn(
+            num_code=num_audio_tokens,
+            repetition_penalty=repetition_penalty,
+            top_p=top_p,
+            top_k=top_k,
+        )
+        self.num_vq = num_vq
+
+    def sample(
+        self,
+        logits: torch.Tensor,
+        *,
+        step: int,
+        new_tokens: torch.Tensor,
+        min_new_token: int,
+        eos_token: torch.Tensor,
+    ) -> torch.Tensor:
+        """One sampling step: (1, num_audio, num_vq) logits -> (1, num_vq) ids."""
+        logits = logits.permute(0, 2, 1).reshape(-1, logits.size(1))
+        logits = logits / self.temperature
+        if step > 0:
+            history = new_tokens[:, 0:step].permute(0, 2, 1)
+            logits_token = history.reshape(history.size(0) * history.size(1), -1)
+            for processor in self.logits_processors:
+                logits = processor(logits_token, logits)
+            for warper in self.logits_warpers:
+                logits = warper(logits_token, logits)
+        if step < min_new_token:
+            logits[:, eos_token] = -torch.inf
+        scores = F.softmax(logits, dim=-1)
+        return torch.multinomial(scores, num_samples=1).view(-1, self.num_vq)
+
+
+class _GraphedTalkerStep:
+    """CUDA graph over one talker decode step for a fixed cache length.
+
+    Per-step inputs reach the captured region through persistent device
+    buffers (token ids, position ids, cache position, additive mask row);
+    the captured logits tensor is read in place after each replay.
+    """
+
+    def __init__(self, backend: "_FastBackend") -> None:
+        self.backend = backend
+        self.graph = torch.cuda.CUDAGraph()
+        self.logits: torch.Tensor | None = None
+        try:
+            self._capture()
+        except Exception:
+            # Release the graph's private pool eagerly; the raising object
+            # may linger on traceback frames.
+            try:
+                self.graph.reset()
+            except Exception:
+                pass
+            raise
+
+    @torch.no_grad()
+    def _capture(self) -> None:
+        backend = self.backend
+        device = backend.device
+        with torch.cuda.device(device):
+            current_stream = torch.cuda.current_stream(device=device)
+            warmup_stream = torch.cuda.Stream(device=device)
+            warmup_stream.wait_stream(current_stream)
+            with torch.cuda.stream(warmup_stream):
+                for _ in range(2):
+                    backend.step_forward()
+            current_stream.wait_stream(warmup_stream)
+
+            capture_stream = torch.cuda.Stream(device=device)
+            capture_stream.wait_stream(current_stream)
+            with torch.cuda.graph(
+                self.graph,
+                stream=capture_stream,
+                capture_error_mode="thread_local",
+            ):
+                self.logits = backend.step_forward()
+            current_stream.wait_stream(capture_stream)
+        if self.logits is None:
+            raise RuntimeError("MiniCPM-o talker CUDA graph captured no outputs")
+
+    @torch.no_grad()
+    def replay(self) -> torch.Tensor:
+        self.graph.replay()
+        assert self.logits is not None
+        return self.logits
+
+
+class _FastBackend:
+    """StaticCache-backed step executor with an explicit additive mask."""
+
+    def __init__(self, tts: Any, *, max_cache_len: int) -> None:
+        from transformers import StaticCache
+
+        self.tts = tts
+        self.device = next(tts.model.parameters()).device
+        self.dtype = next(tts.model.parameters()).dtype
+        self.max_cache_len = max_cache_len
+        self.cache = StaticCache(config=tts.model.config, max_cache_len=max_cache_len)
+        num_vq = tts.config.num_vq
+        self.token_buf = torch.zeros(1, 1, num_vq, dtype=torch.long, device=self.device)
+        self.pos_buf = torch.zeros(1, 1, dtype=torch.long, device=self.device)
+        self.cache_pos_buf = torch.zeros(1, dtype=torch.long, device=self.device)
+        self.mask_buf = torch.full(
+            (1, 1, 1, max_cache_len),
+            _mask_min(self.dtype),
+            dtype=self.dtype,
+            device=self.device,
+        )
+        self._graph: _GraphedTalkerStep | None = None
+        self._graph_failed = False
+
+    @torch.no_grad()
+    def prefill(self, inputs_embeds: torch.Tensor) -> torch.Tensor:
+        """Run the condition through the backbone; returns (1, num_audio, num_vq)."""
+        cond_len = inputs_embeds.shape[1]
+        if cond_len + 1 >= self.max_cache_len:
+            raise ValueError(
+                f"talker condition ({cond_len}) does not fit the static cache "
+                f"({self.max_cache_len})"
+            )
+        positions = torch.arange(cond_len, dtype=torch.long, device=self.device)
+        # Reset the mask to "condition visible, everything else blocked".
+        # Stale KV content past the mask is unreachable, so the cache itself
+        # never needs zeroing between requests.
+        self.mask_buf.fill_(_mask_min(self.dtype))
+        self.mask_buf[..., :cond_len] = 0.0
+        outputs = self.tts.model(
+            inputs_embeds=inputs_embeds,
+            position_ids=positions.unsqueeze(0),
+            cache_position=positions,
+            past_key_values=self.cache,
+            use_cache=True,
+        )
+        return self._head_logits(outputs.last_hidden_state[:, -1:])
+
+    def stage_step(self, tokens: torch.Tensor, position: int) -> None:
+        """Stage device inputs for the step at absolute cache slot ``position``."""
+        self.token_buf.copy_(tokens.view(1, 1, -1))
+        self.pos_buf.fill_(position)
+        self.cache_pos_buf.fill_(position)
+        self.mask_buf[..., position] = 0.0
+
+    @torch.no_grad()
+    def step_forward(self) -> torch.Tensor:
+        """One decode step from the staged buffers; returns float logits."""
+        tts = self.tts
+        code_emb = [
+            tts.emb_code[q](self.token_buf[:, :, q]) for q in range(tts.config.num_vq)
+        ]
+        inputs_embeds = torch.stack(code_emb, 3).sum(3)
+        outputs = tts.model(
+            inputs_embeds=inputs_embeds,
+            position_ids=self.pos_buf,
+            cache_position=self.cache_pos_buf,
+            past_key_values=self.cache,
+            attention_mask=self.mask_buf,
+            use_cache=True,
+        )
+        return self._head_logits(outputs.last_hidden_state)
+
+    def _head_logits(self, hidden: torch.Tensor) -> torch.Tensor:
+        tts = self.tts
+        logits = torch.stack(
+            [tts.head_code[q](hidden) for q in range(tts.config.num_vq)], dim=3
+        )
+        return logits[:, -1].float()
+
+    def step(
+        self, tokens: torch.Tensor, position: int, *, use_graph: bool
+    ) -> torch.Tensor:
+        self.stage_step(tokens, position)
+        if use_graph and not self._graph_failed:
+            if self._graph is None:
+                try:
+                    self._graph = _GraphedTalkerStep(self)
+                    logger.info("MiniCPM-o talker decode CUDA graph captured")
+                except Exception:
+                    self._graph_failed = True
+                    logger.warning(
+                        "MiniCPM-o talker CUDA graph capture failed; "
+                        "falling back to eager static-cache decode",
+                        exc_info=True,
+                    )
+            if self._graph is not None:
+                return self._graph.replay()
+        return self.step_forward()
+
+
+class TalkerDecodeLoop:
+    """Drop-in replacement for the remote ``MiniCPMTTS.generate`` loop."""
+
+    def __init__(
+        self,
+        tts: Any,
+        *,
+        gen_logits_fn: Callable[..., tuple],
+        max_cache_len: int | None = None,
+    ) -> None:
+        self._tts = tts
+        self._gen_logits = gen_logits_fn
+        self._max_cache_len = int(max_cache_len or tts.config.max_position_embeddings)
+        self._fast: _FastBackend | None = None
+
+    def _fast_backend(self) -> _FastBackend:
+        if self._fast is None:
+            self._fast = _FastBackend(self._tts, max_cache_len=self._max_cache_len)
+        return self._fast
+
+    @torch.inference_mode()
+    def generate(
+        self,
+        inputs_embeds: torch.Tensor,
+        eos_token: torch.Tensor,
+        *,
+        min_new_token: int,
+        max_new_token: int,
+        sampling_params: Any,
+        mode: str = "fast",
+    ) -> torch.Tensor:
+        """Generate codec ids for one utterance; returns (1, N, num_vq).
+
+        Loop semantics (ordering of processors/warpers, min-token EOS mask,
+        EOS-step exclusion from the returned ids, final-step trim on
+        max_new_token) mirror the remote non-streaming ``generate``.
+        """
+        assert inputs_embeds.shape[0] == 1, "talker decode is batch-1"
+        tts = self._tts
+        device = inputs_embeds.device
+        num_vq = tts.config.num_vq
+        eos_token = eos_token.to(device)
+        sampling = _SamplingState(
+            num_vq=num_vq,
+            num_audio_tokens=tts.config.num_audio_tokens,
+            temperature=sampling_params.temperature,
+            gen_logits_fn=self._gen_logits,
+            repetition_penalty=sampling_params.repetition_penalty,
+            top_p=sampling_params.top_p,
+            top_k=sampling_params.top_k,
+            device=device,
+        )
+        new_tokens = torch.zeros(
+            1, max_new_token, num_vq, dtype=torch.long, device=device
+        )
+        finish = torch.zeros(1, dtype=torch.bool, device=device)
+        cond_len = inputs_embeds.shape[1]
+        use_graph = mode == "fast" and _graph_env_enabled()
+
+        if mode == "fast":
+            backend = self._fast_backend()
+            logits = backend.prefill(inputs_embeds)
+        else:
+            backend = None
+            past_key_values = None
+            logits, past_key_values = self._compat_step(
+                inputs_embeds,
+                torch.arange(cond_len, dtype=torch.long, device=device).unsqueeze(0),
+                past_key_values,
+            )
+
+        t = 0
+        for t in range(max_new_token):
+            if t > 0:
+                position = cond_len + t - 1
+                if mode == "fast":
+                    logits = backend.step(
+                        new_tokens[:, t - 1], position, use_graph=use_graph
+                    )
+                else:
+                    code_emb = [
+                        tts.emb_code[q](new_tokens[:, t - 1 : t, q])
+                        for q in range(num_vq)
+                    ]
+                    step_embeds = torch.stack(code_emb, 3).sum(3)
+                    pos = torch.tensor([[position]], dtype=torch.long, device=device)
+                    logits, past_key_values = self._compat_step(
+                        step_embeds, pos, past_key_values
+                    )
+            idx_next = sampling.sample(
+                logits,
+                step=t,
+                new_tokens=new_tokens,
+                min_new_token=min_new_token,
+                eos_token=eos_token,
+            )
+            finish.logical_or_(idx_next.eq(eos_token).any(1))
+            new_tokens[:, t] = idx_next
+            if finish.all():
+                break
+
+        if not bool(finish.all()):
+            logger.warning(
+                "MiniCPM-o talker hit max_new_token=%d without EOS", max_new_token
+            )
+        return new_tokens[:, 0:t, :]
+
+    def _compat_step(
+        self,
+        inputs_embeds: torch.Tensor,
+        position_ids: torch.Tensor,
+        past_key_values: Any,
+    ) -> tuple[torch.Tensor, Any]:
+        tts = self._tts
+        outputs = tts.model(
+            inputs_embeds=inputs_embeds,
+            position_ids=position_ids,
+            cache_position=position_ids.view(-1),
+            past_key_values=past_key_values,
+            use_cache=True,
+        )
+        logits = torch.stack(
+            [
+                tts.head_code[q](outputs.last_hidden_state)
+                for q in range(tts.config.num_vq)
+            ],
+            dim=3,
+        )
+        return logits[:, -1].float(), outputs.past_key_values

--- a/sglang_omni/models/minicpm_o/components/talker_decode.py
+++ b/sglang_omni/models/minicpm_o/components/talker_decode.py
@@ -170,6 +170,7 @@ class _FastBackend:
         )
         self._graph: _GraphedTalkerStep | None = None
         self._graph_failed = False
+        self._used = False
 
     @torch.no_grad()
     def prefill(self, inputs_embeds: torch.Tensor) -> torch.Tensor:
@@ -180,10 +181,16 @@ class _FastBackend:
                 f"talker condition ({cond_len}) does not fit the static cache "
                 f"({self.max_cache_len})"
             )
+        # transformers v5's StaticLayer.update ignores the cache_position we
+        # pass and always writes at arange + cumulative_length, a device
+        # tensor the captured graph keeps advancing across replays. Without a
+        # per-request reset the write positions climb monotonically: request
+        # 2+ conditions on request 1's stale KV, and after ~4 requests the
+        # writes walk off the cache end (index_copy_ device assert).
+        if self._used:
+            self.cache.reset()
+        self._used = True
         positions = torch.arange(cond_len, dtype=torch.long, device=self.device)
-        # Reset the mask to "condition visible, everything else blocked".
-        # Stale KV content past the mask is unreachable, so the cache itself
-        # never needs zeroing between requests.
         self.mask_buf.fill_(_mask_min(self.dtype))
         self.mask_buf[..., :cond_len] = 0.0
         outputs = self.tts.model(

--- a/sglang_omni/models/minicpm_o/config.py
+++ b/sglang_omni/models/minicpm_o/config.py
@@ -183,9 +183,7 @@ class MiniCPMOSpeechPipelineConfig(MiniCPMOPipelineConfig):
     (stepaudio2 Token2wav). Audio output arrives non-streaming, one wav per
     request."""
 
-    terminal_stages_fn: str | None = (
-        f"{_PKG}.request_builders.resolve_terminal_stages"
-    )
+    terminal_stages_fn: str | None = f"{_PKG}.request_builders.resolve_terminal_stages"
     stages: list[StageConfig] = Field(default_factory=_speech_stages)
 
     def stage_factory_kwargs(self, stage_name: str) -> dict[str, Any]:

--- a/sglang_omni/models/minicpm_o/config.py
+++ b/sglang_omni/models/minicpm_o/config.py
@@ -3,7 +3,7 @@
 
 from __future__ import annotations
 
-from typing import ClassVar
+from typing import Any, ClassVar
 
 from pydantic import Field
 
@@ -81,17 +81,29 @@ def _aggregate_stage(*, process: str, gpu: int) -> StageConfig:
     )
 
 
-def _thinker_stage(*, gpu: int, process: str) -> StageConfig:
+def _thinker_stage(
+    *, gpu: int, process: str, speech_enabled: bool = False
+) -> StageConfig:
     return EngineStageConfig(
         name="thinker",
         process=process,
         factory_path=f"{_PKG}.stages.create_sglang_thinker_executor_from_config",
         factory=FactoryArgs(max_seq_len=8192, enable_async_decode=True),
         gpu=gpu,
-        next="decode",
+        next=["decode", "talker"] if speech_enabled else "decode",
+        route_fn=(
+            f"{_PKG}.request_builders.resolve_thinker_next_stages"
+            if speech_enabled
+            else None
+        ),
         stream_to=["decode"],
         project_payload={
             "decode": f"{_PKG}.request_builders.project_thinker_to_decode",
+            **(
+                {"talker": f"{_PKG}.request_builders.project_thinker_to_talker"}
+                if speech_enabled
+                else {}
+            ),
         },
     )
 
@@ -106,6 +118,29 @@ def _decode_stage(*, process: str) -> StageConfig:
     )
 
 
+def _talker_stage(*, gpu: int, process: str) -> StageConfig:
+    return StageConfig(
+        name="talker",
+        process=process,
+        factory_path=f"{_PKG}.stages.create_talker_executor",
+        gpu=gpu,
+        next="code2wav",
+        project_payload={
+            "code2wav": f"{_PKG}.request_builders.project_talker_to_code2wav",
+        },
+    )
+
+
+def _code2wav_stage(*, gpu: int, process: str) -> StageConfig:
+    return StageConfig(
+        name="code2wav",
+        process=process,
+        factory_path=f"{_PKG}.stages.create_code2wav_executor",
+        gpu=gpu,
+        terminal=True,
+    )
+
+
 def _default_stages() -> list[StageConfig]:
     return [
         _preprocessing_stage(process="pipeline"),
@@ -114,6 +149,19 @@ def _default_stages() -> list[StageConfig]:
         _aggregate_stage(process="pipeline", gpu=0),
         _thinker_stage(gpu=0, process="pipeline"),
         _decode_stage(process="pipeline"),
+    ]
+
+
+def _speech_stages() -> list[StageConfig]:
+    return [
+        _preprocessing_stage(process="pipeline"),
+        _image_encoder_stage(process="pipeline", gpu=0),
+        _audio_encoder_stage(process="pipeline", gpu=0),
+        _aggregate_stage(process="pipeline", gpu=0),
+        _thinker_stage(gpu=0, process="pipeline", speech_enabled=True),
+        _decode_stage(process="pipeline"),
+        _talker_stage(gpu=0, process="pipeline"),
+        _code2wav_stage(gpu=0, process="pipeline"),
     ]
 
 
@@ -130,4 +178,25 @@ class MiniCPMOPipelineConfig(PipelineConfig):
     stages: list[StageConfig] = Field(default_factory=_default_stages)
 
 
-EntryClass = MiniCPMOPipelineConfig
+class MiniCPMOSpeechPipelineConfig(MiniCPMOPipelineConfig):
+    """Speech pipeline: text stages + talker (MiniCPMTTS) + code2wav
+    (stepaudio2 Token2wav). Audio output arrives non-streaming, one wav per
+    request."""
+
+    terminal_stages_fn: str | None = (
+        f"{_PKG}.request_builders.resolve_terminal_stages"
+    )
+    stages: list[StageConfig] = Field(default_factory=_speech_stages)
+
+    def stage_factory_kwargs(self, stage_name: str) -> dict[str, Any]:
+        if stage_name in (THINKER_STAGE, "preprocessing"):
+            return {"speech_enabled": True}
+        return {}
+
+
+EntryClass = MiniCPMOSpeechPipelineConfig
+
+Variants = {
+    "text": MiniCPMOPipelineConfig,
+    "speech": MiniCPMOSpeechPipelineConfig,
+}

--- a/sglang_omni/models/minicpm_o/request_builders.py
+++ b/sglang_omni/models/minicpm_o/request_builders.py
@@ -132,9 +132,7 @@ def project_encoder_to_mm_aggregate(payload: StagePayload) -> StagePayload:
     return _payload_with_state(payload, projected)
 
 
-def resolve_thinker_next_stages(
-    request_id: str, output: StagePayload
-) -> list[str]:
+def resolve_thinker_next_stages(request_id: str, output: StagePayload) -> list[str]:
     del request_id
     if should_generate_audio_output(output):
         return [DECODE_STAGE, TALKER_STAGE]
@@ -519,12 +517,8 @@ def build_talker_request(
     full_sequence = [int(t) for t in prompt_ids] + output_ids
     prompt_len = len(prompt_ids)
 
-    tts_bos_indices = [
-        i for i, t in enumerate(full_sequence) if t == tts_bos_token_id
-    ]
-    tts_eos_indices = [
-        i for i, t in enumerate(full_sequence) if t == tts_eos_token_id
-    ]
+    tts_bos_indices = [i for i, t in enumerate(full_sequence) if t == tts_bos_token_id]
+    tts_eos_indices = [i for i, t in enumerate(full_sequence) if t == tts_eos_token_id]
     if not tts_bos_indices:
         empty = torch.empty(0, dtype=torch.long)
         return {"tts_token_ids": empty, "tts_hidden": empty}
@@ -543,9 +537,7 @@ def build_talker_request(
         return {"tts_token_ids": empty, "tts_hidden": empty}
 
     tokens = torch.tensor(full_sequence[start:end], dtype=torch.long)
-    hidden = torch.stack(
-        [hidden_seq[i - hidden_base] for i in range(start, end)]
-    )
+    hidden = torch.stack([hidden_seq[i - hidden_base] for i in range(start, end)])
     return {"tts_token_ids": tokens, "tts_hidden": hidden}
 
 

--- a/sglang_omni/models/minicpm_o/request_builders.py
+++ b/sglang_omni/models/minicpm_o/request_builders.py
@@ -25,6 +25,34 @@ AUDIO_STAGE = "audio_encoder"
 THINKER_STAGE = "thinker"
 DECODE_STAGE = "decode"
 MM_AGGREGATE_STAGE = "mm_aggregate"
+TALKER_STAGE = "talker"
+CODE2WAV_STAGE = "code2wav"
+
+
+def output_modalities(request: Any) -> set[str] | None:
+    params = getattr(request, "params", None) or {}
+    modalities = params.get("output_modalities") or params.get("modalities")
+    if modalities is None:
+        return None
+    if isinstance(modalities, str):
+        values = (modalities,)
+    elif isinstance(modalities, (list, tuple, set)):
+        values = modalities
+    else:
+        return None
+    return {str(modality).lower() for modality in values}
+
+
+def should_generate_audio_output(
+    payload_or_request: Any,
+) -> bool:
+    request = (
+        payload_or_request.request
+        if isinstance(payload_or_request, StagePayload)
+        else payload_or_request
+    )
+    modalities = output_modalities(request)
+    return modalities is None or "audio" in modalities
 
 
 def _resolve_seed(params: dict[str, Any]) -> int | None:
@@ -95,6 +123,47 @@ def project_encoder_to_mm_aggregate(payload: StagePayload) -> StagePayload:
     stage_name = next(iter(state.encoder_outs))
     projected = MiniCPMOPipelineState(
         encoder_outs={stage_name: state.encoder_outs[stage_name]}
+    )
+    return _payload_with_state(payload, projected)
+
+
+def resolve_thinker_next_stages(
+    request_id: str, output: StagePayload
+) -> list[str]:
+    del request_id
+    if should_generate_audio_output(output):
+        return [DECODE_STAGE, TALKER_STAGE]
+    return [DECODE_STAGE]
+
+
+def resolve_terminal_stages(request: Any) -> list[str]:
+    if should_generate_audio_output(request):
+        return [DECODE_STAGE, CODE2WAV_STAGE]
+    return [DECODE_STAGE]
+
+
+def project_thinker_to_talker(payload: StagePayload) -> StagePayload:
+    """Keep only what the talker consumes: prompt ids + thinker output ids
+    and the per-step hidden state sequence."""
+    state = MiniCPMOPipelineState.from_dict(payload.data)
+    thinker_out = state.thinker_out if isinstance(state.thinker_out, dict) else {}
+    extra = thinker_out.get("extra_model_outputs") or {}
+    projected = MiniCPMOPipelineState(
+        prompt=dict(state.prompt) if isinstance(state.prompt, dict) else None,
+        thinker_out={
+            "output_ids": list(thinker_out.get("output_ids") or []),
+            "extra_model_outputs": {
+                "hidden_states_seq": extra.get("hidden_states_seq") or [],
+            },
+        },
+    )
+    return _payload_with_state(payload, projected)
+
+
+def project_talker_to_code2wav(payload: StagePayload) -> StagePayload:
+    state = MiniCPMOPipelineState.from_dict(payload.data)
+    projected = MiniCPMOPipelineState(
+        engine_outputs={TALKER_STAGE: state.engine_outputs.get(TALKER_STAGE) or {}},
     )
     return _payload_with_state(payload, projected)
 
@@ -406,6 +475,81 @@ def apply_thinker_result(
     state.thinker_out = thinker_out
     state.engine_outputs[stage_name] = thinker_out
     return thinker_out
+
+
+# ---------------------------------------------------------------------------
+# Talker request builders
+# ---------------------------------------------------------------------------
+
+
+def build_talker_request(
+    state: MiniCPMOPipelineState,
+    *,
+    tts_bos_token_id: int,
+    tts_eos_token_id: int,
+) -> dict[str, torch.Tensor]:
+    """Slice the ``<|tts_bos|>``…``<|tts_eos|>`` span for the TTS condition.
+
+    Mirrors the remote code's tts_bound: over the full sequence (prompt +
+    generated), start = last ``<|tts_bos|>`` index + 1, end = last
+    ``<|tts_eos|>`` index (or sequence end when absent). Each position pairs
+    its token id with the thinker's last-layer hidden state at the same
+    position. ``hidden_states_seq`` entry k covers full-sequence position
+    ``prompt_len - 1 + k`` (prefill captures the last prompt position; decode
+    step k captures the position of output token k-1), so positions before
+    ``prompt_len - 1`` have no hidden state and cannot enter the span.
+    """
+    prompt = state.prompt or {}
+    input_ids = prompt.get("input_ids")
+    prompt_ids = (
+        input_ids.reshape(-1).tolist()
+        if isinstance(input_ids, torch.Tensor)
+        else list(input_ids or [])
+    )
+    thinker_out = state.thinker_out if isinstance(state.thinker_out, dict) else {}
+    output_ids = [int(t) for t in (thinker_out.get("output_ids") or [])]
+    extra = thinker_out.get("extra_model_outputs") or {}
+    hidden_seq = extra.get("hidden_states_seq") or []
+
+    full_sequence = [int(t) for t in prompt_ids] + output_ids
+    prompt_len = len(prompt_ids)
+
+    tts_bos_indices = [
+        i for i, t in enumerate(full_sequence) if t == tts_bos_token_id
+    ]
+    tts_eos_indices = [
+        i for i, t in enumerate(full_sequence) if t == tts_eos_token_id
+    ]
+    if not tts_bos_indices:
+        empty = torch.empty(0, dtype=torch.long)
+        return {"tts_token_ids": empty, "tts_hidden": empty}
+    start = tts_bos_indices[-1] + 1
+    end = tts_eos_indices[-1] if tts_eos_indices else len(full_sequence)
+
+    hidden_base = prompt_len - 1  # full-sequence position of hidden_seq[0]
+    if start < hidden_base:
+        raise ValueError(
+            f"tts span start {start} precedes first captured hidden position "
+            f"{hidden_base}; prompt-side spans are not supported"
+        )
+    end = min(end, hidden_base + len(hidden_seq))
+    if end <= start:
+        empty = torch.empty(0, dtype=torch.long)
+        return {"tts_token_ids": empty, "tts_hidden": empty}
+
+    tokens = torch.tensor(full_sequence[start:end], dtype=torch.long)
+    hidden = torch.stack(
+        [hidden_seq[i - hidden_base] for i in range(start, end)]
+    )
+    return {"tts_token_ids": tokens, "tts_hidden": hidden}
+
+
+def apply_talker_result(
+    state: MiniCPMOPipelineState,
+    *,
+    result: dict[str, Any],
+) -> None:
+    state.engine_outputs[TALKER_STAGE] = dict(result)
 
 
 def make_thinker_scheduler_adapters(

--- a/sglang_omni/models/minicpm_o/request_builders.py
+++ b/sglang_omni/models/minicpm_o/request_builders.py
@@ -30,8 +30,13 @@ CODE2WAV_STAGE = "code2wav"
 
 
 def output_modalities(request: Any) -> set[str] | None:
-    params = getattr(request, "params", None) or {}
-    modalities = params.get("output_modalities") or params.get("modalities")
+    # The serving client forwards the API-level ``modalities`` field as
+    # ``metadata["output_modalities"]`` (same contract qwen3_omni reads).
+    metadata = getattr(request, "metadata", None) or {}
+    modalities = metadata.get("output_modalities")
+    if modalities is None:
+        params = getattr(request, "params", None) or {}
+        modalities = params.get("output_modalities") or params.get("modalities")
     if modalities is None:
         return None
     if isinstance(modalities, str):

--- a/sglang_omni/models/minicpm_o/stages.py
+++ b/sglang_omni/models/minicpm_o/stages.py
@@ -7,6 +7,7 @@ import logging
 import os
 from typing import Any
 
+from sglang_omni.profiler.event_recorder import emit as _emit_event
 from sglang_omni.proto import StagePayload
 
 logger = logging.getLogger(__name__)
@@ -50,6 +51,23 @@ def create_aggregate_executor():
 ENCODER_CACHE_MAX_ENTRIES = 64
 ENCODER_CACHE_MAX_BYTES = 4 * 1024**3
 
+_ENCODER_MODALITY = {"image_encoder": "image", "audio_encoder": "audio"}
+
+
+def _encoder_item_count(model_inputs: dict[str, Any]) -> int | None:
+    """Items in one encoder payload: image slices or audio mel chunks."""
+    pixel_values = model_inputs.get("pixel_values")
+    if pixel_values is not None:
+        try:
+            return len(pixel_values)
+        except TypeError:
+            return None
+    audio_features = model_inputs.get("audio_features")
+    shape = getattr(audio_features, "shape", None)
+    if shape is not None and len(shape) > 0:
+        return int(shape[0])
+    return None
+
 
 def _run_single_encoder_payload(
     payload: StagePayload,
@@ -69,16 +87,50 @@ def _run_single_encoder_payload(
     state = MiniCPMOPipelineState.from_dict(payload.data)
     request = build_encoder_request(state, stage_name=stage_name)
     if request.skip_result is not None:
+        # Note (ruoyu): skip runs emit no encoder events so the profiler's
+        # encoder intervals only cover real encode/cache work.
         result = request.skip_result
     else:
-        result = None
-        if cache is not None and request.cache_key is not None:
-            result = cache.get(request.cache_key)
-        if result is None:
-            with torch.no_grad():
-                result = model(**request.model_inputs)
-            if cache is not None and request.cache_key is not None:
-                cache.put(request.cache_key, result)
+        modality = _ENCODER_MODALITY.get(stage_name, stage_name)
+        # Note (ruoyu): batch_size counts payloads per dispatch (qwen3_omni
+        # parity); num_items counts slices/chunks inside this payload.
+        start_metadata: dict[str, Any] = {"modality": modality, "batch_size": 1}
+        num_items = _encoder_item_count(request.model_inputs)
+        if num_items is not None:
+            start_metadata["num_items"] = num_items
+        _emit_event(
+            request_id=payload.request_id,
+            stage=None,
+            event_name="encoder_start",
+            metadata=start_metadata,
+        )
+        cacheable = cache is not None and request.cache_key is not None
+        cache_hit = False
+        status = "error"
+        try:
+            result = None
+            if cacheable:
+                result = cache.get(request.cache_key)
+                cache_hit = result is not None
+            if result is None:
+                with torch.no_grad():
+                    result = model(**request.model_inputs)
+                if cacheable:
+                    cache.put(request.cache_key, result)
+            status = "ok"
+        finally:
+            _emit_event(
+                request_id=payload.request_id,
+                stage=None,
+                event_name="encoder_end",
+                metadata={
+                    "modality": modality,
+                    "batch_size": 1,
+                    "cacheable": cacheable,
+                    "cache_hit": cache_hit,
+                    "status": status,
+                },
+            )
     apply_encoder_result(state, stage_name=stage_name, result=result)
     payload.data = state.to_dict()
     return payload
@@ -136,6 +188,54 @@ def create_audio_encoder_executor(
     return _create_encoder_executor(model, stage_name="audio_encoder")
 
 
+def _run_talker_payload(
+    payload: StagePayload,
+    *,
+    model: Any,
+    tts_bos_token_id: int,
+    tts_eos_token_id: int,
+) -> StagePayload:
+    """Run one talker request, framed by ``talker_generate_start``/``end``
+    profiler events carrying the tts-span and codec token counts."""
+    from sglang_omni.models.minicpm_o.payload_types import MiniCPMOPipelineState
+    from sglang_omni.models.minicpm_o.request_builders import (
+        apply_talker_result,
+        build_talker_request,
+    )
+
+    state = MiniCPMOPipelineState.from_dict(payload.data)
+    request = build_talker_request(
+        state,
+        tts_bos_token_id=tts_bos_token_id,
+        tts_eos_token_id=tts_eos_token_id,
+    )
+    tts_tokens = int(request["tts_token_ids"].numel())
+    _emit_event(
+        request_id=payload.request_id,
+        stage=None,
+        event_name="talker_generate_start",
+        metadata={"tts_tokens": tts_tokens},
+    )
+    result = None
+    status = "error"
+    try:
+        result = model(**request)
+        status = "ok"
+    finally:
+        end_metadata = {"tts_tokens": tts_tokens, "status": status}
+        if result is not None:
+            end_metadata["codec_tokens"] = int(result["codec_tokens"].numel())
+        _emit_event(
+            request_id=payload.request_id,
+            stage=None,
+            event_name="talker_generate_end",
+            metadata=end_metadata,
+        )
+    apply_talker_result(state, result=result)
+    payload.data = state.to_dict()
+    return payload
+
+
 def create_talker_executor(
     model_path: str,
     *,
@@ -145,18 +245,11 @@ def create_talker_executor(
     from transformers import AutoTokenizer
 
     from sglang_omni.models.minicpm_o.components.talker import MiniCPMOTalker
-    from sglang_omni.models.minicpm_o.payload_types import MiniCPMOPipelineState
-    from sglang_omni.models.minicpm_o.request_builders import (
-        apply_talker_result,
-        build_talker_request,
-    )
     from sglang_omni.models.weight_loader import resolve_model_path
     from sglang_omni.scheduling.simple_scheduler import SimpleScheduler
     from sglang_omni.utils.device import resolve_device_spec
 
-    model = MiniCPMOTalker(
-        model_path, device=resolve_device_spec(device), dtype=dtype
-    )
+    model = MiniCPMOTalker(model_path, device=resolve_device_spec(device), dtype=dtype)
     tokenizer = AutoTokenizer.from_pretrained(
         str(resolve_model_path(model_path)), trust_remote_code=True
     )
@@ -164,18 +257,76 @@ def create_talker_executor(
     tts_eos_token_id = tokenizer.convert_tokens_to_ids("<|tts_eos|>")
 
     def _talk(payload: StagePayload) -> StagePayload:
-        state = MiniCPMOPipelineState.from_dict(payload.data)
-        request = build_talker_request(
-            state,
+        return _run_talker_payload(
+            payload,
+            model=model,
             tts_bos_token_id=tts_bos_token_id,
             tts_eos_token_id=tts_eos_token_id,
         )
-        result = model(**request)
-        apply_talker_result(state, result=result)
-        payload.data = state.to_dict()
-        return payload
 
     return SimpleScheduler(_talk)
+
+
+def _run_code2wav_payload(payload: StagePayload, *, model: Any) -> StagePayload:
+    """Vocode one utterance, framed by profiler events.
+
+    Event names mirror qwen3_omni's code2wav events
+    (``code2wav_decode_start``/``end``, ``code2wav_first_audio``) so the
+    existing profiler views and analysis tooling read both models. This
+    vocoder is single-shot, so ``code2wav_first_audio`` fires when the whole
+    utterance is ready — that is the honest TTFA milestone for this pipeline.
+    """
+    from sglang_omni.models.minicpm_o.payload_types import MiniCPMOPipelineState
+    from sglang_omni.models.minicpm_o.request_builders import TALKER_STAGE
+    from sglang_omni.utils.audio_payload import audio_waveform_payload
+
+    state = MiniCPMOPipelineState.from_dict(payload.data)
+    talker_out = state.engine_outputs.get(TALKER_STAGE) or {}
+    codec_tokens = talker_out["codec_tokens"]
+    n_codec = int(codec_tokens.numel())
+    _emit_event(
+        request_id=payload.request_id,
+        stage=None,
+        event_name="code2wav_decode_start",
+        metadata={"codec_tokens": n_codec},
+    )
+    result = None
+    status = "error"
+    try:
+        result = model(codec_tokens=codec_tokens)
+        status = "ok"
+    finally:
+        end_metadata: dict[str, Any] = {"codec_tokens": n_codec, "status": status}
+        if result is not None:
+            waveform = result["waveform"]
+            sample_rate = int(result["sample_rate"])
+            samples = int(waveform.shape[0])
+            end_metadata["audio_samples"] = samples
+            end_metadata["audio_seconds"] = samples / sample_rate
+        _emit_event(
+            request_id=payload.request_id,
+            stage=None,
+            event_name="code2wav_decode_end",
+            metadata=end_metadata,
+        )
+    if samples:
+        _emit_event(
+            request_id=payload.request_id,
+            stage=None,
+            event_name="code2wav_first_audio",
+            metadata={"samples": samples},
+        )
+    # Terminal payload goes back through msgpack: keep only the audio
+    # fields, no tensors from the pipeline state.
+    payload.data = dict(
+        audio_waveform_payload(
+            waveform,
+            sample_rate=sample_rate,
+            modality="audio",
+            source_hint="MiniCPM-o",
+        )
+    )
+    return payload
 
 
 def create_code2wav_executor(
@@ -184,29 +335,13 @@ def create_code2wav_executor(
     device: str | None = None,
 ):
     from sglang_omni.models.minicpm_o.components.code2wav import MiniCPMOCode2Wav
-    from sglang_omni.models.minicpm_o.payload_types import MiniCPMOPipelineState
-    from sglang_omni.models.minicpm_o.request_builders import TALKER_STAGE
     from sglang_omni.scheduling.simple_scheduler import SimpleScheduler
-    from sglang_omni.utils.audio_payload import audio_waveform_payload
     from sglang_omni.utils.device import resolve_device_spec
 
     model = MiniCPMOCode2Wav(model_path, device=resolve_device_spec(device))
 
     def _vocode(payload: StagePayload) -> StagePayload:
-        state = MiniCPMOPipelineState.from_dict(payload.data)
-        talker_out = state.engine_outputs.get(TALKER_STAGE) or {}
-        result = model(codec_tokens=talker_out["codec_tokens"])
-        # Terminal payload goes back through msgpack: keep only the audio
-        # fields, no tensors from the pipeline state.
-        payload.data = dict(
-            audio_waveform_payload(
-                result["waveform"],
-                sample_rate=int(result["sample_rate"]),
-                modality="audio",
-                source_hint="MiniCPM-o",
-            )
-        )
-        return payload
+        return _run_code2wav_payload(payload, model=model)
 
     return SimpleScheduler(_vocode)
 

--- a/sglang_omni/models/minicpm_o/stages.py
+++ b/sglang_omni/models/minicpm_o/stages.py
@@ -21,13 +21,16 @@ def create_preprocessing_executor(
     model_path: str,
     *,
     max_seq_len: int | None = None,
+    speech_enabled: bool = False,
 ):
     from sglang_omni.models.minicpm_o.components.preprocessor import (
         MiniCPMOPreprocessor,
     )
     from sglang_omni.scheduling.simple_scheduler import SimpleScheduler
 
-    preprocessor = MiniCPMOPreprocessor(model_path, max_seq_len=max_seq_len)
+    preprocessor = MiniCPMOPreprocessor(
+        model_path, max_seq_len=max_seq_len, speech_enabled=speech_enabled
+    )
 
     async def _preprocess(payload: StagePayload) -> StagePayload:
         return await preprocessor(payload)
@@ -133,6 +136,81 @@ def create_audio_encoder_executor(
     return _create_encoder_executor(model, stage_name="audio_encoder")
 
 
+def create_talker_executor(
+    model_path: str,
+    *,
+    device: str | None = None,
+    dtype: str | None = None,
+):
+    from transformers import AutoTokenizer
+
+    from sglang_omni.models.minicpm_o.components.talker import MiniCPMOTalker
+    from sglang_omni.models.minicpm_o.payload_types import MiniCPMOPipelineState
+    from sglang_omni.models.minicpm_o.request_builders import (
+        apply_talker_result,
+        build_talker_request,
+    )
+    from sglang_omni.models.weight_loader import resolve_model_path
+    from sglang_omni.scheduling.simple_scheduler import SimpleScheduler
+    from sglang_omni.utils.device import resolve_device_spec
+
+    model = MiniCPMOTalker(
+        model_path, device=resolve_device_spec(device), dtype=dtype
+    )
+    tokenizer = AutoTokenizer.from_pretrained(
+        str(resolve_model_path(model_path)), trust_remote_code=True
+    )
+    tts_bos_token_id = tokenizer.convert_tokens_to_ids("<|tts_bos|>")
+    tts_eos_token_id = tokenizer.convert_tokens_to_ids("<|tts_eos|>")
+
+    def _talk(payload: StagePayload) -> StagePayload:
+        state = MiniCPMOPipelineState.from_dict(payload.data)
+        request = build_talker_request(
+            state,
+            tts_bos_token_id=tts_bos_token_id,
+            tts_eos_token_id=tts_eos_token_id,
+        )
+        result = model(**request)
+        apply_talker_result(state, result=result)
+        payload.data = state.to_dict()
+        return payload
+
+    return SimpleScheduler(_talk)
+
+
+def create_code2wav_executor(
+    model_path: str,
+    *,
+    device: str | None = None,
+):
+    from sglang_omni.models.minicpm_o.components.code2wav import MiniCPMOCode2Wav
+    from sglang_omni.models.minicpm_o.payload_types import MiniCPMOPipelineState
+    from sglang_omni.models.minicpm_o.request_builders import TALKER_STAGE
+    from sglang_omni.scheduling.simple_scheduler import SimpleScheduler
+    from sglang_omni.utils.audio_payload import audio_waveform_payload
+    from sglang_omni.utils.device import resolve_device_spec
+
+    model = MiniCPMOCode2Wav(model_path, device=resolve_device_spec(device))
+
+    def _vocode(payload: StagePayload) -> StagePayload:
+        state = MiniCPMOPipelineState.from_dict(payload.data)
+        talker_out = state.engine_outputs.get(TALKER_STAGE) or {}
+        result = model(codec_tokens=talker_out["codec_tokens"])
+        # Terminal payload goes back through msgpack: keep only the audio
+        # fields, no tensors from the pipeline state.
+        payload.data = dict(
+            audio_waveform_payload(
+                result["waveform"],
+                sample_rate=int(result["sample_rate"]),
+                modality="audio",
+                source_hint="MiniCPM-o",
+            )
+        )
+        return payload
+
+    return SimpleScheduler(_vocode)
+
+
 def create_decode_executor(model_path: str):
     # State keys deliberately mirror qwen3_omni, so its streaming text
     # detokenizer applies unchanged.
@@ -160,6 +238,7 @@ def create_sglang_thinker_executor_from_config(
     total_gpu_memory_fraction: float | None = None,
     enable_async_decode: bool = True,
     async_decode_min_batch_size: int = 2,
+    speech_enabled: bool = False,
 ):
     """Returns OmniScheduler for the MiniCPM-o thinker."""
     from sglang_omni.models.minicpm_o.bootstrap import create_thinker_scheduler
@@ -205,6 +284,7 @@ def create_sglang_thinker_executor_from_config(
         total_gpu_memory_fraction=total_gpu_memory_fraction,
         enable_async_decode=enable_async_decode,
         async_decode_min_batch_size=async_decode_min_batch_size,
+        speech_enabled=speech_enabled,
     )
     logger.info(
         f"sglang_ar_started stage=thinker gpu_id={gpu_id} "

--- a/sglang_omni/models/minicpm_o/thinker_model_runner.py
+++ b/sglang_omni/models/minicpm_o/thinker_model_runner.py
@@ -83,7 +83,5 @@ class MiniCPMOThinkerModelRunner(ThinkerModelRunner):
             if hidden is None:
                 continue
             hidden = hidden.reshape(-1, hidden.shape[-1])[-1]
-            seq = sched_req.data.extra_model_outputs.setdefault(
-                "hidden_states_seq", []
-            )
+            seq = sched_req.data.extra_model_outputs.setdefault("hidden_states_seq", [])
             seq.append(hidden.detach().to("cpu"))

--- a/sglang_omni/models/minicpm_o/thinker_model_runner.py
+++ b/sglang_omni/models/minicpm_o/thinker_model_runner.py
@@ -35,3 +35,55 @@ class MiniCPMOThinkerModelRunner(ThinkerModelRunner):
         self._image_token_id = -1
         self._video_token_id = -1
         self._audio_token_id = -1
+
+    # The base ThinkerModelRunner pins both hooks to NULL (qwen3_omni captures
+    # hidden states via forward hooks instead). MiniCPM-o's talker consumes the
+    # per-step last-layer hidden state through the output processor, so request
+    # capture here. FULL rather than LAST: decode CUDA graphs are captured with
+    # FULL (enable_return_hidden_states) and their can_run gate requires an
+    # exact hidden-mode match; for decode both modes return the same rows, and
+    # post_process_outputs keeps only the last row per request anyway.
+    def requested_capture_hidden_mode_prefill(
+        self, schedule_batch: Any, requests: list
+    ) -> Any:
+        del schedule_batch, requests
+        from sglang.srt.model_executor.forward_batch_info import CaptureHiddenMode
+
+        return CaptureHiddenMode.FULL
+
+    def requested_capture_hidden_mode_decode(
+        self, schedule_batch: Any, requests: list
+    ) -> Any:
+        del schedule_batch, requests
+        from sglang.srt.model_executor.forward_batch_info import CaptureHiddenMode
+
+        return CaptureHiddenMode.FULL
+
+    def post_process_outputs(
+        self,
+        result: Any,
+        scheduler_output: Any,
+        outputs: dict[str, Any],
+    ) -> None:
+        """Accumulate per-step last-layer hidden states for the talker.
+
+        ``_finalize`` merges ``extra`` into ``extra_model_outputs`` with a
+        plain ``update``, which would keep only the final step's hidden. The
+        talker needs the whole sequence, so collect each step's vector into
+        ``hidden_states_seq``: entry 0 is the last prompt position (prefill),
+        entry i>0 is the position of output token i-1 (its decode-step input).
+        """
+        del result
+        for sched_req in scheduler_output.requests:
+            req_output = outputs.get(sched_req.request_id)
+            extra = getattr(req_output, "extra", None)
+            if not isinstance(extra, dict):
+                continue
+            hidden = extra.pop("hidden_states", None)
+            if hidden is None:
+                continue
+            hidden = hidden.reshape(-1, hidden.shape[-1])[-1]
+            seq = sched_req.data.extra_model_outputs.setdefault(
+                "hidden_states_seq", []
+            )
+            seq.append(hidden.detach().to("cpu"))

--- a/sglang_omni/profiler/views.py
+++ b/sglang_omni/profiler/views.py
@@ -137,6 +137,8 @@ _STAGE_INTERVAL_EVENTS = (
     ("stage_input_received", "stage_complete"),
     ("encoder_start", "encoder_end"),
     ("preprocess_start", "preprocess_end"),
+    ("talker_generate_start", "talker_generate_end"),
+    ("code2wav_decode_start", "code2wav_decode_end"),
     ("scheduler_request_build_start", "scheduler_request_build_end"),
     ("scheduler_request_build_end", "scheduler_queue_enter"),
     ("scheduler_queue_enter", "scheduler_prefill_start"),

--- a/tests/unit_test/minicpm_o/test_speech_events.py
+++ b/tests/unit_test/minicpm_o/test_speech_events.py
@@ -1,0 +1,208 @@
+# SPDX-License-Identifier: Apache-2.0
+"""Unit tests for the MiniCPM-o speech-path profiler events (GPU-free)."""
+
+import json
+
+import numpy as np
+import pytest
+import torch
+
+from sglang_omni.models.minicpm_o.payload_types import MiniCPMOPipelineState
+from sglang_omni.models.minicpm_o.stages import (
+    _run_code2wav_payload,
+    _run_single_encoder_payload,
+    _run_talker_payload,
+)
+from sglang_omni.profiler.event_recorder import get_recorder
+from sglang_omni.proto import OmniRequest, StagePayload
+
+TTS_BOS = 900
+TTS_EOS = 901
+
+
+def _payload(
+    state: MiniCPMOPipelineState, request_id: str = "req-events"
+) -> StagePayload:
+    return StagePayload(
+        request_id=request_id,
+        request=OmniRequest(inputs="hi", params={}, metadata={}),
+        data=state.to_dict(),
+    )
+
+
+def _read_events(event_dir) -> list[dict]:
+    events = []
+    for path in sorted(event_dir.glob("*.jsonl")):
+        with path.open(encoding="utf-8") as fp:
+            for line in fp:
+                events.append(json.loads(line))
+    return events
+
+
+@pytest.fixture()
+def event_dir(tmp_path):
+    recorder = get_recorder()
+    # The recorder is a process-global singleton; a leaked active session
+    # from another test would silently swallow this test's events.
+    assert not recorder.is_active()
+    recorder.start("test-run", str(tmp_path), "speech")
+    yield tmp_path
+    recorder.stop()
+
+
+class _FakeTalker:
+    def __call__(self, **request):
+        n = int(request["tts_token_ids"].numel())
+        return {"codec_tokens": torch.arange(2 * n, dtype=torch.long)}
+
+
+def _talker_state() -> MiniCPMOPipelineState:
+    output_ids = [10, 11, 12, TTS_EOS]
+    hidden_seq = [torch.full((4,), float(i)) for i in range(len(output_ids) + 1)]
+    return MiniCPMOPipelineState(
+        prompt={"input_ids": torch.tensor([1, 2, TTS_BOS], dtype=torch.long)},
+        thinker_out={
+            "output_ids": output_ids,
+            "extra_model_outputs": {"hidden_states_seq": hidden_seq},
+        },
+    )
+
+
+def test_talker_events_carry_token_counts(event_dir):
+    out = _run_talker_payload(
+        _payload(_talker_state()),
+        model=_FakeTalker(),
+        tts_bos_token_id=TTS_BOS,
+        tts_eos_token_id=TTS_EOS,
+    )
+    state = MiniCPMOPipelineState.from_dict(out.data)
+    assert int(state.engine_outputs["talker"]["codec_tokens"].numel()) == 6
+
+    events = {e["event_name"]: e for e in _read_events(event_dir)}
+    assert events["talker_generate_start"]["metadata"] == {"tts_tokens": 3}
+    assert events["talker_generate_end"]["metadata"] == {
+        "tts_tokens": 3,
+        "codec_tokens": 6,
+        "status": "ok",
+    }
+
+
+class _FailingTalker:
+    def __call__(self, **request):
+        raise RuntimeError("talker exploded")
+
+
+def test_talker_failure_still_closes_interval(event_dir):
+    with pytest.raises(RuntimeError, match="talker exploded"):
+        _run_talker_payload(
+            _payload(_talker_state()),
+            model=_FailingTalker(),
+            tts_bos_token_id=TTS_BOS,
+            tts_eos_token_id=TTS_EOS,
+        )
+
+    events = {e["event_name"]: e for e in _read_events(event_dir)}
+    assert events["talker_generate_end"]["metadata"] == {
+        "tts_tokens": 3,
+        "status": "error",
+    }
+
+
+class _FakeCode2Wav:
+    def __call__(self, *, codec_tokens):
+        n = int(codec_tokens.numel())
+        return {
+            "waveform": np.zeros(n * 480, dtype=np.float32),
+            "sample_rate": 24000,
+        }
+
+
+def test_code2wav_events_carry_audio_metadata(event_dir):
+    state = MiniCPMOPipelineState(
+        engine_outputs={"talker": {"codec_tokens": torch.arange(5, dtype=torch.long)}}
+    )
+    out = _run_code2wav_payload(_payload(state), model=_FakeCode2Wav())
+    assert out.data["sample_rate"] == 24000
+
+    events = {e["event_name"]: e for e in _read_events(event_dir)}
+    assert events["code2wav_decode_start"]["metadata"] == {"codec_tokens": 5}
+    assert events["code2wav_decode_end"]["metadata"] == {
+        "codec_tokens": 5,
+        "audio_samples": 2400,
+        "audio_seconds": pytest.approx(0.1),
+        "status": "ok",
+    }
+    assert events["code2wav_first_audio"]["metadata"] == {"samples": 2400}
+
+
+def test_code2wav_empty_output_skips_first_audio(event_dir):
+    state = MiniCPMOPipelineState(
+        engine_outputs={"talker": {"codec_tokens": torch.empty(0, dtype=torch.long)}}
+    )
+    _run_code2wav_payload(_payload(state), model=_FakeCode2Wav())
+
+    names = [e["event_name"] for e in _read_events(event_dir)]
+    assert "code2wav_decode_end" in names
+    assert "code2wav_first_audio" not in names
+
+
+class _FakeEncoder:
+    def __init__(self):
+        self.calls = 0
+
+    def __call__(self, **inputs):
+        self.calls += 1
+        return {"embeddings": torch.ones(2, 4)}
+
+
+def _encoder_payload() -> StagePayload:
+    state = MiniCPMOPipelineState(
+        encoder_inputs={
+            "image_encoder": {
+                "cache_key": "k1",
+                "pixel_values": [torch.zeros(3, 2, 2), torch.zeros(3, 2, 2)],
+            }
+        }
+    )
+    return _payload(state)
+
+
+def test_encoder_events_record_cache_hits(event_dir):
+    from sglang_omni.scheduling.stage_cache import StageOutputCache
+
+    model = _FakeEncoder()
+    cache = StageOutputCache(max_size=4, max_bytes=1 << 20, cache_device="cpu")
+    for _ in range(2):
+        _run_single_encoder_payload(
+            _encoder_payload(), stage_name="image_encoder", model=model, cache=cache
+        )
+    assert model.calls == 1
+
+    events = _read_events(event_dir)
+    starts = [e for e in events if e["event_name"] == "encoder_start"]
+    assert all(e["metadata"]["num_items"] == 2 for e in starts)
+    ends = [e for e in events if e["event_name"] == "encoder_end"]
+    assert [e["metadata"]["cache_hit"] for e in ends] == [False, True]
+    assert all(e["metadata"]["modality"] == "image" for e in ends)
+    assert all(e["metadata"]["cacheable"] for e in ends)
+    assert all(e["metadata"]["status"] == "ok" for e in ends)
+
+
+def test_encoder_item_count_covers_both_modalities():
+    from sglang_omni.models.minicpm_o.stages import _encoder_item_count
+
+    assert _encoder_item_count({"pixel_values": [1, 2, 3]}) == 3
+    assert _encoder_item_count({"audio_features": torch.zeros(4, 80, 10)}) == 4
+    assert _encoder_item_count({}) is None
+
+
+def test_encoder_skip_run_emits_no_events(event_dir):
+    model = _FakeEncoder()
+    _run_single_encoder_payload(
+        _payload(MiniCPMOPipelineState()),
+        stage_name="image_encoder",
+        model=model,
+        cache=None,
+    )
+    assert model.calls == 0
+    assert _read_events(event_dir) == []

--- a/tests/unit_test/minicpm_o/test_talker_decode.py
+++ b/tests/unit_test/minicpm_o/test_talker_decode.py
@@ -98,16 +98,21 @@ def test_fast_matches_compat_on_tiny_llama():
         assert torch.equal(compat, fast)
 
 
-def test_fast_backend_is_reused_across_requests():
+def test_fast_backend_reuse_is_stateless_across_requests():
+    # Request B runs on a backend that already served request A (different
+    # condition). Any state leak — stale KV attended through the mask, or an
+    # unreset StaticCache write position — makes B diverge from a fresh
+    # compat run of B.
     torch.manual_seed(0)
     tts = _TinyTTS()
     loop = TalkerDecodeLoop(tts, gen_logits_fn=_empty_gen_logits)
-    first = _generate(loop, tts, mode="fast", seed=7)
+    _generate(loop, tts, mode="fast", seed=7)
     backend = loop._fast
     assert backend is not None
-    second = _generate(loop, tts, mode="fast", seed=7)
+    fast_b = _generate(loop, tts, mode="fast", seed=21)
     assert loop._fast is backend
-    assert torch.equal(first, second)
+    compat_b = _generate(loop, tts, mode="compat", seed=21)
+    assert torch.equal(fast_b, compat_b)
 
 
 class _ScriptedModel(nn.Module):

--- a/tests/unit_test/minicpm_o/test_talker_decode.py
+++ b/tests/unit_test/minicpm_o/test_talker_decode.py
@@ -1,0 +1,210 @@
+# SPDX-License-Identifier: Apache-2.0
+"""Unit tests for the MiniCPM-o talker fast decode loop (GPU-free).
+
+The fast path's CUDA graph cannot run on CPU; these tests pin
+SGLANG_OMNI_MINICPMO_TALKER_GRAPH=0 so ``mode="fast"`` exercises the
+StaticCache + explicit-mask eager loop, and compare it against the
+``compat`` loop (op-for-op the remote generate) on a tiny real LlamaModel.
+"""
+
+import types
+
+import pytest
+import torch
+import torch.nn as nn
+
+from sglang_omni.models.minicpm_o.components.talker_decode import (
+    MINICPMO_TALKER_GRAPH_ENV,
+    TalkerDecodeLoop,
+    _SamplingState,
+)
+
+NUM_AUDIO = 32
+EOS = NUM_AUDIO - 1
+HIDDEN = 32
+
+
+def _empty_gen_logits(**_kwargs):
+    return [], []
+
+
+def _sampling_params(temperature=0.05):
+    return types.SimpleNamespace(
+        temperature=temperature, top_p=0.85, top_k=25, repetition_penalty=1.05
+    )
+
+
+class _TinyTTS(nn.Module):
+    """Minimal stand-in for the remote MiniCPMTTS module."""
+
+    def __init__(self):
+        super().__init__()
+        modeling_llama = pytest.importorskip(
+            "transformers.models.llama.modeling_llama",
+            reason="local transformers install cannot import LlamaModel",
+            exc_type=ImportError,
+        )
+        from transformers import LlamaConfig
+
+        LlamaModel = modeling_llama.LlamaModel
+        llama_config = LlamaConfig(
+            hidden_size=HIDDEN,
+            intermediate_size=64,
+            num_attention_heads=4,
+            num_key_value_heads=4,
+            num_hidden_layers=2,
+            max_position_embeddings=128,
+            vocab_size=8,
+            attn_implementation="eager",
+        )
+        self.model = LlamaModel(llama_config)
+        self.emb_code = nn.ModuleList([nn.Embedding(NUM_AUDIO, HIDDEN)])
+        self.head_code = nn.ModuleList([nn.Linear(HIDDEN, NUM_AUDIO, bias=False)])
+        self.config = types.SimpleNamespace(
+            num_vq=1,
+            num_audio_tokens=NUM_AUDIO,
+            max_position_embeddings=128,
+        )
+        self.eval()
+
+
+@pytest.fixture(autouse=True)
+def _no_graph(monkeypatch):
+    monkeypatch.setenv(MINICPMO_TALKER_GRAPH_ENV, "0")
+
+
+def _generate(loop, tts, *, mode, seed, max_new_token=24, min_new_token=0):
+    torch.manual_seed(seed)
+    cond = torch.randn(1, 5, HIDDEN)
+    torch.manual_seed(seed + 1)
+    return loop.generate(
+        cond,
+        torch.tensor([EOS], dtype=torch.long),
+        min_new_token=min_new_token,
+        max_new_token=max_new_token,
+        sampling_params=_sampling_params(),
+        mode=mode,
+    )
+
+
+def test_fast_matches_compat_on_tiny_llama():
+    torch.manual_seed(0)
+    tts = _TinyTTS()
+    loop = TalkerDecodeLoop(tts, gen_logits_fn=_empty_gen_logits)
+    for seed in (7, 13):
+        compat = _generate(loop, tts, mode="compat", seed=seed)
+        fast = _generate(loop, tts, mode="fast", seed=seed)
+        assert compat.shape == fast.shape
+        assert torch.equal(compat, fast)
+
+
+def test_fast_backend_is_reused_across_requests():
+    torch.manual_seed(0)
+    tts = _TinyTTS()
+    loop = TalkerDecodeLoop(tts, gen_logits_fn=_empty_gen_logits)
+    first = _generate(loop, tts, mode="fast", seed=7)
+    backend = loop._fast
+    assert backend is not None
+    second = _generate(loop, tts, mode="fast", seed=7)
+    assert loop._fast is backend
+    assert torch.equal(first, second)
+
+
+class _ScriptedModel(nn.Module):
+    """Backbone stub emitting a scripted hidden state per decode step."""
+
+    def __init__(self, eos_at_step):
+        super().__init__()
+        self.eos_at_step = eos_at_step
+        self.calls = 0
+
+    def forward(self, *, inputs_embeds, position_ids, **_kwargs):
+        step = self.calls
+        self.calls += 1
+        hidden = torch.zeros(1, inputs_embeds.shape[1], NUM_AUDIO)
+        token = EOS if step >= self.eos_at_step else (step % (NUM_AUDIO - 1))
+        hidden[:, -1, token] = 50.0
+        return types.SimpleNamespace(last_hidden_state=hidden, past_key_values=None)
+
+
+def _scripted_tts(eos_at_step):
+    tts = nn.Module()
+    tts.model = _ScriptedModel(eos_at_step)
+    tts.emb_code = nn.ModuleList([nn.Embedding(NUM_AUDIO, NUM_AUDIO)])
+    tts.head_code = nn.ModuleList([nn.Identity()])
+    tts.config = types.SimpleNamespace(
+        num_vq=1, num_audio_tokens=NUM_AUDIO, max_position_embeddings=128
+    )
+    return tts
+
+
+def test_eos_stops_and_is_excluded():
+    tts = _scripted_tts(eos_at_step=4)
+    loop = TalkerDecodeLoop(tts, gen_logits_fn=_empty_gen_logits)
+    out = loop.generate(
+        torch.zeros(1, 3, NUM_AUDIO),
+        torch.tensor([EOS], dtype=torch.long),
+        min_new_token=0,
+        max_new_token=24,
+        sampling_params=_sampling_params(temperature=0.01),
+        mode="compat",
+    )
+    # steps 0..3 emit non-EOS tokens, step 4 emits EOS and is excluded.
+    assert out.shape == (1, 4, 1)
+    assert EOS not in out.view(-1).tolist()
+
+
+def test_min_new_token_blocks_early_eos():
+    tts = _scripted_tts(eos_at_step=0)
+    loop = TalkerDecodeLoop(tts, gen_logits_fn=_empty_gen_logits)
+    out = loop.generate(
+        torch.zeros(1, 3, NUM_AUDIO),
+        torch.tensor([EOS], dtype=torch.long),
+        min_new_token=6,
+        max_new_token=24,
+        sampling_params=_sampling_params(temperature=0.01),
+        mode="compat",
+    )
+    # EOS is masked for the first 6 steps, fires at step 6 and is excluded.
+    assert out.shape == (1, 6, 1)
+    assert EOS not in out.view(-1).tolist()
+
+
+def test_sampling_state_passes_windowed_history():
+    seen = []
+
+    def _spy_processor(logits_token, logits):
+        seen.append(logits_token.shape)
+        return logits
+
+    def _gen_logits(**_kwargs):
+        return [], [_spy_processor]
+
+    sampling = _SamplingState(
+        num_vq=1,
+        num_audio_tokens=NUM_AUDIO,
+        temperature=1.0,
+        gen_logits_fn=_gen_logits,
+        repetition_penalty=1.05,
+        top_p=0.85,
+        top_k=25,
+        device=torch.device("cpu"),
+    )
+    new_tokens = torch.zeros(1, 10, 1, dtype=torch.long)
+    logits = torch.randn(1, NUM_AUDIO, 1)
+    sampling.sample(
+        logits,
+        step=0,
+        new_tokens=new_tokens,
+        min_new_token=0,
+        eos_token=torch.tensor([EOS]),
+    )
+    sampling.sample(
+        logits,
+        step=3,
+        new_tokens=new_tokens,
+        min_new_token=0,
+        eos_token=torch.tensor([EOS]),
+    )
+    # step 0 skips processors entirely; step 3 passes the (num_vq, t) history.
+    assert seen == [(1, 3)]

--- a/tests/unit_test/minicpm_o/test_talker_request.py
+++ b/tests/unit_test/minicpm_o/test_talker_request.py
@@ -1,0 +1,99 @@
+# SPDX-License-Identifier: Apache-2.0
+"""Unit tests for the thinker→talker tts-span slicing."""
+
+import pytest
+import torch
+
+from sglang_omni.models.minicpm_o.payload_types import MiniCPMOPipelineState
+from sglang_omni.models.minicpm_o.request_builders import build_talker_request
+
+TTS_BOS = 900
+TTS_EOS = 901
+
+
+def _state(prompt_ids, output_ids, hidden_dim=4):
+    # hidden_seq[0] covers the last prompt position; entry i>0 covers the
+    # position of output token i-1.
+    hidden_seq = [
+        torch.full((hidden_dim,), float(i)) for i in range(len(output_ids) + 1)
+    ]
+    return MiniCPMOPipelineState(
+        prompt={"input_ids": torch.tensor(prompt_ids, dtype=torch.long)},
+        thinker_out={
+            "output_ids": list(output_ids),
+            "extra_model_outputs": {"hidden_states_seq": hidden_seq},
+        },
+    )
+
+
+def _build(state):
+    return build_talker_request(
+        state, tts_bos_token_id=TTS_BOS, tts_eos_token_id=TTS_EOS
+    )
+
+
+def test_span_between_bos_and_eos():
+    # prompt ends with tts_bos; output = [t0, t1, t2, tts_eos]
+    state = _state([1, 2, TTS_BOS], [10, 11, 12, TTS_EOS])
+    out = _build(state)
+    assert out["tts_token_ids"].tolist() == [10, 11, 12]
+    # positions 3,4,5 → hidden_seq indices 1,2,3
+    assert out["tts_hidden"][:, 0].tolist() == [1.0, 2.0, 3.0]
+
+
+def test_span_without_eos_extends_to_end():
+    state = _state([1, TTS_BOS], [10, 11])
+    out = _build(state)
+    assert out["tts_token_ids"].tolist() == [10, 11]
+    assert out["tts_hidden"][:, 0].tolist() == [1.0, 2.0]
+
+
+def test_bos_inside_output():
+    # tts_bos generated mid-output; span starts after it.
+    state = _state([1, 2], [5, TTS_BOS, 10, 11, TTS_EOS])
+    out = _build(state)
+    assert out["tts_token_ids"].tolist() == [10, 11]
+    # full positions 4,5 → hidden indices 3,4
+    assert out["tts_hidden"][:, 0].tolist() == [3.0, 4.0]
+
+
+def test_last_bos_wins():
+    state = _state([TTS_BOS, 2], [TTS_BOS, 10, TTS_EOS])
+    out = _build(state)
+    assert out["tts_token_ids"].tolist() == [10]
+
+
+def test_no_bos_returns_empty():
+    state = _state([1, 2], [10, 11])
+    out = _build(state)
+    assert out["tts_token_ids"].numel() == 0
+    assert out["tts_hidden"].numel() == 0
+
+
+def test_eos_immediately_after_bos_returns_empty():
+    state = _state([1, TTS_BOS], [TTS_EOS])
+    out = _build(state)
+    assert out["tts_token_ids"].numel() == 0
+
+
+def test_prompt_side_span_rejected():
+    # bos deep inside prompt: hidden states were never captured there.
+    state = _state([TTS_BOS, 7, 8], [10])
+    with pytest.raises(ValueError, match="precedes first captured hidden"):
+        _build(state)
+
+
+def test_end_clamped_to_captured_hidden():
+    # Fewer hidden entries than output tokens (e.g. final step not captured).
+    state = MiniCPMOPipelineState(
+        prompt={"input_ids": torch.tensor([1, TTS_BOS], dtype=torch.long)},
+        thinker_out={
+            "output_ids": [10, 11, 12],
+            "extra_model_outputs": {
+                "hidden_states_seq": [torch.zeros(4), torch.ones(4)]
+            },
+        },
+    )
+    out = _build(state)
+    # hidden covers full-sequence positions 1..2 only → span clamps to [10].
+    assert out["tts_token_ids"].tolist() == [10]


### PR DESCRIPTION
## Motivation

The profile in #1904 shows the talker is ~85% of per-request speech compute:
the remote `MiniCPMTTS.generate` runs one eager HF llama step per codec token
(batch 1, DynamicCache), and every concurrent speech request queues behind it
serially. This PR CUDA-graphs the per-step decode chain.

Stacked on #1904 (first two commits are that PR).

## Modifications

`components/talker_decode.py` reimplements the remote non-streaming loop over
the same weights:

- Prefill runs the condition eagerly into a preallocated `StaticCache`
  (max_position_embeddings slots); the per-step chain (code embedding → llama
  decode step → code head) is captured once as a CUDA graph and replayed with
  device-staged inputs.
- The decode step passes an explicitly maintained 4D additive mask instead of
  letting HF build masks per step — mask construction is host-side and not
  capture-safe; a device-resident mask buffer (one slot opened per step) is.
- Sampling stays eager and reuses the checkpoint's own `gen_logits`
  processors/warpers verbatim, so sampling semantics are unchanged (windowed
  repetition penalty, top-p/top-k order, min-token EOS mask, EOS-step
  exclusion, max-token trim).
- transformers v5 pitfall found the hard way: `StaticLayer.update` ignores the
  passed `cache_position` and writes at `arange + cumulative_length`, a device
  tensor the captured graph keeps advancing across replays. The backend resets
  the cache between requests; without it, request 2+ conditions on stale KV
  and writes walk off the cache end (`index_copy_` device assert).

Kill switches: `SGLANG_OMNI_MINICPMO_TALKER_FAST=0` restores the remote
generate; `SGLANG_OMNI_MINICPMO_TALKER_GRAPH=0` keeps the fast loop without
graph capture. Capture failure falls back to eager static-cache decode with a
logged warning.

## Verification (H100, Modal, same container, 3 arms x 16 requests)

Client: benchmark_omni_rollout_stress, MMMU image + text → text + audio,
c=1,1,2,4,8, max_tokens=128; all arms 16/16 success, 0 failures.

| arm | talker generate avg | p95 | E2E mean c1 (warm) | c2 | c4 | c8 |
|-----|--------------------|-----|--------------------|----|----|----|
| baseline (remote generate) | 22,821 ms | 25,514 | 24.8 s | 38.2 | 60.1 | 104.4 |
| fast-eager (no graph) | 24,737 ms | 27,237 | 24.7 s | 43.4 | 64.1 | 114.5 |
| fast-graph | **2,891 ms** | 3,342 | **4.3 s** | **6.1** | **9.3** | **14.6** |

- Talker generate **7.9x**; E2E speech latency **5.8–7.2x** (c1→c8).
  fast-eager ≈ baseline shows the win is the graph, not the cache layout.
- Output-quality proxies: codec token count distributions match across arms
  (baseline 746/842/975 min/avg/max vs fast-graph 784/847/952) — natural EOS
  termination with the same length statistics; code2wav decode times and
  audio durations unchanged. An audible spot-check by ear is still worth
  doing before merge.
- Loop-parity gate: compat mode (op-for-op the remote loop) vs fast mode
  produce identical token sequences on a tiny real LlamaModel
  (`tests/unit_test/minicpm_o/test_talker_decode.py`, runs under the CI
  transformers; also executed in the benchmark container before serving). A
  second-request test guards the static-cache reset (two different conditions
  through one backend).

First-request graph capture costs ~5 s once per process (the c1 cold round:
9.9 s vs 4.3 s warm).

## Limitations / follow-ups

- The talker stage is still serial across requests (bare SimpleScheduler);
  at c8 the queue still adds ~6 s p95 on top of the 2.9 s service time.
  Streaming speech output and/or talker batching are the next levers.
- Batch is 1 per generate, matching the remote loop's own assert.
