### PR TITLE
[XPU][Perf] Stop silently losing the Qwen3-ASR encoder graph on non-CUDA devices

### DIFF
--- a/sglang_omni/models/qwen3_asr/encoder_cuda_graph.py
+++ b/sglang_omni/models/qwen3_asr/encoder_cuda_graph.py
@@ -12,12 +12,15 @@ from __future__ import annotations
 
 import logging
 from dataclasses import dataclass
-from typing import Any
+from typing import TYPE_CHECKING, Any
 
 import torch
 from sglang.srt.layers.attention.vision import VisionAttentionMetadata
 
 from sglang_omni.platforms import current_platform
+
+if TYPE_CHECKING:
+    from sglang_omni.platforms.device_graph import DeviceGraphBackend
 
 logger = logging.getLogger(__name__)
 
@@ -53,7 +56,7 @@ def build_buckets(max_batch: int, max_tokens_per_clip: int) -> tuple[int, ...]:
 
 @dataclass
 class _CapturedGraph:
-    graph: torch.cuda.CUDAGraph
+    graph: Any  # the accelerator's graph type, named per backend
     hidden_states: torch.Tensor  # [bucket, hidden] static input
     cu_seqlens: torch.Tensor  # [max_windows + 1] static window boundaries
     attention_metadata: VisionAttentionMetadata | None
@@ -76,11 +79,14 @@ class Qwen3ASREncoderLayerStackGraphRunner:
         *,
         buckets: tuple[int, ...],
         max_batch_size: int,
+        graph_backend: DeviceGraphBackend,
     ) -> None:
         self._tower = audio_tower
+        self._graph_backend = graph_backend
         param = next(audio_tower.parameters())
         self._device = param.device
         self._dtype = param.dtype
+        self._device_module = torch.get_device_module(self._device)
         cfg = audio_tower.config
 
         chunk_tokens = _get_feat_extract_output_lengths_int(cfg.n_window * 2)
@@ -170,16 +176,19 @@ class Qwen3ASREncoderLayerStackGraphRunner:
             with torch.no_grad():
                 return self._layer_stack(static_hs, static_cu)
 
-        side = torch.cuda.Stream(device)
-        side.wait_stream(torch.cuda.current_stream(device))
-        with torch.cuda.stream(side):
+        device_module = self._device_module
+        side = device_module.Stream(device)
+        side.wait_stream(device_module.current_stream(device))
+        with device_module.stream(side):
             for _ in range(3):
                 run_once()
-        torch.cuda.current_stream(device).wait_stream(side)
-        torch.cuda.synchronize(device)
+        device_module.current_stream(device).wait_stream(side)
+        device_module.synchronize(device)
 
-        graph = torch.cuda.CUDAGraph()
-        with torch.cuda.graph(graph, capture_error_mode="thread_local"):
+        # Note (siju): each bucket keeps its own pool. Sharing one is only safe
+        # for graphs replayed in capture order, and a request picks its bucket
+        # from the clip length, so any order is possible.
+        with self._graph_backend.capture(thread_local_errors=True) as graph:
             static_out = run_once()
         logger.info(
             "[qwen3-asr] captured encoder layer-stack graph bucket=%d windows=%d out=%s",

--- a/sglang_omni/models/qwen3_asr/sglang_model.py
+++ b/sglang_omni/models/qwen3_asr/sglang_model.py
@@ -160,10 +160,15 @@ class Qwen3ASRForConditionalGeneration(nn.Module):
     def init_encoder_graphs(
         self, *, max_batch_size: int, max_tokens_per_clip: int
     ) -> None:
+        device = next(self.audio_tower.parameters()).device
+        graph_backend = current_platform.get_device_graph_backend(device)
+        if graph_backend is None:
+            return
         runner = Qwen3ASREncoderLayerStackGraphRunner(
             self.audio_tower,
             buckets=build_buckets(max_batch_size, max_tokens_per_clip),
             max_batch_size=max_batch_size,
+            graph_backend=graph_backend,
         )
         runner.capture_all()
         self._encoder_graph_runner = runner

--- a/sglang_omni/platforms/cuda.py
+++ b/sglang_omni/platforms/cuda.py
@@ -14,6 +14,7 @@ from sglang_omni.vendor.sglang.server_args import override_server_args
 
 if TYPE_CHECKING:
     from sglang_omni.pipeline.stage_workers import StageLaunchConfig
+    from sglang_omni.platforms.device_graph import DeviceGraphBackend
 
 logger = logging.getLogger(__name__)
 
@@ -48,6 +49,11 @@ def _is_fp8_cutlass_moe_supported() -> bool:
 
 
 class CUDAOmniPlatform(CudaDeviceMixin, OmniPlatform):
+    def _get_device_graph_backend(self) -> DeviceGraphBackend:
+        from sglang_omni.platforms.device_graph import CudaDeviceGraphBackend
+
+        return CudaDeviceGraphBackend()
+
     def get_stage_process_env(
         self,
         spec: StageLaunchConfig,

--- a/sglang_omni/platforms/device_graph.py
+++ b/sglang_omni/platforms/device_graph.py
@@ -1,0 +1,83 @@
+# SPDX-License-Identifier: Apache-2.0
+"""Graph capture for the model-owned graph paths, one backend per accelerator.
+
+A model that captures its own graphs asks its platform for the backend instead of
+naming torch.cuda. The graph object and the capture context's keywords differ per
+accelerator, and SGLang resolves them explicitly for the same reason, so the
+choice belongs on the platform rather than in a per-model branch.
+"""
+
+from __future__ import annotations
+
+from contextlib import AbstractContextManager, contextmanager
+from typing import Any, Iterator, Protocol
+
+import torch
+
+
+class DeviceGraphBackend(Protocol):
+    """Records a model-owned graph on one accelerator."""
+
+    def capture(
+        self,
+        *,
+        pool: Any | None = None,
+        stream: Any | None = None,
+        thread_local_errors: bool = False,
+    ) -> AbstractContextManager[Any]:
+        """Open a capture and yield the graph it records into."""
+        ...
+
+
+class CudaDeviceGraphBackend:
+    """CUDA, and the backends that present through torch.cuda: HIP and MUSA."""
+
+    @contextmanager
+    def capture(
+        self,
+        *,
+        pool: Any | None = None,
+        stream: Any | None = None,
+        thread_local_errors: bool = False,
+    ) -> Iterator[Any]:
+        graph = torch.cuda.CUDAGraph()
+        kwargs: dict[str, Any] = {}
+        if pool is not None:
+            kwargs["pool"] = pool
+        if stream is not None:
+            kwargs["stream"] = stream
+        if thread_local_errors:
+            kwargs["capture_error_mode"] = "thread_local"
+        with torch.cuda.graph(cuda_graph=graph, **kwargs):
+            yield graph
+
+
+class XpuDeviceGraphBackend:
+    """Intel XPU."""
+
+    @contextmanager
+    def capture(
+        self,
+        *,
+        pool: Any | None = None,
+        stream: Any | None = None,
+        thread_local_errors: bool = False,
+    ) -> Iterator[Any]:
+        # Note (siju): XPU's graph context declares no capture_error_mode and
+        # rejects it as a TypeError, so the request is dropped, not translated.
+        del thread_local_errors
+        graph = torch.xpu.XPUGraph()
+        kwargs: dict[str, Any] = {}
+        if pool is not None:
+            kwargs["pool"] = pool
+        if stream is not None:
+            kwargs["stream"] = stream
+        with torch.xpu.graph(xpu_graph=graph, **kwargs):
+            yield graph
+
+
+__all__ = [
+    "CudaDeviceGraphBackend",
+    "DeviceGraphBackend",
+    "XpuDeviceGraphBackend",
+]

--- a/sglang_omni/platforms/interface.py
+++ b/sglang_omni/platforms/interface.py
@@ -10,8 +10,11 @@ from sglang.srt.platforms.device_mixin import DeviceMixin
 from sglang_omni.utils.misc import normalize_quantization
 
 if TYPE_CHECKING:
+    import torch
+
     from sglang_omni.comm.data_ref import TransportKind
     from sglang_omni.pipeline.stage_workers import StageLaunchConfig
+    from sglang_omni.platforms.device_graph import DeviceGraphBackend
 
 
 class OmniPlatform(DeviceMixin):
@@ -56,6 +59,21 @@ class OmniPlatform(DeviceMixin):
         if server_quantization is not None:
             effective_quantization = server_quantization
         return effective_quantization
+
+    def get_device_graph_backend(
+        self, device: torch.device
+    ) -> DeviceGraphBackend | None:
+        """The backend that records model-owned graphs on this device, or None.
+
+        None is also the answer for a device that is not this platform's own, so
+        a caller holding a tensor's device does not have to check that first.
+        """
+        if device.type != self.device_type:
+            return None
+        return self._get_device_graph_backend()
+
+    def _get_device_graph_backend(self) -> DeviceGraphBackend | None:
+        return None
 
     def enable_code2wav_graph(self):
         """Check if current platform support Graph for code2wav in Qwen3-Omni"""

--- a/sglang_omni/platforms/rocm.py
+++ b/sglang_omni/platforms/rocm.py
@@ -13,10 +13,16 @@ if TYPE_CHECKING:
     from sglang.srt.server_args import ServerArgs
 
     from sglang_omni.pipeline.stage_workers import StageLaunchConfig
+    from sglang_omni.platforms.device_graph import DeviceGraphBackend
 
 
 class ROCMOmniPlatform(RocmDeviceMixin, OmniPlatform):
     """ROCm policy with PyTorch's CUDA-compatible HIP device surface."""
+
+    def _get_device_graph_backend(self) -> DeviceGraphBackend:
+        from sglang_omni.platforms.device_graph import CudaDeviceGraphBackend
+
+        return CudaDeviceGraphBackend()
 
     def get_stage_process_env(
         self,

--- a/sglang_omni/platforms/xpu.py
+++ b/sglang_omni/platforms/xpu.py
@@ -17,6 +17,7 @@ if TYPE_CHECKING:
     from sglang.srt.server_args import ServerArgs
 
     from sglang_omni.pipeline.stage_workers import StageLaunchConfig
+    from sglang_omni.platforms.device_graph import DeviceGraphBackend
 
 
 class XPUOmniPlatform(OmniPlatform):
@@ -52,6 +53,11 @@ class XPUOmniPlatform(OmniPlatform):
     def enable_thinker_decode_graph(self) -> bool:
         # Capture leaves the scheduler thread's stream recording; host reads fail.
         return False
+
+    def _get_device_graph_backend(self) -> DeviceGraphBackend:
+        from sglang_omni.platforms.device_graph import XpuDeviceGraphBackend
+
+        return XpuDeviceGraphBackend()
 
     def get_decode_cuda_graph_backend(self) -> str | None:
         # SGLang leaves XPU decode capture opt-in and accepts only full.

--- a/tests/unit_test/platforms/test_device_graph.py
+++ b/tests/unit_test/platforms/test_device_graph.py
@@ -1,0 +1,114 @@
+# SPDX-License-Identifier: Apache-2.0
+"""Each backend records into its own graph type with its own context keywords."""
+
+from __future__ import annotations
+
+import inspect
+from contextlib import nullcontext
+from types import SimpleNamespace
+
+import pytest
+import torch
+
+from sglang_omni.platforms.device_graph import (
+    CudaDeviceGraphBackend,
+    XpuDeviceGraphBackend,
+)
+
+
+def _recording_module(graph_attr: str) -> SimpleNamespace:
+    """A torch.cuda / torch.xpu stand-in that records how graph() was called."""
+    calls: list[dict[str, object]] = []
+
+    class _Graph:
+        pass
+
+    def graph(**kwargs):
+        calls.append(kwargs)
+        return nullcontext()
+
+    return SimpleNamespace(calls=calls, graph=graph, **{graph_attr: _Graph})
+
+
+def test_cuda_backend_records_into_a_cuda_graph(monkeypatch) -> None:
+    module = _recording_module("CUDAGraph")
+    monkeypatch.setattr(torch, "cuda", module)
+    pool = object()
+
+    with CudaDeviceGraphBackend().capture(
+        pool=pool, stream="s", thread_local_errors=True
+    ) as graph:
+        pass
+
+    assert isinstance(graph, module.CUDAGraph)
+    assert module.calls[-1] == {
+        "cuda_graph": graph,
+        "pool": pool,
+        "stream": "s",
+        # CUDA scopes a capture failure to the process unless asked otherwise.
+        "capture_error_mode": "thread_local",
+    }
+
+
+def test_cuda_backend_asks_for_nothing_it_was_not_given(monkeypatch) -> None:
+    module = _recording_module("CUDAGraph")
+    monkeypatch.setattr(torch, "cuda", module)
+
+    with CudaDeviceGraphBackend().capture() as graph:
+        pass
+
+    assert module.calls[-1] == {"cuda_graph": graph}
+
+
+def test_xpu_backend_records_into_an_xpu_graph_without_error_mode(monkeypatch) -> None:
+    """XPU's context declares no capture_error_mode and rejects it as TypeError."""
+    module = _recording_module("XPUGraph")
+    monkeypatch.setattr(torch, "xpu", module)
+    pool = object()
+
+    with XpuDeviceGraphBackend().capture(
+        pool=pool, stream="s", thread_local_errors=True
+    ) as graph:
+        pass
+
+    assert isinstance(graph, module.XPUGraph)
+    assert module.calls[-1] == {"xpu_graph": graph, "pool": pool, "stream": "s"}
+
+
+def test_each_backend_uses_the_keyword_its_torch_context_declares() -> None:
+    """The stub tests above accept any keyword, so pin the real ones here.
+
+    Both contexts are plain Python classes that a build without the device still
+    exposes, so this runs anywhere.
+    """
+    cuda = inspect.signature(torch.cuda.graph).parameters
+    xpu = inspect.signature(torch.xpu.graph).parameters
+
+    assert "cuda_graph" in cuda and "capture_error_mode" in cuda
+    assert "xpu_graph" in xpu and "capture_error_mode" not in xpu
+
+
+@pytest.mark.parametrize("backend", [CudaDeviceGraphBackend(), XpuDeviceGraphBackend()])
+def test_a_capture_that_raises_still_closes_its_context(backend, monkeypatch) -> None:
+    """The graph context must exit on the body's exception, not swallow it."""
+    exited: list[bool] = []
+
+    class _Ctx:
+        def __enter__(self):
+            return None
+
+        def __exit__(self, *args):
+            exited.append(True)
+            return False
+
+    module = _recording_module("CUDAGraph")
+    module.graph = lambda **kwargs: _Ctx()
+    module.XPUGraph = module.CUDAGraph
+    monkeypatch.setattr(torch, "cuda", module)
+    monkeypatch.setattr(torch, "xpu", module)
+
+    with pytest.raises(ValueError):
+        with backend.capture():
+            raise ValueError("capture body failed")
+
+    assert exited == [True]

--- a/tests/unit_test/qwen3_asr/test_encoder_cuda_graph.py
+++ b/tests/unit_test/qwen3_asr/test_encoder_cuda_graph.py
@@ -119,21 +119,31 @@ def asr_server_args():
 
 
 @pytest.mark.accelerator
-@pytest.mark.skipif(not torch.cuda.is_available(), reason="requires CUDA")
+@pytest.mark.skipif(
+    current_platform.get_device_graph_backend(
+        SimpleNamespace(type=current_platform.device_type)
+    )
+    is None,
+    reason="requires an accelerator whose platform names a graph backend",
+)
 def test_graph_matches_eager_tower(asr_server_args):
     from sglang.srt.configs.qwen3_omni import Qwen3OmniMoeAudioEncoderConfig
     from sglang.srt.distributed import (
         init_distributed_environment,
         initialize_model_parallel,
     )
-    from sglang.srt.distributed.parallel_state import model_parallel_is_initialized
+    from sglang.srt.distributed.parallel_state import (
+        get_default_distributed_backend,
+        model_parallel_is_initialized,
+    )
 
     from sglang_omni.models.qwen3_asr.audio_lengths import qwen3_asr_num_audio_tokens
     from sglang_omni.models.qwen3_asr.encoder_cuda_graph import eager_preamble
 
+    device = current_platform.device_type
     if not model_parallel_is_initialized():
         init_distributed_environment(
-            backend="nccl",
+            backend=get_default_distributed_backend(device),
             world_size=1,
             rank=0,
             local_rank=0,
@@ -153,7 +163,8 @@ def test_graph_matches_eager_tower(asr_server_args):
         n_window_infer=800,
     )
     torch.manual_seed(0)
-    tower = Qwen3OmniMoeAudioEncoder(cfg).cuda().eval().to(torch.bfloat16)
+    tower = Qwen3OmniMoeAudioEncoder(cfg).to(device).eval().to(torch.bfloat16)
+    tower_device = next(tower.parameters()).device
     with torch.no_grad():
         for name, prm in tower.named_parameters():
             if prm.dim() >= 2:
@@ -164,18 +175,21 @@ def test_graph_matches_eager_tower(asr_server_args):
                 prm.zero_()
 
     runner = Qwen3ASREncoderLayerStackGraphRunner(
-        tower, buckets=build_buckets(4, 104), max_batch_size=4
+        tower,
+        buckets=build_buckets(4, 104),
+        max_batch_size=4,
+        graph_backend=current_platform.get_device_graph_backend(tower_device),
     )
     runner.capture_all()
     assert runner._graphs and not runner._failed
+    pools = [entry.graph.pool() for entry in runner._graphs.values()]
+    assert len(set(pools)) == len(pools)
 
-    # [500] and [450] share a bucket, so the second replay also checks that
-    # stale rows from the first never leak into the output.
-    for frame_lens in ([500], [450], [300, 500, 120], [800, 800, 800, 800]):
-        feats = (torch.randn(128, sum(frame_lens), device="cuda") * 0.05).to(
+    def check(frame_lens):
+        feats = (torch.randn(128, sum(frame_lens), device=device) * 0.05).to(
             torch.bfloat16
         )
-        lens = torch.tensor(frame_lens, device="cuda", dtype=torch.long)
+        lens = torch.tensor(frame_lens, device=device, dtype=torch.long)
         with torch.no_grad():
             ref = tower(feats, feature_lens=lens).last_hidden_state.squeeze(0)
         wl = window_lens_from_token_counts(
@@ -186,10 +200,38 @@ def test_graph_matches_eager_tower(asr_server_args):
         diff = (out.float() - ref.float()).abs().max().item()
         assert diff < 3e-2, f"{frame_lens}: max|diff|={diff}"
 
+    # [500] and [450] share a bucket, so the second replay also checks that
+    # stale rows from the first never leak into the output. The descending pass
+    # is the order a long clip followed by a short one produces, which no shared
+    # graph memory may assume away.
+    sequence = ([500], [450], [300, 500, 120], [800, 800, 800, 800])
+    for frame_lens in sequence:
+        check(frame_lens)
+    for frame_lens in reversed(sequence):
+        check(frame_lens)
+
     assert (
         runner.run(
-            torch.zeros(9999, 64, device="cuda", dtype=torch.bfloat16),
+            torch.zeros(9999, 64, device=device, dtype=torch.bfloat16),
             [104] * 96 + [15],
         )
         is None
     )
+
+
+def test_init_encoder_graphs_declines_a_device_that_cannot_capture():
+    """A CPU tower must not build a runner that fails every bucket in turn.
+
+    __new__ skips the checkpoint work; only the tower's device decides this.
+    """
+    model = sglang_model.Qwen3ASRForConditionalGeneration.__new__(
+        sglang_model.Qwen3ASRForConditionalGeneration
+    )
+    model.audio_tower = SimpleNamespace(parameters=lambda: iter([torch.zeros(1)]))
+    model._encoder_graph_runner = "untouched"
+
+    sglang_model.Qwen3ASRForConditionalGeneration.init_encoder_graphs(
+        model, max_batch_size=4, max_tokens_per_clip=780
+    )
+
+    assert model._encoder_graph_runner == "untouched"

--- a/tests/unit_test/test_platforms.py
+++ b/tests/unit_test/test_platforms.py
@@ -167,3 +167,46 @@ def test_xpu_keeps_the_qwen3_omni_thinker_decode_eager() -> None:
     assert xpu_platform.XPUOmniPlatform().enable_thinker_decode_graph() is False
     assert OmniPlatform().enable_thinker_decode_graph() is True
     assert CPUOmniPlatform().enable_thinker_decode_graph() is True
+
+
+def test_each_platform_names_the_graph_backend_its_hardware_uses() -> None:
+    """The accelerators that capture name a backend; the rest answer None.
+
+    NPU, CPU and Apple keep the base None: before this hook they would have run
+    a CUDA capture path and failed inside it.
+    """
+    from sglang_omni.platforms.apple import AppleOmniPlatform
+    from sglang_omni.platforms.device_graph import (
+        CudaDeviceGraphBackend,
+        XpuDeviceGraphBackend,
+    )
+    from sglang_omni.platforms.musa import MUSAOmniPlatform
+    from sglang_omni.platforms.npu import NPUOmniPlatform
+
+    expected = {
+        CUDAOmniPlatform: CudaDeviceGraphBackend,
+        ROCMOmniPlatform: CudaDeviceGraphBackend,
+        MUSAOmniPlatform: CudaDeviceGraphBackend,
+        xpu_platform.XPUOmniPlatform: XpuDeviceGraphBackend,
+        NPUOmniPlatform: None,
+        CPUOmniPlatform: None,
+        AppleOmniPlatform: None,
+        OmniPlatform: None,
+    }
+    for platform_class, backend_class in expected.items():
+        platform = platform_class()
+        device = SimpleNamespace(type=platform.device_type)
+        backend = platform.get_device_graph_backend(device)
+        if backend_class is None:
+            assert backend is None, platform_class.__name__
+        else:
+            assert isinstance(backend, backend_class), platform_class.__name__
+
+
+def test_a_platform_declines_a_device_that_is_not_its_own() -> None:
+    """A caller holding a tensor's device does not have to check that first."""
+    platform = CUDAOmniPlatform()
+
+    assert platform.get_device_graph_backend(torch.device("xpu", 0)) is None
+    assert platform.get_device_graph_backend(torch.device("meta")) is None
+    assert platform.get_device_graph_backend(torch.device("cpu")) is None


### PR DESCRIPTION
## Motivation

Qwen3-ASR captures a CUDA graph for its audio encoder, on by default. The capture
code calls `torch.cuda.Stream(...)` directly, so on any non-CUDA accelerator every
bucket raises `torch.cuda.Stream requires CUDA support`. `capture_all` catches that
per bucket, logs a warning, and falls back to eager — so the feature is simply lost,
without failing.

Ten other model graph modules hardcode `torch.cuda` the same way. Rather than fix
each one separately, this adds one small helper for the two things they all need —
create the graph type this device uses, and open a capture on it — and converts
Qwen3-ASR as the first user.


## Modifications

Backend selection goes through the platform, so no call site names torch.cuda and
nothing discovers graph classes or context keywords at runtime.

New `sglang_omni/platforms/device_graph.py` — one backend per accelerator behind a
Protocol, next to the platforms that select it:

- `DeviceGraphBackend.capture(*, pool, stream, thread_local_errors)` — opens a
  capture and yields the graph it records into.
- `CudaDeviceGraphBackend` — `torch.cuda.CUDAGraph()` +
  `torch.cuda.graph(cuda_graph=..., capture_error_mode="thread_local")`, the same
  call the Qwen3-ASR runner made before this PR.
- `XpuDeviceGraphBackend` — `torch.xpu.XPUGraph()` + `torch.xpu.graph(xpu_graph=...)`,
  which declares no `capture_error_mode` and rejects it as a `TypeError`, so the
  request is dropped rather than translated.

New on the platform:

- `OmniPlatform.get_device_graph_backend(device)` — the backend for this device, or
  `None`. It returns `None` for a device that is not this platform's own, so a
  caller holding a tensor's device does not have to check that first, and a host
  with no accelerator resolves to the CPU platform and gets `None` for everything.
  That is where the availability gating lives now: it is the platform's answer
  rather than a helper probing `torch`.
- `_get_device_graph_backend()` — the per-platform override. CUDA and ROCm name the
  CUDA backend (HIP presents through `torch.cuda`), XPU names its own, **MUSA
  inherits CUDA's** through `MUSAOmniPlatform(CUDAOmniPlatform)` and TorchADA, and
  NPU, CPU and Apple keep the base `None` — where before they would have entered a
  CUDA capture path and failed inside it.

Qwen3-ASR then resolves the backend once from the audio tower's real device, passes
it into the encoder graph runner, and keeps `torch.get_device_module` for streams and
synchronization. `init_encoder_graphs` builds no runner when the platform names no
backend, instead of one that fails every bucket in turn.
`test_graph_matches_eager_tower` drops its CUDA-only skip and runs wherever the
platform names a backend. No other model graph path migrates here.

CUDA behaviour is unchanged, and the tests assert the call it issues against a
recording stub rather than arguing it.

## Related Issues

Part of #1588 (Intel XPU roadmap, "Enable XPU graph capture"). Follows #1679, which
did the engine-owned decode graph; this is the model-owned side.

## Accuracy Test

Arc Pro B60, Qwen3-ASR-1.7B. Before: 0 buckets captured, 3 failed with
`torch.cuda.Stream requires CUDA support`. After: 6 captured, 0 failed, replay
within 3e-2 of eager (`test_graph_matches_eager_tower` now runs on XPU).
Transcripts unchanged.

## Benchmark & Profiling

One card, 12 byte-distinct clips so the encoder cache cannot hide the work.
A/B/A, medians.

| Measurement | graph | eager | delta |
|---|---|---|---|
| latency, 4.6 s clip | 205 / 219 ms | 229 ms | ~6% |
| throughput, concurrency 8 | 22.21 req/s | 21.38 req/s | 3.9% |

Capture costs ~3 s of startup.

Small on purpose: decode and prefill graphs are already captured on XPU, so this
covers the audio encoder only. The saving is per call rather than per second of
audio (13 ms at 4.6 s, 21 ms at 13.9 s, 12 ms at 27.7 s), which is what removing
launch overhead looks like.

## Checklist

- [x] Format your code according with pre-commit.
- [x] Add unit tests.
- [x] Update documentation / docstrings / example tutorials as needed.
- [x] Provide throughput / latency benchmark results and accuracy evaluation results as needed.
- [ ] For reviewers: If you haven't made any contributions to this PR and are only assisting with merging the main branch, please remove yourself as a co-author when merging the PR.

## CI

CI runs on self-hosted GPU runners and requires a maintainer to add the
`run-ci` label. Once labeled, every subsequent push re-triggers CI as
long as the label remains. Use `/tag-and-rerun-ci higgs` or
`/tag-and-rerun-ci moss` or `/tag-and-rerun-ci qwen3-tts` to select a TTS CI
model, and
`/tag-and-rerun-ci fun-asr`, `/tag-and-rerun-ci qwen3-asr` or
`/tag-and-rerun-ci whisper-asr` to select an ASR CI model. One selector from
each family can be combined, for example `/tag-and-rerun-ci moss fun-asr`.
Draft PRs are skipped even if labeled.

