### PR TITLE
[Qwen3-TTS] Widen streaming vocoder decode CUDA graph coverage

### DIFF
--- a/sglang_omni/models/qwen3_tts/streaming_vocoder.py
+++ b/sglang_omni/models/qwen3_tts/streaming_vocoder.py
@@ -48,13 +48,18 @@ def _decode_graph_frame_counts(
 ) -> tuple[int, ...]:
     """Decode-window frame counts a streaming request can produce.
 
-    Two families reach the vocoder decode:
+    A decode spans window_start to window_end, so a chunk of s fresh frames
+    reaching the decoder with e frames already emitted and r reference frames
+    spans r + e + s, minus max(0, r + e - left_context). That collapses to two
+    families:
 
-    * startup, before the left-context buffer fills: the running sums of the
-      chunk schedule (initial chunk, then each ramp stride), capped where the
-      buffer saturates;
-    * steady: ``left_context`` plus any fresh-frame count from 1 up to a full
-      ``steady_stride``, since arrival timing makes the realized stride jitter.
+    * saturated, once r + e has reached left_context: exactly left_context + s,
+      for every stride s the chunk schedule can ask for. The steady stride also
+      jitters with arrival timing, so every fresh-frame count from 1 up to a
+      full steady stride is reachable.
+    * filling, while r + e is still below left_context: r + e + s. With no
+      reference frames that is the running sum of the chunk schedule, and it
+      only ever falls short of the saturated count for the same stride.
 
     Capturing this whole span keeps the common decodes on the CUDA-graph path
     instead of the eager fallback.
@@ -64,10 +69,10 @@ def _decode_graph_frame_counts(
     for stride in (initial_chunk_frames, *followup_stride_ramp, steady_stride):
         if stride <= 0:
             continue
+        saturated = left_context + stride
+        counts.add(saturated)
         cumulative += stride
-        window = min(cumulative, left_context + steady_stride)
-        if window > 0:
-            counts.add(window)
+        counts.add(min(cumulative, saturated))
     for fresh in range(1, steady_stride + 1):
         counts.add(left_context + fresh)
     return tuple(sorted(counts))

--- a/sglang_omni/models/qwen3_tts/streaming_vocoder.py
+++ b/sglang_omni/models/qwen3_tts/streaming_vocoder.py
@@ -39,6 +39,40 @@ DEFAULT_QWEN3_TTS_LEFT_CONTEXT_FRAMES = 16
 _QWEN3_TTS_CODEBOOK_SIZE = 2048
 
 
+def _decode_graph_frame_counts(
+    *,
+    left_context: int,
+    initial_chunk_frames: int,
+    followup_stride_ramp: tuple[int, ...],
+    steady_stride: int,
+) -> tuple[int, ...]:
+    """Decode-window frame counts a streaming request can produce.
+
+    Two families reach the vocoder decode:
+
+    * startup, before the left-context buffer fills: the running sums of the
+      chunk schedule (initial chunk, then each ramp stride), capped where the
+      buffer saturates;
+    * steady: ``left_context`` plus any fresh-frame count from 1 up to a full
+      ``steady_stride``, since arrival timing makes the realized stride jitter.
+
+    Capturing this whole span keeps the common decodes on the CUDA-graph path
+    instead of the eager fallback.
+    """
+    counts: set[int] = set()
+    cumulative = 0
+    for stride in (initial_chunk_frames, *followup_stride_ramp, steady_stride):
+        if stride <= 0:
+            continue
+        cumulative += stride
+        window = min(cumulative, left_context + steady_stride)
+        if window > 0:
+            counts.add(window)
+    for fresh in range(1, steady_stride + 1):
+        counts.add(left_context + fresh)
+    return tuple(sorted(counts))
+
+
 @dataclass
 class _Qwen3TTSStreamState:
     code_chunks: list[torch.Tensor] = field(default_factory=list)
@@ -444,11 +478,25 @@ class Qwen3TTSStreamingVocoderScheduler(
             if self._enable_stateful_codec_decoder
             else None
         )
+        # note (luojiaxuan): streaming delivers a wide, jittery range of decode
+        # window sizes, not just the exact ramp strides: the startup phase
+        # decodes the accumulating prefix before the left-context buffer fills
+        # (the running sums of the chunk schedule), and steady decodes vary by
+        # a few frames around the stride from arrival timing. Capturing only
+        # left_context + {ramp} left the majority of decodes on the eager path
+        # (measured ~72% eager, 4-5x slower). Capture the whole contiguous span
+        # the scheduler can produce so the hot path stays on the graph.
+        graph_frames = _decode_graph_frame_counts(
+            left_context=int(stream_left_context_frames),
+            initial_chunk_frames=int(initial_chunk_frames),
+            followup_stride_ramp=followup_stride_ramp,
+            steady_stride=int(stream_followup_stride),
+        )
         self._initial_decode_graphs = _Qwen3TTSInitialDecodeGraphs(
             self._decoder,
             device=self._device,
             num_quantizers=num_quantizers,
-            input_frames=int(stream_left_context_frames) + int(initial_chunk_frames),
+            input_frames=graph_frames,
             batch_sizes=(1,) if self._deterministic_inference else (1, 2, 4, 8),
             enabled=bool(
                 initial_cuda_graph
@@ -456,18 +504,11 @@ class Qwen3TTSStreamingVocoderScheduler(
                 and not self._enable_stateful_codec_decoder
             ),
         )
-        # note (Junnan Li): windows truncated below the full left context
-        # (short or absent reference codes early in a stream) fall back to
-        # eager decode, as the legacy first follow-up already does.
-        followup_frames = tuple(
-            int(stream_left_context_frames) + int(stride)
-            for stride in (*followup_stride_ramp, stream_followup_stride)
-        )
         self._followup_decode_graphs = _Qwen3TTSInitialDecodeGraphs(
             self._decoder,
             device=self._device,
             num_quantizers=num_quantizers,
-            input_frames=followup_frames,
+            input_frames=graph_frames,
             batch_sizes=(1,) if self._deterministic_inference else (1, 2, 4, 8),
             enabled=bool(
                 followup_cuda_graph

--- a/tests/unit_test/qwen3_tts/test_pipeline.py
+++ b/tests/unit_test/qwen3_tts/test_pipeline.py
@@ -2932,6 +2932,20 @@ def test_decode_graph_frame_counts_cover_startup_and_steady() -> None:
         followup_stride_ramp=(),
         steady_stride=8,
     ) == (8, 16, 17, 18, 19, 20, 21, 22, 23, 24)
+    # A stride wider than the steady stride still saturates at left_context +
+    # that stride, so its full-context window has to stay captured.
+    assert 32 in _decode_graph_frame_counts(
+        left_context=16,
+        initial_chunk_frames=16,
+        followup_stride_ramp=(),
+        steady_stride=8,
+    )
+    assert 32 in _decode_graph_frame_counts(
+        left_context=16,
+        initial_chunk_frames=8,
+        followup_stride_ramp=(16,),
+        steady_stride=8,
+    )
 
 
 def test_qwen3_tts_streaming_vocoder_chunk_ramp_covers_graph_shapes() -> None:

--- a/tests/unit_test/qwen3_tts/test_pipeline.py
+++ b/tests/unit_test/qwen3_tts/test_pipeline.py
@@ -2910,6 +2910,31 @@ def test_qwen3_tts_streaming_vocoder_chunk_ramp_schedules_early_chunks() -> None
     assert emitted_frames == [2, 4, 8, 8], "past the ramp the steady stride rules"
 
 
+def test_decode_graph_frame_counts_cover_startup_and_steady() -> None:
+    from sglang_omni.models.qwen3_tts.streaming_vocoder import (
+        _decode_graph_frame_counts,
+    )
+
+    counts = _decode_graph_frame_counts(
+        left_context=16,
+        initial_chunk_frames=2,
+        followup_stride_ramp=(4, 8),
+        steady_stride=8,
+    )
+    # Startup prefix sums 2, 2+4=6, 6+8=14, capped; steady band 17..24.
+    assert counts == (2, 6, 14, 17, 18, 19, 20, 21, 22, 23, 24)
+    # Every steady fresh-frame count from 1..stride is covered.
+    assert all((16 + f) in counts for f in range(1, 9))
+    # Non-positive strides are ignored, no zero window is captured.
+    assert 0 not in counts
+    assert _decode_graph_frame_counts(
+        left_context=16,
+        initial_chunk_frames=8,
+        followup_stride_ramp=(),
+        steady_stride=8,
+    ) == (8, 16, 17, 18, 19, 20, 21, 22, 23, 24)
+
+
 def test_qwen3_tts_streaming_vocoder_chunk_ramp_covers_graph_shapes() -> None:
     scheduler = Qwen3TTSStreamingVocoderScheduler(
         _FakeQwen3TTSTokenizer(),
@@ -2917,8 +2942,10 @@ def test_qwen3_tts_streaming_vocoder_chunk_ramp_covers_graph_shapes() -> None:
         stream_chunk_ramp=(2, 4, 8),
     )
     left = scheduler._stream_left_context_frames
-    assert scheduler._initial_decode_graphs._input_frames == (left + 2,)
-    assert scheduler._followup_decode_graphs._input_frames == (left + 4, left + 8)
+    # Startup prefix sums {2, 6, 14} plus the steady jitter band left+1..left+8.
+    expected = tuple(sorted({2, 6, 14} | {left + f for f in range(1, 9)}))
+    assert scheduler._initial_decode_graphs._input_frames == expected
+    assert scheduler._followup_decode_graphs._input_frames == expected
 
     payload = make_payload(inputs="target", params={"stream": True})
     scheduler._on_streaming_new_request(payload.request_id, payload)

--- a/tests/unit_test/qwen3_tts/test_pipeline.py
+++ b/tests/unit_test/qwen3_tts/test_pipeline.py
@@ -1993,13 +1993,12 @@ def test_qwen3_tts_streaming_vocoder_default_initial_chunk_is_continuity_safe() 
         device="cpu",
     )
 
+    left = scheduler._stream_left_context_frames
+    # Startup prefix sums plus the steady jitter band left+1..left+stride.
+    expected = tuple(sorted({8} | {left + f for f in range(0, 9)}))
     assert scheduler.create_stream_state("request").initial_chunk_frames == 8
-    assert scheduler._initial_decode_graphs._input_frames == (
-        scheduler._stream_left_context_frames + 8,
-    )
-    assert scheduler._followup_decode_graphs._input_frames == (
-        scheduler._stream_left_context_frames + 8,
-    )
+    assert scheduler._initial_decode_graphs._input_frames == expected
+    assert scheduler._followup_decode_graphs._input_frames == expected
 
 
 def _qwen3_tts_stream_item(


### PR DESCRIPTION
## Motivation

Profiling the streaming vocoder decode at 10 RPS (H200, 1.7B CustomVoice, SeedTTS EN) showed the decode split sharply by CUDA-graph coverage:

- graphed shapes: **5–21 ms**
- eager `chunked_decode` fallback: **25–52 ms** (4–5× slower)

and **72% of all decodes were eager, consuming 88% of total decode time** (avg 33.5 ms eager vs 12.4 ms graphed). The cause: the decode graphs captured only `left_context + {ramp strides}` (e.g. frames 20 and 24), but real streaming produces a much wider frame-count distribution:

- **startup**, before the left-context buffer fills: the running sums of the chunk schedule (frames 2, 6, 14 for a 2→4→8 ramp) — ~45% of decodes;
- **steady**, jittering a few frames around the stride from arrival timing (frames 17–23) — ~27%.

Only frames 20/24 (~28%) hit the graph.

## Change

`_decode_graph_frame_counts` derives the full span a streaming request can produce — the chunk-schedule prefix sums (startup) unioned with the contiguous steady band `left_context + 1..steady_stride` — and both the initial and follow-up decode graph sets capture it. No behavior change beyond graph coverage; eager decode remains the correctness fallback for any uncaptured shape.

## Measured (H200, 1.7B CustomVoice, SeedTTS EN, 16+16 admission, same tree/host, only this change)

| r10 | success | underrun | eager % |
|---|---|---|---|
| before | 94.2% | 26.8% | 72% |
| **after** | **100%** | **0.5–0.7%** | 13% |

That matches the reference engine's 10 RPS operating point (100% success, ~0.6% underrun). At 20 RPS underruns drop from 22–27% to **0.17%**; the residual 20 RPS success gap (~66% at 16+16) is now pure admission capacity, not decode — and with decode no longer the bottleneck, raising admission to 32 lifts 20 RPS success to ~80% without the continuity collapse that admission-raising caused before this change.

Cost: one-time graph capture at startup grows from a couple of shapes to ~11 frame counts × {1,2,4,8} batches; measured +46 s startup, well within the existing warmup, and comfortably inside H200 memory. The remaining ~13% eager are frame counts outside the derived set (rarer jitter); further coverage is a follow-up.

## Tests

`test_decode_graph_frame_counts_cover_startup_and_steady` pins the derivation (startup prefix sums + steady band, zero/degenerate strides ignored); the existing graph-coverage test is updated to the widened set.
