### PR TITLE
[Qwen3-TTS] Let the preprocessing stage run in its own process

### DIFF
--- a/docs/basic_usage/tts_process_topology.md
+++ b/docs/basic_usage/tts_process_topology.md
@@ -78,7 +78,9 @@ topology compilation, before any worker starts.
 Qwen3-TTS keeps prepared requests in process-local module state only while
 `preprocessing` and `tts_engine` share a process; placed in its own process the
 preprocessing stage loads a prompt frontend and ships the prepared prompt
-tensors through `typed_tensor` payload fields, so that edge can cross too.
+tensors through `tensor_cpu` payload fields, so that edge can cross too. The
+`tensor_cpu` codec keeps each tensor's own dtype and lets the relay carry it
+outside the control plane, which `typed_tensor` would not do.
 
 Ming-Omni-TTS carries preprocessing fields in `StagePayload.data` and serializes the reference encoder's `spk_emb` and `prompt_latent` tensors with the `typed_tensor` wire codec. Both `preprocessing -> reference_encode` and `reference_encode -> tts_engine` can therefore cross process boundaries.
 

--- a/docs/basic_usage/tts_process_topology.md
+++ b/docs/basic_usage/tts_process_topology.md
@@ -71,10 +71,14 @@ startup:
 Not every handoff tolerates a process boundary: some stages exchange state
 through process-local registries a second process cannot read (for example,
 MOSS-TTS pipelines hand prepared requests from preprocessing to the AR engine
-through a process-local queue, and Qwen3-TTS keeps prepared requests in
-process-local module state). Splitting such an edge fails at serving time
+through a process-local queue). Splitting such an edge fails at serving time
 rather than at config validation — keep those stages in one process as the
 shipped configs do.
+
+Qwen3-TTS keeps prepared requests in process-local module state only while
+`preprocessing` and `tts_engine` share a process; placed in its own process the
+preprocessing stage loads a prompt frontend and ships the prepared prompt
+tensors through `typed_tensor` payload fields, so that edge can cross too.
 
 Ming-Omni-TTS carries preprocessing fields in `StagePayload.data` and serializes the reference encoder's `spk_emb` and `prompt_latent` tensors with the `typed_tensor` wire codec. Both `preprocessing -> reference_encode` and `reference_encode -> tts_engine` can therefore cross process boundaries.
 

--- a/docs/basic_usage/tts_process_topology.md
+++ b/docs/basic_usage/tts_process_topology.md
@@ -71,9 +71,9 @@ startup:
 Not every handoff tolerates a process boundary: some stages exchange state
 through process-local registries a second process cannot read (for example,
 MOSS-TTS pipelines hand prepared requests from preprocessing to the AR engine
-through a process-local queue). Splitting such an edge fails at serving time
-rather than at config validation — keep those stages in one process as the
-shipped configs do.
+through a process-local queue). A model declares those edges through
+`PipelineConfig.process_local_edges`, and splitting one is refused during
+topology compilation, before any worker starts.
 
 Qwen3-TTS keeps prepared requests in process-local module state only while
 `preprocessing` and `tts_engine` share a process; placed in its own process the

--- a/docs/cookbook/qwen3_tts.md
+++ b/docs/cookbook/qwen3_tts.md
@@ -206,18 +206,20 @@ preprocessing (speech-tokenizer encode, speaker embedding, prompt embedding)
 then competes with the AR scheduler and the vocoder for the same interpreter,
 which caps single-replica throughput once concurrency passes ~32. Moving the
 preprocessing stage to its own process removes that contention: the stage
-loads a prompt-only frontend (embedding tables, text projection, speaker
-encoder, speech tokenizer, about 1 GB on a 1.7B checkpoint) and ships the
-prepared prompt tensors to the engine through the payload. Every GPU stage
-must then declare a memory fraction:
+loads a prompt-only frontend (embedding tables, text projection, predictor
+codec embeddings, speaker encoder) plus the speech tokenizer, together about
+2.2 GB of GPU memory for the extra process on a 1.7B checkpoint, and ships the
+prepared prompt tensors to the engine through the payload. Every GPU stage must
+then declare a memory fraction, and the engine's static fraction has to agree
+with the one it declares:
 
 ```bash
-sgl-omni serve --model-path Qwen/Qwen3-TTS-12Hz-1.7B-Base   --preprocessing.process tts_frontend --preprocessing.gpu 0   --preprocessing.gpu_memory_fraction 0.05   --tts_engine.gpu_memory_fraction 0.75 --vocoder.gpu_memory_fraction 0.12
+sgl-omni serve   --model-path Qwen/Qwen3-TTS-12Hz-1.7B-Base   --preprocessing.process tts_frontend   --preprocessing.gpu_memory_fraction 0.05   --tts_engine.gpu_memory_fraction 0.75   --tts_engine.engine.mem_fraction_static 0.75   --vocoder.gpu_memory_fraction 0.12
 ```
 
 `--vocoder.process vocoder` composes with it (lower `tts_engine` to 0.72 and
-give the vocoder 0.15). Outputs are identical to the single-process layout
-for the same seed; the extra process costs its CUDA context plus the frontend
+give the vocoder 0.15). Six SeedTTS samples at a fixed seed produced identical
+PCM in both layouts; the extra process costs its CUDA context plus the frontend
 weights.
 
 ## Synthesizing Speech

--- a/docs/cookbook/qwen3_tts.md
+++ b/docs/cookbook/qwen3_tts.md
@@ -217,6 +217,7 @@ with the one it declares:
 sgl-omni serve \
   --model-path Qwen/Qwen3-TTS-12Hz-1.7B-Base \
   --preprocessing.process tts_frontend \
+  --preprocessing.gpu 0 \
   --preprocessing.gpu_memory_fraction 0.05 \
   --tts_engine.gpu_memory_fraction 0.75 \
   --tts_engine.engine.mem_fraction_static 0.75 \

--- a/docs/cookbook/qwen3_tts.md
+++ b/docs/cookbook/qwen3_tts.md
@@ -199,6 +199,26 @@ the reduced decode occupancy can offset the prefill savings.
 Leave coalescing disabled for latency-sensitive traffic or workloads where the
 added wait does not produce enough additional batching.
 
+### Process topology
+
+By default all three stages share one process. Per-request reference
+preprocessing (speech-tokenizer encode, speaker embedding, prompt embedding)
+then competes with the AR scheduler and the vocoder for the same interpreter,
+which caps single-replica throughput once concurrency passes ~32. Moving the
+preprocessing stage to its own process removes that contention: the stage
+loads a prompt-only frontend (embedding tables, text projection, speaker
+encoder, speech tokenizer, about 1 GB on a 1.7B checkpoint) and ships the
+prepared prompt tensors to the engine through the payload. Every GPU stage
+must then declare a memory fraction:
+
+```bash
+sgl-omni serve --model-path Qwen/Qwen3-TTS-12Hz-1.7B-Base   --preprocessing.process tts_frontend --preprocessing.gpu 0   --preprocessing.gpu_memory_fraction 0.05   --tts_engine.gpu_memory_fraction 0.75 --vocoder.gpu_memory_fraction 0.12
+```
+
+`--vocoder.process vocoder` composes with it (lower `tts_engine` to 0.72 and
+give the vocoder 0.15). Outputs are identical to the single-process layout
+for the same seed; the extra process costs its CUDA context plus the frontend
+weights.
 
 ## Synthesizing Speech
 

--- a/docs/cookbook/qwen3_tts.md
+++ b/docs/cookbook/qwen3_tts.md
@@ -214,7 +214,13 @@ then declare a memory fraction, and the engine's static fraction has to agree
 with the one it declares:
 
 ```bash
-sgl-omni serve   --model-path Qwen/Qwen3-TTS-12Hz-1.7B-Base   --preprocessing.process tts_frontend   --preprocessing.gpu_memory_fraction 0.05   --tts_engine.gpu_memory_fraction 0.75   --tts_engine.engine.mem_fraction_static 0.75   --vocoder.gpu_memory_fraction 0.12
+sgl-omni serve \
+  --model-path Qwen/Qwen3-TTS-12Hz-1.7B-Base \
+  --preprocessing.process tts_frontend \
+  --preprocessing.gpu_memory_fraction 0.05 \
+  --tts_engine.gpu_memory_fraction 0.75 \
+  --tts_engine.engine.mem_fraction_static 0.75 \
+  --vocoder.gpu_memory_fraction 0.12
 ```
 
 `--vocoder.process vocoder` composes with it (lower `tts_engine` to 0.72 and

--- a/sglang_omni/models/qwen3_tts/config.py
+++ b/sglang_omni/models/qwen3_tts/config.py
@@ -39,13 +39,6 @@ class Qwen3TTSPipelineConfig(PipelineConfig):
         defaults = Qwen3TtsEngineBuilder().generation_defaults(dtype="bfloat16")
         return {k: defaults[k] for k in ("max_running_requests", "max_queued_requests")}
 
-    @classmethod
-    def process_local_edges(cls) -> frozenset[tuple[str, str]]:
-        # Note (Akazaakane): preprocessing stores prepared requests in the module-level
-        # _PREPROCESSING_CONTEXT/_PREPARED_REQUESTS registries that the AR engine
-        # builder reads in-process.
-        return frozenset({("preprocessing", "tts_engine")})
-
     model_path: str
     # note (0xtoward): Keep deterministic inference opt-in because it serializes
     # preprocessing and vocoder decoding and disables the vocoder CUDA graphs,
@@ -78,14 +71,23 @@ class Qwen3TTSPipelineConfig(PipelineConfig):
         ),
     ]
 
+    def preprocessing_in_own_process(self) -> bool:
+        stages = {stage.name: stage for stage in self.stages}
+        return stages["preprocessing"].process != stages["tts_engine"].process
+
     def stage_factory_kwargs(self, stage_name: str) -> dict[str, Any]:
+        kwargs: dict[str, Any] = {}
+        # Note (Jiaxin Deng): outside the engine process the preprocessing stage
+        # loads its own prompt frontend and ships prepared tensors in the payload.
+        if stage_name == "preprocessing" and self.preprocessing_in_own_process():
+            kwargs["load_frontend"] = True
         if not self.enable_deterministic_inference:
-            return {}
+            return kwargs
         # note (0xtoward): deterministic inference serializes preprocessing
         # and vocoder decoding and disables the vocoder CUDA graphs.
         # Applied at launch so an explicit factory.* value still wins.
         if stage_name == "preprocessing":
-            return {"max_concurrency": 1}
+            return {**kwargs, "max_concurrency": 1}
         if stage_name == "tts_engine":
             return {"server_args_overrides": {"enable_deterministic_inference": True}}
         if stage_name == "vocoder":
@@ -94,7 +96,7 @@ class Qwen3TTSPipelineConfig(PipelineConfig):
                 "initial_cuda_graph": False,
                 "followup_cuda_graph": False,
             }
-        return {}
+        return kwargs
 
     def requires_uploaded_voice_for_named_voice(self) -> bool:
         return _is_qwen3_tts_base_model(self.model_path)

--- a/sglang_omni/models/qwen3_tts/config.py
+++ b/sglang_omni/models/qwen3_tts/config.py
@@ -49,7 +49,10 @@ class Qwen3TTSPipelineConfig(PipelineConfig):
             name="preprocessing",
             process="pipeline",
             factory_path=f"{_PKG}.stages.create_preprocessing_executor",
-            gpu=0,
+            # Note (Jiaxin Deng): no gpu declaration here. Sharing the engine's
+            # process the stage holds no GPU budget of its own, and declaring one
+            # makes every layout that shares the card demand a fraction for it. A
+            # split frontend passes --preprocessing.gpu with its own fraction.
             next="tts_engine",
         ),
         EngineStageConfig(

--- a/sglang_omni/models/qwen3_tts/config.py
+++ b/sglang_omni/models/qwen3_tts/config.py
@@ -49,6 +49,7 @@ class Qwen3TTSPipelineConfig(PipelineConfig):
             name="preprocessing",
             process="pipeline",
             factory_path=f"{_PKG}.stages.create_preprocessing_executor",
+            gpu=0,
             next="tts_engine",
         ),
         EngineStageConfig(

--- a/sglang_omni/models/qwen3_tts/payload_types.py
+++ b/sglang_omni/models/qwen3_tts/payload_types.py
@@ -34,3 +34,11 @@ class Qwen3TTSState(DeclarativeStateBase):
     finish_reason: str | None = None
     ref_code_len: int = wire(0, emit="truthy", codec="int")
     audio_samples: Any | None = wire(None, codec="tensor_list")
+    # Note (Jiaxin Deng): set only by a preprocessing stage that runs outside the
+    # engine process; the AR request builder consumes and clears them.
+    prepared_prompt_embeds: Any | None = wire(None, codec="typed_tensor")
+    prepared_text_tail: Any | None = wire(None, codec="typed_tensor")
+    prepared_ref_code: Any | None = wire(None, codec="typed_tensor")
+    prepared_pad_embed: Any | None = wire(None, codec="typed_tensor")
+    prepared_input_ids: list[int] | None = None
+    prepared_gen_kwargs: dict[str, Any] | None = None

--- a/sglang_omni/models/qwen3_tts/payload_types.py
+++ b/sglang_omni/models/qwen3_tts/payload_types.py
@@ -35,10 +35,12 @@ class Qwen3TTSState(DeclarativeStateBase):
     ref_code_len: int = wire(0, emit="truthy", codec="int")
     audio_samples: Any | None = wire(None, codec="tensor_list")
     # Note (Jiaxin Deng): set only by a preprocessing stage that runs outside the
-    # engine process; the AR request builder consumes and clears them.
-    prepared_prompt_embeds: Any | None = wire(None, codec="typed_tensor")
-    prepared_text_tail: Any | None = wire(None, codec="typed_tensor")
-    prepared_ref_code: Any | None = wire(None, codec="typed_tensor")
-    prepared_pad_embed: Any | None = wire(None, codec="typed_tensor")
+    # engine process; the AR request builder consumes and clears them. tensor_cpu
+    # keeps them on the relay in their own dtype instead of widening bf16 to fp32
+    # and base64 into the control-plane message.
+    prepared_prompt_embeds: Any | None = wire(None, codec="tensor_cpu")
+    prepared_text_tail: Any | None = wire(None, codec="tensor_cpu")
+    prepared_ref_code: Any | None = wire(None, codec="tensor_cpu")
+    prepared_pad_embed: Any | None = wire(None, codec="tensor_cpu")
     prepared_input_ids: list[int] | None = None
     prepared_gen_kwargs: dict[str, Any] | None = None

--- a/sglang_omni/models/qwen3_tts/prompt_frontend.py
+++ b/sglang_omni/models/qwen3_tts/prompt_frontend.py
@@ -1,0 +1,175 @@
+# SPDX-License-Identifier: Apache-2.0
+"""Standalone Qwen3-TTS prompt frontend.
+
+Holds only what request preprocessing needs from the talker (embedding tables, the
+text projection, the predictor codec embeddings and the speaker encoder) so the
+preprocessing stage can run in its own process without the 1.7B transformer.
+"""
+
+from __future__ import annotations
+
+import json
+import os
+from collections.abc import Iterable, Iterator
+from typing import Any
+
+import torch
+from torch import nn
+
+from sglang_omni.models.qwen3_tts.compat import (
+    apply_qwen_tts_transformers_compatibility_patches,
+)
+from sglang_omni.models.qwen3_tts.sglang_model import Qwen3TTSPromptBuilderMixin
+
+_TALKER_PREFIX = "talker."
+_SPEAKER_ENCODER_PREFIX = "speaker_encoder."
+
+
+class _PromptProjection(nn.Module):
+    """Linear-SiLU-Linear with the talker checkpoint field names."""
+
+    def __init__(self, in_size: int, intermediate_size: int, out_size: int) -> None:
+        super().__init__()
+        self.linear_fc1 = nn.Linear(in_size, intermediate_size, bias=True)
+        self.act = nn.SiLU()
+        self.linear_fc2 = nn.Linear(intermediate_size, out_size, bias=True)
+
+    def forward(self, x: torch.Tensor) -> torch.Tensor:
+        return self.linear_fc2(self.act(self.linear_fc1(x)))
+
+
+class _PromptEmbeddings(nn.Module):
+    def __init__(self, config: Any) -> None:
+        super().__init__()
+        self.codec_embedding = nn.Embedding(config.vocab_size, config.hidden_size)
+        self.text_embedding = nn.Embedding(
+            config.text_vocab_size, config.text_hidden_size
+        )
+        # Note (Jiaxin Deng): the prompt builders only read this buffer's device
+        # and dtype; the talker's real feedback buffer lives in the engine.
+        self.register_buffer(
+            "_feedback_buffer", torch.zeros(1, config.hidden_size), persistent=False
+        )
+
+    def get_input_embeddings(self) -> nn.Embedding:
+        return self.codec_embedding
+
+    def get_text_embeddings(self) -> nn.Embedding:
+        return self.text_embedding
+
+
+class _PromptPredictorEmbeddings(nn.Module):
+    def __init__(self, config: Any) -> None:
+        super().__init__()
+        cp_config = config.code_predictor_config
+        self.model = nn.Module()
+        self.model.codec_embedding = nn.ModuleList(
+            [
+                nn.Embedding(cp_config.vocab_size, config.hidden_size)
+                for _ in range(config.num_code_groups - 1)
+            ]
+        )
+
+
+class Qwen3TTSPromptFrontend(Qwen3TTSPromptBuilderMixin, nn.Module):
+    """Talker-compatible prompt builder without the transformer stacks."""
+
+    def __init__(self, root_config: Any, *, device: Any, dtype: torch.dtype) -> None:
+        nn.Module.__init__(self)
+        config = root_config.talker_config
+        self.root_config = root_config
+        self.config = config
+        self.vocab_size = config.vocab_size
+        self.tts_model_type = getattr(root_config, "tts_model_type", "base")
+        self.speaker_encoder_sample_rate = getattr(
+            getattr(root_config, "speaker_encoder_config", None),
+            "sample_rate",
+            24000,
+        )
+        self.text_projection = _PromptProjection(
+            config.text_hidden_size, config.text_hidden_size, config.hidden_size
+        )
+        self.model = _PromptEmbeddings(config)
+        self.code_predictor = _PromptPredictorEmbeddings(config)
+        if self.tts_model_type == "base":
+            apply_qwen_tts_transformers_compatibility_patches()
+            from qwen_tts.core.models.modeling_qwen3_tts import Qwen3TTSSpeakerEncoder
+
+            self.speaker_encoder = Qwen3TTSSpeakerEncoder(
+                root_config.speaker_encoder_config
+            )
+        else:
+            self.speaker_encoder = None
+        self.speech_tokenizer = None
+        self.to(device=device, dtype=dtype)
+        self.requires_grad_(False)
+
+    def checkpoint_weight_names(self) -> set[str]:
+        names = set()
+        for name, _ in self.named_parameters():
+            if name.startswith(_SPEAKER_ENCODER_PREFIX):
+                names.add(name)
+            else:
+                names.add(_TALKER_PREFIX + name)
+        return names
+
+    def load_weights(self, weights: Iterable[tuple[str, torch.Tensor]]) -> None:
+        params = dict(self.named_parameters())
+        loaded: set[str] = set()
+        for name, tensor in weights:
+            if name.startswith(_TALKER_PREFIX):
+                target = name[len(_TALKER_PREFIX) :]
+            elif name.startswith(_SPEAKER_ENCODER_PREFIX):
+                target = name
+            else:
+                continue
+            param = params.get(target)
+            if param is None:
+                continue
+            param.data.copy_(tensor.to(device=param.device, dtype=param.dtype))
+            loaded.add(target)
+        missing = sorted(set(params) - loaded)
+        if missing:
+            raise RuntimeError(
+                f"Qwen3-TTS prompt frontend is missing {len(missing)} weights "
+                f"(e.g. {missing[:3]})"
+            )
+
+
+def iter_checkpoint_tensors(
+    checkpoint_dir: str, names: set[str]
+) -> Iterator[tuple[str, torch.Tensor]]:
+    """Yield only the named tensors from a safetensors checkpoint directory."""
+    from safetensors import safe_open
+
+    index_path = os.path.join(checkpoint_dir, "model.safetensors.index.json")
+    if os.path.exists(index_path):
+        with open(index_path, encoding="utf-8") as f:
+            weight_map = json.load(f)["weight_map"]
+        shards = sorted({weight_map[name] for name in names if name in weight_map})
+    else:
+        shards = sorted(
+            entry
+            for entry in os.listdir(checkpoint_dir)
+            if entry.endswith(".safetensors")
+        )
+    for shard in shards:
+        with safe_open(
+            os.path.join(checkpoint_dir, shard), framework="pt", device="cpu"
+        ) as handle:
+            for name in handle.keys():
+                if name in names:
+                    yield name, handle.get_tensor(name)
+
+
+def load_qwen3_tts_prompt_frontend(
+    checkpoint_dir: str, *, device: Any, dtype: torch.dtype
+) -> Qwen3TTSPromptFrontend:
+    from transformers import AutoConfig
+
+    root_config = AutoConfig.from_pretrained(checkpoint_dir)
+    frontend = Qwen3TTSPromptFrontend(root_config, device=device, dtype=dtype)
+    frontend.load_weights(
+        iter_checkpoint_tensors(checkpoint_dir, frontend.checkpoint_weight_names())
+    )
+    return frontend

--- a/sglang_omni/models/qwen3_tts/request_builders.py
+++ b/sglang_omni/models/qwen3_tts/request_builders.py
@@ -141,6 +141,9 @@ class Qwen3TTSPreparedRequest:
 class Qwen3TTSPreprocessingContext:
     model: Any
     wrapper: Any
+    # Note (Jiaxin Deng): True when preprocessing runs outside the engine process,
+    # so prepared tensors travel in the payload instead of the module registry.
+    standalone: bool = False
 
 
 _PREPROCESSING_CONTEXT: Qwen3TTSPreprocessingContext | None = None
@@ -151,7 +154,9 @@ _ADHOC_REFERENCE_SERVICE_ENTRY: (
 _PREPARED_REQUESTS_LOCK = threading.Lock()
 
 
-def set_qwen3_tts_preprocessing_context(*, model: Any, wrapper: Any) -> None:
+def set_qwen3_tts_preprocessing_context(
+    *, model: Any, wrapper: Any, standalone: bool = False
+) -> None:
     """Register model objects used by the preprocessing stage."""
 
     global _PREPROCESSING_CONTEXT
@@ -160,6 +165,7 @@ def set_qwen3_tts_preprocessing_context(*, model: Any, wrapper: Any) -> None:
         _PREPROCESSING_CONTEXT = Qwen3TTSPreprocessingContext(
             model=model,
             wrapper=wrapper,
+            standalone=standalone,
         )
         _PREPARED_REQUESTS.clear()
 
@@ -1186,6 +1192,8 @@ def preprocess_qwen3_tts_payload(
         wrapper=context.wrapper,
         default_stream_codec_output=default_stream_codec_output,
     )
+    if context.standalone:
+        return _store_prepared_qwen3_tts_payload(payload, prepared)
     with _PREPARED_REQUESTS_LOCK:
         _PREPARED_REQUESTS[payload.request_id] = prepared
 
@@ -1195,6 +1203,80 @@ def preprocess_qwen3_tts_payload(
         request_id=payload.request_id,
         request=payload.request,
         data=data,
+    )
+
+
+_PREPARED_PAYLOAD_TENSOR_FIELDS = (
+    "prepared_prompt_embeds",
+    "prepared_text_tail",
+    "prepared_ref_code",
+    "prepared_pad_embed",
+)
+_PREPARED_PAYLOAD_FIELDS = (
+    *_PREPARED_PAYLOAD_TENSOR_FIELDS,
+    "prepared_input_ids",
+    "prepared_gen_kwargs",
+)
+
+
+def _store_prepared_qwen3_tts_payload(
+    payload: StagePayload, prepared: Qwen3TTSPreparedRequest
+) -> StagePayload:
+    """Carry the prepared tensors in the payload for an engine in another process."""
+
+    state = prepared.state
+    state.prepared_prompt_embeds = prepared.prompt_input_embeds
+    state.prepared_text_tail = prepared.trailing_text_hidden
+    state.prepared_ref_code = prepared.ref_code
+    state.prepared_pad_embed = prepared.tts_pad_embed
+    state.prepared_input_ids = list(prepared.input_ids_list)
+    state.prepared_gen_kwargs = dict(prepared.gen_kwargs)
+    return StagePayload(
+        request_id=payload.request_id,
+        request=payload.request,
+        data=state.to_dict(),
+    )
+
+
+def _load_prepared_qwen3_tts_request(
+    payload: StagePayload, *, model: Any
+) -> Qwen3TTSPreparedRequest | None:
+    """Inverse of _store_prepared_qwen3_tts_payload; clears the fields it consumed."""
+
+    data = payload.data
+    if not isinstance(data, dict) or data.get("prepared_input_ids") is None:
+        return None
+    state = Qwen3TTSState.from_dict(data)
+    feedback_buffer = model.model._feedback_buffer
+    device, dtype = feedback_buffer.device, feedback_buffer.dtype
+    prompt_input_embeds = state.prepared_prompt_embeds.to(device=device, dtype=dtype)
+    trailing_text_hidden = state.prepared_text_tail.to(device=device, dtype=dtype)
+    ref_code = (
+        state.prepared_ref_code.to(device=device)
+        if state.prepared_ref_code is not None
+        else None
+    )
+    tts_pad_embed = state.prepared_pad_embed.to(device=device, dtype=dtype)
+    input_ids_list = [int(token) for token in state.prepared_input_ids]
+    gen_kwargs = dict(state.prepared_gen_kwargs or {})
+    for name in _PREPARED_PAYLOAD_FIELDS:
+        setattr(state, name, None)
+        data.pop(name, None)
+    for name in _PREPARED_PAYLOAD_TENSOR_FIELDS:
+        for suffix in ("_bytes", "_shape", "_dtype"):
+            data.pop(name + suffix, None)
+    return Qwen3TTSPreparedRequest(
+        state=state,
+        input_ids_list=input_ids_list,
+        input_ids=torch.tensor(input_ids_list, dtype=torch.long),
+        attention_mask=torch.ones(
+            (1, int(prompt_input_embeds.shape[0])), device=device, dtype=torch.long
+        ),
+        trailing_text_hidden=trailing_text_hidden,
+        ref_code=ref_code,
+        prompt_input_embeds=prompt_input_embeds,
+        tts_pad_embed=tts_pad_embed,
+        gen_kwargs=gen_kwargs,
     )
 
 
@@ -1210,6 +1292,8 @@ def build_sglang_qwen3_tts_request(
     from sglang.srt.sampling.sampling_params import SamplingParams
 
     prepared = pop_prepared_qwen3_tts_request(payload)
+    if prepared is None:
+        prepared = _load_prepared_qwen3_tts_request(payload, model=model)
     if prepared is None:
         raise RuntimeError(
             "Qwen3-TTS AR request builder requires a payload prepared by "

--- a/sglang_omni/models/qwen3_tts/request_builders.py
+++ b/sglang_omni/models/qwen3_tts/request_builders.py
@@ -1228,6 +1228,9 @@ def _store_prepared_qwen3_tts_payload(
     state.prepared_pad_embed = prepared.tts_pad_embed
     state.prepared_input_ids = list(prepared.input_ids_list)
     state.prepared_gen_kwargs = dict(prepared.gen_kwargs)
+    # Note (Jiaxin Deng): the reference clip is consumed here and read by nothing
+    # downstream, so it would otherwise ride every later hop as raw media.
+    state.ref_audio = None
     return StagePayload(
         request_id=payload.request_id,
         request=payload.request,

--- a/sglang_omni/models/qwen3_tts/request_builders.py
+++ b/sglang_omni/models/qwen3_tts/request_builders.py
@@ -1206,14 +1206,11 @@ def preprocess_qwen3_tts_payload(
     )
 
 
-_PREPARED_PAYLOAD_TENSOR_FIELDS = (
+_PREPARED_PAYLOAD_FIELDS = (
     "prepared_prompt_embeds",
     "prepared_text_tail",
     "prepared_ref_code",
     "prepared_pad_embed",
-)
-_PREPARED_PAYLOAD_FIELDS = (
-    *_PREPARED_PAYLOAD_TENSOR_FIELDS,
     "prepared_input_ids",
     "prepared_gen_kwargs",
 )
@@ -1252,7 +1249,7 @@ def _load_prepared_qwen3_tts_request(
     prompt_input_embeds = state.prepared_prompt_embeds.to(device=device, dtype=dtype)
     trailing_text_hidden = state.prepared_text_tail.to(device=device, dtype=dtype)
     ref_code = (
-        state.prepared_ref_code.to(device=device)
+        state.prepared_ref_code.to(device=device, dtype=torch.long)
         if state.prepared_ref_code is not None
         else None
     )
@@ -1262,9 +1259,6 @@ def _load_prepared_qwen3_tts_request(
     for name in _PREPARED_PAYLOAD_FIELDS:
         setattr(state, name, None)
         data.pop(name, None)
-    for name in _PREPARED_PAYLOAD_TENSOR_FIELDS:
-        for suffix in ("_bytes", "_shape", "_dtype"):
-            data.pop(name + suffix, None)
     return Qwen3TTSPreparedRequest(
         state=state,
         input_ids_list=input_ids_list,

--- a/sglang_omni/models/qwen3_tts/sglang_model.py
+++ b/sglang_omni/models/qwen3_tts/sglang_model.py
@@ -391,156 +391,13 @@ class Qwen3TTSCodePredictor(nn.Module):
         return self.small_to_mtp_projection(hidden_states)
 
 
-class Qwen3TTSTalker(nn.Module):
-    """Qwen3-TTS Base talker with SGLang-managed KV cache for the main AR loop."""
+class Qwen3TTSPromptBuilderMixin:
+    """Prompt construction shared by the talker and the standalone prompt frontend.
 
-    # The outer forward substitutes ForwardBatch.mrope_positions whenever they
-    # are present. Prefill CUDA graph runners capture the inner text model
-    # directly and use this marker to preserve that position contract.
-    is_mrope_enabled = True
-
-    def __init__(self, config: Any, quant_config: Any = None, prefix: str = "") -> None:
-        del quant_config
-        super().__init__()
-        if hasattr(config, "talker_config"):
-            root_config = config
-            config = config.talker_config
-        else:
-            root_config = None
-        self.root_config = root_config
-        self.config = config
-        self.vocab_size = config.vocab_size
-        self.tts_model_type = getattr(root_config, "tts_model_type", "base")
-        self.tokenizer_type = getattr(root_config, "tokenizer_type", "")
-        self.tts_model_size = getattr(root_config, "tts_model_size", "")
-        self.speaker_encoder_sample_rate = getattr(
-            getattr(root_config, "speaker_encoder_config", None),
-            "sample_rate",
-            24000,
-        )
-
-        self.text_projection = ResizeMLP(
-            config.text_hidden_size,
-            config.text_hidden_size,
-            config.hidden_size,
-            prefix=add_prefix("text_projection", prefix),
-        )
-        self.model = Qwen3TTSTalkerTextModel(config, prefix=add_prefix("model", prefix))
-        self.codec_head = ReplicatedLinear(
-            config.hidden_size,
-            config.vocab_size,
-            bias=False,
-            prefix=add_prefix("codec_head", prefix),
-        )
-        self.code_predictor = Qwen3TTSCodePredictor(
-            config,
-            prefix=add_prefix("code_predictor", prefix),
-        )
-
-        if root_config is not None and self.tts_model_type == "base":
-            apply_qwen_tts_transformers_compatibility_patches()
-            from qwen_tts.core.models.modeling_qwen3_tts import Qwen3TTSSpeakerEncoder
-
-            self.speaker_encoder = Qwen3TTSSpeakerEncoder(
-                root_config.speaker_encoder_config
-            )
-        else:
-            self.speaker_encoder = None
-        self.speech_tokenizer = None
-
-        server_args = get_global_server_args()
-        max_batch_size = server_args.max_running_requests
-        hidden_size = config.hidden_size
-        predictor_len = config.num_code_groups + 1
-        device = self.model.codec_embedding.weight.device
-        dtype = self.model.codec_embedding.weight.dtype
-        self._feedback_buffer = self.model._feedback_buffer
-        self._feedback_mask = self.model._feedback_mask
-        self._decode_feedback_embedding = self.model._decode_feedback_embedding
-        cp_layers = self.code_predictor.model.layers
-        cp_attn = cp_layers[0].self_attn
-        self._predictor_positions = torch.arange(
-            predictor_len, device=device, dtype=torch.long
-        )
-        self._predictor_position_rows = (
-            self._predictor_positions[:, None]
-            .expand(predictor_len, max_batch_size)
-            .contiguous()
-        )
-        self._predictor_k_cache = torch.zeros(
-            len(cp_layers),
-            max_batch_size,
-            cp_attn.num_kv_heads,
-            predictor_len,
-            cp_attn.head_dim,
-            device=device,
-            dtype=dtype,
-        )
-        self._predictor_v_cache = torch.zeros_like(self._predictor_k_cache)
-        self._sampled_token_ids = torch.zeros(
-            max_batch_size, dtype=torch.long, device=device
-        )
-        self._output_codes = torch.zeros(
-            max_batch_size,
-            config.num_code_groups,
-            dtype=torch.long,
-            device=device,
-        )
-        self._output_embeds = torch.zeros(
-            max_batch_size, hidden_size, device=device, dtype=dtype
-        )
-        self._predictor_embedding_buffer = torch.empty(
-            max_batch_size, hidden_size, device=device, dtype=dtype
-        )
-        self._sub_batch_size = 0
-        self._sub_sample_max_row_index = -1
-        self._sub_temperature_tensor = torch.full(
-            (max_batch_size,), 0.9, device=device, dtype=torch.float32
-        )
-        self._sub_top_p_tensor = torch.ones(
-            max_batch_size, device=device, dtype=torch.float32
-        )
-        self._sub_top_k_tensor = torch.full(
-            (max_batch_size,), 50, device=device, dtype=torch.long
-        )
-        self._semantic_sampling_seed_tensor = torch.zeros(
-            max_batch_size, device=device, dtype=torch.long
-        )
-        self._sub_sampling_seed_tensor = torch.zeros(
-            max_batch_size, device=device, dtype=torch.long
-        )
-        self._sub_do_sample_tensor = torch.zeros(
-            max_batch_size, device=device, dtype=torch.bool
-        )
-        self._sub_identity_row_indices_tensor = torch.arange(
-            max_batch_size, device=device, dtype=torch.long
-        )
-        self._sub_sample_row_indices_tensor = torch.zeros(
-            max_batch_size, device=device, dtype=torch.long
-        )
-        self._sub_sample_count = 0
-        self._sub_has_sampled_rows = False
-        self._sub_sampled_has_top_p = False
-        self._sub_sampled_max_top_k = 0
-        self._sub_sampled_has_unbounded_top_k = False
-        self._decode_prep_rids: list | None = None
-        self._predictor_graph_batch_sizes = self._normalize_predictor_graph_batch_sizes(
-            server_args,
-            max_batch_size=max_batch_size,
-        )
-        self._predictor_graphs: dict[tuple, _PredictorDecodeGraph] = {}
-        self._predictor_graph_disabled: set[tuple] = set()
-        # Note: (Jiaxin Deng) None = resolved at decode time; the bootstrap
-        # defers graph capture past init, so nothing is decided here.
-        self._predictor_graph_enabled: bool | None = None
-        self._predictor_graph_failure_count = 0
-        self._predictor_graph_capacity_fallback_count = 0
-        self._predictor_graph_capacity_warned = False
-        self._predictor_graph_capture_count = 0
-        self._predictor_graph_pool = None
-        _bind_default_weight_loaders(self)
-        self._cached_params_dict = dict(self.named_parameters())
-        self._sampler = None
+    Expects ``model`` (embedding tables and ``_feedback_buffer``), ``text_projection``,
+    ``code_predictor.model.codec_embedding``, ``speaker_encoder``, ``speech_tokenizer``,
+    ``config``/``root_config`` and ``speaker_encoder_sample_rate`` on the instance.
+    """
 
     @property
     def device(self) -> torch.device:
@@ -988,6 +845,158 @@ class Qwen3TTSTalker(nn.Module):
             [text_embed] + [tts_pad_embed] * (codec_lens - text_lens), dim=1
         )
         return text_embed + codec_embed, tts_pad_embed
+
+
+class Qwen3TTSTalker(Qwen3TTSPromptBuilderMixin, nn.Module):
+    """Qwen3-TTS Base talker with SGLang-managed KV cache for the main AR loop."""
+
+    # The outer forward substitutes ForwardBatch.mrope_positions whenever they
+    # are present. Prefill CUDA graph runners capture the inner text model
+    # directly and use this marker to preserve that position contract.
+    is_mrope_enabled = True
+
+    def __init__(self, config: Any, quant_config: Any = None, prefix: str = "") -> None:
+        del quant_config
+        super().__init__()
+        if hasattr(config, "talker_config"):
+            root_config = config
+            config = config.talker_config
+        else:
+            root_config = None
+        self.root_config = root_config
+        self.config = config
+        self.vocab_size = config.vocab_size
+        self.tts_model_type = getattr(root_config, "tts_model_type", "base")
+        self.tokenizer_type = getattr(root_config, "tokenizer_type", "")
+        self.tts_model_size = getattr(root_config, "tts_model_size", "")
+        self.speaker_encoder_sample_rate = getattr(
+            getattr(root_config, "speaker_encoder_config", None),
+            "sample_rate",
+            24000,
+        )
+
+        self.text_projection = ResizeMLP(
+            config.text_hidden_size,
+            config.text_hidden_size,
+            config.hidden_size,
+            prefix=add_prefix("text_projection", prefix),
+        )
+        self.model = Qwen3TTSTalkerTextModel(config, prefix=add_prefix("model", prefix))
+        self.codec_head = ReplicatedLinear(
+            config.hidden_size,
+            config.vocab_size,
+            bias=False,
+            prefix=add_prefix("codec_head", prefix),
+        )
+        self.code_predictor = Qwen3TTSCodePredictor(
+            config,
+            prefix=add_prefix("code_predictor", prefix),
+        )
+
+        if root_config is not None and self.tts_model_type == "base":
+            apply_qwen_tts_transformers_compatibility_patches()
+            from qwen_tts.core.models.modeling_qwen3_tts import Qwen3TTSSpeakerEncoder
+
+            self.speaker_encoder = Qwen3TTSSpeakerEncoder(
+                root_config.speaker_encoder_config
+            )
+        else:
+            self.speaker_encoder = None
+        self.speech_tokenizer = None
+
+        server_args = get_global_server_args()
+        max_batch_size = server_args.max_running_requests
+        hidden_size = config.hidden_size
+        predictor_len = config.num_code_groups + 1
+        device = self.model.codec_embedding.weight.device
+        dtype = self.model.codec_embedding.weight.dtype
+        self._feedback_buffer = self.model._feedback_buffer
+        self._feedback_mask = self.model._feedback_mask
+        self._decode_feedback_embedding = self.model._decode_feedback_embedding
+        cp_layers = self.code_predictor.model.layers
+        cp_attn = cp_layers[0].self_attn
+        self._predictor_positions = torch.arange(
+            predictor_len, device=device, dtype=torch.long
+        )
+        self._predictor_position_rows = (
+            self._predictor_positions[:, None]
+            .expand(predictor_len, max_batch_size)
+            .contiguous()
+        )
+        self._predictor_k_cache = torch.zeros(
+            len(cp_layers),
+            max_batch_size,
+            cp_attn.num_kv_heads,
+            predictor_len,
+            cp_attn.head_dim,
+            device=device,
+            dtype=dtype,
+        )
+        self._predictor_v_cache = torch.zeros_like(self._predictor_k_cache)
+        self._sampled_token_ids = torch.zeros(
+            max_batch_size, dtype=torch.long, device=device
+        )
+        self._output_codes = torch.zeros(
+            max_batch_size,
+            config.num_code_groups,
+            dtype=torch.long,
+            device=device,
+        )
+        self._output_embeds = torch.zeros(
+            max_batch_size, hidden_size, device=device, dtype=dtype
+        )
+        self._predictor_embedding_buffer = torch.empty(
+            max_batch_size, hidden_size, device=device, dtype=dtype
+        )
+        self._sub_batch_size = 0
+        self._sub_sample_max_row_index = -1
+        self._sub_temperature_tensor = torch.full(
+            (max_batch_size,), 0.9, device=device, dtype=torch.float32
+        )
+        self._sub_top_p_tensor = torch.ones(
+            max_batch_size, device=device, dtype=torch.float32
+        )
+        self._sub_top_k_tensor = torch.full(
+            (max_batch_size,), 50, device=device, dtype=torch.long
+        )
+        self._semantic_sampling_seed_tensor = torch.zeros(
+            max_batch_size, device=device, dtype=torch.long
+        )
+        self._sub_sampling_seed_tensor = torch.zeros(
+            max_batch_size, device=device, dtype=torch.long
+        )
+        self._sub_do_sample_tensor = torch.zeros(
+            max_batch_size, device=device, dtype=torch.bool
+        )
+        self._sub_identity_row_indices_tensor = torch.arange(
+            max_batch_size, device=device, dtype=torch.long
+        )
+        self._sub_sample_row_indices_tensor = torch.zeros(
+            max_batch_size, device=device, dtype=torch.long
+        )
+        self._sub_sample_count = 0
+        self._sub_has_sampled_rows = False
+        self._sub_sampled_has_top_p = False
+        self._sub_sampled_max_top_k = 0
+        self._sub_sampled_has_unbounded_top_k = False
+        self._decode_prep_rids: list | None = None
+        self._predictor_graph_batch_sizes = self._normalize_predictor_graph_batch_sizes(
+            server_args,
+            max_batch_size=max_batch_size,
+        )
+        self._predictor_graphs: dict[tuple, _PredictorDecodeGraph] = {}
+        self._predictor_graph_disabled: set[tuple] = set()
+        # Note: (Jiaxin Deng) None = resolved at decode time; the bootstrap
+        # defers graph capture past init, so nothing is decided here.
+        self._predictor_graph_enabled: bool | None = None
+        self._predictor_graph_failure_count = 0
+        self._predictor_graph_capacity_fallback_count = 0
+        self._predictor_graph_capacity_warned = False
+        self._predictor_graph_capture_count = 0
+        self._predictor_graph_pool = None
+        _bind_default_weight_loaders(self)
+        self._cached_params_dict = dict(self.named_parameters())
+        self._sampler = None
 
     def prepare_decode_buffers(self, requests: list[Any]) -> None:
         batch_size = len(requests)

--- a/sglang_omni/models/qwen3_tts/stages.py
+++ b/sglang_omni/models/qwen3_tts/stages.py
@@ -108,8 +108,20 @@ def create_preprocessing_executor(
     *,
     max_concurrency: int = 8,
     stream_codec_output: bool = True,
+    load_frontend: bool = False,
+    device: str | None = None,
+    gpu_id: int | None = None,
+    dtype: str = "bfloat16",
+    attn_implementation: str | None = None,
 ) -> ThreadedSimpleScheduler:
-    del model_path
+    if load_frontend:
+        _load_standalone_preprocessing_context(
+            model_path,
+            device=device,
+            gpu_id=gpu_id,
+            dtype=dtype,
+            attn_implementation=attn_implementation,
+        )
     # note (luojiaxuan): preprocessing must admit several requests at once. A
     # serial executor keeps at most one reference-code request in flight, so
     # the speech-tokenizer batcher would only ever see batches of one; the
@@ -121,6 +133,56 @@ def create_preprocessing_executor(
         ),
         max_concurrency=max_concurrency,
         abort_callback=cleanup_prepared_qwen3_tts_request,
+    )
+
+
+def _load_standalone_preprocessing_context(
+    model_path: str,
+    *,
+    device: str | None,
+    gpu_id: int | None,
+    dtype: str,
+    attn_implementation: str | None,
+) -> None:
+    """Load the prompt frontend for a preprocessing stage outside the engine process."""
+    from transformers import AutoProcessor
+
+    from sglang_omni.models.qwen3_tts import request_builders
+    from sglang_omni.models.qwen3_tts.prompt_frontend import (
+        load_qwen3_tts_prompt_frontend,
+    )
+
+    _register_qwen3_tts_hf_config()
+    try:
+        from qwen_tts import Qwen3TTSModel
+    except ImportError as exc:
+        raise RuntimeError(_QWEN_TTS_INSTALL_HINT) from exc
+
+    checkpoint_dir = _resolve_checkpoint(model_path)
+    if gpu_id is not None:
+        device = f"cuda:{gpu_id}"
+    device = resolve_device_spec(device or "cuda")
+    torch_dtype = getattr(torch, dtype) if isinstance(dtype, str) else dtype
+    logger.info(f"Loading Qwen3-TTS prompt frontend from {checkpoint_dir} on {device}")
+    frontend = load_qwen3_tts_prompt_frontend(
+        checkpoint_dir, device=device, dtype=torch_dtype
+    )
+    frontend.load_speech_tokenizer(
+        _load_qwen3_tts_tokenizer(
+            checkpoint_dir,
+            device=device,
+            dtype=dtype,
+            attn_implementation=attn_implementation,
+        )
+    )
+    processor = AutoProcessor.from_pretrained(checkpoint_dir, fix_mistral_regex=True)
+    wrapper = Qwen3TTSModel(
+        model=frontend,
+        processor=processor,
+        generate_defaults=_load_qwen3_tts_generate_defaults(checkpoint_dir),
+    )
+    request_builders.set_qwen3_tts_preprocessing_context(
+        model=frontend, wrapper=wrapper, standalone=True
     )
 
 

--- a/sglang_omni/models/qwen3_tts/stages.py
+++ b/sglang_omni/models/qwen3_tts/stages.py
@@ -159,9 +159,7 @@ def _load_standalone_preprocessing_context(
         raise RuntimeError(_QWEN_TTS_INSTALL_HINT) from exc
 
     checkpoint_dir = _resolve_checkpoint(model_path)
-    if gpu_id is not None:
-        device = f"cuda:{gpu_id}"
-    device = resolve_device_spec(device or "cuda")
+    device = resolve_device_spec(device, gpu_id)
     torch_dtype = getattr(torch, dtype) if isinstance(dtype, str) else dtype
     logger.info(f"Loading Qwen3-TTS prompt frontend from {checkpoint_dir} on {device}")
     frontend = load_qwen3_tts_prompt_frontend(

--- a/tests/unit_test/qwen3_tts/test_pipeline.py
+++ b/tests/unit_test/qwen3_tts/test_pipeline.py
@@ -267,7 +267,7 @@ def test_qwen3_tts_config_and_registry_contracts() -> None:
     ]
     assert config.stages[1].factory_path.endswith("create_sglang_tts_engine_executor")
     assert config.terminal_stages == ["vocoder"]
-    assert config.gpu_placement == {"preprocessing": 0, "tts_engine": 0, "vocoder": 0}
+    assert config.gpu_placement == {"tts_engine": 0, "vocoder": 0}
     assert config.stages[1].factory.device is None
     assert config.stages[2].factory.device is None
     assert {stage.process for stage in config.stages} == {"pipeline"}
@@ -5941,8 +5941,9 @@ def test_qwen3_tts_config_loads_frontend_only_outside_engine_process() -> None:
     assert config.stage_factory_kwargs("preprocessing") == {}
 
     split = config.model_copy(deep=True)
+    # A split frontend declares its own gpu, the way the documented recipe does.
     split.stages[0] = split.stages[0].model_copy(
-        update={"process": "tts_frontend", "gpu_memory_fraction": 0.05}
+        update={"process": "tts_frontend", "gpu": 0, "gpu_memory_fraction": 0.05}
     )
     split.stages[1] = split.stages[1].model_copy(update={"gpu_memory_fraction": 0.75})
     split.stages[2] = split.stages[2].model_copy(update={"gpu_memory_fraction": 0.12})
@@ -5966,6 +5967,22 @@ def test_qwen3_tts_config_loads_frontend_only_outside_engine_process() -> None:
         "load_frontend": True,
         "max_concurrency": 1,
     }
+
+
+def test_qwen3_tts_shared_gpu_layout_demands_no_preprocessing_fraction() -> None:
+    """Sharing the engine's process, preprocessing has no GPU budget to declare.
+
+    Declaring one would make every layout that puts a second process group on the
+    card refuse to start until preprocessing is given a fraction it does not use.
+    """
+    from sglang_omni.config.placement import build_stage_placement_plan
+
+    config = Qwen3TTSPipelineConfig(model_path="model")
+    shared = config.model_copy(deep=True)
+    shared.stages[2] = shared.stages[2].model_copy(update={"process": "vocoder"})
+
+    placement = build_stage_placement_plan(shared)
+    assert placement.gpus[0].missing_fraction_stage_names == ("tts_engine", "vocoder")
 
 
 def test_qwen3_tts_prompt_frontend_builds_a_custom_voice_prompt() -> None:

--- a/tests/unit_test/qwen3_tts/test_pipeline.py
+++ b/tests/unit_test/qwen3_tts/test_pipeline.py
@@ -5778,6 +5778,15 @@ def _prepared_request_fixture(*, dtype: torch.dtype) -> Qwen3TTSPreparedRequest:
     )
 
 
+def test_qwen3_tts_prepared_payload_drops_the_consumed_reference_clip() -> None:
+    prepared = _prepared_request_fixture(dtype=torch.bfloat16)
+    prepared.state.ref_audio = "data:audio/wav;base64,UklGRiQ="
+    stored = qwen3_request_builders._store_prepared_qwen3_tts_payload(
+        make_payload(inputs="target"), prepared
+    )
+    assert stored.data.get("ref_audio") is None
+
+
 def test_qwen3_tts_prepared_payload_round_trips_tensors_and_clears_fields() -> None:
     prepared = _prepared_request_fixture(dtype=torch.bfloat16)
     payload = make_payload(inputs="target")

--- a/tests/unit_test/qwen3_tts/test_pipeline.py
+++ b/tests/unit_test/qwen3_tts/test_pipeline.py
@@ -267,7 +267,7 @@ def test_qwen3_tts_config_and_registry_contracts() -> None:
     ]
     assert config.stages[1].factory_path.endswith("create_sglang_tts_engine_executor")
     assert config.terminal_stages == ["vocoder"]
-    assert config.gpu_placement == {"tts_engine": 0, "vocoder": 0}
+    assert config.gpu_placement == {"preprocessing": 0, "tts_engine": 0, "vocoder": 0}
     assert config.stages[1].factory.device is None
     assert config.stages[2].factory.device is None
     assert {stage.process for stage in config.stages} == {"pipeline"}
@@ -5783,7 +5783,11 @@ def test_qwen3_tts_prepared_payload_round_trips_tensors_and_clears_fields() -> N
     payload = make_payload(inputs="target")
     stored = qwen3_request_builders._store_prepared_qwen3_tts_payload(payload, prepared)
     assert qwen3_request_builders._QWEN3_TTS_PREPARED_MARKER not in stored.data
-    assert isinstance(stored.data["prepared_prompt_embeds_bytes"], bytes)
+    # tensor_cpu keeps the tensor on the relay in its own dtype instead of widening
+    # it and packing it into the control-plane message.
+    shipped = stored.data["prepared_prompt_embeds"]
+    assert isinstance(shipped, torch.Tensor)
+    assert shipped.dtype == torch.bfloat16 and shipped.device.type == "cpu"
     assert stored.data["prepared_input_ids"] == [11, 12, 13, 14, 15]
 
     engine_model = SimpleNamespace(
@@ -5919,22 +5923,85 @@ def test_qwen3_tts_standalone_preprocessing_ships_tensors_without_registry(
 
 
 def test_qwen3_tts_config_loads_frontend_only_outside_engine_process() -> None:
+    from sglang_omni.config.placement import build_stage_placement_plan
+    from tests.unit_test.pipeline.helpers import build_compiled_process_topology
+
     config = Qwen3TTSPipelineConfig(model_path="model")
     assert Qwen3TTSPipelineConfig.process_local_edges() == frozenset()
     assert config.preprocessing_in_own_process() is False
     assert config.stage_factory_kwargs("preprocessing") == {}
 
     split = config.model_copy(deep=True)
-    split.stages[0] = split.stages[0].model_copy(update={"process": "tts_frontend"})
+    split.stages[0] = split.stages[0].model_copy(
+        update={"process": "tts_frontend", "gpu_memory_fraction": 0.05}
+    )
+    split.stages[1] = split.stages[1].model_copy(update={"gpu_memory_fraction": 0.75})
+    split.stages[2] = split.stages[2].model_copy(update={"gpu_memory_fraction": 0.12})
     assert split.preprocessing_in_own_process() is True
     assert split.stage_factory_kwargs("preprocessing") == {"load_frontend": True}
     assert split.stage_factory_kwargs("tts_engine") == {}
+    # The edge this change unpins: compiling it used to raise because
+    # process_local_edges pinned preprocessing to the engine process.
+    topology = build_compiled_process_topology(split)
+    assert topology.stage_to_process == {
+        "preprocessing": "tts_frontend",
+        "tts_engine": "pipeline",
+        "vocoder": "pipeline",
+    }
+    placement = build_stage_placement_plan(split)
+    assert placement.gpus[0].total_gpu_memory_fraction == pytest.approx(0.92)
+    assert placement.gpus[0].missing_fraction_stage_names == ()
 
     split.enable_deterministic_inference = True
     assert split.stage_factory_kwargs("preprocessing") == {
         "load_frontend": True,
         "max_concurrency": 1,
     }
+
+
+def test_qwen3_tts_prompt_frontend_builds_a_custom_voice_prompt() -> None:
+    """The frontend must satisfy the prompt builders it inherits, not just load weights."""
+    from sglang_omni.models.qwen3_tts import prompt_frontend
+
+    talker = SimpleNamespace(
+        vocab_size=6,
+        hidden_size=4,
+        text_vocab_size=9,
+        text_hidden_size=3,
+        num_code_groups=3,
+        code_predictor_config=SimpleNamespace(vocab_size=5),
+        spk_id={"vivian": 3},
+        codec_language_id={"en": 1},
+        codec_pad_id=0,
+        codec_bos_id=1,
+        codec_nothink_id=2,
+        codec_think_id=3,
+        codec_think_bos_id=4,
+        codec_think_eos_id=5,
+    )
+    root = SimpleNamespace(
+        talker_config=talker,
+        tts_model_type="custom_voice",
+        tts_bos_token_id=0,
+        tts_eos_token_id=1,
+        tts_pad_token_id=2,
+    )
+    frontend = prompt_frontend.Qwen3TTSPromptFrontend(
+        root, device="cpu", dtype=torch.float32
+    )
+    input_id = torch.arange(12, dtype=torch.long).unsqueeze(0) % 9
+    embeds, attention_mask, trailing, ref_code = frontend.build_custom_voice_inputs(
+        input_id=input_id,
+        voice="vivian",
+        language="en",
+        non_streaming_mode=False,
+        instruct_id=None,
+    )
+    assert ref_code is None
+    assert embeds.shape[0] == 1 and embeds.shape[-1] == talker.hidden_size
+    assert attention_mask.shape == (1, embeds.shape[1])
+    assert trailing.shape[-1] == talker.hidden_size
+    assert torch.isfinite(embeds).all()
 
 
 def test_qwen3_tts_prompt_frontend_loads_only_prompt_weights(tmp_path) -> None:

--- a/tests/unit_test/qwen3_tts/test_pipeline.py
+++ b/tests/unit_test/qwen3_tts/test_pipeline.py
@@ -5761,3 +5761,247 @@ def test_qwen3_tts_decode_isolates_rows_with_out_of_range_codes(
 
     scheduler._launch_decode_plans([_plan(7), _plan(8)], stream=None).resolve()
     assert [int(item.max()) for item in seen] == ([7, 8] if deterministic else [8])
+
+
+def _prepared_request_fixture(*, dtype: torch.dtype) -> Qwen3TTSPreparedRequest:
+    prompt = torch.randn(5, 4).to(dtype)
+    return Qwen3TTSPreparedRequest(
+        state=Qwen3TTSState(text="hello", seed=3),
+        input_ids_list=[11, 12, 13, 14, 15],
+        input_ids=torch.tensor([11, 12, 13, 14, 15], dtype=torch.long),
+        attention_mask=torch.ones((1, 5), dtype=torch.long),
+        trailing_text_hidden=torch.randn(2, 4).to(dtype),
+        ref_code=torch.tensor([[1, 2000], [3, 4]], dtype=torch.long),
+        prompt_input_embeds=prompt,
+        tts_pad_embed=torch.randn(4).to(dtype),
+        gen_kwargs={"max_new_tokens": 8, "top_k": 7},
+    )
+
+
+def test_qwen3_tts_prepared_payload_round_trips_tensors_and_clears_fields() -> None:
+    prepared = _prepared_request_fixture(dtype=torch.bfloat16)
+    payload = make_payload(inputs="target")
+    stored = qwen3_request_builders._store_prepared_qwen3_tts_payload(payload, prepared)
+    assert qwen3_request_builders._QWEN3_TTS_PREPARED_MARKER not in stored.data
+    assert isinstance(stored.data["prepared_prompt_embeds_bytes"], bytes)
+    assert stored.data["prepared_input_ids"] == [11, 12, 13, 14, 15]
+
+    engine_model = SimpleNamespace(
+        model=SimpleNamespace(_feedback_buffer=torch.zeros(1, 4, dtype=torch.bfloat16))
+    )
+    loaded = qwen3_request_builders._load_prepared_qwen3_tts_request(
+        stored, model=engine_model
+    )
+    assert loaded is not None
+    assert loaded.prompt_input_embeds.dtype == torch.bfloat16
+    assert torch.equal(loaded.prompt_input_embeds, prepared.prompt_input_embeds)
+    assert torch.equal(loaded.trailing_text_hidden, prepared.trailing_text_hidden)
+    assert torch.equal(loaded.tts_pad_embed, prepared.tts_pad_embed)
+    assert loaded.ref_code.dtype == torch.long
+    assert torch.equal(loaded.ref_code, prepared.ref_code)
+    assert loaded.input_ids_list == prepared.input_ids_list
+    assert torch.equal(loaded.input_ids, prepared.input_ids)
+    assert loaded.attention_mask.shape == (1, 5)
+    assert loaded.gen_kwargs == prepared.gen_kwargs
+    assert loaded.state.text == "hello" and loaded.state.seed == 3
+    assert loaded.state.prepared_input_ids is None
+    assert not [key for key in stored.data if key.startswith("prepared_")]
+    assert (
+        qwen3_request_builders._load_prepared_qwen3_tts_request(
+            stored, model=engine_model
+        )
+        is None
+    )
+
+
+def test_qwen3_tts_request_builder_consumes_prepared_payload(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    install_fake_sglang(monkeypatch)
+    prepared = _prepared_request_fixture(dtype=torch.float32)
+    prepared.ref_code = None
+    payload = qwen3_request_builders._store_prepared_qwen3_tts_payload(
+        make_payload(inputs="target"), prepared
+    )
+    data = build_sglang_qwen3_tts_request(
+        payload,
+        model=SimpleNamespace(
+            config=SimpleNamespace(codec_eos_token_id=42, vocab_size=1200),
+            model=SimpleNamespace(_feedback_buffer=torch.zeros(1, 4)),
+        ),
+        wrapper=object(),
+    )
+    assert torch.equal(data.prompt_input_embeds, prepared.prompt_input_embeds)
+    assert data.prefill_input_embeds is data.prompt_input_embeds
+    assert data.ref_code is None and data.ref_code_len == 0
+    assert data.req.origin_input_ids == [11, 12, 13, 14, 15]
+    assert data.max_new_tokens == 8
+    assert data.req.sampling_params.top_k == 7
+    assert torch.equal(data.pending_text_queue.rows, prepared.trailing_text_hidden)
+    assert not [key for key in payload.data if key.startswith("prepared_")]
+
+
+def test_qwen3_tts_standalone_preprocessing_ships_tensors_without_registry(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    get_speaker_artifact_cache().clear()
+    qwen3_request_builders.clear_qwen3_tts_preprocessing_context()
+
+    class FakeWrapper:
+        def _tokenize_texts(self, texts):
+            return [torch.arange(len(texts[0]), dtype=torch.long).unsqueeze(0)]
+
+        def _build_assistant_text(self, text):
+            return text
+
+        def _build_ref_text(self, text):
+            return text
+
+        def _merge_generate_kwargs(self, **kwargs):
+            return kwargs
+
+    class FakeModel:
+        device = torch.device("cpu")
+        root_config = SimpleNamespace(tts_pad_token_id=0)
+        model = SimpleNamespace(_feedback_buffer=torch.empty((1, 4)))
+        speech_tokenizer = object()
+        speaker_encoder_sample_rate = 24000
+
+        def build_voice_clone_inputs(self, **kwargs):
+            del kwargs
+            return (
+                torch.arange(8, dtype=torch.float32).view(1, 2, 4),
+                torch.ones((1, 2), dtype=torch.long),
+                torch.ones((1, 1, 4)),
+                torch.tensor([[1, 2], [3, 4]], dtype=torch.long),
+            )
+
+    monkeypatch.setattr(
+        qwen3_request_builders,
+        "_get_qwen3_tts_adhoc_reference_service_locked",
+        lambda model, wrapper: None,
+    )
+    monkeypatch.setattr(
+        qwen3_request_builders,
+        "_prepare_qwen3_tts_base_request",
+        lambda *, state, model, wrapper: model.build_voice_clone_inputs(),
+    )
+    monkeypatch.setattr(
+        qwen3_request_builders,
+        "_build_qwen3_tts_pad_embed",
+        lambda model: torch.zeros(4),
+    )
+    qwen3_request_builders.set_qwen3_tts_preprocessing_context(
+        model=FakeModel(), wrapper=FakeWrapper(), standalone=True
+    )
+    try:
+        payload = make_payload(
+            inputs="target",
+            tts_params={"ref_audio": "ref.wav", "ref_text": "ref"},
+        )
+        out = qwen3_request_builders.preprocess_qwen3_tts_payload(payload)
+        with qwen3_request_builders._PREPARED_REQUESTS_LOCK:
+            assert not qwen3_request_builders._PREPARED_REQUESTS
+    finally:
+        qwen3_request_builders.clear_qwen3_tts_preprocessing_context()
+
+    assert qwen3_request_builders._QWEN3_TTS_PREPARED_MARKER not in out.data
+    assert qwen3_request_builders.pop_prepared_qwen3_tts_request(out) is None
+    loaded = qwen3_request_builders._load_prepared_qwen3_tts_request(
+        out, model=FakeModel()
+    )
+    assert loaded is not None
+    assert torch.equal(
+        loaded.prompt_input_embeds, torch.arange(8, dtype=torch.float32).view(2, 4)
+    )
+    assert torch.equal(loaded.ref_code, torch.tensor([[1, 2], [3, 4]]))
+    assert len(loaded.input_ids_list) == 2
+
+
+def test_qwen3_tts_config_loads_frontend_only_outside_engine_process() -> None:
+    config = Qwen3TTSPipelineConfig(model_path="model")
+    assert Qwen3TTSPipelineConfig.process_local_edges() == frozenset()
+    assert config.preprocessing_in_own_process() is False
+    assert config.stage_factory_kwargs("preprocessing") == {}
+
+    split = config.model_copy(deep=True)
+    split.stages[0] = split.stages[0].model_copy(update={"process": "tts_frontend"})
+    assert split.preprocessing_in_own_process() is True
+    assert split.stage_factory_kwargs("preprocessing") == {"load_frontend": True}
+    assert split.stage_factory_kwargs("tts_engine") == {}
+
+    split.enable_deterministic_inference = True
+    assert split.stage_factory_kwargs("preprocessing") == {
+        "load_frontend": True,
+        "max_concurrency": 1,
+    }
+
+
+def test_qwen3_tts_prompt_frontend_loads_only_prompt_weights(tmp_path) -> None:
+    from safetensors.torch import save_file
+
+    from sglang_omni.models.qwen3_tts import prompt_frontend
+
+    talker = SimpleNamespace(
+        vocab_size=6,
+        hidden_size=4,
+        text_vocab_size=9,
+        text_hidden_size=3,
+        num_code_groups=3,
+        code_predictor_config=SimpleNamespace(vocab_size=5),
+    )
+    root = SimpleNamespace(talker_config=talker, tts_model_type="custom_voice")
+    frontend = prompt_frontend.Qwen3TTSPromptFrontend(
+        root, device="cpu", dtype=torch.float32
+    )
+    assert frontend.speaker_encoder is None
+    assert frontend.device.type == "cpu" and frontend.dtype == torch.float32
+    assert frontend.model._feedback_buffer.shape == (1, 4)
+
+    names = frontend.checkpoint_weight_names()
+    assert names == {
+        "talker.model.codec_embedding.weight",
+        "talker.model.text_embedding.weight",
+        "talker.text_projection.linear_fc1.weight",
+        "talker.text_projection.linear_fc1.bias",
+        "talker.text_projection.linear_fc2.weight",
+        "talker.text_projection.linear_fc2.bias",
+        "talker.code_predictor.model.codec_embedding.0.weight",
+        "talker.code_predictor.model.codec_embedding.1.weight",
+    }
+    tensors = {
+        name: torch.randn(
+            dict(frontend.named_parameters())[name[len("talker.") :]].shape
+        )
+        for name in names
+    }
+    tensors["talker.model.layers.0.self_attn.q_proj.weight"] = torch.zeros(2, 2)
+    save_file(tensors, str(tmp_path / "model.safetensors"))
+
+    frontend.load_weights(prompt_frontend.iter_checkpoint_tensors(str(tmp_path), names))
+    assert torch.equal(
+        frontend.model.text_embedding.weight,
+        tensors["talker.model.text_embedding.weight"],
+    )
+    assert torch.equal(
+        frontend.code_predictor.model.codec_embedding[1].weight,
+        tensors["talker.code_predictor.model.codec_embedding.1.weight"],
+    )
+    hidden = torch.randn(1, 2, 3)
+    fc1 = tensors["talker.text_projection.linear_fc1.weight"]
+    fc2 = tensors["talker.text_projection.linear_fc2.weight"]
+    expected = (
+        torch.nn.functional.silu(
+            hidden @ fc1.T + tensors["talker.text_projection.linear_fc1.bias"]
+        )
+        @ fc2.T
+        + tensors["talker.text_projection.linear_fc2.bias"]
+    )
+    assert torch.allclose(frontend.text_projection(hidden), expected)
+
+    with pytest.raises(RuntimeError, match="missing 1 weights"):
+        frontend.load_weights(
+            prompt_frontend.iter_checkpoint_tensors(
+                str(tmp_path), names - {"talker.model.text_embedding.weight"}
+            )
+        )


### PR DESCRIPTION
## Motivation

Per-request reference preprocessing (speech-tokenizer encode, speaker embedding, prompt embedding, radix key hashing) runs inside the engine process today, because prepared requests reach the AR request builder through module-level registries and `process_local_edges` pins that edge. On one H200 at concurrency 64 that thread group holds 38% of the engine process's active samples and competes with the AR scheduler for the interpreter.

## Modifications

* `Qwen3TTSPromptBuilderMixin` carries the talker's prompt-building methods unchanged. `Qwen3TTSPromptFrontend` is a talker-compatible module holding only the embedding tables, text projection, predictor codec embeddings and speaker encoder, loaded by name from the checkpoint.
* When `preprocessing` is placed in a process other than `tts_engine`, the stage loads that frontend plus the speech tokenizer and ships the prepared tensors in the payload (`tensor_cpu`, so they ride the relay in their own dtype). The AR request builder consumes and clears them, and the reference clip is dropped once preprocessing has consumed it, so it stops riding the later hops as raw media. The single-process layout keeps the registry path unchanged.
* `process_local_edges()` no longer pins the `preprocessing -> tts_engine` edge. The shared-process stage still declares no `gpu`: it holds no budget of its own there, and declaring one would make every layout that puts a second process group on the card demand a fraction for it. A split frontend passes its own `gpu` so the placement plan counts it.

Opt in with dotted overrides, no config class change:

```
--preprocessing.process tts_frontend --preprocessing.gpu 0 --preprocessing.gpu_memory_fraction 0.05 \
--tts_engine.gpu_memory_fraction 0.75 --tts_engine.engine.mem_fraction_static 0.75 \
--vocoder.gpu_memory_fraction 0.12
```

## Accuracy Test

Six SeedTTS samples at a fixed seed, concurrency 1: PCM md5 identical across two single-process runs and the split layout (6/6).

## Benchmark & Profiling

H200, 1.7B Base, SeedTTS EN 1088 streaming, closed loop at concurrency = cap, fresh server per point. ABAB, 3 rounds, 6 points per arm, medians:

| cap | one process | preprocessing process | delta | TTFA p95 | c50 |
|---:|---:|---:|---:|---|---:|
| 32 | 12.51 QPS | 14.09 QPS | **1.13× (+12.6%)** | 1.14 to 1.00 s | 98.9 to 99.6 |
| 64 | 12.04 QPS | 14.81 QPS | **1.23× (+23.0%)** | 4.67 to 3.91 s | 44.9 to 80.4 |

Every split point is above every one-process point at both caps. Per-request stage timeline (built-in `RequestEventRecorder`, 664 requests per arm, cap 64) attributes it:

| interval, p50 | one process | split | delta |
|---|---:|---:|---:|
| tts_engine stage | 4868 ms | 4190 ms | **-13.9%** |
| queue_enter to prefill_start | 771 ms | 560 ms | **-27.4%** |
| prefill_end to stage_complete | 3192 ms | 2776 ms | **-13.0%** |
| tts_engine stage p95 | 25641 ms | 8009 ms | **-68.8%** |

The decode interval shrinks 13% although its GPU work is identical in both arms, and the stage p95 drops 69%: the reference encoders were interrupting the decode loop inside the same interpreter. Composes with `--vocoder.process vocoder` (3-round ABAB on top of it: cap 32 **1.07× (+7.3%)**, cap 64 **1.03× (+2.7%)**).

## Notes

* The frontend process loads the full speech tokenizer through the existing loader; a decoder-free load is a follow-up.
* The uploaded-voice speaker cache is a per-process global, so the preprocessing stage's copy is invalidated by key version rather than by `clear_voice` on the API process. That was already true before this change.
* Deterministic mode still serializes preprocessing and gains one serialization hop.

## Checklist

- [x] Format your code according with pre-commit.
- [x] Add unit tests.
- [x] Update documentation / docstrings / example tutorials as needed.
- [x] Provide throughput / latency benchmark results and accuracy evaluation results as needed.
