### PR TITLE
[Fun-ASR] Map renamed HF checkpoint weights

### DIFF
--- a/sglang_omni/models/fun_asr/sglang_model.py
+++ b/sglang_omni/models/fun_asr/sglang_model.py
@@ -22,6 +22,7 @@ from sglang.srt.managers.schedule_batch import (
 from sglang.srt.model_executor.forward_batch_info import ForwardBatch
 from sglang.srt.model_loader.weight_utils import default_weight_loader
 from sglang.srt.models.qwen3 import Qwen3ForCausalLM
+from sglang.srt.models.utils import WeightsMapper
 from sglang.srt.utils import add_prefix
 from transformers.activations import ACT2FN
 
@@ -29,6 +30,15 @@ from .configuration_fun_asr import FunAsrNanoConfig
 from .tool_funcs.audio_lengths import fun_asr_low_frame_rate_length
 
 logger = logging.getLogger(__name__)
+
+FUN_ASR_HF_TO_SGLANG_MAPPER = WeightsMapper(
+    orig_to_new_substr={
+        ".feedforward_sequential_memory.": ".fsmn.",
+    },
+    orig_to_new_prefix={
+        "model.audio_adaptor.": "model.multi_modal_projector.",
+    },
+)
 
 
 def _sanm_mask_from_lengths(
@@ -540,6 +550,8 @@ class FunAsrNanoForConditionalGeneration(nn.Module):
         return hidden_states
 
     def load_weights(self, weights: Iterable[Tuple[str, torch.Tensor]]):
+        weights = FUN_ASR_HF_TO_SGLANG_MAPPER.apply(weights)
+
         # Qwen3 LLM: q/k/v → qkv_proj, gate/up → gate_up_proj (sglang stacked).
         llm_stacked_params = [
             ("qkv_proj", "q_proj", "q"),

--- a/sglang_omni/models/fun_asr/sglang_model.py
+++ b/sglang_omni/models/fun_asr/sglang_model.py
@@ -31,6 +31,8 @@ from .tool_funcs.audio_lengths import fun_asr_low_frame_rate_length
 
 logger = logging.getLogger(__name__)
 
+# Note (Akazaakane): Normalize the September 2026 HF key renames while keeping
+# the existing module names compatible with the pinned earlier checkpoint.
 FUN_ASR_HF_TO_SGLANG_MAPPER = WeightsMapper(
     orig_to_new_substr={
         ".feedforward_sequential_memory.": ".fsmn.",

--- a/tests/unit_test/fun_asr/test_model.py
+++ b/tests/unit_test/fun_asr/test_model.py
@@ -87,6 +87,34 @@ def test_fun_asr_weight_loader_loads_current_audio_prefixes() -> None:
     assert torch.equal(model.audio_tower.layer_norm.weight, expected)
 
 
+def test_fun_asr_weight_loader_maps_new_checkpoint_names() -> None:
+    model = _weight_loader_target()
+    model.audio_tower.stem = nn.Module()
+    model.audio_tower.stem.fsmn = nn.Module()
+    model.audio_tower.stem.fsmn.conv = nn.Conv1d(2, 2, 1, bias=False)
+    model.multi_modal_projector.blocks = nn.ModuleList([nn.Module()])
+    model.multi_modal_projector.blocks[0].fc1 = nn.Linear(2, 2, bias=False)
+    expected_fsmn = torch.full_like(model.audio_tower.stem.fsmn.conv.weight, 2.0)
+    expected_adaptor = torch.full_like(
+        model.multi_modal_projector.blocks[0].fc1.weight, 3.0
+    )
+
+    model.load_weights(
+        [
+            (
+                "model.audio_tower.stem.feedforward_sequential_memory.conv.weight",
+                expected_fsmn,
+            ),
+            ("model.audio_adaptor.blocks.0.fc1.weight", expected_adaptor),
+        ]
+    )
+
+    assert torch.equal(model.audio_tower.stem.fsmn.conv.weight, expected_fsmn)
+    assert torch.equal(
+        model.multi_modal_projector.blocks[0].fc1.weight, expected_adaptor
+    )
+
+
 def test_fun_asr_weight_loader_rejects_unknown_audio_weights() -> None:
     model = _weight_loader_target()
 


### PR DESCRIPTION
## Motivation

The September 2026 `FunAudioLLM/Fun-ASR-Nano-2512-hf` checkpoint renamed the FSMN module to `feedforward_sequential_memory` and moved adaptor SANM weights under `model.audio_adaptor.`. The existing loader expects the pinned checkpoint naming, so the new keys no longer load correctly.

## Modifications

- Preserve the existing internal `fsmn` and `multi_modal_projector` module names.
- Add a `WeightsMapper` that maps the new HF checkpoint names to those canonical internal names before the existing loader runs.
- Add focused regression coverage for both renamed key forms.

## Related Issues

Alternative implementation for #1926.

## Accuracy Test

PR #1931 passes compatibility testing for both Fun-ASR checkpoints.

  - Branch: 1bd51567 — Map renamed HF checkpoint weights (https://github.com/sgl-project/sglang-omni/pull/1931)
  - Fun-ASR unit tests: 85 passed
  - Old pinned checkpoint 972ee603…: startup, CUDA-graph attestation, and transcription passed.
  - New checkpoint 1fd03aa…
    (https://huggingface.co/FunAudioLLM/Fun-ASR-Nano-2512-hf/commit/1fd03aa58072a4c00bf0a0b149cc4cf0d36d11ed): startup,
    renamed-weight loading, CUDA-graph attestation, and transcription passed.

  - Both produced: “How many cars are there in the picture?”
  - No missing/unexpected weight errors occurred.

  Logs: /tmp/pr1931_fun_asr_old.log, /tmp/pr1931_fun_asr_new.log.

  Conclusion: PR 1931 fixes the new checkpoint while preserving compatibility with the old checkpoint.

## Benchmark & Profiling

Not run. The change only remaps checkpoint keys before the existing weight loader.

## Checklist

- [x] Format your code according with pre-commit.
- [x] Add unit tests.
- [x] Update documentation / docstrings / example tutorials as needed. No documentation change is needed for this internal loader fix.
- [x] Provide throughput / latency benchmark results and accuracy evaluation results as needed. Not applicable to checkpoint-key remapping.
- [ ] For reviewers: If you have not made any contributions to this PR and are only assisting with merging the main branch, please remove yourself as a co-author when merging the PR.