### PR TITLE
[Qwen3-TTS] Ship the first-audio chunk ramp on by default

### DIFF
--- a/docs/basic_usage/tts.md
+++ b/docs/basic_usage/tts.md
@@ -593,7 +593,7 @@ The table below lists all parameters accepted by the `/v1/audio/speech` endpoint
 | `response_format` | string | `"wav"` | Output audio format: `wav`, `mp3`, `flac`, `pcm`, `aac`, or `opus` |
 | `speed` | float | `1.0` | Playback speed multiplier from `0.25` to `4.0` |
 | `stream` | bool | `false` | Enable raw PCM streaming. When true, `response_format` must be `pcm` |
-| `initial_codec_chunk_frames` | int | `null` | Optional first codec chunk size for streaming TTFA / playback-continuity tuning. When omitted, each model applies its own default: Qwen3-TTS uses `8`, Higgs TTS uses `20`, MOSS-TTS Local uses `5`, and ZONOS2 uses `40`. An explicit `0` uses the model's steady chunk size from the start. Ming-Omni-TTS rejects the field entirely |
+| `initial_codec_chunk_frames` | int | `null` | Optional first codec chunk size for streaming TTFA / playback-continuity tuning. When omitted, each model applies its own default: Qwen3-TTS ramps `1 -> 2 -> 4` into the steady stride, Higgs TTS uses `20`, MOSS-TTS Local uses `5`, and ZONOS2 uses `40`. An explicit `0` uses the model's steady chunk size from the start. Ming-Omni-TTS rejects the field entirely |
 | `stream_codec_output` | bool | `true` | Qwen3-TTS only. Forward codec frames to the vocoder as they are generated. Set `false` to restore whole-utterance decoding for CustomVoice / VoiceDesign |
 | `references` | list | `null` | Reference audio for voice cloning. Each item has `audio_path` (local path / file URL / data URL / remote URL) and `text` |
 | `ref_audio` | string | `null` | Reference audio path / URL / base64 string. Equivalent to `references[0].audio_path` |

--- a/docs/cookbook/qwen3_tts.md
+++ b/docs/cookbook/qwen3_tts.md
@@ -371,9 +371,10 @@ python -m sglang_omni.cli serve --config qwen3_tts_ramp.yaml
 ```
 
 Smaller early chunks lower time-to-first-audio but start playback with less
-buffered audio, so the continuity cost grows with concurrency: keep
-`[2, 4, 8]` to low concurrency, prefer `[4, 8]` up to moderate concurrency,
-and keep the default schedule for saturated serving. The ramp is mutually
+buffered audio, so the continuity cost grows with concurrency. The default
+`[1, 2, 4]` is the most aggressive schedule and suits low concurrency; prefer
+`[2, 4, 8]` at moderate concurrency and `[4, 8]` for saturated serving, where
+the wider first chunk buys back the playback cushion. The ramp is mutually
 exclusive with the legacy `initial_chunk_frames` /
 `stream_initial_followup_stride` options, its first entry must not exceed the
 steady stride, and a per-request `initial_codec_chunk_frames` still overrides
@@ -396,7 +397,7 @@ only the first chunk.
 | `max_new_tokens` | `2048` | Maximum number of generated codec tokens |
 | `seed` | `null` | Random seed for reproducibility |
 | `stream` | `false` | Stream raw PCM audio chunks |
-| `initial_codec_chunk_frames` | `8` (model default when omitted) | First streaming vocoder chunk size in codec frames. Smaller values lower TTFA but underrun more easily; `0` uses the steady stride from the start |
+| `initial_codec_chunk_frames` | ramp `1 -> 2 -> 4` when omitted | First streaming vocoder chunk size in codec frames. An explicit value replaces the ramp's first chunk only. Smaller values lower TTFA but underrun more easily; `0` uses the steady stride from the start |
 | `stream_codec_output` | `true` | Forward codec frames to the vocoder as they are generated. Set `false` to restore whole-utterance decoding for CustomVoice/VoiceDesign |
 
 ## Model Variants

--- a/docs/cookbook/qwen3_tts.md
+++ b/docs/cookbook/qwen3_tts.md
@@ -342,10 +342,11 @@ true incremental codec and vocoder streaming, for both this HTTP endpoint and
 `--preprocessing.factory.stream_codec_output false`, to restore whole-utterance
 decoding.
 
-When `initial_codec_chunk_frames` is omitted, Qwen3-TTS defaults to `8`
-codec frames for the first vocoder chunk so concurrent streams stay continuous.
-Pass a smaller value only when trading continuity for lower time-to-first-audio.
-Utterances that finish in fewer than `8` generated codec frames never reach the
+When `initial_codec_chunk_frames` is omitted, Qwen3-TTS ramps its first chunks
+`1 -> 2 -> 4` codec frames before the steady stride, so first audio leaves after a
+single AR step while the playback cushion is rebuilt within four chunks. Pass an
+explicit value to trade continuity against time-to-first-audio.
+Utterances that finish in fewer than the first chunk's generated codec frames never reach the
 first chunk, so their audio arrives complete in a single final flush.
 
 #### First-audio chunk ramp

--- a/sglang_omni/models/qwen3_tts/streaming_vocoder.py
+++ b/sglang_omni/models/qwen3_tts/streaming_vocoder.py
@@ -34,7 +34,7 @@ logger = logging.getLogger(__name__)
 DEFAULT_QWEN3_TTS_STREAM_STRIDE = 16
 DEFAULT_QWEN3_TTS_STREAM_FOLLOWUP_STRIDE = 8
 DEFAULT_QWEN3_TTS_STREAM_INITIAL_FOLLOWUP_STRIDE = 8
-DEFAULT_QWEN3_TTS_INITIAL_CHUNK_FRAMES = 1
+DEFAULT_QWEN3_TTS_INITIAL_CHUNK_FRAMES = 8
 # note (luojiaxuan): the first chunks ramp 1 -> 2 -> 4 before the steady
 # stride. A one-frame first chunk emits audio after a single AR step instead
 # of eight, and the ramp restores a full playback cushion within four chunks.
@@ -426,6 +426,7 @@ class Qwen3TTSStreamingVocoderScheduler(
             raise ValueError("stream_initial_followup_stride must be > 0")
         if initial_chunk_frames is not None and initial_chunk_frames < 0:
             raise ValueError("initial_chunk_frames must be >= 0")
+        ramp_in_effect = False
         if stream_chunk_ramp is not None:
             # note (Junnan Li): the ramp is the generalized form of the two
             # legacy knobs; a mixed configuration has no single source of
@@ -457,12 +458,14 @@ class Qwen3TTSStreamingVocoderScheduler(
                 raise ValueError("stream_chunk_ramp[0] must be <= stream_stride")
             initial_chunk_frames = chunk_ramp[0]
             followup_stride_ramp = chunk_ramp[1:]
+            ramp_in_effect = True
         elif initial_chunk_frames is None and stream_initial_followup_stride is None:
             initial_chunk_frames = DEFAULT_QWEN3_TTS_STREAM_CHUNK_RAMP[0]
             followup_stride_ramp = tuple(
                 min(stride, stream_followup_stride)
                 for stride in DEFAULT_QWEN3_TTS_STREAM_CHUNK_RAMP[1:]
             )
+            ramp_in_effect = True
         else:
             if initial_chunk_frames is None:
                 initial_chunk_frames = DEFAULT_QWEN3_TTS_INITIAL_CHUNK_FRAMES
@@ -561,7 +564,10 @@ class Qwen3TTSStreamingVocoderScheduler(
         self._followup_stride_ramp = tuple(
             int(stride) for stride in followup_stride_ramp
         )
-        self._chunk_ramp_configured = stream_chunk_ramp is not None
+        # note (luojiaxuan): a ramp is cursored by emitted frames whether it came
+        # from the parameter or from the shipped default; the legacy branch only
+        # fits the single follow-up stride schedule.
+        self._chunk_ramp_configured = ramp_in_effect
         self._initial_max_batch_size = int(initial_max_batch_size)
         self._initial_batch_wait_s = float(initial_batch_wait_ms) / 1000.0
         self._followup_max_batch_size = int(followup_max_batch_size)

--- a/sglang_omni/models/qwen3_tts/streaming_vocoder.py
+++ b/sglang_omni/models/qwen3_tts/streaming_vocoder.py
@@ -458,7 +458,6 @@ class Qwen3TTSStreamingVocoderScheduler(
             initial_chunk_frames = chunk_ramp[0]
             followup_stride_ramp = chunk_ramp[1:]
         elif initial_chunk_frames is None and stream_initial_followup_stride is None:
-            # Neither knob was set, so run the shipped ramp.
             initial_chunk_frames = DEFAULT_QWEN3_TTS_STREAM_CHUNK_RAMP[0]
             followup_stride_ramp = tuple(
                 min(stride, stream_followup_stride)

--- a/sglang_omni/models/qwen3_tts/streaming_vocoder.py
+++ b/sglang_omni/models/qwen3_tts/streaming_vocoder.py
@@ -34,7 +34,11 @@ logger = logging.getLogger(__name__)
 DEFAULT_QWEN3_TTS_STREAM_STRIDE = 16
 DEFAULT_QWEN3_TTS_STREAM_FOLLOWUP_STRIDE = 8
 DEFAULT_QWEN3_TTS_STREAM_INITIAL_FOLLOWUP_STRIDE = 8
-DEFAULT_QWEN3_TTS_INITIAL_CHUNK_FRAMES = 8
+DEFAULT_QWEN3_TTS_INITIAL_CHUNK_FRAMES = 1
+# note (luojiaxuan): the first chunks ramp 1 -> 2 -> 4 before the steady
+# stride. A one-frame first chunk emits audio after a single AR step instead
+# of eight, and the ramp restores a full playback cushion within four chunks.
+DEFAULT_QWEN3_TTS_STREAM_CHUNK_RAMP = (1, 2, 4)
 DEFAULT_QWEN3_TTS_LEFT_CONTEXT_FRAMES = 16
 _QWEN3_TTS_CODEBOOK_SIZE = 2048
 
@@ -453,6 +457,13 @@ class Qwen3TTSStreamingVocoderScheduler(
                 raise ValueError("stream_chunk_ramp[0] must be <= stream_stride")
             initial_chunk_frames = chunk_ramp[0]
             followup_stride_ramp = chunk_ramp[1:]
+        elif initial_chunk_frames is None and stream_initial_followup_stride is None:
+            # Neither knob was set, so run the shipped ramp.
+            initial_chunk_frames = DEFAULT_QWEN3_TTS_STREAM_CHUNK_RAMP[0]
+            followup_stride_ramp = tuple(
+                min(stride, stream_followup_stride)
+                for stride in DEFAULT_QWEN3_TTS_STREAM_CHUNK_RAMP[1:]
+            )
         else:
             if initial_chunk_frames is None:
                 initial_chunk_frames = DEFAULT_QWEN3_TTS_INITIAL_CHUNK_FRAMES

--- a/tests/unit_test/qwen3_tts/test_pipeline.py
+++ b/tests/unit_test/qwen3_tts/test_pipeline.py
@@ -3089,6 +3089,9 @@ def test_qwen3_tts_streaming_vocoder_uses_steady_followup_stride() -> None:
     scheduler = Qwen3TTSStreamingVocoderScheduler(
         _FakeQwen3TTSTokenizer(),
         device="cpu",
+        # note (luojiaxuan): a single-entry ramp leaves no ramp strides, so
+        # follow-ups go straight to the steady stride this test is about.
+        stream_chunk_ramp=(8,),
     )
     payload = make_payload(inputs="target", params={"stream": True})
     scheduler._on_streaming_new_request(payload.request_id, payload)
@@ -3465,6 +3468,10 @@ def test_qwen3_tts_streaming_vocoder_short_utterance_flushes_complete_audio() ->
     scheduler = Qwen3TTSStreamingVocoderScheduler(
         _FakeQwen3TTSTokenizer(),
         device="cpu",
+        # note (luojiaxuan): the utterance has to sit below the first chunk to
+        # reach the final-flush path, which needs a first chunk wider than one
+        # frame to be expressible.
+        stream_chunk_ramp=(8,),
     )
     generated_frames = scheduler._default_initial_chunk_frames - 1
     assert generated_frames > 0

--- a/tests/unit_test/qwen3_tts/test_pipeline.py
+++ b/tests/unit_test/qwen3_tts/test_pipeline.py
@@ -1606,10 +1606,10 @@ def test_qwen3_tts_vocoder_batches_decode_requests(
         max_batch_wait_ms=3,
     )
     assert warmed_schedulers == [scheduler]
-    assert scheduler.create_stream_state("request").initial_chunk_frames == 8
+    assert scheduler.create_stream_state("request").initial_chunk_frames == 1
     assert scheduler._stream_left_context_frames == 16
     assert scheduler._stream_followup_stride == 8
-    assert scheduler._followup_stride_ramp == (8,)
+    assert scheduler._followup_stride_ramp == (2, 4)
     assert scheduler._initial_max_batch_size == 32
     assert scheduler._initial_batch_wait_s == pytest.approx(0.002)
     assert scheduler._followup_max_batch_size == 8
@@ -2212,16 +2212,37 @@ def test_qwen3_tts_vocoder_serializes_followup_batch_collection() -> None:
     assert not first.is_alive()
 
 
-def test_qwen3_tts_streaming_vocoder_default_initial_chunk_is_continuity_safe() -> None:
+def test_qwen3_tts_streaming_vocoder_default_chunk_ramp() -> None:
     scheduler = Qwen3TTSStreamingVocoderScheduler(
         _FakeQwen3TTSTokenizer(),
         device="cpu",
+    )
+    left = scheduler._stream_left_context_frames
+
+    # Shipped ramp is 1 -> 2 -> 4 before the steady stride, so first audio
+    # leaves after a single AR step.
+    assert scheduler.create_stream_state("request").initial_chunk_frames == 1
+    assert scheduler._followup_stride_ramp == (2, 4)
+    assert scheduler._initial_decode_graphs._input_frames == (left + 1,)
+    assert scheduler._followup_decode_graphs._input_frames == (
+        left + 2,
+        left + 4,
+        left + 8,
+    )
+
+
+def test_qwen3_tts_explicit_initial_chunk_frames_keeps_legacy_ramp() -> None:
+    scheduler = Qwen3TTSStreamingVocoderScheduler(
+        _FakeQwen3TTSTokenizer(),
+        device="cpu",
+        initial_chunk_frames=8,
     )
 
     left = scheduler._stream_left_context_frames
     # Startup prefix sums plus the steady jitter band left+1..left+stride.
     expected = tuple(sorted({8} | {left + f for f in range(0, 9)}))
     assert scheduler.create_stream_state("request").initial_chunk_frames == 8
+    assert scheduler._followup_stride_ramp == (8,)
     assert scheduler._initial_decode_graphs._input_frames == expected
     assert scheduler._followup_decode_graphs._input_frames == expected
 

--- a/tests/unit_test/qwen3_tts/test_pipeline.py
+++ b/tests/unit_test/qwen3_tts/test_pipeline.py
@@ -2223,12 +2223,11 @@ def test_qwen3_tts_streaming_vocoder_default_chunk_ramp() -> None:
     # leaves after a single AR step.
     assert scheduler.create_stream_state("request").initial_chunk_frames == 1
     assert scheduler._followup_stride_ramp == (2, 4)
-    assert scheduler._initial_decode_graphs._input_frames == (left + 1,)
-    assert scheduler._followup_decode_graphs._input_frames == (
-        left + 2,
-        left + 4,
-        left + 8,
-    )
+    # Startup prefix sums 1, 1+2, 3+4, 7+8 plus the steady jitter band
+    # left+1..left+8; every ramp stride saturates inside that band.
+    expected = tuple(sorted({1, 3, 7, 15} | {left + f for f in range(1, 9)}))
+    assert scheduler._initial_decode_graphs._input_frames == expected
+    assert scheduler._followup_decode_graphs._input_frames == expected
 
 
 def test_qwen3_tts_explicit_initial_chunk_frames_keeps_legacy_ramp() -> None:

--- a/tests/unit_test/qwen3_tts/test_pipeline.py
+++ b/tests/unit_test/qwen3_tts/test_pipeline.py
@@ -2548,6 +2548,9 @@ def test_qwen3_tts_short_request_final_flush_decodes_synchronously() -> None:
         _FakeQwen3TTSTokenizer(),
         device="cpu",
         async_decode=True,
+        # note (luojiaxuan): the threshold is pinned so the two frames below
+        # stay short of it whatever the shipped first-chunk size is.
+        initial_chunk_frames=8,
     )
     payload = make_payload(inputs="short", params={"stream": True})
     scheduler._on_streaming_new_request(payload.request_id, payload)

--- a/tests/unit_test/qwen3_tts/test_pipeline.py
+++ b/tests/unit_test/qwen3_tts/test_pipeline.py
@@ -2223,11 +2223,49 @@ def test_qwen3_tts_streaming_vocoder_default_chunk_ramp() -> None:
     # leaves after a single AR step.
     assert scheduler.create_stream_state("request").initial_chunk_frames == 1
     assert scheduler._followup_stride_ramp == (2, 4)
-    # Startup prefix sums 1, 1+2, 3+4, 7+8 plus the steady jitter band
-    # left+1..left+8; every ramp stride saturates inside that band.
-    expected = tuple(sorted({1, 3, 7, 15} | {left + f for f in range(1, 9)}))
-    assert scheduler._initial_decode_graphs._input_frames == expected
-    assert scheduler._followup_decode_graphs._input_frames == expected
+    # Drive the real stride selection instead of re-deriving it: the shipped
+    # ramp has to be cursored like a configured one, otherwise the legacy
+    # branch runs 1, 2, 8 and the third window is never captured.
+    state = scheduler.create_stream_state("request")
+    strides, emitted = [], 0
+    for index in range(6):
+        stride = (
+            state.initial_chunk_frames
+            if index == 0
+            else scheduler._next_followup_stride(state)
+        )
+        strides.append(stride)
+        emitted += stride
+        state.emitted_generated_frames = emitted
+        state.decoded_chunks = index + 1
+    assert strides == [1, 2, 4, 8, 8, 8]
+
+    captured = set(scheduler._initial_decode_graphs._input_frames)
+    windows, emitted = [], 0
+    for stride in strides:
+        generated = emitted + stride
+        windows.append(generated - max(0, emitted - left))
+        emitted = generated
+    assert not set(windows) - captured, (
+        f"uncaptured decode windows {sorted(set(windows) - captured)} "
+        f"for schedule {strides}"
+    )
+    assert scheduler._followup_decode_graphs._input_frames == (
+        scheduler._initial_decode_graphs._input_frames
+    )
+
+
+def test_qwen3_tts_stream_initial_followup_stride_keeps_legacy_first_chunk() -> None:
+    """Setting only the follow-up stride must not inherit the ramp's first chunk."""
+    scheduler = Qwen3TTSStreamingVocoderScheduler(
+        _FakeQwen3TTSTokenizer(),
+        device="cpu",
+        stream_initial_followup_stride=4,
+    )
+
+    assert scheduler.create_stream_state("request").initial_chunk_frames == 8
+    assert scheduler._followup_stride_ramp == (4,)
+    assert scheduler._chunk_ramp_configured is False
 
 
 def test_qwen3_tts_explicit_initial_chunk_frames_keeps_legacy_ramp() -> None:


### PR DESCRIPTION
Ships the first-audio chunk ramp **on by default** instead of behind `stream_chunk_ramp`. #1848 added the ramp mechanism but left the shipped default at a flat 8-frame first chunk, so out-of-the-box streaming waits for 8 AR steps (640 ms of audio) before emitting anything.

## Change

Default schedule becomes `1 -> 2 -> 4 -> steady stride` (was `8 -> 8 -> ...`). First audio leaves after a single AR step, and the playback cushion is rebuilt within four chunks. Explicit `initial_chunk_frames` / `stream_initial_followup_stride` / `stream_chunk_ramp` configurations are untouched — the new ramp only applies when no chunk knob is set, and a unit test pins that legacy path.

## Measured (H100, 1.7B CustomVoice, SeedTTS EN, same host/tree, only this change)

| 1 RPS | shipped default (8) | this PR (1 -> 2 -> 4) |
|---|---|---|
| TTFB p50 | 90.1 ms | **36.0 ms** |
| TTFB p95 | 128.0 ms | **63.7 ms** |
| success | 100% | 100% |
| underrun | 0% | 0% |

**-60% first-byte latency at c1.**

Continuity checked under load, since a smaller first chunk is the classic continuity trade:

| 10 RPS (2 seeds) | this PR |
|---|---|
| success | 100% / 100% |
| underrun | 0.34% / 0.83% |

That matches the underrun level of the previous default at the same concurrency, so the smaller first chunk does not cost continuity on this workload. The reference engine we benchmark against uses the same shape (its chunk schedule also starts at a single frame), which is what prompted testing it.

Graph coverage: with the widened decode-graph derivation (#1912) the ramp's frame counts are captured automatically, so the smaller first chunk stays on the CUDA-graph path rather than falling to eager decode.

## Tests

- `test_qwen3_tts_streaming_vocoder_default_chunk_ramp` pins the shipped ramp and the derived graph shapes.
- `test_qwen3_tts_explicit_initial_chunk_frames_keeps_legacy_ramp` pins that an explicit `initial_chunk_frames=8` still produces the old single-stride ramp.
- The vocoder factory default test is updated to the new ramp.
