### PR TITLE
[Fun-ASR] Track HF checkpoint key renames from the Sep 2026 re-convert

### DIFF
--- a/sglang_omni/models/fun_asr/sglang_model.py
+++ b/sglang_omni/models/fun_asr/sglang_model.py
@@ -177,7 +177,9 @@ class EncoderLayerSANM(nn.Module):
         self.final_layer_norm = nn.LayerNorm(size, eps=1e-5)
         self.fc1 = nn.Linear(size, linear_units)
         self.fc2 = nn.Linear(linear_units, size)
-        self.fsmn = FunAsrNanoFSMN(size, kernel_size, attention_dropout_rate)
+        self.feedforward_sequential_memory = FunAsrNanoFSMN(
+            size, kernel_size, attention_dropout_rate
+        )
         self.dropout = nn.Dropout(dropout_rate)
         self.activation_dropout = nn.Dropout(activation_dropout_rate)
         self.activation = ACT2FN[activation_function]
@@ -191,7 +193,9 @@ class EncoderLayerSANM(nn.Module):
         x = self.self_attn_layer_norm(x)
         # note (guozhihao): attn returns v so FSMN does not recompute v_proj.
         attn_out, value_states = self.self_attn(x, mask)
-        x = self.dropout(attn_out + self.fsmn(value_states, mask))
+        x = self.dropout(
+            attn_out + self.feedforward_sequential_memory(value_states, mask)
+        )
         x = _apply_time_mask(x, mask)
         if self.in_size == self.size:
             x = residual + x
@@ -569,6 +573,10 @@ class FunAsrNanoForConditionalGeneration(nn.Module):
                 strict_multimodal = True
             elif name.startswith("model.multi_modal_projector."):
                 name = name.replace("model.", "", 1)
+                is_llm = False
+                strict_multimodal = True
+            elif name.startswith("model.audio_adaptor."):
+                name = name.replace("model.audio_adaptor.", "multi_modal_projector.", 1)
                 is_llm = False
                 strict_multimodal = True
             elif name.startswith("model.language_model."):

--- a/tests/unit_test/fun_asr/test_model.py
+++ b/tests/unit_test/fun_asr/test_model.py
@@ -38,7 +38,7 @@ def test_fun_asr_audio_modules_match_current_checkpoint_parameter_names() -> Non
     assert "stem.self_attn.k_proj.weight" in encoder_names
     assert "stem.self_attn.v_proj.weight" in encoder_names
     assert "stem.self_attn.out_proj.weight" in encoder_names
-    assert "stem.fsmn.conv.weight" in encoder_names
+    assert "stem.feedforward_sequential_memory.conv.weight" in encoder_names
     assert "stem.fc1.weight" in encoder_names
     assert "layers.0.self_attn_layer_norm.weight" in encoder_names
     assert "layers.0.final_layer_norm.weight" in encoder_names
@@ -92,6 +92,44 @@ def test_fun_asr_weight_loader_rejects_unknown_audio_weights() -> None:
 
     with pytest.raises(ValueError, match=r"model\.audio_tower\.missing\.weight"):
         model.load_weights([("model.audio_tower.missing.weight", torch.ones(2))])
+
+
+def test_fun_asr_weight_loader_accepts_checkpoint_format_audio_modules() -> None:
+    model = _weight_loader_target()
+    model.audio_tower = FunAsrNanoAudioEncoder(
+        input_size=8,
+        output_size=8,
+        attention_heads=2,
+        linear_units=16,
+        num_blocks=2,
+        tp_blocks=1,
+        kernel_size=3,
+    )
+    model.multi_modal_projector = FunAsrNanoAdaptor(
+        encoder_dim=8,
+        llm_dim=8,
+        ffn_dim=16,
+        num_layers=1,
+        attention_heads=2,
+    )
+
+    checkpoint = [
+        ("model.audio_tower." + name, torch.full_like(param, 2.0))
+        for name, param in model.audio_tower.named_parameters()
+    ]
+    for name, param in model.multi_modal_projector.named_parameters():
+        prefix = (
+            "model.audio_adaptor."
+            if name.startswith("blocks.")
+            else "model.multi_modal_projector."
+        )
+        checkpoint.append((prefix + name, torch.full_like(param, 2.0)))
+
+    model.load_weights(checkpoint)
+
+    for module in (model.audio_tower, model.multi_modal_projector):
+        for name, param in module.named_parameters():
+            assert torch.equal(param, torch.full_like(param, 2.0)), name
 
 
 def test_fun_asr_audio_feature_shape() -> None:


### PR DESCRIPTION
## Summary

The Fun-ASR-Nano-2512-hf snapshot re-converted for transformers PR #46180 (2026-09-01/02) renamed two things, breaking weight loading:

- The FSMN block is now `feedforward_sequential_memory` (was `fsmn`). Rename our module to match so checkpoint keys and parameters line up 1:1. This failed loudly (strict audio-tower loader).
- The adaptor's SANM blocks moved from `model.multi_modal_projector.` to a new `model.audio_adaptor.` prefix (linears stayed). Map that prefix onto our combined FunAsrNanoAdaptor, strictly. This failed SILENTLY before: the unknown prefix was skipped and the adaptor kept its random init.

Add loader coverage that round-trips every audio-side parameter through checkpoint-format names so naming drift fails in unit tests instead of at (or worse, after) serve time.

## Note

This is a quick patch PR, a comprehensive fix is most likely needed:

1. Pin the checkpoint revision — serve FunAudioLLM/Fun-ASR-Nano-2512-hf@1fd03aa5, not main. Upstream re-converts become deliberate pin-bump PRs, not surprise breakage. (The root cause; config/deploy change.)
2. Loader coverage check — at end of load_weights: raise on any unknown model.* key, and raise if any model parameter was never loaded. Catches every rename/split/omission on any snapshot, loudly, at startup — kills the silent-skip failure mode (the adaptor near-miss).
3. Checkpoint-key fixture test — check in the key list from the pinned snapshot (names only, from the safetensors header, ~KBs); test asserts every key maps to a param and every param is hit. Ties code ↔ pinned snapshot in unit tests, no network/GPU.