### PR TITLE
[MOSS-TTS] Size the delay vocoder step from the client playback buffer

### DIFF
--- a/docs/cookbook/moss_tts.md
+++ b/docs/cookbook/moss_tts.md
@@ -180,6 +180,45 @@ curl -N -X POST http://localhost:8000/v1/audio/speech \
   --output output.pcm
 ```
 
+#### Streaming Step Size
+
+The streaming vocoder decodes `stream_followup_stride` new frames plus
+`stream_overlap_tokens` of recomputed context on every step, so at the shipped
+8 / 8 half of each decode is context and one SeedTTS request costs 84 vocoder
+steps. Raising the fixed stride trades playback continuity for throughput one
+for one, and the trade only pays while the client already has audio buffered,
+which a fixed number cannot know.
+
+`stream_slack_ladder` sizes the step from that buffer instead. After each
+emitted chunk the scheduler advances the request's playback deadline by the
+audio it just handed over, computes the slack (deadline minus now minus
+`stream_slack_margin_s`) and picks the largest rung whose own playback duration
+fits. With a thin buffer it stays on the first rung. It is off by default, and
+when set it replaces `stream_followup_stride` only after the first chunk;
+`initial_codec_chunk_frames` still governs the first one.
+
+```yaml
+stages:
+  vocoder:
+    factory:
+      stream_slack_ladder: [8, 16, 32]
+      stream_slack_margin_s: 1.0
+```
+
+Measured on one H200 with the vocoder in its own process, SeedTTS EN streaming
+at concurrency 8, against the shipped fixed 8:
+
+| step policy | QPS | vs fixed 8 | TTFA p95 | mean playback gap |
+|---|---:|---:|---:|---:|
+| fixed 8 | 3.19 | | 1.93 s | 53 ms |
+| ladder `[8, 16, 32]` | 3.82 | +19.8% | 1.36 s | 79 ms |
+| fixed 32 | 5.34 | +67.4% | 0.82 s | 378 ms |
+
+Per millisecond of added playback gap the ladder buys 0.024 QPS and the fixed
+32 buys 0.0066. The ladder also self limits: once the server is past real time
+no client builds a buffer, so it stays near its first rung instead of spending
+continuity it does not have.
+
 ### Duration Control
 
 MOSS-TTS conditions on a target **duration token count** (codec frames; a larger count yields

--- a/sglang_omni/models/moss_tts/stages.py
+++ b/sglang_omni/models/moss_tts/stages.py
@@ -33,7 +33,10 @@ from sglang_omni.models.moss_tts.request_builders import (
     preprocess_moss_tts_payload,
     set_moss_tts_preprocessing_context,
 )
-from sglang_omni.models.moss_tts.streaming_vocoder import MossStreamingVocoderScheduler
+from sglang_omni.models.moss_tts.streaming_vocoder import (
+    DEFAULT_MOSS_TTS_STREAM_SLACK_MARGIN_S,
+    MossStreamingVocoderScheduler,
+)
 from sglang_omni.models.moss_tts.vocoder import MossTTSVocoder
 from sglang_omni.preprocessing.cache_key import hash_bytes
 from sglang_omni.scheduling.reference_encoder import (
@@ -537,6 +540,8 @@ def create_vocoder_executor(
     max_batch_wait_ms: int = 2,
     stream_stride: int = 8,
     stream_followup_stride: int = 8,
+    stream_slack_ladder: tuple[int, ...] | list[int] | None = None,
+    stream_slack_margin_s: float = DEFAULT_MOSS_TTS_STREAM_SLACK_MARGIN_S,
     stream_overlap_tokens: int = 8,
     stream_holdback_tokens: int = 1,
     initial_chunk_frames: int = 0,
@@ -574,6 +579,8 @@ def create_vocoder_executor(
         vocoder,
         stream_stride=stream_stride,
         stream_followup_stride=stream_followup_stride,
+        stream_slack_ladder=stream_slack_ladder,
+        stream_slack_margin_s=stream_slack_margin_s,
         stream_overlap_tokens=stream_overlap_tokens,
         stream_holdback_tokens=stream_holdback_tokens,
         initial_chunk_frames=initial_chunk_frames,

--- a/sglang_omni/models/moss_tts/streaming_vocoder.py
+++ b/sglang_omni/models/moss_tts/streaming_vocoder.py
@@ -3,7 +3,10 @@
 
 from __future__ import annotations
 
+import math
+import time
 from collections import deque
+from collections.abc import Callable
 from dataclasses import dataclass, field
 from typing import Any, Mapping
 
@@ -19,6 +22,27 @@ from sglang_omni.scheduling.streaming_vocoder import (
     StreamingVocoderBase,
     resolve_initial_codec_chunk_frames,
 )
+
+DEFAULT_MOSS_TTS_STREAM_SLACK_MARGIN_S = 1.0
+
+
+def _validate_slack_ladder(
+    value: tuple[int, ...] | list[int] | None,
+) -> tuple[int, ...] | None:
+    if value is None:
+        return None
+    if not isinstance(value, (tuple, list)):
+        raise TypeError("stream_slack_ladder must be a tuple or list of ints")
+    if not value:
+        raise ValueError("stream_slack_ladder must contain at least one entry")
+    if any(isinstance(f, bool) or not isinstance(f, int) for f in value):
+        raise TypeError("stream_slack_ladder entries must be ints")
+    ladder = tuple(int(f) for f in value)
+    if any(f <= 0 for f in ladder):
+        raise ValueError("stream_slack_ladder entries must be > 0")
+    if any(b <= a for a, b in zip(ladder, ladder[1:])):
+        raise ValueError("stream_slack_ladder must be strictly ascending")
+    return ladder
 
 
 @dataclass
@@ -42,6 +66,7 @@ class _MossStreamState:
     sample_rate: int = 24000
     initial_codec_chunk_frames: int = 0
     samples_per_frame: int | None = None
+    playback_deadline_s: float = 0.0
 
 
 class MossStreamingVocoderScheduler(StreamingVocoderBase[_MossStreamState, None]):
@@ -56,8 +81,11 @@ class MossStreamingVocoderScheduler(StreamingVocoderBase[_MossStreamState, None]
         stream_overlap_tokens: int = 8,
         stream_holdback_tokens: int = 1,
         initial_chunk_frames: int = 0,
+        stream_slack_ladder: tuple[int, ...] | list[int] | None = None,
+        stream_slack_margin_s: float = DEFAULT_MOSS_TTS_STREAM_SLACK_MARGIN_S,
         max_batch_size: int = 8,
         max_batch_wait_ms: int = 2,
+        clock: Callable[[], float] | None = None,
     ) -> None:
         if stream_stride <= 0 or stream_followup_stride <= 0:
             raise ValueError("stream strides must be > 0")
@@ -65,6 +93,13 @@ class MossStreamingVocoderScheduler(StreamingVocoderBase[_MossStreamState, None]
             raise ValueError("stream overlap must be > 0")
         if stream_holdback_tokens < 0:
             raise ValueError("stream holdback must be >= 0")
+        slack_ladder = _validate_slack_ladder(stream_slack_ladder)
+        if isinstance(stream_slack_margin_s, bool) or not isinstance(
+            stream_slack_margin_s, (int, float)
+        ):
+            raise TypeError("stream_slack_margin_s must be a number")
+        if not math.isfinite(stream_slack_margin_s) or stream_slack_margin_s < 0:
+            raise ValueError("stream_slack_margin_s must be finite and >= 0")
 
         self._vocoder = vocoder
         self._audio_vocoder = vocoder._audio_vocoder
@@ -72,6 +107,11 @@ class MossStreamingVocoderScheduler(StreamingVocoderBase[_MossStreamState, None]
         self._stream_followup_stride = int(stream_followup_stride)
         self._stream_overlap_tokens = int(stream_overlap_tokens)
         self._stream_holdback_tokens = int(stream_holdback_tokens)
+        self._slack_ladder = slack_ladder
+        self._slack_margin_s = float(stream_slack_margin_s)
+        self._clock: Callable[[], float] = (
+            clock if clock is not None else time.monotonic
+        )
         self._default_initial_chunk_frames = max(0, int(initial_chunk_frames))
         self._default_n_vq = int(
             getattr(getattr(vocoder._processor, "model_config", None), "n_vq", 0) or 0
@@ -228,8 +268,18 @@ class MossStreamingVocoderScheduler(StreamingVocoderBase[_MossStreamState, None]
                 chunks.append(chunk)
 
         if chunks:
-            state.next_decode_rows = state.delayed_count + self._stream_followup_stride
-            return chunks[0] if len(chunks) == 1 else torch.cat(chunks)
+            delta = chunks[0] if len(chunks) == 1 else torch.cat(chunks)
+            # Note (Jiaxin Deng): the deadline advances before the stride is chosen
+            # so the ladder sees the audio this chunk is about to buffer.
+            now = self._clock()
+            sample_rate = float(state.sample_rate or self._sample_rate)
+            state.playback_deadline_s = max(state.playback_deadline_s, now) + (
+                float(delta.numel()) / sample_rate
+            )
+            state.next_decode_rows = state.delayed_count + self._steady_followup_stride(
+                state, now=now
+            )
+            return delta
 
         if not is_final:
             if len(state.pending_raw_frames) <= self._stream_holdback_tokens:
@@ -239,7 +289,8 @@ class MossStreamingVocoderScheduler(StreamingVocoderBase[_MossStreamState, None]
                 )
             else:
                 state.next_decode_rows = (
-                    state.delayed_count + self._stream_followup_stride
+                    state.delayed_count
+                    + self._steady_followup_stride(state, now=self._clock())
                 )
         return None
 
@@ -351,6 +402,31 @@ class MossStreamingVocoderScheduler(StreamingVocoderBase[_MossStreamState, None]
         state.segments[state.active_segment].closed = True
         state.active_segment = None
 
+    def _steady_followup_stride(self, state: _MossStreamState, *, now: float) -> int:
+        # Note (Jiaxin Deng): a rung is used only when its own playback duration fits
+        # in the client's remaining buffer minus the margin, so a bigger step never
+        # opens a gap the client cannot cover. Measured on H200: raising the step from
+        # 8 to 32 frames is +133% throughput but grows the playback gap 91ms -> 923ms,
+        # so the step has to follow the buffer instead of being configured once.
+        ladder = self._slack_ladder
+        if ladder is None:
+            return self._stream_followup_stride
+        if state.playback_deadline_s <= 0.0:
+            return ladder[0]
+        samples_per_frame = int(
+            state.samples_per_frame or self._default_samples_per_frame or 0
+        )
+        if samples_per_frame <= 0:
+            return ladder[0]
+        sample_rate = float(state.sample_rate or self._sample_rate)
+        slack_s = state.playback_deadline_s - now - self._slack_margin_s
+        stride = ladder[0]
+        for rung in ladder:
+            if rung * samples_per_frame / sample_rate > slack_s:
+                break
+            stride = rung
+        return stride
+
     def _first_decode_rows(self, state: _MossStreamState, n_vq: int) -> int:
         initial_frames = int(state.initial_codec_chunk_frames)
         if initial_frames > 0:
@@ -363,7 +439,11 @@ class MossStreamingVocoderScheduler(StreamingVocoderBase[_MossStreamState, None]
         values: Mapping[str, Any] | None,
     ) -> None:
         self._require_contract(state, "<stream>")
-        steady_frames = self._stream_followup_stride
+        steady_frames = (
+            self._slack_ladder[0]
+            if self._slack_ladder is not None
+            else self._stream_followup_stride
+        )
         state.initial_codec_chunk_frames = resolve_initial_codec_chunk_frames(
             values,
             steady_chunk_frames=steady_frames,

--- a/tests/unit_test/moss_tts/test_streaming_vocoder.py
+++ b/tests/unit_test/moss_tts/test_streaming_vocoder.py
@@ -268,3 +268,173 @@ def test_abort_drops_state_and_late_chunks() -> None:
 
     assert "req" not in scheduler._stream_states
     assert _drain(scheduler) == []
+
+
+class _RealtimeFakeAudioTokenizer(_FakeAudioTokenizer):
+    """Decoder whose output length matches a 10 Hz codec, so slack is measurable in seconds."""
+
+    SAMPLES_PER_FRAME = 2400
+
+    class _Model:
+        class config:
+            hop_length = 2400
+
+    def __init__(self) -> None:
+        self.model = self._Model()
+        self.decode_inputs: list[torch.Tensor] = []
+
+    def decode_codes(self, segments: list[torch.Tensor]) -> list[torch.Tensor]:
+        decoded = []
+        for segment in segments:
+            self.decode_inputs.append(segment.detach().clone())
+            decoded.append(torch.zeros(len(segment) * self.SAMPLES_PER_FRAME))
+        return decoded
+
+
+class _FakeClock:
+    def __init__(self, now: float = 0.0) -> None:
+        self.now = now
+
+    def __call__(self) -> float:
+        return self.now
+
+
+def _make_realtime_scheduler(
+    *,
+    stream_slack_ladder=None,
+    stream_slack_margin_s: float = 1.0,
+    clock=None,
+    stream_followup_stride: int = 2,
+):
+    processor = SimpleNamespace(
+        model_config=SimpleNamespace(n_vq=3, audio_pad_code=99, sampling_rate=24000)
+    )
+    tokenizer = _RealtimeFakeAudioTokenizer()
+    vocoder = MossTTSVocoder(processor, tokenizer, "cpu")
+    scheduler = MossStreamingVocoderScheduler(
+        vocoder,
+        stream_stride=3,
+        stream_followup_stride=stream_followup_stride,
+        stream_overlap_tokens=1,
+        stream_holdback_tokens=0,
+        stream_slack_ladder=stream_slack_ladder,
+        stream_slack_margin_s=stream_slack_margin_s,
+        clock=clock,
+    )
+    return scheduler, tokenizer
+
+
+def test_moss_slack_ladder_rejects_bad_config() -> None:
+    with pytest.raises(TypeError, match="must be a tuple or list"):
+        _make_realtime_scheduler(stream_slack_ladder=8)
+    with pytest.raises(ValueError, match="at least one entry"):
+        _make_realtime_scheduler(stream_slack_ladder=())
+    for non_int in ((8, 16.0), (True, 16), (8, "16")):
+        with pytest.raises(TypeError, match="entries must be ints"):
+            _make_realtime_scheduler(stream_slack_ladder=non_int)
+    for bad in ((0, 16), (-8, 16)):
+        with pytest.raises(ValueError, match="entries must be > 0"):
+            _make_realtime_scheduler(stream_slack_ladder=bad)
+    for not_ascending in ((16, 8), (8, 8, 16), (8, 32, 16)):
+        with pytest.raises(ValueError, match="strictly ascending"):
+            _make_realtime_scheduler(stream_slack_ladder=not_ascending)
+    for bad_margin in (-0.1, float("nan"), float("inf")):
+        with pytest.raises(ValueError, match="stream_slack_margin_s"):
+            _make_realtime_scheduler(
+                stream_slack_ladder=(2, 4), stream_slack_margin_s=bad_margin
+            )
+    with pytest.raises(TypeError, match="stream_slack_margin_s"):
+        _make_realtime_scheduler(stream_slack_ladder=(2, 4), stream_slack_margin_s=True)
+
+
+def test_moss_slack_stride_fit_rule_boundaries() -> None:
+    clock = _FakeClock(100.0)
+    scheduler, _ = _make_realtime_scheduler(
+        stream_slack_ladder=(2, 4, 8), stream_slack_margin_s=1.0, clock=clock
+    )
+    state = scheduler.create_stream_state("req")
+    frame_s = _RealtimeFakeAudioTokenizer.SAMPLES_PER_FRAME / 24000.0
+
+    def stride_for(slack_s: float) -> int:
+        state.playback_deadline_s = clock.now + 1.0 + slack_s
+        return scheduler._steady_followup_stride(state, now=clock.now)
+
+    state.playback_deadline_s = 0.0
+    assert scheduler._steady_followup_stride(state, now=clock.now) == 2
+    assert stride_for(-5.0) == 2
+    assert stride_for(4 * frame_s - 1e-6) == 2
+    assert stride_for(4 * frame_s + 1e-6) == 4
+    assert stride_for(8 * frame_s - 1e-6) == 4
+    assert stride_for(8 * frame_s + 1e-6) == 8
+    assert stride_for(60.0) == 8
+
+
+def test_moss_slack_ladder_default_off_keeps_configured_stride() -> None:
+    clock = _FakeClock(0.0)
+    scheduler, _ = _make_realtime_scheduler(clock=clock, stream_followup_stride=2)
+    assert scheduler._slack_ladder is None
+    state = scheduler.create_stream_state("req")
+    state.playback_deadline_s = 1e6
+    assert scheduler._steady_followup_stride(state, now=clock.now) == 2
+    clock.now = 1e9
+    assert scheduler._steady_followup_stride(state, now=clock.now) == 2
+
+
+def test_moss_slack_ladder_climbs_then_steps_down_with_buffer() -> None:
+    clock = _FakeClock(0.0)
+    scheduler, _ = _make_realtime_scheduler(
+        stream_slack_ladder=(2, 4, 8), stream_slack_margin_s=0.0, clock=clock
+    )
+    raw = torch.arange(120, dtype=torch.long).reshape(40, 3) % 90
+    delayed = _apply_delay_pattern(raw)
+    scheduler._on_streaming_new_request("req", _payload("req", delayed))
+
+    strides: list[int] = []
+    emitted = 0
+    for chunk_id, row in enumerate(delayed):
+        scheduler._on_chunk("req", _item(row.unsqueeze(0), chunk_id))
+        messages = _drain(scheduler)
+        if not messages:
+            continue
+        emitted += len(messages)
+        state = scheduler._stream_states["req"]
+        strides.append(state.next_decode_rows - state.delayed_count)
+
+    assert emitted > 0, "no audio was emitted"
+    # The clock is frozen, so the client buffer only grows: the ladder must climb and
+    # never step back down, and it must reach a rung above the first one.
+    assert strides == sorted(strides), strides
+    assert strides[0] == 2 and max(strides) > 2, strides
+
+    state = scheduler._stream_states["req"]
+    grown = scheduler._steady_followup_stride(state, now=clock.now)
+    clock.now = state.playback_deadline_s
+    assert scheduler._steady_followup_stride(state, now=clock.now) == 2
+    assert grown > 2
+    scheduler.abort("req")
+
+
+def test_moss_vocoder_factory_forwards_slack_ladder(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    from sglang_omni.models.moss_tts import stages
+
+    processor = SimpleNamespace(
+        model_config=SimpleNamespace(n_vq=3, audio_pad_code=99, sampling_rate=24000)
+    )
+    monkeypatch.setattr(stages, "_load_moss_processor", lambda path: processor)
+    monkeypatch.setattr(
+        stages, "_resolve_audio_tokenizer_model_path", lambda *a, **k: "fake"
+    )
+    monkeypatch.setattr(
+        stages, "load_moss_audio_vocoder", lambda *a, **k: _RealtimeFakeAudioTokenizer()
+    )
+    scheduler = stages.create_vocoder_executor(
+        "fake-model",
+        device="cpu",
+        stream_slack_ladder=[2, 4, 8],
+        stream_slack_margin_s=0.5,
+    )
+    assert scheduler._slack_ladder == (2, 4, 8)
+    assert scheduler._slack_margin_s == 0.5
+    assert scheduler._stream_followup_stride == 8


### PR DESCRIPTION
## Motivation

The MOSS-TTS delay streaming vocoder decodes `stream_followup_stride` new frames plus `stream_overlap_tokens` of context on every step and keeps only the new frames. At the shipped 8/8 half of every decode is recomputed context and a SeedTTS request costs 84 vocoder steps, which is what sets throughput: the AR engine finishes a request in 1.4 s while the vocoder stage holds it for 7.5 s.

Raising the fixed step is a large lever and a bad default. It trades playback continuity for throughput one for one, and the trade only pays while the client already has audio buffered, which a fixed number cannot know.

## Modifications

`stream_slack_ladder` makes the step follow the buffer. After each emitted chunk the scheduler advances the request's playback deadline by the audio it just handed over, computes the slack (deadline minus now minus `stream_slack_margin_s`, default 1.0 s) and picks the largest rung whose own playback duration fits in it. With a thin buffer it stays on the first rung. Off by default; when set it replaces `stream_followup_stride` after the first chunk. A clock seam keeps the arithmetic testable.

```yaml
stages:
  vocoder:
    factory:
      stream_slack_ladder: [8, 16, 32]
      stream_slack_margin_s: 1.0
```

## Benchmark & Profiling

H200, single replica with the vocoder in its own process, SeedTTS EN 1088 streaming, closed loop, fresh server per point. Fixed step sweep at cap 32 first, to show the lever and why it cannot be a fixed number:

| step | QPS | vs step 8 | TTFA p95 | underrun mean | c100 |
|---:|---:|---:|---:|---:|---:|
| 8 (shipped) | 3.38 | — | 9.51 s | 91 ms | 78.3 |
| 16 | 5.44 | **1.61× (+60.9%)** | 5.25 s | 300 ms | 9.7 |
| 32 | 7.87 | **2.33× (+132.8%)** | 2.71 s | 923 ms | 0.2 |

Ladder against the shipped default, both caps:

| cap | arm | QPS | vs fixed 8 | TTFA p95 | underrun mean | c100 | c200 |
|---:|---|---:|---:|---:|---:|---:|---:|
| 8 | fixed 8 | 3.19 | — | 1.93 s | 53 ms | 86.7 | 98.8 |
| 8 | ladder | 3.82 | **1.20× (+19.8%)** | 1.36 s | 79 ms | 62.4 | 95.9 |
| 8 | fixed 32 | 5.34 | **1.67× (+67.4%)** | 0.82 s | 378 ms | 0.1 | 0.6 |
| 32 | fixed 8 | 3.44 | — | 9.20 s | 85 ms | 80.2 | 94.5 |
| 32 | ladder | 3.77 | **1.10× (+9.6%)** | 8.09 s | 111 ms | 58.2 | 93.8 |
| 32 | fixed 32 | 7.94 | **2.31× (+131%)** | 2.68 s | 902 ms | 0.3 | 0.5 |

Per millisecond of added mean playback gap the ladder buys 0.024 QPS and the fixed step 32 buys 0.0066. The ladder also self limits: at cap 32 the server is already past real time, no client builds a buffer, the ladder stays near its first rung and `c200` is unchanged, while the fixed step reaches +131% by giving up continuity (`c200` 0.5 means practically every request sees a gap over 200 ms).

Also measured and not the answer: `max_batch_size` 8 to 32 changes nothing (3.384 to 3.358 QPS), so cross-request batching is not what limits the vocoder.

## Notes

* Default off. With a ladder set, `stream_followup_stride` still sizes the chunk before the first emit and `initial_codec_chunk_frames` still overrides the first chunk.
* Each decode keeps the same overlap context, so audio is unchanged by construction, but a WER pass at a larger step has not been run.
* Measured with the vocoder in its own process. The two changes are independent.

## Checklist

- [x] Format your code according with pre-commit.
- [x] Add unit tests.
- [x] Update documentation / docstrings / example tutorials as needed.
- [x] Provide throughput / latency benchmark results and accuracy evaluation results as needed.

