### PR TITLE
[Fix] Resolve prefill graph buckets after ServerArgs auto sizing

### DIFF
--- a/sglang_omni/models/arkasr/engine_builder.py
+++ b/sglang_omni/models/arkasr/engine_builder.py
@@ -15,6 +15,10 @@ from sglang_omni.models.arkasr.encoder_service import (
     build_cache_namespace,
 )
 from sglang_omni.scheduling.engine_factory import AsrEngineBuilder
+from sglang_omni.scheduling.generation_batch_policy import (
+    CudaGraphBackend,
+    build_default_prefill_cuda_graph_bs,
+)
 from sglang_omni.utils.gpu_compat import get_visible_gpu_sm_version
 
 logger = logging.getLogger(__name__)
@@ -23,6 +27,7 @@ logger = logging.getLogger(__name__)
 class ArkasrEngineBuilder(AsrEngineBuilder):
     model_name = "ARK-ASR"
     model_arch_override = "ArkasrForConditionalGeneration"
+    supports_breakable_prefill_cuda_graph = True
 
     def __init__(
         self,
@@ -117,6 +122,7 @@ class ArkasrEngineBuilder(AsrEngineBuilder):
             "chunked_prefill_size": 4096,
             "sampling_backend": "pytorch",
             "dtype": dtype,
+            "cuda_graph_backend_prefill": CudaGraphBackend.BREAKABLE,
         }
         if self.mm_attention_backend is not None:
             defaults["mm_attention_backend"] = self.mm_attention_backend
@@ -125,6 +131,33 @@ class ArkasrEngineBuilder(AsrEngineBuilder):
             if sm_version is not None and sm_version >= 100:
                 defaults["mm_attention_backend"] = "triton_attn"
         return defaults
+
+    def adjust_overrides(self, overrides: dict[str, Any]) -> None:
+        if "context_length" in overrides:
+            self.context_length = int(overrides.pop("context_length"))
+        if overrides.get("cuda_graph_backend_prefill") == CudaGraphBackend.DISABLED:
+            return
+        if "cuda_graph_bs_prefill" in overrides:
+            return
+
+        # SGLang clamps prefill max_bs to context_length after merging
+        # explicit buckets, so derive a ladder that remains coherent.
+        caps = [
+            self.context_length,
+            overrides["max_prefill_tokens"],
+            overrides.get("cuda_graph_max_bs_prefill"),
+            overrides.get("max_total_tokens"),
+        ]
+        if overrides["chunked_prefill_size"] > 0:
+            caps.append(overrides["chunked_prefill_size"])
+        ladder = build_default_prefill_cuda_graph_bs(
+            min(int(cap) for cap in caps if cap is not None)
+        )
+        overrides["cuda_graph_bs_prefill"] = ladder
+        overrides["cuda_graph_max_bs_prefill"] = max(ladder)
+
+    def customize_server_args(self, server_args: Any) -> None:
+        self.context_length = int(server_args.context_length)
 
     def setup_model_resources(
         self,

--- a/sglang_omni/models/arkasr/engine_builder.py
+++ b/sglang_omni/models/arkasr/engine_builder.py
@@ -17,7 +17,6 @@ from sglang_omni.models.arkasr.encoder_service import (
 from sglang_omni.scheduling.engine_factory import AsrEngineBuilder
 from sglang_omni.scheduling.generation_batch_policy import (
     CudaGraphBackend,
-    build_default_prefill_cuda_graph_bs,
     clamp_prefill_cuda_graph_max_bs,
 )
 from sglang_omni.utils.gpu_compat import get_visible_gpu_sm_version
@@ -140,9 +139,7 @@ class ArkasrEngineBuilder(AsrEngineBuilder):
         ):
             return
 
-        overrides["cuda_graph_bs_prefill"] = build_default_prefill_cuda_graph_bs(
-            clamp_prefill_cuda_graph_max_bs(overrides)
-        )
+        clamp_prefill_cuda_graph_max_bs(overrides)
 
     def setup_model_resources(
         self,

--- a/sglang_omni/models/arkasr/engine_builder.py
+++ b/sglang_omni/models/arkasr/engine_builder.py
@@ -140,8 +140,8 @@ class ArkasrEngineBuilder(AsrEngineBuilder):
         if "cuda_graph_bs_prefill" in overrides:
             return
 
-        # Note: (musclemuller) SGLang clamps prefill max_bs to context_length
-        # after merging explicit buckets, so derive a ladder that remains coherent.
+        # Note (musclemuller): Bound the ladder by every effective token cap so
+        # SGLang's post-merge max_bs clamp cannot invalidate explicit buckets.
         caps = [
             self.context_length,
             overrides["max_prefill_tokens"],

--- a/sglang_omni/models/arkasr/engine_builder.py
+++ b/sglang_omni/models/arkasr/engine_builder.py
@@ -18,6 +18,7 @@ from sglang_omni.scheduling.engine_factory import AsrEngineBuilder
 from sglang_omni.scheduling.generation_batch_policy import (
     CudaGraphBackend,
     build_default_prefill_cuda_graph_bs,
+    clamp_prefill_cuda_graph_max_bs,
 )
 from sglang_omni.utils.gpu_compat import get_visible_gpu_sm_version
 
@@ -133,31 +134,15 @@ class ArkasrEngineBuilder(AsrEngineBuilder):
         return defaults
 
     def adjust_overrides(self, overrides: dict[str, Any]) -> None:
-        if "context_length" in overrides:
-            self.context_length = int(overrides.pop("context_length"))
-        if overrides.get("cuda_graph_backend_prefill") == CudaGraphBackend.DISABLED:
-            return
-        if "cuda_graph_bs_prefill" in overrides:
+        if (
+            overrides.get("cuda_graph_backend_prefill") == CudaGraphBackend.DISABLED
+            or "cuda_graph_bs_prefill" in overrides
+        ):
             return
 
-        # Note (musclemuller): Bound the ladder by every effective token cap so
-        # SGLang's post-merge max_bs clamp cannot invalidate explicit buckets.
-        caps = [
-            self.context_length,
-            overrides["max_prefill_tokens"],
-            overrides.get("cuda_graph_max_bs_prefill"),
-            overrides.get("max_total_tokens"),
-        ]
-        if overrides["chunked_prefill_size"] > 0:
-            caps.append(overrides["chunked_prefill_size"])
-        ladder = build_default_prefill_cuda_graph_bs(
-            min(int(cap) for cap in caps if cap is not None)
+        overrides["cuda_graph_bs_prefill"] = build_default_prefill_cuda_graph_bs(
+            clamp_prefill_cuda_graph_max_bs(overrides)
         )
-        overrides["cuda_graph_bs_prefill"] = ladder
-        overrides["cuda_graph_max_bs_prefill"] = max(ladder)
-
-    def customize_server_args(self, server_args: Any) -> None:
-        self.context_length = int(server_args.context_length)
 
     def setup_model_resources(
         self,

--- a/sglang_omni/models/arkasr/engine_builder.py
+++ b/sglang_omni/models/arkasr/engine_builder.py
@@ -140,8 +140,8 @@ class ArkasrEngineBuilder(AsrEngineBuilder):
         if "cuda_graph_bs_prefill" in overrides:
             return
 
-        # SGLang clamps prefill max_bs to context_length after merging
-        # explicit buckets, so derive a ladder that remains coherent.
+        # Note: (musclemuller) SGLang clamps prefill max_bs to context_length
+        # after merging explicit buckets, so derive a ladder that remains coherent.
         caps = [
             self.context_length,
             overrides["max_prefill_tokens"],

--- a/sglang_omni/models/arkasr/sglang_model.py
+++ b/sglang_omni/models/arkasr/sglang_model.py
@@ -66,6 +66,7 @@ class ArkasrForConditionalGeneration(nn.Module):
     def pad_input_ids(self, input_ids: List[int], mm_inputs: MultimodalInputs):
         return self.pattern.pad_input_tokens(input_ids, mm_inputs)
 
+    @torch.no_grad()
     def get_audio_feature(self, items: List[MultimodalDataItem]) -> torch.Tensor:
         """Encode cache-miss audio items in bounded sequential microbatches.
 

--- a/sglang_omni/models/qwen3_asr/engine_builder.py
+++ b/sglang_omni/models/qwen3_asr/engine_builder.py
@@ -23,7 +23,6 @@ from sglang_omni.platforms import current_platform
 from sglang_omni.scheduling.engine_factory import AsrEngineBuilder
 from sglang_omni.scheduling.generation_batch_policy import (
     CudaGraphBackend,
-    build_default_prefill_cuda_graph_bs,
     clamp_prefill_cuda_graph_max_bs,
     get_decode_cuda_graph_bs,
 )
@@ -314,12 +313,10 @@ class Qwen3ASREngineBuilder(AsrEngineBuilder):
             return
         if "cuda_graph_bs_prefill" in overrides:
             return
-        cap = clamp_prefill_cuda_graph_max_bs(
+        clamp_prefill_cuda_graph_max_bs(
             overrides,
             context_length=self.context_length,
         )
-        ladder = build_default_prefill_cuda_graph_bs(cap)
-        overrides["cuda_graph_bs_prefill"] = ladder
 
     def customize_server_args(self, server_args: Any) -> None:
         self.context_length = int(server_args.context_length)

--- a/sglang_omni/scheduling/engine_factory.py
+++ b/sglang_omni/scheduling/engine_factory.py
@@ -12,6 +12,7 @@ from typing import Any, ClassVar
 from sglang_omni.scheduling.generation_batch_policy import (
     CudaGraphBackend,
     build_generation_batch_overrides,
+    finalize_prefill_cuda_graph_buckets,
     get_prefill_cuda_graph_backend,
     nested_prefill_overrides,
     validate_generation_batch_policy,
@@ -21,14 +22,16 @@ from sglang_omni.utils.checkpoint import resolve_checkpoint as _resolve_checkpoi
 logger = logging.getLogger(__name__)
 
 
-def _operator_selected_prefill_graph_backend(
+def _operator_selected_prefill_graph_field(
     server_args_overrides: Mapping[str, Any] | None,
+    flat_name: str,
+    nested_name: str,
 ) -> bool:
     if not server_args_overrides:
         return False
-    if "cuda_graph_backend_prefill" in server_args_overrides:
+    if flat_name in server_args_overrides:
         return True
-    return "backend" in nested_prefill_overrides(server_args_overrides)
+    return nested_name in nested_prefill_overrides(server_args_overrides)
 
 
 def _normalize_context_length(value: Any, *, model_name: str) -> int:
@@ -117,14 +120,36 @@ class SGLangGenerationEngineBuilder(ABC):
             model_name=self.model_name,
         )
 
-        operator_selected_prefill_backend = _operator_selected_prefill_graph_backend(
-            server_args_overrides
+        operator_selected_prefill_backend = _operator_selected_prefill_graph_field(
+            server_args_overrides,
+            "cuda_graph_backend_prefill",
+            "backend",
+        )
+        operator_selected_prefill_buckets = _operator_selected_prefill_graph_field(
+            server_args_overrides,
+            "cuda_graph_bs_prefill",
+            "bs",
+        )
+        operator_selected_prefill_max_bs = _operator_selected_prefill_graph_field(
+            server_args_overrides,
+            "cuda_graph_max_bs_prefill",
+            "max_bs",
         )
         overrides = build_generation_batch_overrides(
             server_args_overrides=server_args_overrides,
             **self.generation_defaults(dtype=dtype),
         )
         self.adjust_overrides(overrides)
+        # Framework ladders are templates until ServerArgs resolves hardware-
+        # dependent token caps. Operator buckets remain explicit and immutable.
+        default_prefill_buckets = None
+        default_prefill_max_bs = None
+        if not operator_selected_prefill_buckets:
+            default_prefill_buckets = overrides.pop("cuda_graph_bs_prefill", None)
+            if not operator_selected_prefill_max_bs:
+                default_prefill_max_bs = overrides.pop(
+                    "cuda_graph_max_bs_prefill", None
+                )
         if "context_length" in overrides:
             if not self.supports_context_length_override:
                 raise ValueError(
@@ -161,6 +186,12 @@ class SGLangGenerationEngineBuilder(ABC):
             **overrides,
         )
         self.customize_server_args(server_args)
+        if not operator_selected_prefill_buckets:
+            finalize_prefill_cuda_graph_buckets(
+                server_args,
+                default_buckets=default_prefill_buckets,
+                default_max_bs=default_prefill_max_bs,
+            )
         self.validate_before_infrastructure(server_args)
 
         infra_kwargs = dict(self.infra_kwargs())

--- a/sglang_omni/scheduling/generation_batch_policy.py
+++ b/sglang_omni/scheduling/generation_batch_policy.py
@@ -70,6 +70,58 @@ def build_default_prefill_cuda_graph_bs(max_num_tokens: int) -> list[int]:
     return values
 
 
+def finalize_prefill_cuda_graph_buckets(
+    server_args: Any,
+    *,
+    default_buckets: Iterable[int] | None,
+    default_max_bs: int | None,
+) -> None:
+    """Materialize framework-owned buckets from resolved token limits."""
+    prefill = server_args.cuda_graph_config.prefill
+    if prefill.backend != CudaGraphBackend.BREAKABLE:
+        return
+
+    caps = [
+        default_max_bs,
+        prefill.max_bs,
+        getattr(server_args, "chunked_prefill_size", None),
+        getattr(server_args, "max_prefill_tokens", None),
+        getattr(server_args, "max_total_tokens", None),
+    ]
+    positive_caps = [
+        int(value) for value in caps if value is not None and int(value) > 0
+    ]
+    if not positive_caps:
+        raise ValueError(
+            "breakable prefill CUDA graphs require a resolved positive token cap"
+        )
+    cap = min(positive_caps)
+
+    if default_buckets is None:
+        buckets = build_default_prefill_cuda_graph_bs(cap)
+    else:
+        buckets = [int(value) for value in default_buckets if int(value) <= cap]
+        if not buckets or buckets[-1] != cap:
+            buckets.append(cap)
+
+    # ServerArgs has already parsed the phase config at this point. Keep its
+    # convenience fields and resolved config bag in sync for serialization and
+    # all downstream readers.
+    from sglang_omni.vendor.sglang.server_args import override_server_args
+
+    override_server_args(
+        server_args,
+        "sglang_omni.prefill_cuda_graph_buckets",
+        cuda_graph_bs_prefill=buckets,
+        cuda_graph_max_bs_prefill=cap,
+    )
+    prefill.bs = buckets
+    prefill.max_bs = cap
+    locked = set(server_args._cuda_graph_config_locked)
+    locked.update({("prefill", "bs"), ("prefill", "max_bs")})
+    object.__setattr__(server_args, "_cuda_graph_config_locked", locked)
+
+
 def clamp_prefill_cuda_graph_max_bs(
     overrides: dict[str, Any],
     *,

--- a/tests/unit_test/arkasr/test_pipeline.py
+++ b/tests/unit_test/arkasr/test_pipeline.py
@@ -10,12 +10,12 @@ import torch.nn as nn
 from sglang.srt.managers.schedule_batch import Modality, MultimodalDataItem
 from transformers import WhisperConfig
 
-import sglang_omni.model_runner.base as model_runner_base
 import sglang_omni.models.arkasr.engine_builder as arkasr_builder
 import sglang_omni.platforms as platforms
 import sglang_omni.scheduling.bootstrap as bootstrap
 import sglang_omni.scheduling.omni_scheduler as omni_scheduler
 import sglang_omni.scheduling.sglang_backend as sglang_backend
+import sglang_omni.utils.cuda_graph_batch_validator as cuda_graph_batch_validator
 from sglang_omni.models.arkasr import request_builders
 from sglang_omni.models.arkasr.audio_lengths import (
     arkasr_audio_token_lengths,
@@ -28,6 +28,10 @@ from sglang_omni.models.arkasr.request_builders import _build_suppressed_token_i
 from sglang_omni.models.arkasr.sglang_model import ArkasrForConditionalGeneration
 from sglang_omni.models.arkasr.stages import create_sglang_arkasr_executor
 from sglang_omni.models.registry import PIPELINE_CONFIG_REGISTRY
+from sglang_omni.scheduling.generation_batch_policy import (
+    build_default_prefill_cuda_graph_bs,
+    build_generation_batch_overrides,
+)
 
 
 def _tiny_config():
@@ -171,21 +175,98 @@ def test_arkasr_stage_default_enables_async_decode():
     assert signature.parameters["async_decode_min_batch_size"].default == 2
 
 
+def _make_engine_builder(
+    *,
+    context_length: int = 1636,
+) -> arkasr_builder.ArkasrEngineBuilder:
+    builder = arkasr_builder.ArkasrEngineBuilder(
+        max_running_requests=32,
+        encoder_max_batch_size=8,
+        max_new_tokens=256,
+        enable_async_decode=True,
+        async_decode_min_batch_size=2,
+        mem_fraction_static=None,
+        mm_embedding_cache_size_bytes=0,
+        enable_torch_compile=False,
+        mm_attention_backend="fa3",
+        request_build_max_workers=8,
+        request_build_max_pending=32,
+    )
+    builder.context_length = context_length
+    return builder
+
+
+def test_arkasr_prefill_graph_defaults() -> None:
+    builder = _make_engine_builder()
+    overrides = build_generation_batch_overrides(
+        **builder.generation_defaults(dtype="bfloat16"),
+    )
+
+    builder.adjust_overrides(overrides)
+
+    assert builder.supports_breakable_prefill_cuda_graph
+    assert overrides["cuda_graph_backend_prefill"] == "breakable"
+    assert overrides["cuda_graph_bs_prefill"] == (
+        build_default_prefill_cuda_graph_bs(builder.context_length)
+    )
+    assert overrides["cuda_graph_max_bs_prefill"] == builder.context_length
+
+
+def test_arkasr_prefill_graph_respects_effective_token_cap() -> None:
+    builder = _make_engine_builder()
+    overrides = build_generation_batch_overrides(
+        server_args_overrides={"context_length": 768, "max_total_tokens": 512},
+        **builder.generation_defaults(dtype="bfloat16"),
+    )
+
+    builder.adjust_overrides(overrides)
+
+    assert builder.context_length == 768
+    assert overrides["cuda_graph_bs_prefill"] == (
+        build_default_prefill_cuda_graph_bs(512)
+    )
+    assert overrides["cuda_graph_max_bs_prefill"] == 512
+
+
+def test_arkasr_prefill_graph_honors_explicit_buckets() -> None:
+    builder = _make_engine_builder()
+    overrides = build_generation_batch_overrides(
+        server_args_overrides={"cuda_graph_bs_prefill": [64, 128]},
+        **builder.generation_defaults(dtype="bfloat16"),
+    )
+
+    builder.adjust_overrides(overrides)
+
+    assert overrides["cuda_graph_bs_prefill"] == [64, 128]
+    assert overrides["cuda_graph_max_bs_prefill"] == 128
+
+
+def test_arkasr_prefill_graph_can_be_disabled() -> None:
+    builder = _make_engine_builder()
+    overrides = build_generation_batch_overrides(
+        server_args_overrides={"disable_prefill_cuda_graph": True},
+        **builder.generation_defaults(dtype="bfloat16"),
+    )
+
+    builder.adjust_overrides(overrides)
+
+    assert overrides["cuda_graph_backend_prefill"] == "disabled"
+    assert "cuda_graph_bs_prefill" not in overrides
+    assert "cuda_graph_max_bs_prefill" not in overrides
+
+
 def _stub_arkasr_engine_build(
     monkeypatch: pytest.MonkeyPatch,
     *,
     want_cuda_graph: bool,
     encoder_service: object,
 ) -> SimpleNamespace:
-    """Stub every out-of-process dependency of ArkasrEngineBuilder.build().
-
-    Returns the recorders the tests assert on. The worker stub stays minimal:
-    helper internals are already covered in
-    tests/unit_test/serve/test_sglang_bootstrap.py.
-    """
+    """Stub every out-of-process dependency of ArkasrEngineBuilder.build()."""
     graph_init_workers: list[object] = []
     adapter_kwargs: dict[str, object] = {}
     encoder_service_kwargs: dict[str, object] = {}
+    attest_calls: list[tuple[object, object]] = []
+    build_kwargs: dict[str, object] = {}
 
     encoder_batch_sizes: list[int] = []
     model_worker = SimpleNamespace(
@@ -243,14 +324,33 @@ def _stub_arkasr_engine_build(
     )
 
     def _fake_server_args_builder(model_path, context_length, **overrides):
+        del model_path
+        build_kwargs.update(overrides)
         server_args = SimpleNamespace(context_length=context_length, **overrides)
+        for name, default in (
+            ("attn_cp_size", 1),
+            ("dcp_size", 1),
+            ("lora_paths", None),
+            ("enable_lora", None),
+            ("moe_a2a_backend", "none"),
+        ):
+            setattr(server_args, name, getattr(server_args, name, default))
+        prefill_bs = overrides.get("cuda_graph_bs_prefill")
         server_args.cuda_graph_config = SimpleNamespace(
             decode=SimpleNamespace(
                 max_bs=overrides["cuda_graph_max_bs"],
                 bs=overrides["cuda_graph_bs"],
             ),
-            prefill=SimpleNamespace(backend="disabled", bs=None, max_bs=None),
+            prefill=SimpleNamespace(
+                backend=overrides.get("cuda_graph_backend_prefill", "disabled"),
+                bs=prefill_bs,
+                max_bs=overrides.get("cuda_graph_max_bs_prefill"),
+            ),
         )
+        server_args._cuda_graph_config_locked = {
+            ("prefill", "backend"),
+            ("prefill", "bs"),
+        }
         return server_args
 
     monkeypatch.setattr(
@@ -273,16 +373,28 @@ def _stub_arkasr_engine_build(
         lambda worker: graph_init_workers.append(worker),
     )
     monkeypatch.setattr(
-        model_runner_base,
-        "ModelRunner",
-        lambda *args, **kwargs: object(),
+        cuda_graph_batch_validator,
+        "attest_prefill_cuda_graphs",
+        lambda model_runner, server_args: attest_calls.append(
+            (model_runner, server_args)
+        ),
     )
     monkeypatch.setattr(sglang_backend, "SGLangOutputProcessor", lambda **k: object())
+    monkeypatch.setattr(
+        arkasr_builder.ArkasrEngineBuilder,
+        "make_model_runner",
+        lambda self, model_worker, output_proc: SimpleNamespace(
+            model_worker=model_worker,
+            output_proc=output_proc,
+        ),
+    )
     monkeypatch.setattr(omni_scheduler, "OmniScheduler", SimpleNamespace)
     return SimpleNamespace(
         graph_init_workers=graph_init_workers,
         adapter_kwargs=adapter_kwargs,
         encoder_service_kwargs=encoder_service_kwargs,
+        attest_calls=attest_calls,
+        build_kwargs=build_kwargs,
         infra_kwargs_seen=infra_kwargs_seen,
         encoder_batch_sizes=encoder_batch_sizes,
         model_worker=model_worker,
@@ -331,6 +443,16 @@ def test_arkasr_factory_triggers_deferred_cuda_graph_capture(
     assert (
         stub.infra_kwargs_seen["model_arch_override"]
         == "ArkasrForConditionalGeneration"
+    )
+    assert stub.infra_kwargs_seen["enable_prefill_input_embeds"] is True
+    assert stub.build_kwargs["cuda_graph_backend_prefill"] == "breakable"
+    assert stub.build_kwargs["cuda_graph_bs_prefill"] == (
+        build_default_prefill_cuda_graph_bs(scheduler.server_args.context_length)
+    )
+    assert stub.attest_calls == (
+        [(stub.model_worker.model_runner, scheduler.server_args)]
+        if want_cuda_graph
+        else []
     )
     assert stub.encoder_batch_sizes == [8]
     assert stub.encoder_service_kwargs["max_queue_size"] == 32

--- a/tests/unit_test/arkasr/test_pipeline.py
+++ b/tests/unit_test/arkasr/test_pipeline.py
@@ -211,21 +211,35 @@ def test_arkasr_prefill_graph_defaults() -> None:
     assert builder.supports_breakable_prefill_cuda_graph
     assert overrides["cuda_graph_backend_prefill"] == "breakable"
     assert overrides["cuda_graph_bs_prefill"] == (
-        build_default_prefill_cuda_graph_bs(builder.context_length)
+        build_default_prefill_cuda_graph_bs(4096)
     )
-    assert overrides["cuda_graph_max_bs_prefill"] == builder.context_length
+    assert overrides["cuda_graph_max_bs_prefill"] == 4096
 
 
-def test_arkasr_prefill_graph_respects_effective_token_cap() -> None:
+def test_arkasr_prefill_graph_allows_unset_chunked_prefill_size() -> None:
     builder = _make_engine_builder()
     overrides = build_generation_batch_overrides(
-        server_args_overrides={"context_length": 768, "max_total_tokens": 512},
+        server_args_overrides={"chunked_prefill_size": None},
         **builder.generation_defaults(dtype="bfloat16"),
     )
 
     builder.adjust_overrides(overrides)
 
-    assert builder.context_length == 768
+    assert overrides["cuda_graph_bs_prefill"] == (
+        build_default_prefill_cuda_graph_bs(4096)
+    )
+    assert overrides["cuda_graph_max_bs_prefill"] == 4096
+
+
+def test_arkasr_prefill_graph_respects_effective_token_cap() -> None:
+    builder = _make_engine_builder()
+    overrides = build_generation_batch_overrides(
+        server_args_overrides={"max_total_tokens": 512},
+        **builder.generation_defaults(dtype="bfloat16"),
+    )
+
+    builder.adjust_overrides(overrides)
+
     assert overrides["cuda_graph_bs_prefill"] == (
         build_default_prefill_cuda_graph_bs(512)
     )
@@ -451,8 +465,9 @@ def test_arkasr_factory_triggers_deferred_cuda_graph_capture(
     assert stub.infra_kwargs_seen["enable_prefill_input_embeds"] is True
     assert stub.build_kwargs["cuda_graph_backend_prefill"] == "breakable"
     assert stub.build_kwargs["cuda_graph_bs_prefill"] == (
-        build_default_prefill_cuda_graph_bs(scheduler.server_args.context_length)
+        build_default_prefill_cuda_graph_bs(4096)
     )
+    assert stub.build_kwargs["cuda_graph_max_bs_prefill"] == 4096
     assert stub.attest_calls == (
         [(stub.model_worker.model_runner, scheduler.server_args)]
         if want_cuda_graph

--- a/tests/unit_test/arkasr/test_pipeline.py
+++ b/tests/unit_test/arkasr/test_pipeline.py
@@ -601,6 +601,16 @@ def test_ark_get_audio_feature_batched_matches_serial_and_uses_one_encoder_call(
     assert torch.allclose(batched, serial, atol=1e-5, rtol=1e-5)
 
 
+def test_ark_get_audio_feature_does_not_build_an_autograd_graph():
+    model = _tiny_ark_audio_mm_model()
+    item = _ark_audio_item(torch.randn(1, 8, 18), 18, hash_id=99)
+
+    output = model.get_audio_feature([item])
+
+    assert output.grad_fn is None
+    assert not output.requires_grad
+
+
 def test_ark_get_audio_feature_splits_large_batches_in_order():
     torch.manual_seed(4)
     model = _tiny_ark_audio_mm_model()

--- a/tests/unit_test/arkasr/test_pipeline.py
+++ b/tests/unit_test/arkasr/test_pipeline.py
@@ -10,12 +10,12 @@ import torch.nn as nn
 from sglang.srt.managers.schedule_batch import Modality, MultimodalDataItem
 from transformers import WhisperConfig
 
+import sglang_omni.model_runner.base as model_runner_base
 import sglang_omni.models.arkasr.engine_builder as arkasr_builder
 import sglang_omni.platforms as platforms
 import sglang_omni.scheduling.bootstrap as bootstrap
 import sglang_omni.scheduling.omni_scheduler as omni_scheduler
 import sglang_omni.scheduling.sglang_backend as sglang_backend
-import sglang_omni.utils.cuda_graph_batch_validator as cuda_graph_batch_validator
 from sglang_omni.models.arkasr import request_builders
 from sglang_omni.models.arkasr.audio_lengths import (
     arkasr_audio_token_lengths,
@@ -29,7 +29,6 @@ from sglang_omni.models.arkasr.sglang_model import ArkasrForConditionalGeneratio
 from sglang_omni.models.arkasr.stages import create_sglang_arkasr_executor
 from sglang_omni.models.registry import PIPELINE_CONFIG_REGISTRY
 from sglang_omni.scheduling.generation_batch_policy import (
-    build_default_prefill_cuda_graph_bs,
     build_generation_batch_overrides,
 )
 
@@ -175,10 +174,7 @@ def test_arkasr_stage_default_enables_async_decode():
     assert signature.parameters["async_decode_min_batch_size"].default == 2
 
 
-def _make_engine_builder(
-    *,
-    context_length: int = 1636,
-) -> arkasr_builder.ArkasrEngineBuilder:
+def test_arkasr_prefill_graph_allows_unset_chunked_prefill_size() -> None:
     builder = arkasr_builder.ArkasrEngineBuilder(
         max_running_requests=32,
         encoder_max_batch_size=8,
@@ -196,28 +192,6 @@ def _make_engine_builder(
         prefill_coalesce_when_idle=True,
         prefill_coalesce_requires_pending_builds=True,
     )
-    builder.context_length = context_length
-    return builder
-
-
-def test_arkasr_prefill_graph_defaults() -> None:
-    builder = _make_engine_builder()
-    overrides = build_generation_batch_overrides(
-        **builder.generation_defaults(dtype="bfloat16"),
-    )
-
-    builder.adjust_overrides(overrides)
-
-    assert builder.supports_breakable_prefill_cuda_graph
-    assert overrides["cuda_graph_backend_prefill"] == "breakable"
-    assert overrides["cuda_graph_bs_prefill"] == (
-        build_default_prefill_cuda_graph_bs(4096)
-    )
-    assert overrides["cuda_graph_max_bs_prefill"] == 4096
-
-
-def test_arkasr_prefill_graph_allows_unset_chunked_prefill_size() -> None:
-    builder = _make_engine_builder()
     overrides = build_generation_batch_overrides(
         server_args_overrides={"chunked_prefill_size": None},
         **builder.generation_defaults(dtype="bfloat16"),
@@ -225,52 +199,8 @@ def test_arkasr_prefill_graph_allows_unset_chunked_prefill_size() -> None:
 
     builder.adjust_overrides(overrides)
 
-    assert overrides["cuda_graph_bs_prefill"] == (
-        build_default_prefill_cuda_graph_bs(4096)
-    )
-    assert overrides["cuda_graph_max_bs_prefill"] == 4096
-
-
-def test_arkasr_prefill_graph_respects_effective_token_cap() -> None:
-    builder = _make_engine_builder()
-    overrides = build_generation_batch_overrides(
-        server_args_overrides={"max_total_tokens": 512},
-        **builder.generation_defaults(dtype="bfloat16"),
-    )
-
-    builder.adjust_overrides(overrides)
-
-    assert overrides["cuda_graph_bs_prefill"] == (
-        build_default_prefill_cuda_graph_bs(512)
-    )
-    assert overrides["cuda_graph_max_bs_prefill"] == 512
-
-
-def test_arkasr_prefill_graph_honors_explicit_buckets() -> None:
-    builder = _make_engine_builder()
-    overrides = build_generation_batch_overrides(
-        server_args_overrides={"cuda_graph_bs_prefill": [64, 128]},
-        **builder.generation_defaults(dtype="bfloat16"),
-    )
-
-    builder.adjust_overrides(overrides)
-
-    assert overrides["cuda_graph_bs_prefill"] == [64, 128]
-    assert overrides["cuda_graph_max_bs_prefill"] == 128
-
-
-def test_arkasr_prefill_graph_can_be_disabled() -> None:
-    builder = _make_engine_builder()
-    overrides = build_generation_batch_overrides(
-        server_args_overrides={"disable_prefill_cuda_graph": True},
-        **builder.generation_defaults(dtype="bfloat16"),
-    )
-
-    builder.adjust_overrides(overrides)
-
-    assert overrides["cuda_graph_backend_prefill"] == "disabled"
-    assert "cuda_graph_bs_prefill" not in overrides
-    assert "cuda_graph_max_bs_prefill" not in overrides
+    assert overrides["cuda_graph_backend_prefill"] == "breakable"
+    assert overrides["cuda_graph_bs_prefill"][-1] == overrides["max_prefill_tokens"]
 
 
 def _stub_arkasr_engine_build(
@@ -279,12 +209,15 @@ def _stub_arkasr_engine_build(
     want_cuda_graph: bool,
     encoder_service: object,
 ) -> SimpleNamespace:
-    """Stub every out-of-process dependency of ArkasrEngineBuilder.build()."""
+    """Stub every out-of-process dependency of ArkasrEngineBuilder.build().
+
+    Returns the recorders the tests assert on. The worker stub stays minimal:
+    helper internals are already covered in
+    tests/unit_test/serve/test_sglang_bootstrap.py.
+    """
     graph_init_workers: list[object] = []
     adapter_kwargs: dict[str, object] = {}
     encoder_service_kwargs: dict[str, object] = {}
-    attest_calls: list[tuple[object, object]] = []
-    build_kwargs: dict[str, object] = {}
 
     encoder_batch_sizes: list[int] = []
     model_worker = SimpleNamespace(
@@ -342,33 +275,14 @@ def _stub_arkasr_engine_build(
     )
 
     def _fake_server_args_builder(model_path, context_length, **overrides):
-        del model_path
-        build_kwargs.update(overrides)
         server_args = SimpleNamespace(context_length=context_length, **overrides)
-        for name, default in (
-            ("attn_cp_size", 1),
-            ("dcp_size", 1),
-            ("lora_paths", None),
-            ("enable_lora", None),
-            ("moe_a2a_backend", "none"),
-        ):
-            setattr(server_args, name, getattr(server_args, name, default))
-        prefill_bs = overrides.get("cuda_graph_bs_prefill")
         server_args.cuda_graph_config = SimpleNamespace(
             decode=SimpleNamespace(
                 max_bs=overrides["cuda_graph_max_bs"],
                 bs=overrides["cuda_graph_bs"],
             ),
-            prefill=SimpleNamespace(
-                backend=overrides.get("cuda_graph_backend_prefill", "disabled"),
-                bs=prefill_bs,
-                max_bs=overrides.get("cuda_graph_max_bs_prefill"),
-            ),
+            prefill=SimpleNamespace(backend="disabled", bs=None, max_bs=None),
         )
-        server_args._cuda_graph_config_locked = {
-            ("prefill", "backend"),
-            ("prefill", "bs"),
-        }
         return server_args
 
     monkeypatch.setattr(
@@ -391,28 +305,16 @@ def _stub_arkasr_engine_build(
         lambda worker: graph_init_workers.append(worker),
     )
     monkeypatch.setattr(
-        cuda_graph_batch_validator,
-        "attest_prefill_cuda_graphs",
-        lambda model_runner, server_args: attest_calls.append(
-            (model_runner, server_args)
-        ),
+        model_runner_base,
+        "ModelRunner",
+        lambda *args, **kwargs: object(),
     )
     monkeypatch.setattr(sglang_backend, "SGLangOutputProcessor", lambda **k: object())
-    monkeypatch.setattr(
-        arkasr_builder.ArkasrEngineBuilder,
-        "make_model_runner",
-        lambda self, model_worker, output_proc: SimpleNamespace(
-            model_worker=model_worker,
-            output_proc=output_proc,
-        ),
-    )
     monkeypatch.setattr(omni_scheduler, "OmniScheduler", SimpleNamespace)
     return SimpleNamespace(
         graph_init_workers=graph_init_workers,
         adapter_kwargs=adapter_kwargs,
         encoder_service_kwargs=encoder_service_kwargs,
-        attest_calls=attest_calls,
-        build_kwargs=build_kwargs,
         infra_kwargs_seen=infra_kwargs_seen,
         encoder_batch_sizes=encoder_batch_sizes,
         model_worker=model_worker,
@@ -461,17 +363,6 @@ def test_arkasr_factory_triggers_deferred_cuda_graph_capture(
     assert (
         stub.infra_kwargs_seen["model_arch_override"]
         == "ArkasrForConditionalGeneration"
-    )
-    assert stub.infra_kwargs_seen["enable_prefill_input_embeds"] is True
-    assert stub.build_kwargs["cuda_graph_backend_prefill"] == "breakable"
-    assert stub.build_kwargs["cuda_graph_bs_prefill"] == (
-        build_default_prefill_cuda_graph_bs(4096)
-    )
-    assert stub.build_kwargs["cuda_graph_max_bs_prefill"] == 4096
-    assert stub.attest_calls == (
-        [(stub.model_worker.model_runner, scheduler.server_args)]
-        if want_cuda_graph
-        else []
     )
     assert stub.encoder_batch_sizes == [8]
     assert stub.encoder_service_kwargs["max_queue_size"] == 32

--- a/tests/unit_test/arkasr/test_pipeline.py
+++ b/tests/unit_test/arkasr/test_pipeline.py
@@ -28,9 +28,6 @@ from sglang_omni.models.arkasr.request_builders import _build_suppressed_token_i
 from sglang_omni.models.arkasr.sglang_model import ArkasrForConditionalGeneration
 from sglang_omni.models.arkasr.stages import create_sglang_arkasr_executor
 from sglang_omni.models.registry import PIPELINE_CONFIG_REGISTRY
-from sglang_omni.scheduling.generation_batch_policy import (
-    build_generation_batch_overrides,
-)
 
 
 def _tiny_config():
@@ -174,40 +171,12 @@ def test_arkasr_stage_default_enables_async_decode():
     assert signature.parameters["async_decode_min_batch_size"].default == 2
 
 
-def test_arkasr_prefill_graph_allows_unset_chunked_prefill_size() -> None:
-    builder = arkasr_builder.ArkasrEngineBuilder(
-        max_running_requests=32,
-        encoder_max_batch_size=8,
-        max_new_tokens=256,
-        enable_async_decode=True,
-        async_decode_min_batch_size=2,
-        mem_fraction_static=None,
-        mm_embedding_cache_size_bytes=0,
-        enable_torch_compile=False,
-        mm_attention_backend="fa3",
-        request_build_max_workers=8,
-        request_build_max_pending=32,
-        prefill_coalesce_requests=16,
-        prefill_coalesce_wait_ms=32.0,
-        prefill_coalesce_when_idle=True,
-        prefill_coalesce_requires_pending_builds=True,
-    )
-    overrides = build_generation_batch_overrides(
-        server_args_overrides={"chunked_prefill_size": None},
-        **builder.generation_defaults(dtype="bfloat16"),
-    )
-
-    builder.adjust_overrides(overrides)
-
-    assert overrides["cuda_graph_backend_prefill"] == "breakable"
-    assert overrides["cuda_graph_bs_prefill"][-1] == overrides["max_prefill_tokens"]
-
-
 def _stub_arkasr_engine_build(
     monkeypatch: pytest.MonkeyPatch,
     *,
     want_cuda_graph: bool,
     encoder_service: object,
+    resolved_chunked_prefill_size: int | None = None,
 ) -> SimpleNamespace:
     """Stub every out-of-process dependency of ArkasrEngineBuilder.build().
 
@@ -275,14 +244,44 @@ def _stub_arkasr_engine_build(
     )
 
     def _fake_server_args_builder(model_path, context_length, **overrides):
-        server_args = SimpleNamespace(context_length=context_length, **overrides)
+        flat = dict(overrides)
+        if resolved_chunked_prefill_size is not None:
+            flat["chunked_prefill_size"] = resolved_chunked_prefill_size
+        for name, default in (
+            ("attn_cp_size", 1),
+            ("dcp_size", 1),
+            ("lora_paths", None),
+            ("enable_lora", None),
+            ("moe_a2a_backend", "none"),
+        ):
+            flat.setdefault(name, default)
+        server_args = SimpleNamespace(context_length=context_length, **flat)
+        prefill_backend = (
+            overrides.get("cuda_graph_backend_prefill", "disabled")
+            if resolved_chunked_prefill_size is not None
+            else "disabled"
+        )
+        prefill_bs = overrides.get("cuda_graph_bs_prefill")
         server_args.cuda_graph_config = SimpleNamespace(
             decode=SimpleNamespace(
                 max_bs=overrides["cuda_graph_max_bs"],
                 bs=overrides["cuda_graph_bs"],
             ),
-            prefill=SimpleNamespace(backend="disabled", bs=None, max_bs=None),
+            prefill=SimpleNamespace(
+                backend=prefill_backend,
+                bs=prefill_bs,
+                max_bs=overrides.get("cuda_graph_max_bs_prefill"),
+            ),
         )
+        server_args._cuda_graph_config_locked = {
+            ("prefill", field)
+            for field, key in (
+                ("backend", "cuda_graph_backend_prefill"),
+                ("bs", "cuda_graph_bs_prefill"),
+                ("max_bs", "cuda_graph_max_bs_prefill"),
+            )
+            if key in overrides
+        }
         return server_args
 
     monkeypatch.setattr(
@@ -319,6 +318,27 @@ def _stub_arkasr_engine_build(
         encoder_batch_sizes=encoder_batch_sizes,
         model_worker=model_worker,
     )
+
+
+def test_arkasr_prefill_graph_uses_resolved_auto_chunk_size(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    stub = _stub_arkasr_engine_build(
+        monkeypatch,
+        want_cuda_graph=False,
+        encoder_service=SimpleNamespace(close=lambda: None),
+        resolved_chunked_prefill_size=2048,
+    )
+
+    scheduler = create_sglang_arkasr_executor(
+        "AutoArk-AI/ARK-ASR-3B",
+        server_args_overrides={"chunked_prefill_size": None},
+    )
+
+    prefill = scheduler.server_args.cuda_graph_config.prefill
+    assert max(prefill.bs) == 2048
+    assert prefill.max_bs == 2048
+    assert stub.infra_kwargs_seen["enable_prefill_input_embeds"] is True
 
 
 @pytest.mark.parametrize("want_cuda_graph", [True, False])

--- a/tests/unit_test/arkasr/test_pipeline.py
+++ b/tests/unit_test/arkasr/test_pipeline.py
@@ -191,6 +191,10 @@ def _make_engine_builder(
         mm_attention_backend="fa3",
         request_build_max_workers=8,
         request_build_max_pending=32,
+        prefill_coalesce_requests=16,
+        prefill_coalesce_wait_ms=32.0,
+        prefill_coalesce_when_idle=True,
+        prefill_coalesce_requires_pending_builds=True,
     )
     builder.context_length = context_length
     return builder

--- a/tests/unit_test/fun_asr/test_pipeline.py
+++ b/tests/unit_test/fun_asr/test_pipeline.py
@@ -211,10 +211,9 @@ def test_fun_asr_threads_generation_batch_and_request_build_policy(monkeypatch) 
                 max_bs=overrides.get("cuda_graph_max_bs_prefill"),
             )
         )
-        server_args._cuda_graph_config_locked = {
-            ("prefill", "backend"),
-            ("prefill", "bs"),
-        }
+        server_args._cuda_graph_config_locked = {("prefill", "backend")}
+        if prefill_bs is not None:
+            server_args._cuda_graph_config_locked.add(("prefill", "bs"))
         return server_args
 
     model_worker = SimpleNamespace(
@@ -266,10 +265,15 @@ def test_fun_asr_threads_generation_batch_and_request_build_policy(monkeypatch) 
         64,
     ]
     assert build_kwargs["cuda_graph_backend_prefill"] == "breakable"
-    assert build_kwargs["cuda_graph_bs_prefill"] == build_default_prefill_cuda_graph_bs(
-        256
+    assert "cuda_graph_bs_prefill" not in build_kwargs
+    assert (
+        scheduler.server_args.cuda_graph_config.prefill.bs
+        == build_default_prefill_cuda_graph_bs(256)
     )
-    assert scheduler.server_args._cuda_graph_config_locked == {("prefill", "bs")}
+    assert scheduler.server_args._cuda_graph_config_locked == {
+        ("prefill", "bs"),
+        ("prefill", "max_bs"),
+    }
     assert infra_kwargs[-1]["enable_prefill_input_embeds"] is True
     assert validations == [
         {"model_name": "Fun-ASR", "server_args": scheduler.server_args}

--- a/tests/unit_test/higgs_tts/test_pipeline.py
+++ b/tests/unit_test/higgs_tts/test_pipeline.py
@@ -372,10 +372,11 @@ def test_higgs_tts_engine_default_enables_breakable_prefill_graphs(
     assert captured["overrides"]["max_running_requests"] == 64
     assert "cuda_graph_config" not in captured["overrides"]
     assert captured["overrides"]["cuda_graph_backend_prefill"] == "breakable"
-    assert captured["overrides"][
-        "cuda_graph_bs_prefill"
-    ] == build_default_prefill_cuda_graph_bs(512)
+    assert "cuda_graph_bs_prefill" not in captured["overrides"]
     assert captured["server_args"].cuda_graph_config.prefill.backend == "breakable"
+    assert captured[
+        "server_args"
+    ].cuda_graph_config.prefill.bs == build_default_prefill_cuda_graph_bs(512)
     assert ("prefill", "backend") not in captured[
         "server_args"
     ]._cuda_graph_config_locked

--- a/tests/unit_test/qwen3_asr/test_pipeline.py
+++ b/tests/unit_test/qwen3_asr/test_pipeline.py
@@ -3,7 +3,6 @@
 from __future__ import annotations
 
 import inspect
-import logging
 from pathlib import Path
 from types import SimpleNamespace
 
@@ -25,7 +24,6 @@ from sglang_omni.models.qwen3_asr.stages import create_sglang_qwen3_asr_executor
 from sglang_omni.models.registry import PIPELINE_CONFIG_REGISTRY
 from sglang_omni.scheduling.generation_batch_policy import (
     build_generation_batch_overrides,
-    validate_generation_batch_policy,
 )
 
 
@@ -55,6 +53,8 @@ def _fake_server_args_builder(build_kwargs: dict[str, object]):
             ("moe_a2a_backend", "none"),
         ):
             flat.setdefault(name, default)
+        if flat.get("chunked_prefill_size") is None:
+            flat["chunked_prefill_size"] = 2048
         server_args = SimpleNamespace(context_length=context_length, **flat)
         prefill_bs = overrides.get("cuda_graph_bs_prefill")
         server_args.cuda_graph_config = SimpleNamespace(
@@ -574,45 +574,6 @@ def test_qwen3_asr_threads_explicit_cuda_graph_bs(monkeypatch, caplog) -> None:
     ]
 
 
-@pytest.mark.parametrize(
-    ("context_length", "expected_cap"),
-    [
-        (1636, 1636),
-        (512, 512),
-        (8192, 4096),
-    ],
-)
-def test_prefill_ladder_never_exceeds_the_context_length(
-    context_length: int, expected_cap: int
-) -> None:
-    builder = _make_engine_builder(
-        mm_attention_backend="fa3", context_length=context_length
-    )
-    overrides = build_generation_batch_overrides(
-        **builder.generation_defaults(dtype="bfloat16")
-    )
-
-    builder.adjust_overrides(overrides)
-
-    assert max(overrides["cuda_graph_bs_prefill"]) == expected_cap
-
-
-def test_qwen3_asr_prefill_ladder_is_accepted_by_the_shared_policy(caplog) -> None:
-    builder = _make_engine_builder(mm_attention_backend="fa3")
-    overrides = build_generation_batch_overrides(
-        **builder.generation_defaults(dtype="bfloat16")
-    )
-    builder.adjust_overrides(overrides)
-    server_args = _fake_server_args_builder({})("dummy", 1636, **overrides)
-
-    with caplog.at_level(logging.WARNING):
-        validate_generation_batch_policy(
-            model_name="Qwen3-ASR", server_args=server_args
-        )
-
-    assert not any("padding factor" in record.message for record in caplog.records)
-
-
 def test_qwen3_asr_build_initializes_and_attests_prefill_graphs(monkeypatch) -> None:
     recorded = _patch_engine_dependencies(monkeypatch, want_cuda_graph=True)
 
@@ -628,6 +589,7 @@ def test_qwen3_asr_build_initializes_and_attests_prefill_graphs(monkeypatch) -> 
     [
         ({"context_length": 1000}, 1000),
         ({"chunked_prefill_size": 512}, 512),
+        ({"chunked_prefill_size": None}, 2048),
         ({"chunked_prefill_size": 0}, 4096),
         ({"max_prefill_tokens": 768}, 768),
         ({"cuda_graph_max_bs_prefill": 512}, 512),
@@ -636,7 +598,7 @@ def test_qwen3_asr_build_initializes_and_attests_prefill_graphs(monkeypatch) -> 
 )
 def test_qwen3_asr_ladder_respects_deployment_cap_overrides(
     monkeypatch: pytest.MonkeyPatch,
-    cap_override: dict[str, int],
+    cap_override: dict[str, int | None],
     expected_cap: int,
 ) -> None:
     recorded = _patch_engine_dependencies(monkeypatch, want_cuda_graph=True)

--- a/tests/unit_test/scheduling/test_prefill_graph_policy.py
+++ b/tests/unit_test/scheduling/test_prefill_graph_policy.py
@@ -12,6 +12,7 @@ import pytest
 from sglang_omni.scheduling.generation_batch_policy import (
     build_default_prefill_cuda_graph_bs,
     build_generation_batch_overrides,
+    finalize_prefill_cuda_graph_buckets,
     validate_generation_batch_policy,
 )
 from sglang_omni.vendor.sglang.server_args import override_server_args
@@ -170,6 +171,49 @@ def test_breakable_rejects_buckets_above_max_prefill_tokens() -> None:
                 max_prefill_tokens=16384,
             )
         )
+
+
+def test_framework_buckets_use_resolved_auto_chunk_size() -> None:
+    server_args = _server_args(
+        prefill_backend="breakable",
+        prefill_bs=build_default_prefill_cuda_graph_bs(4096),
+        prefill_max_bs=4096,
+        locked=frozenset({("prefill", "backend")}),
+        chunked_prefill_size=2048,
+        max_prefill_tokens=4096,
+    )
+
+    finalize_prefill_cuda_graph_buckets(
+        server_args,
+        default_buckets=None,
+        default_max_bs=4096,
+    )
+
+    assert max(server_args.cuda_graph_config.prefill.bs) == 2048
+    assert server_args.cuda_graph_config.prefill.max_bs == 2048
+    assert ("prefill", "bs") in server_args._cuda_graph_config_locked
+    _validate(server_args)
+
+
+def test_framework_bucket_template_is_trimmed_after_resolution() -> None:
+    server_args = _server_args(
+        prefill_backend="breakable",
+        prefill_bs=build_default_prefill_cuda_graph_bs(4096),
+        prefill_max_bs=4096,
+        locked=frozenset({("prefill", "backend")}),
+        chunked_prefill_size=2048,
+        max_prefill_tokens=4096,
+    )
+
+    finalize_prefill_cuda_graph_buckets(
+        server_args,
+        default_buckets=[1, 2, *build_default_prefill_cuda_graph_bs(4096)],
+        default_max_bs=4096,
+    )
+
+    assert server_args.cuda_graph_config.prefill.bs[:2] == [1, 2]
+    assert max(server_args.cuda_graph_config.prefill.bs) == 2048
+    _validate(server_args)
 
 
 @pytest.mark.parametrize(


### PR DESCRIPTION
## Summary

Stacked on #1528. Please merge #1528 first; until then, the follow-up change is the final commit `a14cfb53`.

Framework-owned prefill CUDA graph buckets were materialized before SGLang resolved nullable hardware-sized limits. On GPUs below 35 GiB, `chunked_prefill_size: null` resolves to 2048 after ARK-ASR/Qwen3-ASR had already locked a 4096 ladder, so Omni rejected startup before infrastructure creation.

This is a shared lifecycle issue rather than an ARK-only issue. MOSS-Transcribe also carries a framework-owned 4096 template; Fun-ASR and Higgs-TTS use smaller 256/512 templates but now follow the same resolved path.

## Fix

- Hold framework-owned prefill ladders as templates instead of passing them into `ServerArgs` as locked values.
- After `ServerArgs` finishes hardware auto-resolution, generate or trim the ladder against resolved `chunked_prefill_size`, `max_prefill_tokens`, `max_total_tokens`, and the declared framework cap.
- Keep operator-provided bucket lists untouched; contradictory explicit configurations still fail the existing validator.
- Keep the convenience fields, resolved phase config, and `_cuda_graph_config_locked` provenance synchronized.
- Replace the shallow ARK override test with a full builder regression that simulates `null -> 2048` and verifies infrastructure creation.

## Tests

- Red before fix: full ARK builder failed with `cuda_graph_bs_prefill buckets above chunked_prefill_size are unreachable (4096 > 2048)`.
- Core affected-policy selection: `46 passed`.
- Expanded engine factory / policy / ARK-ASR / Qwen3-ASR / Fun-ASR / MOSS-Transcribe selection: `142 passed`; its only stale raw-override assertion was updated to the resolved config seam and rerun separately: `1 passed`.
- Pre-commit hooks: passed.
- Higgs-TTS collection is not runnable in the local no-GPU Docker host because `sgl_kernel` requires `libcuda.so.1`; its existing assertion was updated to verify the final resolved 512-bucket bag and is left to accelerator CI.
