### PR TITLE
[Qwen3-Omni Perf] Size the talker KV pool from the talker's 20 layers instead of the thinker's 48

### DIFF
--- a/docker/xpu.Dockerfile
+++ b/docker/xpu.Dockerfile
@@ -58,6 +58,16 @@ RUN apt-get update && apt-get install -y --no-install-recommends \
         intel-igc-core-2 intel-igc-opencl-2 \
     && rm -rf /var/lib/apt/lists/*
 
+# note(wenyao): The Intel base image does not provide pip on PATH. Bootstrap
+# Python 3.12 in a virtual environment, with tools to build native dependencies.
+RUN apt-get update && apt-get install -y --no-install-recommends \
+        python3.12-dev python3.12-venv build-essential \
+    && rm -rf /var/lib/apt/lists/*
+ENV VIRTUAL_ENV=/opt/venv
+RUN python3.12 -m venv ${VIRTUAL_ENV}
+ENV PATH="${VIRTUAL_ENV}/bin:${PATH}"
+RUN python --version && python -m pip --version && pip --version
+
 # Minors differ on purpose: the XPU channel ships no torchaudio newer than 2.11+xpu.
 RUN pip install --no-cache-dir --extra-index-url ${TORCH_XPU_INDEX} \
         torch==2.13.0+xpu \

--- a/docker/xpu.Dockerfile
+++ b/docker/xpu.Dockerfile
@@ -58,16 +58,6 @@ RUN apt-get update && apt-get install -y --no-install-recommends \
         intel-igc-core-2 intel-igc-opencl-2 \
     && rm -rf /var/lib/apt/lists/*
 
-# note(wenyao): The Intel base image does not provide pip on PATH. Bootstrap
-# Python 3.12 in a virtual environment, with tools to build native dependencies.
-RUN apt-get update && apt-get install -y --no-install-recommends \
-        python3.12-dev python3.12-venv build-essential \
-    && rm -rf /var/lib/apt/lists/*
-ENV VIRTUAL_ENV=/opt/venv
-RUN python3.12 -m venv ${VIRTUAL_ENV}
-ENV PATH="${VIRTUAL_ENV}/bin:${PATH}"
-RUN python --version && python -m pip --version && pip --version
-
 # Minors differ on purpose: the XPU channel ships no torchaudio newer than 2.11+xpu.
 RUN pip install --no-cache-dir --extra-index-url ${TORCH_XPU_INDEX} \
         torch==2.13.0+xpu \

--- a/sglang_omni/model_runner/model_worker.py
+++ b/sglang_omni/model_runner/model_worker.py
@@ -152,8 +152,8 @@ class ModelWorker:
         model_config.num_key_value_heads = text_cfg.num_key_value_heads
         model_config.hidden_size = text_cfg.hidden_size
         model_config.num_hidden_layers = text_cfg.num_hidden_layers
-        # SGLang sizes the KV pool from the larger of these two and set the
-        # second from the root text config at construction.
+        # note(ratish): SGLang sizes the KV pool from the larger of these two
+        # and set the second from the root text config at construction.
         model_config.num_attention_layers = text_cfg.num_hidden_layers
         if arch == "MingTTSSGLangModel":
             model_config.head_dim = int(text_cfg.head_dim)

--- a/sglang_omni/model_runner/model_worker.py
+++ b/sglang_omni/model_runner/model_worker.py
@@ -152,11 +152,8 @@ class ModelWorker:
         model_config.num_key_value_heads = text_cfg.num_key_value_heads
         model_config.hidden_size = text_cfg.hidden_size
         model_config.num_hidden_layers = text_cfg.num_hidden_layers
-        # SGLang set num_attention_layers from the root text config at
-        # construction and sizes the KV pool from the larger of it and
-        # num_hidden_layers, so a sub model with fewer layers than the root
-        # (the Qwen3-Omni talker, 20 against the thinker's 48) would otherwise
-        # get a pool of cells for layers it never writes.
+        # SGLang sizes the KV pool from the larger of these two and set the
+        # second from the root text config at construction.
         model_config.num_attention_layers = text_cfg.num_hidden_layers
         if arch == "MingTTSSGLangModel":
             model_config.head_dim = int(text_cfg.head_dim)

--- a/sglang_omni/model_runner/model_worker.py
+++ b/sglang_omni/model_runner/model_worker.py
@@ -152,6 +152,12 @@ class ModelWorker:
         model_config.num_key_value_heads = text_cfg.num_key_value_heads
         model_config.hidden_size = text_cfg.hidden_size
         model_config.num_hidden_layers = text_cfg.num_hidden_layers
+        # SGLang set num_attention_layers from the root text config at
+        # construction and sizes the KV pool from the larger of it and
+        # num_hidden_layers, so a sub model with fewer layers than the root
+        # (the Qwen3-Omni talker, 20 against the thinker's 48) would otherwise
+        # get a pool of cells for layers it never writes.
+        model_config.num_attention_layers = text_cfg.num_hidden_layers
         if arch == "MingTTSSGLangModel":
             model_config.head_dim = int(text_cfg.head_dim)
             model_config.v_head_dim = model_config.head_dim

--- a/tests/README.md
+++ b/tests/README.md
@@ -78,6 +78,7 @@ tests/
     ├── models/
     │   └── test_model_capabilities.py
     ├── model_runner/
+    │   ├── test_arch_override.py
     │   ├── test_hidden_capture.py
     │   └── test_prefill_cuda_graph_usage.py
     ├── audar_tts/
@@ -473,6 +474,9 @@ that happened to contain an older version of the test.
     error propagation with same-device stream checks, using CPU stand-ins
     where no GPU is present.
 - `unit_test/model_runner/`: Shared model-runner contract tests:
+  - arch override pool sizing: a sub-model engine's KV pool takes the
+    sub-model's layer count through SGLang's layer resolver (the Qwen3-Omni
+    talker at 20 layers, the thinker at 48).
   - graph-safe hidden-state capture: stable registered buffers refreshed by
     decoder-layer pre-hooks, capacity validation, graph-replay row reads, and
     buffer address stability across forwards, including real breakable CUDA

--- a/tests/unit_test/model_runner/test_arch_override.py
+++ b/tests/unit_test/model_runner/test_arch_override.py
@@ -1,0 +1,74 @@
+# SPDX-License-Identifier: Apache-2.0
+"""The arch override rewrites every field SGLang sizes the KV pool from.
+
+SGLang builds the engine's ModelConfig from the root checkpoint config and
+picks the thinker text config for a model that has one, so a sub model
+with fewer layers (the Qwen3-Omni talker) starts with the thinker's layer
+count in both num_hidden_layers and num_attention_layers. The pool takes
+the larger of the two, so the override has to rewrite both.
+"""
+
+from __future__ import annotations
+
+from types import SimpleNamespace
+
+import pytest
+
+pytest.importorskip("sglang")
+
+from sglang_omni.model_runner.model_worker import ModelWorker  # noqa: E402
+
+
+def _qwen3_omni_engine_config():
+    thinker_text = SimpleNamespace(
+        num_hidden_layers=48,
+        num_attention_heads=32,
+        num_key_value_heads=4,
+        hidden_size=2048,
+        head_dim=128,
+        vocab_size=152064,
+    )
+    talker_text = SimpleNamespace(
+        num_hidden_layers=20,
+        num_attention_heads=16,
+        num_key_value_heads=2,
+        hidden_size=1024,
+        head_dim=128,
+        vocab_size=3072,
+    )
+    hf_config = SimpleNamespace(
+        architectures=["Qwen3OmniMoeForConditionalGeneration"],
+        thinker_config=SimpleNamespace(text_config=thinker_text),
+        talker_config=SimpleNamespace(text_config=talker_text),
+    )
+    return SimpleNamespace(
+        hf_config=hf_config,
+        hf_text_config=thinker_text,
+        num_attention_heads=thinker_text.num_attention_heads,
+        num_key_value_heads=thinker_text.num_key_value_heads,
+        hidden_size=thinker_text.hidden_size,
+        num_hidden_layers=thinker_text.num_hidden_layers,
+        num_attention_layers=thinker_text.num_hidden_layers,
+        head_dim=thinker_text.head_dim,
+        vocab_size=thinker_text.vocab_size,
+    )
+
+
+def test_talker_override_sizes_the_pool_from_the_talker_layers() -> None:
+    config = _qwen3_omni_engine_config()
+    ModelWorker._apply_arch_override(config, "Qwen3OmniTalker")
+    assert config.hf_config.architectures == ["Qwen3OmniTalker"]
+    assert config.hf_text_config is config.hf_config.talker_config.text_config
+    assert config.num_hidden_layers == 20
+    assert config.num_attention_layers == 20
+    assert config.num_key_value_heads == 2
+    assert config.num_attention_heads == 16
+    assert config.hidden_size == 1024
+
+
+def test_thinker_override_keeps_the_thinker_layers() -> None:
+    config = _qwen3_omni_engine_config()
+    ModelWorker._apply_arch_override(config, "Qwen3OmniThinkerForCausalLM")
+    assert config.num_hidden_layers == 48
+    assert config.num_attention_layers == 48
+    assert config.num_key_value_heads == 4

--- a/tests/unit_test/model_runner/test_arch_override.py
+++ b/tests/unit_test/model_runner/test_arch_override.py
@@ -1,11 +1,12 @@
 # SPDX-License-Identifier: Apache-2.0
-"""The arch override rewrites every field SGLang sizes the KV pool from.
+"""The KV pool of a sub model engine is sized from the sub model's layers.
 
-SGLang builds the engine's ModelConfig from the root checkpoint config and
-picks the thinker text config for a model that has one, so a sub model
-with fewer layers (the Qwen3-Omni talker) starts with the thinker's layer
-count in both num_hidden_layers and num_attention_layers. The pool takes
-the larger of the two, so the override has to rewrite both.
+SGLang builds the engine's ModelConfig from the root checkpoint config and,
+for a config with a thinker_config, takes the thinker's text config, so
+the Qwen3-Omni talker engine starts with the thinker's 48 layers in both
+num_hidden_layers and num_attention_layers. SGLang then sizes the pool
+from the larger of the two through resolve_layer_indices. The override
+has to leave the pool at the talker's 20 layers and the thinker's at 48.
 """
 
 from __future__ import annotations
@@ -15,6 +16,11 @@ from types import SimpleNamespace
 import pytest
 
 pytest.importorskip("sglang")
+
+from sglang.srt.model_executor.model_runner_components.layer_setup import (  # noqa: E402
+    resolve_layer_indices,
+)
+from sglang.srt.speculative.spec_info import SpeculativeAlgorithm  # noqa: E402
 
 from sglang_omni.model_runner.model_worker import ModelWorker  # noqa: E402
 
@@ -49,26 +55,31 @@ def _qwen3_omni_engine_config():
         hidden_size=thinker_text.hidden_size,
         num_hidden_layers=thinker_text.num_hidden_layers,
         num_attention_layers=thinker_text.num_hidden_layers,
+        num_nextn_predict_layers=None,
         head_dim=thinker_text.head_dim,
         vocab_size=thinker_text.vocab_size,
     )
 
 
-def test_talker_override_sizes_the_pool_from_the_talker_layers() -> None:
+def _pool_layers(config) -> int:
+    return resolve_layer_indices(
+        model=object(),
+        model_config=config,
+        is_draft_worker=False,
+        spec_algorithm=SpeculativeAlgorithm.NONE,
+    ).num_effective_layers
+
+
+def test_talker_pool_is_sized_from_the_talker_layers() -> None:
     config = _qwen3_omni_engine_config()
+    assert _pool_layers(config) == 48
     ModelWorker._apply_arch_override(config, "Qwen3OmniTalker")
-    assert config.hf_config.architectures == ["Qwen3OmniTalker"]
-    assert config.hf_text_config is config.hf_config.talker_config.text_config
-    assert config.num_hidden_layers == 20
-    assert config.num_attention_layers == 20
+    assert _pool_layers(config) == 20
     assert config.num_key_value_heads == 2
-    assert config.num_attention_heads == 16
-    assert config.hidden_size == 1024
 
 
-def test_thinker_override_keeps_the_thinker_layers() -> None:
+def test_thinker_pool_keeps_the_thinker_layers() -> None:
     config = _qwen3_omni_engine_config()
     ModelWorker._apply_arch_override(config, "Qwen3OmniThinkerForCausalLM")
-    assert config.num_hidden_layers == 48
-    assert config.num_attention_layers == 48
+    assert _pool_layers(config) == 48
     assert config.num_key_value_heads == 4


### PR DESCRIPTION
## Mechanics

SGLang builds a sub model engine's `ModelConfig` from the whole checkpoint config. For a config with a `thinker_config`, `get_hf_text_config` picks the thinker's text config, so the talker engine starts with the thinker's shape: `num_hidden_layers = 48` and `num_attention_layers = 48`, both set at construction (`sglang/srt/configs/model_config.py`).

`ModelWorker._apply_arch_override` then repoints the engine at the sub model. For `Qwen3OmniTalker` it rewrites `hf_text_config`, the head counts, `hidden_size` and `num_hidden_layers` (20) from `talker_config.text_config`, but not `num_attention_layers`, which stays 48. SGLang sizes the KV pool from `max(num_hidden_layers, num_attention_layers)` (`model_runner_components/layer_setup.py`) unless the model object exposes `end_layer`, and the top level talker does not. The talker's pool was therefore allocated for 48 layers of cells per token while the model writes 20 (`components/talker.py`, `make_layers(config.num_hidden_layers)`).

Every boot log shows it: the talker pool reports 24.5 KB of K per token on both the bf16 and the fp8 profile, which is 48 layers × 2 KV heads × 128 × 2 bytes. The talker's shape needs 10 KB. The thinker's pool is exact for its own shape. 58 percent of the talker's KV budget was cells no layer ever wrote.

## Change

One line in `_apply_arch_override`: `num_attention_layers` is rewritten from the sub model's `num_hidden_layers`, next to the existing `num_hidden_layers` rewrite. For the mapped architectures whose sub config SGLang already selects (`llm_config`, `language_config`, `text_config`) this is a no op. For the Qwen3-Omni talker the pool's layer count drops from 48 to 20. The code predictor is unaffected, its five layers keep their own K and V tensors outside the pool.

No computation and no output changes. The 20 layers the model writes keep the same cells and bytes, only the 28 unused layers of cells per token disappear, so the same fraction holds 2.4 times the tokens.

## Measurement

Qwen3-Omni bf16 colocated on one H100 (`examples/configs/qwen3_omni_colocated_h100_bf16.yaml`), SeedTTS English, all 1088 samples, plain TTS per the benchmark README, warmup 1. A is main `216e946dd`, B is this branch.

| pool at boot | A | B |
|---|---|---|
| thinker tokens | 5248 | 5248 |
| talker tokens | 14675 | 35220 |

| concurrency | metric | A | B | delta |
|---|---|---|---|---|
| c16 | completed | 1088/1088 | 1088/1088 | |
| c16 | qps | 8.123 | 8.405 | +3.5% |
| c16 | latency mean s | 1.964 | 1.896 | -3.5% |
| c16 | latency p95 s | 2.907 | 2.756 | -5.2% |
| c16 | rtf mean | 0.5399 | 0.5219 | -3.3% |
| c32 | completed | 1088/1088 | 1088/1088 | |
| c32 | qps | 8.313 | 10.074 | +21.2% |
| c32 | latency mean s | 3.822 | 3.163 | -17.2% |
| c32 | latency p95 s | 5.110 | 4.602 | -9.9% |
| c32 | rtf mean | 1.0859 | 0.8735 | -19.6% |

WER with Qwen3-ASR-1.7B on all 1088 outputs: c16 2.311% against 1.767%, c32 2.303% against 2.420%. Paired 95 percent intervals cross zero at both concurrencies. The benchmark sends no sampling seed, so byte identity across arms was not testable.

The gain is capacity: on this profile the talker pool is what bounds admission, and c32 is the talker's `max_running_requests`. On profiles whose talker pool already exceeds what 32 rows need (fp8 colocated H100) the fix frees memory without changing throughput.

## Tests

`tests/unit_test/model_runner/test_arch_override.py`: the talker override leaves 20 in both layer fields with the talker's heads, the thinker override keeps 48.
