### PR TITLE
[MOSS-TTS] Run the delay vocoder in its own process by default

### DIFF
--- a/docs/basic_usage/tts_process_topology.md
+++ b/docs/basic_usage/tts_process_topology.md
@@ -22,6 +22,12 @@ stages:
     process: pipeline
 ```
 
+MOSS-TTS delay ships the isolated layout as its default, with declared GPU
+memory fractions 0.10 / 0.72 / 0.18 for `preprocessing`, `tts_engine` and
+`vocoder`. `config_cls: MossTTSSingleProcessPipelineConfig` selects the
+single-process variant, which the bounded 24 GB and 32 GB configurations and
+the MPS DP2 recipe pin because their measured budgets describe that layout.
+
 ## Changing Placement at Launch
 
 The same field is set from the command line with the dotted spelling, without

--- a/docs/cookbook/moss_tts.md
+++ b/docs/cookbook/moss_tts.md
@@ -29,7 +29,12 @@ The processor ships with the checkpoint, so no extra TTS package is needed. Deco
 
 ## Server Configuration
 
-The pipeline is `preprocessing → tts_engine → vocoder`.
+The pipeline is `preprocessing → tts_engine → vocoder`. By default the vocoder
+runs in its own process (GPU memory fractions 0.10 / 0.72 / 0.18 for the three
+stages): its Python decode loop no longer shares the interpreter with the AR
+scheduler, which on H200 lifts single-replica throughput by about 70% at every
+concurrency cap. `config_cls: MossTTSSingleProcessPipelineConfig` restores the
+single-process layout; the bounded 24 GB and 32 GB configurations keep it.
 
 ```bash
 sgl-omni serve \

--- a/examples/configs/moss_tts_24gb.yaml
+++ b/examples/configs/moss_tts_24gb.yaml
@@ -1,4 +1,4 @@
-config_cls: MossTTSPipelineConfig
+config_cls: MossTTSSingleProcessPipelineConfig
 model_path: OpenMOSS-Team/MOSS-TTS-v1.5
 
 stages:

--- a/examples/configs/moss_tts_32gb.yaml
+++ b/examples/configs/moss_tts_32gb.yaml
@@ -1,4 +1,4 @@
-config_cls: MossTTSPipelineConfig
+config_cls: MossTTSSingleProcessPipelineConfig
 model_path: OpenMOSS-Team/MOSS-TTS-v1.5
 
 stages:

--- a/examples/mps_dp/config.py
+++ b/examples/mps_dp/config.py
@@ -29,6 +29,7 @@ WEIGHT_SHARE_VALIDATED_CONFIGS: dict[str, str] = {
     "HiggsTtsPipelineConfig": "HiggsMultimodalQwen3ForConditionalGeneration",
     "MossTTSLocalPipelineConfig": "MossTTSLocalSGLangModel",
     "MossTTSPipelineConfig": "MossTTSDelaySGLangModel",
+    "MossTTSSingleProcessPipelineConfig": "MossTTSDelaySGLangModel",
     "MossTranscribeDiarizePipelineConfig": (
         "MossTranscribeDiarizeForConditionalGeneration"
     ),

--- a/examples/mps_dp/configs/moss_delay_h100_dp2.yaml
+++ b/examples/mps_dp/configs/moss_delay_h100_dp2.yaml
@@ -3,7 +3,9 @@
 # shared weights. Unshared DP2 does not fit at these budgets; sharing is what
 # makes the second replica's KV pool profile to the common cap.
 
-config_cls: MossTTSPipelineConfig
+# The validated budgets below describe the single-process layout, so this recipe
+# pins it rather than following the default vocoder-process topology.
+config_cls: MossTTSSingleProcessPipelineConfig
 name: mossd
 model_path: OpenMOSS-Team/MOSS-TTS-v1.5
 

--- a/sglang_omni/models/moss_tts/config.py
+++ b/sglang_omni/models/moss_tts/config.py
@@ -17,6 +17,9 @@ from sglang_omni.config import (
 _PKG = "sglang_omni.models.moss_tts"
 _REF_AUDIO_CACHE_MAX_ITEMS = 8192
 _REF_AUDIO_CACHE_MAX_BYTES = 64 * 1024 * 1024
+_COLOCATED_PREPROCESSING_GPU_MEMORY_FRACTION = 0.10
+_COLOCATED_AR_GPU_MEMORY_FRACTION = 0.72
+_COLOCATED_VOCODER_GPU_MEMORY_FRACTION = 0.18
 
 
 class MossTTSPreprocessingFactoryArgs(FactoryArgs):
@@ -44,6 +47,56 @@ class MossTTSVocoderStageConfig(StageConfig):
     )
 
 
+def _stages(*, colocated: bool) -> list[StageConfig]:
+    # Note (Jiaxin Deng): the vocoder's Python decode loop shares the interpreter
+    # with the AR scheduler when both live in one process; on H200 isolating it
+    # lifts single-replica throughput by ~70% at every concurrency cap.
+    return [
+        MossTTSPreprocessingStageConfig(
+            name="preprocessing",
+            process="pipeline",
+            factory_path=f"{_PKG}.stages.create_preprocessing_executor",
+            factory=MossTTSPreprocessingFactoryArgs(
+                compute_dtype="bfloat16",
+                ref_audio_cache=True,
+                ref_audio_cache_max_items=_REF_AUDIO_CACHE_MAX_ITEMS,
+                ref_audio_cache_max_bytes=_REF_AUDIO_CACHE_MAX_BYTES,
+            ),
+            gpu_memory_fraction=(
+                _COLOCATED_PREPROCESSING_GPU_MEMORY_FRACTION if colocated else None
+            ),
+            gpu=0,
+            next="tts_engine",
+        ),
+        EngineStageConfig(
+            name="tts_engine",
+            process="pipeline",
+            factory_path=f"{_PKG}.stages.create_sglang_tts_engine_executor",
+            factory=FactoryArgs(dtype="bfloat16"),
+            gpu_memory_fraction=(
+                _COLOCATED_AR_GPU_MEMORY_FRACTION if colocated else None
+            ),
+            gpu=0,
+            next="vocoder",
+            stream_to=["vocoder"],
+        ),
+        MossTTSVocoderStageConfig(
+            name="vocoder",
+            process="vocoder" if colocated else "pipeline",
+            factory_path=f"{_PKG}.stages.create_vocoder_executor",
+            factory=MossTTSVocoderFactoryArgs(
+                dtype="float32", compute_dtype="bfloat16"
+            ),
+            gpu_memory_fraction=(
+                _COLOCATED_VOCODER_GPU_MEMORY_FRACTION if colocated else None
+            ),
+            gpu=0,
+            terminal=True,
+            can_accept_stream_before_payload=True,
+        ),
+    ]
+
+
 class MossTTSPipelineConfig(PipelineConfig):
     """MOSS-TTS Delay pipeline: preprocessing -> AR engine -> vocoder."""
 
@@ -69,44 +122,21 @@ class MossTTSPipelineConfig(PipelineConfig):
         # PreparedRequestQueue that the AR stage pops in-process.
         return frozenset({("preprocessing", "tts_engine")})
 
-    stages: list[StageConfig] = [
-        MossTTSPreprocessingStageConfig(
-            name="preprocessing",
-            process="pipeline",
-            factory_path=f"{_PKG}.stages.create_preprocessing_executor",
-            factory=MossTTSPreprocessingFactoryArgs(
-                compute_dtype="bfloat16",
-                ref_audio_cache=True,
-                ref_audio_cache_max_items=_REF_AUDIO_CACHE_MAX_ITEMS,
-                ref_audio_cache_max_bytes=_REF_AUDIO_CACHE_MAX_BYTES,
-            ),
-            gpu=0,
-            next="tts_engine",
-        ),
-        EngineStageConfig(
-            name="tts_engine",
-            process="pipeline",
-            factory_path=f"{_PKG}.stages.create_sglang_tts_engine_executor",
-            factory=FactoryArgs(dtype="bfloat16"),
-            gpu=0,
-            next="vocoder",
-            stream_to=["vocoder"],
-        ),
-        MossTTSVocoderStageConfig(
-            name="vocoder",
-            process="pipeline",
-            factory_path=f"{_PKG}.stages.create_vocoder_executor",
-            factory=MossTTSVocoderFactoryArgs(
-                dtype="float32", compute_dtype="bfloat16"
-            ),
-            gpu=0,
-            terminal=True,
-            can_accept_stream_before_payload=True,
-        ),
-    ]
+    stages: list[StageConfig] = Field(default_factory=lambda: _stages(colocated=True))
 
     def supports_uploaded_voice_references(self) -> bool:
         return True
 
 
+class MossTTSSingleProcessPipelineConfig(MossTTSPipelineConfig):
+    """All three stages in one process, the layout before the vocoder split."""
+
+    stages: list[StageConfig] = Field(default_factory=lambda: _stages(colocated=False))
+
+
 EntryClass = MossTTSPipelineConfig
+
+Variants = {
+    "default": MossTTSPipelineConfig,
+    "single_process": MossTTSSingleProcessPipelineConfig,
+}

--- a/sglang_omni/models/moss_tts/engine_builder.py
+++ b/sglang_omni/models/moss_tts/engine_builder.py
@@ -22,6 +22,19 @@ class MossTtsEngineBuilder(TtsEngineBuilder):
     supports_context_length_override = True
     supports_breakable_prefill_cuda_graph = True
 
+    def __init__(self, *, total_gpu_memory_fraction: float | None = None) -> None:
+        super().__init__()
+        self.total_gpu_memory_fraction = total_gpu_memory_fraction
+
+    def infra_kwargs(self) -> dict[str, Any]:
+        # Note (Jiaxin Deng): without this the declared stage budget stops at the
+        # placement validator and KV sizing profiles against whatever the card happens
+        # to have free, so capacity would depend on which process loaded first. Emitted
+        # only when a budget is declared, so the single-process path is untouched.
+        if self.total_gpu_memory_fraction is None:
+            return {}
+        return {"total_gpu_memory_fraction": self.total_gpu_memory_fraction}
+
     def resolve_context_length(
         self,
         checkpoint_dir: str,

--- a/sglang_omni/models/moss_tts/stages.py
+++ b/sglang_omni/models/moss_tts/stages.py
@@ -497,15 +497,24 @@ def create_sglang_tts_engine_executor(
     gpu_id: int | None = None,
     dtype: str = "bfloat16",
     total_gpu_memory_fraction: float | None = None,
+    process_total_gpu_memory_fraction: float | None = None,
     server_args_overrides: dict[str, Any] | None = None,
 ) -> Any:
     overrides = dict(server_args_overrides or {})
-    # Note (Jiaxin Deng): a declared stage fraction only reserves the card on paper,
-    # so the AR engine has to be told about it or it profiles against the whole GPU
-    # and the vocoder process has nothing left to claim.
-    if total_gpu_memory_fraction is not None and "mem_fraction_static" not in overrides:
-        overrides["mem_fraction_static"] = float(total_gpu_memory_fraction)
-    return MossTtsEngineBuilder().build(
+    # Note (Jiaxin Deng): a declared stage fraction only reserves the card on paper, so
+    # the AR engine has to be told about it or it profiles against the whole GPU and the
+    # vocoder process has nothing left to claim. The process total is the right
+    # denominator when the group hosts more than this one GPU stage.
+    engine_fraction = (
+        process_total_gpu_memory_fraction
+        if process_total_gpu_memory_fraction is not None
+        else total_gpu_memory_fraction
+    )
+    if engine_fraction is not None and "mem_fraction_static" not in overrides:
+        overrides["mem_fraction_static"] = float(
+            total_gpu_memory_fraction or engine_fraction
+        )
+    return MossTtsEngineBuilder(total_gpu_memory_fraction=engine_fraction).build(
         model_path,
         device=device,
         gpu_id=gpu_id,

--- a/sglang_omni/models/moss_tts/stages.py
+++ b/sglang_omni/models/moss_tts/stages.py
@@ -496,14 +496,21 @@ def create_sglang_tts_engine_executor(
     device: str = "cuda:0",
     gpu_id: int | None = None,
     dtype: str = "bfloat16",
+    total_gpu_memory_fraction: float | None = None,
     server_args_overrides: dict[str, Any] | None = None,
 ) -> Any:
+    overrides = dict(server_args_overrides or {})
+    # Note (Jiaxin Deng): a declared stage fraction only reserves the card on paper,
+    # so the AR engine has to be told about it or it profiles against the whole GPU
+    # and the vocoder process has nothing left to claim.
+    if total_gpu_memory_fraction is not None and "mem_fraction_static" not in overrides:
+        overrides["mem_fraction_static"] = float(total_gpu_memory_fraction)
     return MossTtsEngineBuilder().build(
         model_path,
         device=device,
         gpu_id=gpu_id,
         dtype=dtype,
-        server_args_overrides=server_args_overrides,
+        server_args_overrides=overrides or None,
     )
 
 

--- a/tests/unit_test/moss_tts/test_pipeline.py
+++ b/tests/unit_test/moss_tts/test_pipeline.py
@@ -24,8 +24,12 @@ from benchmarks.tasks.tts import (
     estimate_moss_tts_duration_tokens,
 )
 from sglang_omni.config.manager import ConfigManager
+from sglang_omni.config.placement import build_stage_placement_plan
 from sglang_omni.config.runtime import resolve_stage_factory_args
-from sglang_omni.models.moss_tts.config import MossTTSPipelineConfig
+from sglang_omni.models.moss_tts.config import (
+    MossTTSPipelineConfig,
+    MossTTSSingleProcessPipelineConfig,
+)
 from sglang_omni.models.moss_tts.payload_types import MossTTSState
 from sglang_omni.models.moss_tts.request_builders import (
     _INF_DELAY,
@@ -39,6 +43,7 @@ from sglang_omni.models.moss_tts.request_builders import (
 from sglang_omni.models.registry import PIPELINE_CONFIG_REGISTRY
 from sglang_omni.proto import OmniRequest, StagePayload
 from sglang_omni.scheduling.types import RequestOutput
+from tests.unit_test.pipeline.helpers import build_compiled_process_topology
 
 
 def install_fake_sglang(monkeypatch: pytest.MonkeyPatch) -> None:
@@ -115,7 +120,11 @@ def test_moss_tts_config_and_registry_contracts() -> None:
         "tts_engine": 0,
         "vocoder": 0,
     }
-    assert {stage.process for stage in config.stages} == {"pipeline"}
+    assert [stage.process for stage in config.stages] == [
+        "pipeline",
+        "pipeline",
+        "vocoder",
+    ]
     assert config.supports_uploaded_voice_references() is True
     tts_engine = next(stage for stage in config.stages if stage.name == "tts_engine")
     vocoder = next(stage for stage in config.stages if stage.name == "vocoder")
@@ -2474,3 +2483,33 @@ def test_moss_preprocess_pre_start_abort_does_not_block(
         assert not snap.inflight
     finally:
         rb.clear_moss_tts_preprocessing_context()
+
+
+def test_default_topology_isolates_vocoder_process() -> None:
+    config = MossTTSPipelineConfig(model_path="fake-model")
+    stages = {stage.name: stage for stage in config.stages}
+    assert stages["preprocessing"].process == "pipeline"
+    assert stages["tts_engine"].process == "pipeline"
+    assert stages["vocoder"].process == "vocoder"
+    assert stages["preprocessing"].gpu_memory_fraction == pytest.approx(0.10)
+    assert stages["tts_engine"].gpu_memory_fraction == pytest.approx(0.72)
+    assert stages["vocoder"].gpu_memory_fraction == pytest.approx(0.18)
+    placement = build_stage_placement_plan(config)
+    assert placement.gpus[0].total_gpu_memory_fraction == pytest.approx(1.0)
+    assert placement.gpus[0].missing_fraction_stage_names == ()
+    topology = build_compiled_process_topology(config)
+    assert topology.stage_to_process == {
+        "preprocessing": "pipeline",
+        "tts_engine": "pipeline",
+        "vocoder": "vocoder",
+    }
+
+
+def test_single_process_variant_keeps_legacy_topology() -> None:
+    config = MossTTSSingleProcessPipelineConfig(model_path="fake-model")
+    assert {stage.process for stage in config.stages} == {"pipeline"}
+    assert all(stage.gpu_memory_fraction is None for stage in config.stages)
+    topology = build_compiled_process_topology(config)
+    assert [(group.name, group.stage_names) for group in topology.groups] == [
+        ("pipeline", ("preprocessing", "tts_engine", "vocoder"))
+    ]

--- a/tests/unit_test/moss_tts/test_pipeline.py
+++ b/tests/unit_test/moss_tts/test_pipeline.py
@@ -180,7 +180,9 @@ def test_moss_tts_production_config_resolves_codec_memory_policy() -> None:
 def test_moss_tts_32gb_config_bounds_runtime_memory() -> None:
     config = ConfigManager.from_file("examples/configs/moss_tts_32gb.yaml").config
 
-    assert isinstance(config, MossTTSPipelineConfig)
+    # The measured budgets in these files describe the single-process layout.
+    assert isinstance(config, MossTTSSingleProcessPipelineConfig)
+    assert {stage.process for stage in config.stages} == {"pipeline"}
     stages = {stage.name: stage for stage in config.stages}
     preprocessing_args = resolve_stage_factory_args(
         stages["preprocessing"], config, gpu_id=0
@@ -206,7 +208,9 @@ def test_moss_tts_32gb_config_bounds_runtime_memory() -> None:
 def test_moss_tts_24gb_config_bounds_runtime_memory() -> None:
     config = ConfigManager.from_file("examples/configs/moss_tts_24gb.yaml").config
 
-    assert isinstance(config, MossTTSPipelineConfig)
+    # The measured budgets in these files describe the single-process layout.
+    assert isinstance(config, MossTTSSingleProcessPipelineConfig)
+    assert {stage.process for stage in config.stages} == {"pipeline"}
     stages = {stage.name: stage for stage in config.stages}
     preprocessing_args = resolve_stage_factory_args(
         stages["preprocessing"], config, gpu_id=0
@@ -2503,6 +2507,9 @@ def test_default_topology_isolates_vocoder_process() -> None:
         "tts_engine": "pipeline",
         "vocoder": "vocoder",
     }
+    # A declared fraction only reserves the card on paper unless the engine is told.
+    engine_args = resolve_stage_factory_args(stages["tts_engine"], config, gpu_id=0)
+    assert engine_args["total_gpu_memory_fraction"] == pytest.approx(0.72)
 
 
 def test_single_process_variant_keeps_legacy_topology() -> None:

--- a/tests/unit_test/serve/test_mps_dp_support.py
+++ b/tests/unit_test/serve/test_mps_dp_support.py
@@ -22,7 +22,10 @@ from sglang_omni.models.higgs_tts.config import HiggsTtsPipelineConfig
 from sglang_omni.models.moss_transcribe_diarize.config import (
     MossTranscribeDiarizePipelineConfig,
 )
-from sglang_omni.models.moss_tts.config import MossTTSPipelineConfig
+from sglang_omni.models.moss_tts.config import (
+    MossTTSPipelineConfig,
+    MossTTSSingleProcessPipelineConfig,
+)
 from sglang_omni.models.moss_tts_local.config import MossTTSLocalPipelineConfig
 from sglang_omni.models.qwen3_asr.config import Qwen3ASRPipelineConfig
 from sglang_omni.models.whisper_asr.config import WhisperASRPipelineConfig
@@ -43,6 +46,7 @@ VALIDATED_CONFIG_CLASSES = {
     "HiggsTtsPipelineConfig": HiggsTtsPipelineConfig,
     "MossTTSLocalPipelineConfig": MossTTSLocalPipelineConfig,
     "MossTTSPipelineConfig": MossTTSPipelineConfig,
+    "MossTTSSingleProcessPipelineConfig": MossTTSSingleProcessPipelineConfig,
     "MossTranscribeDiarizePipelineConfig": MossTranscribeDiarizePipelineConfig,
     "Qwen3ASRPipelineConfig": Qwen3ASRPipelineConfig,
     "WhisperASRPipelineConfig": WhisperASRPipelineConfig,


### PR DESCRIPTION
## Motivation

With all three stages in one process the delay vocoder's Python decode loop competes with the AR scheduler for the interpreter. On one H200 the single replica sits at 1.9 QPS at every concurrency cap and first-audio p95 is already 8.5 s at cap 16. A per-request stage timeline shows why: the AR engine finishes a request in 1.4 s while the vocoder stage holds it for 7.5 s.

## Modifications

* `MossTTSPipelineConfig` stages come from `_stages(colocated=True)`: the vocoder runs in process `vocoder`, with GPU memory fractions 0.10 / 0.72 / 0.18.
* `create_sglang_tts_engine_executor` now declares the fractions the compiled pipeline passes it. The stage's own `total_gpu_memory_fraction` becomes `mem_fraction_static`, and the process total reaches the model runner through `MossTtsEngineBuilder.infra_kwargs`, so the KV pool sizes from the declared budget instead of whatever the card has free. Undeclared, signature injection dropped both: the engine profiled against the whole card and the vocoder's declared 0.18 was not actually free.
* `MossTTSSingleProcessPipelineConfig` (variant `single_process`) keeps the previous layout. The 24 GB, 32 GB and MPS DP2 example configs pin it, because their measured budgets describe that layout, and the MPS weight-share allowlist accepts it.

## Benchmark & Profiling

H200, single replica, SeedTTS EN 1088 streaming, closed loop at concurrency = cap, fresh server per point, zero failed requests:

| cap | QPS one process | QPS vocoder process | delta | TTFA p95 one process | TTFA p95 vocoder process |
|---:|---:|---:|---:|---:|---:|
| 16 | 1.87 | 3.19 | **1.71× (+70.6%)** | 8.5 s | 4.7 s |
| 32 | 1.89 | 3.39 | **1.79× (+79.4%)** | 17.7 s | 9.5 s |
| 64 | 1.95 | 3.33 | **1.71× (+70.8%)** | 35.0 s | 19.7 s |
| 96 | 1.99 | 3.41 | **1.71× (+71.4%)** | 52.7 s | 29.6 s |
| 128 | 1.97 | 3.42 | **1.74× (+73.6%)** | 71.7 s | 38.7 s |

On this branch, default config class against `MossTTSSingleProcessPipelineConfig` at cap 32, ABBA, fresh server per point:

| arm | round 1 | round 2 | mean | delta | TTFA p95 | GPU processes |
|---|---:|---:|---:|---:|---|---|
| single process | 1.92 | 1.90 | 1.91 | — | 17.3 / 17.6 s | 1 (132.6 GB) |
| default | 3.43 | 3.37 | 3.40 | **1.78× (+78%)** | 9.2 / 9.5 s | 2 (128.5 GB + 2.4 GB) |

+78% at cap 32, far above this rig's run-to-run spread of a few percent.

## Notes

* Each stage runs the same code in both layouts and only the process boundary moves, over an edge the relay already carried. A fixed-seed output comparison has not been run on this branch.
* Extra cost measured on H200: a second GPU process of 2.4 GB next to the engine's 128.5 GB.
* The MPS DP2 recipe declares `tts_engine.gpu_memory_fraction: 0.37`, which the factory now consumes, so its KV profiling path changes. Re-measured on one H200, `N=2` with weight sharing, before and after:

| | KV profiling | available for KV | KV pool per replica | GPU memory | DP2 |
|---|---|---|---|---|---|
| before | upstream free memory | not accounted | 30000 tok, K 2.06 + V 2.06 GB | 26394 + 8880 MiB | up |
| after | `stage_load_fallback`, fraction 0.370 | 34.75 / 51.85 GiB | 30000 tok, K 2.06 + V 2.06 GB | 26394 + 8880 MiB | up |

The recipe pins `max_total_tokens: 30000` and that stays the binding constraint at either headroom, so the pool and the footprint are unchanged and the published DP2 numbers still hold.

## Checklist

- [x] Format your code according with pre-commit.
- [x] Add unit tests.
- [x] Update documentation / docstrings / example tutorials as needed.
- [x] Provide throughput / latency benchmark results and accuracy evaluation results as needed.
