### PR TITLE
fix: guard trace_path_template.format() to prevent stage crash

### DIFF
--- a/sglang_omni/pipeline/stage/runtime.py
+++ b/sglang_omni/pipeline/stage/runtime.py
@@ -1789,12 +1789,20 @@ class Stage:
     def _on_profiler_start(self, msg: ProfilerStartMessage) -> None:
         run_id = msg.run_id
         if msg.enable_torch and not TorchProfiler.is_active():
-            base_tpl = msg.trace_path_template.format(run_id=run_id, stage=self.name)
-            template = f"{base_tpl}_pid{os.getpid()}"
-            prof_dir = os.environ.get("SGLANG_TORCH_PROFILER_DIR")
-            if prof_dir and not os.path.isabs(template):
-                template = os.path.join(prof_dir, template)
-            TorchProfiler.start(template, run_id=run_id)
+            try:
+                base_tpl = msg.trace_path_template.format(run_id=run_id, stage=self.name)
+                template = f"{base_tpl}_pid{os.getpid()}"
+                prof_dir = os.environ.get("SGLANG_TORCH_PROFILER_DIR")
+                if prof_dir and not os.path.isabs(template):
+                    template = os.path.join(prof_dir, template)
+                TorchProfiler.start(template, run_id=run_id)
+            except KeyError:
+                logger.warning(
+                    "Stage %s failed to start torch profiler: "
+                    "trace_path_template contains an unsupported placeholder. "
+                    "Supported placeholders are {run_id} and {stage}.",
+                    self.name,
+                )
         if msg.event_dir is not None:
             try:
                 _get_recorder().start(

--- a/sglang_omni/pipeline/stage/runtime.py
+++ b/sglang_omni/pipeline/stage/runtime.py
@@ -1791,18 +1791,19 @@ class Stage:
         if msg.enable_torch and not TorchProfiler.is_active():
             try:
                 base_tpl = msg.trace_path_template.format(run_id=run_id, stage=self.name)
+            except (AttributeError, IndexError, KeyError, ValueError):
+                logger.warning(
+                    "Stage %s failed to start torch profiler: "
+                    "trace_path_template is invalid or contains an unsupported placeholder. "
+                    "Supported placeholders are {run_id} and {stage}.",
+                    self.name,
+                )
+            else:
                 template = f"{base_tpl}_pid{os.getpid()}"
                 prof_dir = os.environ.get("SGLANG_TORCH_PROFILER_DIR")
                 if prof_dir and not os.path.isabs(template):
                     template = os.path.join(prof_dir, template)
                 TorchProfiler.start(template, run_id=run_id)
-            except KeyError:
-                logger.warning(
-                    "Stage %s failed to start torch profiler: "
-                    "trace_path_template contains an unsupported placeholder. "
-                    "Supported placeholders are {run_id} and {stage}.",
-                    self.name,
-                )
         if msg.event_dir is not None:
             try:
                 _get_recorder().start(

--- a/tests/unit_test/pipeline/test_stage.py
+++ b/tests/unit_test/pipeline/test_stage.py
@@ -6,6 +6,8 @@ import asyncio
 import logging
 import pickle
 import threading
+from types import SimpleNamespace
+from unittest.mock import Mock
 
 import pytest
 import torch
@@ -37,6 +39,28 @@ from tests.unit_test.fixtures.pipeline_fakes import (
     tensor_equal,
 )
 from tests.unit_test.pipeline.helpers import make_stage
+
+
+@pytest.mark.parametrize("template", [None, "{unknown}", "{", "{}"])
+def test_invalid_profiler_template_preserves_event_recording(monkeypatch, template):
+    profiler = Mock()
+    profiler.is_active.return_value = False
+    recorder = Mock()
+    monkeypatch.setattr(stage_runtime_module, "TorchProfiler", profiler)
+    monkeypatch.setattr(stage_runtime_module, "_get_recorder", lambda: recorder)
+    Stage._on_profiler_start(
+        SimpleNamespace(name="test-stage"),
+        SimpleNamespace(
+            run_id="run",
+            enable_torch=True,
+            trace_path_template=template,
+            event_dir="events",
+        ),
+    )
+    profiler.start.assert_not_called()
+    recorder.start.assert_called_once_with(
+        run_id="run", event_dir="events", stage="test-stage"
+    )
 
 
 @pytest.fixture(autouse=True)


### PR DESCRIPTION
## Motivation

POST /start_profile with an unsupported placeholder (e.g. `{pid}`) in `trace_path_template` raises `KeyError` inside `Stage._on_profiler_start`. This kills the stage process and the entire serving pipeline, contradicting the profiler's own documented discipline that "Profiling must never break serving".

## Fix

Wrap the TorchProfiler start path in `try/except KeyError` and log a warning, matching the existing pattern used by the event-recorder path directly below. The serving continues gracefully instead of crashing.

## Verification

- The reproduction case from #1913 now logs a warning instead of crashing
- Existing profiler functionality with valid placeholders is unchanged

## Related

Fixes #1913
