### PR TITLE
[Config] Add a runtime-resolution channel for hardware-resolved engine fields

### DIFF
--- a/sglang_omni/cli/config.py
+++ b/sglang_omni/cli/config.py
@@ -198,11 +198,13 @@ def _resolve_sources(
             resolved.provenance.record_resolved(
                 path_text, derivation_patch.path.read(derived)
             )
-        # Hardware-resolved engine fields left at "auto" only get a value
-        # inside ServerArgs construction, on the GPU the stage lands on.
-        # This preview runs without one, so the honest answer is a pending
-        # runtime entry, rendered as "auto (resolved from GPU memory at
-        # launch)" instead of a value this command cannot know.
+        # Hardware-resolved engine fields left at "auto" only get a value at
+        # launch: the stage's builder may fill them from its own generation
+        # defaults, and whatever is still unset then is resolved by SGLang
+        # from the GPU the stage lands on. This preview runs without either
+        # (builder defaults need a constructed builder, the GPU is not
+        # here), so the honest answer is a pending runtime entry naming both
+        # possible settlers instead of a value this command cannot know.
         engine_stage_names = set(_engine_stage_names(derived))
         for stage in derived.stages:
             if stage.name not in engine_stage_names:
@@ -220,7 +222,10 @@ def _resolve_sources(
                         path=path_text,
                         configured=None,
                         resolved=PENDING,
-                        origin="sglang hardware resolution at launch",
+                        origin=(
+                            "settled at launch: the stage builder's defaults, "
+                            "else sglang's hardware resolution"
+                        ),
                     ),
                 )
         return Resolution(baseline, replace(resolved, config=derived))
@@ -347,12 +352,16 @@ def explain(
             print("No configuration source touched the pipeline's defaults.")
             return
         for listed in provenance.paths():
-            winner = provenance.winner(listed)
-            if winner is None:
-                # A runtime-only path: no source wrote it, the launch will.
-                runtime = provenance.runtime[listed]
+            runtime = provenance.runtime.get(listed)
+            if runtime is not None:
+                # The launch has the last word, exactly as `explain <path>`
+                # reports it — even when a source also wrote the path (a
+                # yaml `mem_fraction_static: null` is a source write whose
+                # value the launch settles).
                 print(f"{listed} = {runtime.resolved!r}  <- runtime ({runtime.origin})")
                 continue
+            winner = provenance.winner(listed)
+            assert winner is not None  # a non-runtime path has entries
             value = provenance.resolved_value(listed, winner.value)
             print(f"{listed} = {value!r}  <- {winner.source.describe()}")
         return

--- a/sglang_omni/cli/config.py
+++ b/sglang_omni/cli/config.py
@@ -18,6 +18,11 @@ from sglang_omni.config.patch import (
 )
 from sglang_omni.config.path import ConfigPath, ConfigPathError
 from sglang_omni.config.resolver import ConfigResolver, ResolvedConfig, diff_configs
+from sglang_omni.config.runtime_resolution import (
+    PENDING,
+    RUNTIME_RESOLVED_FIELDS,
+    RuntimeResolution,
+)
 from sglang_omni.config.schema import PipelineConfig
 from sglang_omni.config.sources import (
     dump_user_config,
@@ -132,6 +137,7 @@ def _resolve_sources(
     # derivation; importing them here keeps the two commands building
     # identical configurations.
     from sglang_omni.cli.serve import (
+        _engine_stage_names,
         apply_tensor_parallel_engine_overrides,
         patches_from_broadcast_flags,
         tensor_parallel_engine_writes,
@@ -192,6 +198,31 @@ def _resolve_sources(
             resolved.provenance.record_resolved(
                 path_text, derivation_patch.path.read(derived)
             )
+        # Hardware-resolved engine fields left at "auto" only get a value
+        # inside ServerArgs construction, on the GPU the stage lands on.
+        # This preview runs without one, so the honest answer is a pending
+        # runtime entry, rendered as "auto (resolved from GPU memory at
+        # launch)" instead of a value this command cannot know.
+        engine_stage_names = set(_engine_stage_names(derived))
+        for stage in derived.stages:
+            if stage.name not in engine_stage_names:
+                continue
+            engine = getattr(stage, "engine", None)
+            engine_values = engine.overrides() if engine is not None else {}
+            stage_name = stage.name
+            for field_name in RUNTIME_RESOLVED_FIELDS:
+                if engine_values.get(field_name) is not None:
+                    continue
+                path_text = f"stages.{stage_name}.engine.{field_name}"
+                resolved.provenance.record_runtime(
+                    path_text,
+                    RuntimeResolution(
+                        path=path_text,
+                        configured=None,
+                        resolved=PENDING,
+                        origin="sglang hardware resolution at launch",
+                    ),
+                )
         return Resolution(baseline, replace(resolved, config=derived))
     except (ConfigPathError, ValueError) as exc:
         # An unknown path, a path the schema will not let a user write, two
@@ -315,11 +346,15 @@ def explain(
         if not provenance.paths():
             print("No configuration source touched the pipeline's defaults.")
             return
-        for touched in provenance.paths():
-            winner = provenance.winner(touched)
-            assert winner is not None  # a touched path always has a winner
-            value = provenance.resolved_value(touched, winner.value)
-            print(f"{touched} = {value!r}  <- {winner.source.describe()}")
+        for listed in provenance.paths():
+            winner = provenance.winner(listed)
+            if winner is None:
+                # A runtime-only path: no source wrote it, the launch will.
+                runtime = provenance.runtime[listed]
+                print(f"{listed} = {runtime.resolved!r}  <- runtime ({runtime.origin})")
+                continue
+            value = provenance.resolved_value(listed, winner.value)
+            print(f"{listed} = {value!r}  <- {winner.source.describe()}")
         return
 
     try:
@@ -329,7 +364,7 @@ def explain(
         # Carries `did you mean:` suggestions, which a traceback would bury.
         raise typer.BadParameter(str(exc)) from exc
 
-    if provenance.touched(compiled.raw):
+    if provenance.touched(compiled.raw) or provenance.runtime_resolved(compiled.raw):
         print(provenance.explain(compiled.raw))
         return
     try:

--- a/sglang_omni/config/patch.py
+++ b/sglang_omni/config/patch.py
@@ -83,12 +83,21 @@ class SourceKind(str, Enum):
     CLI_FLAG = "cli_flag"
     CLI_DOTTED = "cli_dotted"
 
+    RUNTIME = "runtime"
+    """A value the launch itself settled (e.g. SGLang resolving an "auto"
+    field from GPU memory inside ``ServerArgs``). Observation only: it is
+    deliberately absent from ``_DEFAULT_LAYER`` below, so building a
+    :class:`ConfigPatch` from it raises — runtime resolutions never enter
+    patch precedence. They travel through
+    :mod:`sglang_omni.config.runtime_resolution` instead."""
+
 
 _DEFAULT_LAYER: dict[SourceKind, Layer] = {
     SourceKind.MODEL_DEFAULT: Layer.MODEL_DEFAULT,
     SourceKind.YAML_FILE: Layer.USER_FILE,
     SourceKind.CLI_FLAG: Layer.CLI,
     SourceKind.CLI_DOTTED: Layer.CLI,
+    # SourceKind.RUNTIME intentionally has no layer; see its docstring.
 }
 
 

--- a/sglang_omni/config/provenance.py
+++ b/sglang_omni/config/provenance.py
@@ -26,6 +26,7 @@ from sglang_omni.config.patch import (
     ConfigSource,
     SourceKind,
 )
+from sglang_omni.config.runtime_resolution import RuntimeResolution
 
 __all__ = ["ProvenanceEntry", "ProvenanceMap", "BASELINE_SOURCE"]
 
@@ -78,6 +79,12 @@ class ProvenanceMap:
     resolved: dict[str, Any] = field(default_factory=dict)
     """Post-validation value per touched path, read back off the built config."""
 
+    runtime: dict[str, RuntimeResolution] = field(default_factory=dict)
+    """Values the launch itself settled, per path — a separate channel from
+    the patch history above. A runtime entry may sit on a path no patch
+    touched (an "auto" field nobody wrote); such paths are still listed and
+    explainable."""
+
     # ------------------------------------------------------------------
     # building
     # ------------------------------------------------------------------
@@ -93,6 +100,9 @@ class ProvenanceMap:
     def record_resolved(self, path: str, value: Any) -> None:
         self.resolved[path] = value
 
+    def record_runtime(self, path: str, resolution: RuntimeResolution) -> None:
+        self.runtime[path] = resolution
+
     @classmethod
     def from_patchset(cls, patchset: ConfigPatchSet) -> "ProvenanceMap":
         out = cls()
@@ -106,7 +116,7 @@ class ProvenanceMap:
     # ------------------------------------------------------------------
 
     def paths(self) -> list[str]:
-        return sorted(self.entries)
+        return sorted(self.entries.keys() | self.runtime.keys())
 
     def winner(self, path: str) -> ProvenanceEntry | None:
         for entry in reversed(self.entries.get(path, [])):
@@ -116,6 +126,9 @@ class ProvenanceMap:
 
     def touched(self, path: str) -> bool:
         return path in self.entries
+
+    def runtime_resolved(self, path: str) -> bool:
+        return path in self.runtime
 
     def resolved_value(self, path: str, default: Any = None) -> Any:
         """The value the built config holds at a touched path."""
@@ -128,12 +141,30 @@ class ProvenanceMap:
         validation may have rewritten what the winning source supplied. The
         winner's own line keeps the source's value, with the rewrite noted.
 
-        Callers ask :meth:`touched` first; an untouched path raises ``KeyError``.
+        A runtime resolution (a value the launch itself settled — see
+        :mod:`sglang_omni.config.runtime_resolution`) is rendered as one
+        extra line after the patch history; on a path no patch touched it
+        is the whole story.
+
+        Callers ask :meth:`touched` or :meth:`runtime_resolved` first; a
+        path known to neither raises ``KeyError``.
         """
-        history = self.entries[path]
+        runtime = self.runtime.get(path)
+        history = self.entries.get(path)
+        if history is None:
+            if runtime is None:
+                raise KeyError(path)
+            # No source wrote this path; the launch alone settled it.
+            return (
+                f"{path} = {runtime.resolved!r}\n"
+                f"  {runtime.resolved!r}  <- runtime ({runtime.origin})"
+            )
         winner = self.winner(path)
         resolved = self.resolved.get(path, _UNSET)
-        if winner is None:
+        if runtime is not None:
+            # The launch has the last word over what validation produced.
+            headline = f"{path} = {runtime.resolved!r}"
+        elif winner is None:
             headline = path
         elif resolved is _UNSET:
             headline = f"{path} = {winner.value!r}"
@@ -143,4 +174,6 @@ class ProvenanceMap:
         if path in self.baseline:
             lines.append(f"  {self.baseline[path]!r}  <- {BASELINE_SOURCE.describe()}")
         lines.extend(f"  {entry.render(resolved)}" for entry in history)
+        if runtime is not None:
+            lines.append(f"  {runtime.resolved!r}  <- runtime ({runtime.origin})")
         return "\n".join(lines)

--- a/sglang_omni/config/resolver.py
+++ b/sglang_omni/config/resolver.py
@@ -11,7 +11,10 @@ What it deliberately does *not* do:
   themselves into patches before they get here;
 * it does not compute placement, process topology or SGLang server args —
   those are downstream consumers of the resolved value, and must not write
-  back into it.
+  back into the config model. Values the launch itself settles (an "auto"
+  field SGLang resolves from the GPU) are recorded as observations in the
+  provenance's runtime channel
+  (:mod:`sglang_omni.config.runtime_resolution`), never as patches.
 """
 
 from __future__ import annotations

--- a/sglang_omni/config/runtime_resolution.py
+++ b/sglang_omni/config/runtime_resolution.py
@@ -1,0 +1,174 @@
+# SPDX-License-Identifier: Apache-2.0
+"""Observing values that only become concrete at launch.
+
+Several engine fields carry ``None`` through the whole config pipeline on
+purpose: ``None`` means "auto", and SGLang's ``ServerArgs.__post_init__``
+resolves it from the GPU it lands on (``chunked_prefill_size`` becomes 2048
+on a small card, 8192 on an H100, and so on). Until that moment the value
+does not exist anywhere in this repo — no config source can know it, and
+deriving anything from it earlier reads a value that is not there yet.
+
+This module is the channel for those observations:
+
+* :func:`capture_runtime_resolutions` diffs the overrides a builder passed
+  into ``ServerArgs`` against the constructed object and reports every field
+  the runtime filled in or rewrote.
+* :class:`RuntimeResolutionRecord` keeps the observations queryable inside
+  the stage worker process that made them.
+* :func:`require_resolved` is the guardrail for derivation code: it refuses
+  an unresolved "auto" with a message naming the safe place to run instead.
+
+Deliberately not patches: a runtime resolution is a fact about what the
+launch did, not a configuration write, so it never enters patch precedence
+(:mod:`sglang_omni.config.patch`) and never mutates the config model
+(:mod:`sglang_omni.config.resolver`). Provenance renders it as a separate
+line via :meth:`~sglang_omni.config.provenance.ProvenanceMap.record_runtime`.
+"""
+
+from __future__ import annotations
+
+from collections.abc import Mapping
+from dataclasses import dataclass, field
+from typing import Any
+
+__all__ = [
+    "PENDING",
+    "RUNTIME_RESOLVED_FIELDS",
+    "RuntimeResolution",
+    "RuntimeResolutionRecord",
+    "RUNTIME_RESOLUTION_RECORD",
+    "capture_runtime_resolutions",
+    "require_resolved",
+]
+
+
+class _Pending:
+    """Sentinel for "will be resolved at launch, on hardware we cannot see"."""
+
+    def __repr__(self) -> str:  # pragma: no cover - trivial
+        return "auto (resolved from GPU memory at launch)"
+
+
+PENDING = _Pending()
+"""Resolved value used by GPU-less previews (``sgl-omni config resolve``)."""
+
+
+RUNTIME_RESOLVED_FIELDS: tuple[str, ...] = (
+    "chunked_prefill_size",
+    "mem_fraction_static",
+    "cuda_graph_max_bs",
+    "max_total_tokens",
+)
+"""ServerArgs fields whose ``None`` means "auto, resolve from the GPU".
+
+The set mirrors what SGLang's ``ServerArgs._handle_gpu_memory_settings``
+fills in from device memory. Extend it when upstream grows a new
+hardware-resolved field.
+"""
+
+SERVER_ARGS_HARDWARE_RESOLUTION = "sglang ServerArgs hardware resolution"
+"""Origin string for values SGLang filled in during construction."""
+
+_UNSET = object()
+
+
+@dataclass(frozen=True)
+class RuntimeResolution:
+    """One field the runtime settled after configuration was finished."""
+
+    path: str
+    """Dotted config path or bare ServerArgs field name."""
+
+    configured: Any
+    """What the configuration supplied (``None`` == "auto")."""
+
+    resolved: Any
+    """What the constructed ``ServerArgs`` holds (or :data:`PENDING`)."""
+
+    origin: str
+    """Who settled it, e.g. :data:`SERVER_ARGS_HARDWARE_RESOLUTION`."""
+
+    def describe(self) -> str:
+        configured = "auto" if self.configured is None else repr(self.configured)
+        return f"{self.path}: {configured} -> {self.resolved!r} ({self.origin})"
+
+
+def capture_runtime_resolutions(
+    configured: Mapping[str, Any],
+    server_args: Any,
+    *,
+    fields: tuple[str, ...] = RUNTIME_RESOLVED_FIELDS,
+) -> list[RuntimeResolution]:
+    """Report every hardware-resolved field the constructed args changed.
+
+    ``configured`` is the overrides mapping handed to ``ServerArgs``; a field
+    absent from it counts as unset (``None``), because ``ServerArgs`` defaults
+    it to ``None`` and resolves from there. Fields the runtime left exactly as
+    configured are not reported — a resolution is a change of value, and an
+    explicitly-set field passing through unchanged is not one.
+    """
+    out: list[RuntimeResolution] = []
+    for name in fields:
+        resolved = getattr(server_args, name, _UNSET)
+        if resolved is _UNSET:
+            continue
+        supplied = configured.get(name)
+        if resolved == supplied:
+            continue
+        out.append(
+            RuntimeResolution(
+                path=name,
+                configured=supplied,
+                resolved=resolved,
+                origin=SERVER_ARGS_HARDWARE_RESOLUTION,
+            )
+        )
+    return out
+
+
+def require_resolved(value: Any, *, field_name: str, hint: str = "") -> Any:
+    """Refuse to derive from a value that is still "auto".
+
+    Derivation code that consumes a hardware-resolved field calls this at the
+    top; before ``ServerArgs`` construction the field is ``None`` and the
+    derived result would be built on a value that does not exist yet (the
+    prefill CUDA graph ladder bug class). Returns ``value`` unchanged when it
+    is concrete.
+    """
+    if value is None:
+        message = (
+            f"{field_name} is still unresolved ('auto'); it only becomes "
+            "concrete inside ServerArgs construction. Derive from it in "
+            "finalize_runtime_derived(), which runs after resolution — "
+            "not in adjust_overrides()."
+        )
+        if hint:
+            message += f" {hint}"
+        raise ValueError(message)
+    return value
+
+
+@dataclass
+class RuntimeResolutionRecord:
+    """Process-local registry of what each stage's launch resolved.
+
+    Lives in the stage worker process that constructed the ``ServerArgs``;
+    the parent's provenance cannot be reached from here (the config crosses
+    a spawn boundary as plain kwargs), so diagnostics in the same process
+    query this instead.
+    """
+
+    _by_stage: dict[str, list[RuntimeResolution]] = field(default_factory=dict)
+
+    def record(self, stage: str, resolutions: list[RuntimeResolution]) -> None:
+        self._by_stage[stage] = list(resolutions)
+
+    def get(self, stage: str) -> list[RuntimeResolution]:
+        return list(self._by_stage.get(stage, []))
+
+    def all(self) -> dict[str, list[RuntimeResolution]]:
+        return {stage: list(items) for stage, items in self._by_stage.items()}
+
+
+RUNTIME_RESOLUTION_RECORD = RuntimeResolutionRecord()
+"""The worker process's registry; builders also keep their own list."""

--- a/sglang_omni/config/runtime_resolution.py
+++ b/sglang_omni/config/runtime_resolution.py
@@ -53,17 +53,20 @@ PENDING = _Pending()
 """Resolved value used by GPU-less previews (``sgl-omni config resolve``)."""
 
 
-RUNTIME_RESOLVED_FIELDS: tuple[str, ...] = (
-    "chunked_prefill_size",
-    "mem_fraction_static",
-    "cuda_graph_max_bs",
-    "max_total_tokens",
-)
-"""ServerArgs fields whose ``None`` means "auto, resolve from the GPU".
+RUNTIME_RESOLVED_FIELDS: dict[str, str] = {
+    "chunked_prefill_size": "chunked_prefill_size",
+    "mem_fraction_static": "mem_fraction_static",
+    # The omni override name; ServerArgs has no attribute of that name — the
+    # builder aliases it to cuda_graph_max_bs_decode and the resolved value
+    # lands on the nested cuda_graph_config.
+    "cuda_graph_max_bs": "cuda_graph_config.decode.max_bs",
+}
+"""Override name -> dotted ``ServerArgs`` attribute path for "auto" fields.
 
 The set mirrors what SGLang's ``ServerArgs._handle_gpu_memory_settings``
-fills in from device memory. Extend it when upstream grows a new
-hardware-resolved field.
+fills in from device memory (``max_total_tokens`` is not among them: it is
+resolved later, from the allocated KV pool). Extend it when upstream grows
+a new hardware-resolved field.
 """
 
 SERVER_ARGS_HARDWARE_RESOLUTION = "sglang ServerArgs hardware resolution"
@@ -93,11 +96,19 @@ class RuntimeResolution:
         return f"{self.path}: {configured} -> {self.resolved!r} ({self.origin})"
 
 
+def _read_attr_path(obj: Any, dotted: str) -> Any:
+    for part in dotted.split("."):
+        obj = getattr(obj, part, _UNSET)
+        if obj is _UNSET:
+            return _UNSET
+    return obj
+
+
 def capture_runtime_resolutions(
     configured: Mapping[str, Any],
     server_args: Any,
     *,
-    fields: tuple[str, ...] = RUNTIME_RESOLVED_FIELDS,
+    fields: Mapping[str, str] = RUNTIME_RESOLVED_FIELDS,
 ) -> list[RuntimeResolution]:
     """Report every hardware-resolved field the constructed args changed.
 
@@ -108,8 +119,8 @@ def capture_runtime_resolutions(
     explicitly-set field passing through unchanged is not one.
     """
     out: list[RuntimeResolution] = []
-    for name in fields:
-        resolved = getattr(server_args, name, _UNSET)
+    for name, attr_path in fields.items():
+        resolved = _read_attr_path(server_args, attr_path)
         if resolved is _UNSET:
             continue
         supplied = configured.get(name)

--- a/sglang_omni/scheduling/engine_factory.py
+++ b/sglang_omni/scheduling/engine_factory.py
@@ -9,6 +9,11 @@ from collections.abc import Mapping
 from numbers import Integral
 from typing import Any, ClassVar
 
+from sglang_omni.config.runtime_resolution import (
+    RUNTIME_RESOLUTION_RECORD,
+    RuntimeResolution,
+    capture_runtime_resolutions,
+)
 from sglang_omni.scheduling.generation_batch_policy import (
     CudaGraphBackend,
     build_generation_batch_overrides,
@@ -172,6 +177,17 @@ class SGLangGenerationEngineBuilder(ABC):
             )
         self.validate_before_infrastructure(server_args)
 
+        # ServerArgs construction is where "auto" fields become concrete
+        # (SGLang resolves them from GPU memory in __post_init__). Read the
+        # settled values back, record them, and only then let builders derive
+        # from them — this is the first point in the lifecycle where a
+        # derivation from these fields reads a value that actually exists.
+        self.runtime_resolutions = capture_runtime_resolutions(overrides, server_args)
+        RUNTIME_RESOLUTION_RECORD.record(self.model_name, self.runtime_resolutions)
+        for resolution in self.runtime_resolutions:
+            logger.info(f"{self.model_name}: runtime-resolved {resolution.describe()}")
+        self.finalize_runtime_derived(server_args, self.runtime_resolutions)
+
         infra_kwargs = dict(self.infra_kwargs())
         if self.model_arch_override is not None:
             infra_kwargs.setdefault("model_arch_override", self.model_arch_override)
@@ -292,10 +308,35 @@ class SGLangGenerationEngineBuilder(ABC):
         del model, server_args
 
     def adjust_overrides(self, overrides: dict[str, Any]) -> None:
+        """Adjust the overrides dict before ServerArgs construction.
+
+        Runs while "auto" fields (``chunked_prefill_size`` and friends) are
+        still ``None`` — SGLang only resolves them from GPU memory inside
+        ``ServerArgs``. Do not derive dependent values from them here; that
+        belongs in :meth:`finalize_runtime_derived`, and derivation code can
+        call :func:`~sglang_omni.config.runtime_resolution.require_resolved`
+        to enforce it.
+        """
         del overrides
 
     def customize_server_args(self, server_args: Any) -> None:
         del server_args
+
+    def finalize_runtime_derived(
+        self,
+        server_args: Any,
+        resolutions: list[RuntimeResolution],
+    ) -> None:
+        """Derive framework values that depend on hardware-resolved fields.
+
+        Runs after ``ServerArgs`` construction and
+        :meth:`customize_server_args`, before any CUDA graph decisions are
+        read off ``server_args`` — the only place in the build where fields
+        like ``chunked_prefill_size`` are guaranteed concrete. ``resolutions``
+        lists what the runtime filled in or rewrote, configured value
+        included, so a builder can tell operator intent from auto resolution.
+        """
+        del server_args, resolutions
 
     def infra_kwargs(self) -> dict[str, Any]:
         return {}

--- a/sglang_omni/scheduling/engine_factory.py
+++ b/sglang_omni/scheduling/engine_factory.py
@@ -165,15 +165,14 @@ class SGLangGenerationEngineBuilder(ABC):
             context_length=self.context_length,
             **overrides,
         )
-        self.customize_server_args(server_args)
-        self.validate_before_infrastructure(server_args)
-
         # ServerArgs construction is where "auto" fields become concrete
         # (SGLang resolves them from GPU memory in __post_init__). Read the
-        # settled values back, record them, and only then let builders derive
-        # from them — this is the first point in the lifecycle where a
-        # derivation from these fields reads a value that actually exists.
+        # settled values back immediately — before customize_server_args,
+        # whose builder writes (zonos2 forces chunked_prefill_size=0) would
+        # otherwise be recorded as the hardware's resolution.
         self.runtime_resolutions = capture_runtime_resolutions(overrides, server_args)
+        self.customize_server_args(server_args)
+        self.validate_before_infrastructure(server_args)
         RUNTIME_RESOLUTION_RECORD.record(self.model_name, self.runtime_resolutions)
         for resolution in self.runtime_resolutions:
             logger.info(f"{self.model_name}: runtime-resolved {resolution.describe()}")

--- a/sglang_omni/scheduling/engine_factory.py
+++ b/sglang_omni/scheduling/engine_factory.py
@@ -166,15 +166,6 @@ class SGLangGenerationEngineBuilder(ABC):
             **overrides,
         )
         self.customize_server_args(server_args)
-        if (
-            overrides.get("chunked_prefill_size") is None
-            and get_prefill_cuda_graph_backend(server_args) != CudaGraphBackend.DISABLED
-        ):
-            logger.info(
-                f"{self.model_name}: chunked_prefill_size was unset, SGLang resolved "
-                f"{server_args.chunked_prefill_size}, prefill CUDA graph cap "
-                f"{server_args.cuda_graph_config.prefill.max_bs}"
-            )
         self.validate_before_infrastructure(server_args)
 
         # ServerArgs construction is where "auto" fields become concrete
@@ -186,6 +177,17 @@ class SGLangGenerationEngineBuilder(ABC):
         RUNTIME_RESOLUTION_RECORD.record(self.model_name, self.runtime_resolutions)
         for resolution in self.runtime_resolutions:
             logger.info(f"{self.model_name}: runtime-resolved {resolution.describe()}")
+        if (
+            overrides.get("chunked_prefill_size") is None
+            and get_prefill_cuda_graph_backend(server_args) != CudaGraphBackend.DISABLED
+        ):
+            # The consumer of the resolved chunk: SGLang capped its prefill
+            # graph ladder by it. Logged next to the resolution lines above so
+            # the value and its consequence read together.
+            logger.info(
+                f"{self.model_name}: prefill CUDA graph cap follows the resolved "
+                f"chunked_prefill_size: {server_args.cuda_graph_config.prefill.max_bs}"
+            )
         self.finalize_runtime_derived(server_args, self.runtime_resolutions)
 
         infra_kwargs = dict(self.infra_kwargs())

--- a/tests/unit_test/config/test_cli_config.py
+++ b/tests/unit_test/config/test_cli_config.py
@@ -593,7 +593,10 @@ class TestRuntimeResolvedRendering:
         output = output_of(result)
         assert f"stages.{stage}.engine.chunked_prefill_size" in output
         assert "auto (resolved from GPU memory at launch)" in output
-        assert "runtime (sglang hardware resolution at launch)" in output
+        assert (
+            "runtime (settled at launch: the stage builder's defaults, else sglang's hardware resolution)"
+            in output
+        )
 
     def test_explain_answers_for_an_auto_field(self, runner, config_file, stage):
         result = runner.invoke(
@@ -638,4 +641,33 @@ class TestRuntimeResolvedRendering:
         )
 
         assert result.exit_code == 0, output_of(result)
-        assert "runtime (sglang hardware resolution at launch)" in output_of(result)
+        assert (
+            "runtime (settled at launch: the stage builder's defaults, else sglang's hardware resolution)"
+            in output_of(result)
+        )
+
+    def test_listing_and_explain_agree_on_a_source_written_auto(
+        self, runner, tmp_path, base_config, stage
+    ):
+        """A source writing the literal null (the kv_cache_bytes recipe
+        recommends `mem_fraction_static: null`) touches the path AND leaves
+        it auto; the no-argument listing must report the same pending value
+        `explain <path>` does, not the yaml's None."""
+        path = f"stages.{stage}.engine.mem_fraction_static"
+        data = {
+            "config_cls": base_config.config_cls,
+            "model_path": "dummy",
+            "stages": {stage: {"engine": {"mem_fraction_static": None}}},
+        }
+        null_file = tmp_path / "null.yaml"
+        null_file.write_text(yaml.safe_dump(data, sort_keys=False))
+
+        result = runner.invoke(config_app, ["explain", "--config", str(null_file)])
+
+        assert result.exit_code == 0, output_of(result)
+        listing_line = next(
+            line
+            for line in output_of(result).splitlines()
+            if line.startswith(f"{path} =")
+        )
+        assert "auto (resolved from GPU memory at launch)" in listing_line

--- a/tests/unit_test/config/test_cli_config.py
+++ b/tests/unit_test/config/test_cli_config.py
@@ -576,3 +576,66 @@ class TestServeErrors:
         output = output_of(result)
         assert "Missing value" in output
         assert "Traceback" not in output
+
+
+class TestRuntimeResolvedRendering:
+    """Hardware-resolved engine fields left at "auto" get a value only on the
+    GPU the stage lands on; the preview cannot know it. The commands say so
+    with a pending runtime line instead of guessing or staying silent."""
+
+    def test_provenance_lists_a_pending_runtime_line(self, runner, config_file, stage):
+        result = runner.invoke(
+            config_app,
+            ["resolve", "--config", str(config_file), "--show", "provenance"],
+        )
+
+        assert result.exit_code == 0, output_of(result)
+        output = output_of(result)
+        assert f"stages.{stage}.engine.chunked_prefill_size" in output
+        assert "auto (resolved from GPU memory at launch)" in output
+        assert "runtime (sglang hardware resolution at launch)" in output
+
+    def test_explain_answers_for_an_auto_field(self, runner, config_file, stage):
+        result = runner.invoke(
+            config_app,
+            [
+                "explain",
+                f"stages.{stage}.engine.chunked_prefill_size",
+                "--config",
+                str(config_file),
+            ],
+        )
+
+        assert result.exit_code == 0, output_of(result)
+        output = output_of(result)
+        assert "auto (resolved from GPU memory at launch)" in output
+
+    def test_explicit_value_gets_no_pending_line(self, runner, config_file, stage):
+        result = runner.invoke(
+            config_app,
+            [
+                "explain",
+                f"stages.{stage}.engine.chunked_prefill_size",
+                "--config",
+                str(config_file),
+                f"--{stage}.engine.chunked_prefill_size",
+                "4096",
+            ],
+        )
+
+        assert result.exit_code == 0, output_of(result)
+        output = output_of(result)
+        assert "4096" in output
+        assert "auto (resolved from GPU memory at launch)" not in output
+
+    def test_explain_listing_survives_runtime_only_paths(
+        self, runner, plain_config_file
+    ):
+        """The no-argument listing used to assert every path had a winner;
+        runtime-only paths have none."""
+        result = runner.invoke(
+            config_app, ["explain", "--config", str(plain_config_file)]
+        )
+
+        assert result.exit_code == 0, output_of(result)
+        assert "runtime (sglang hardware resolution at launch)" in output_of(result)

--- a/tests/unit_test/config/test_runtime_resolution.py
+++ b/tests/unit_test/config/test_runtime_resolution.py
@@ -99,6 +99,16 @@ class TestCapture:
         )
         assert resolution.origin == HARDWARE
 
+    def test_cuda_graph_max_bs_reads_the_nested_decode_config(self):
+        """ServerArgs has no cuda_graph_max_bs attribute; the omni override
+        is aliased at construction and the resolved value lands on
+        cuda_graph_config.decode.max_bs."""
+        args = server_args(
+            cuda_graph_config=SimpleNamespace(decode=SimpleNamespace(max_bs=160))
+        )
+        (resolution,) = capture_runtime_resolutions({}, args)
+        assert (resolution.path, resolution.resolved) == ("cuda_graph_max_bs", 160)
+
 
 class TestRequireResolved:
     def test_passes_a_concrete_value_through(self):

--- a/tests/unit_test/config/test_runtime_resolution.py
+++ b/tests/unit_test/config/test_runtime_resolution.py
@@ -1,0 +1,183 @@
+# SPDX-License-Identifier: Apache-2.0
+"""Unit tests for the runtime-resolution channel.
+
+The invariants under test:
+
+* a field the runtime filled in (configured ``None``, resolved concrete) is
+  reported; a field that passed through unchanged is not — a resolution is a
+  change of value, not an echo;
+* ``require_resolved`` refuses an unresolved "auto" with a message naming
+  the safe derivation site, and passes concrete values through;
+* runtime observations never become patches: ``SourceKind.RUNTIME`` has no
+  layer, so patch construction from it fails structurally;
+* provenance renders runtime entries — on touched paths as an extra line,
+  on untouched paths without the historical ``KeyError``.
+"""
+
+from __future__ import annotations
+
+from types import SimpleNamespace
+
+import pytest
+
+from sglang_omni.config.patch import (
+    ConfigPatch,
+    ConfigPatchSet,
+    ConfigSource,
+    SourceKind,
+)
+from sglang_omni.config.provenance import ProvenanceMap
+from sglang_omni.config.resolver import ConfigResolver
+from sglang_omni.config.runtime_resolution import (
+    RuntimeResolution,
+    RuntimeResolutionRecord,
+    capture_runtime_resolutions,
+    require_resolved,
+)
+from sglang_omni.config.schema import PipelineConfig
+
+MEM_FRACTION = "stages.thinker.engine.mem_fraction_static"
+CHUNK = "stages.thinker.engine.chunked_prefill_size"
+
+CLI = ConfigSource(SourceKind.CLI_DOTTED, "command line")
+
+HARDWARE = "sglang ServerArgs hardware resolution"
+
+
+def server_args(**fields):
+    """A stand-in for a constructed ServerArgs: just resolved attributes."""
+    return SimpleNamespace(**fields)
+
+
+def runtime(path, resolved, configured=None):
+    return RuntimeResolution(
+        path=path, configured=configured, resolved=resolved, origin=HARDWARE
+    )
+
+
+class TestCapture:
+    def test_reports_a_field_the_runtime_filled_in(self):
+        resolutions = capture_runtime_resolutions(
+            {"chunked_prefill_size": None},
+            server_args(chunked_prefill_size=2048),
+        )
+        assert [(r.path, r.configured, r.resolved) for r in resolutions] == [
+            ("chunked_prefill_size", None, 2048)
+        ]
+
+    def test_absent_key_counts_as_auto(self):
+        """ServerArgs defaults the field to None itself; not writing it is
+        the same request as writing null."""
+        resolutions = capture_runtime_resolutions(
+            {}, server_args(chunked_prefill_size=8192)
+        )
+        assert resolutions[0].configured is None
+        assert resolutions[0].resolved == 8192
+
+    def test_explicit_value_passing_through_is_not_reported(self):
+        resolutions = capture_runtime_resolutions(
+            {"chunked_prefill_size": 4096},
+            server_args(chunked_prefill_size=4096),
+        )
+        assert resolutions == []
+
+    def test_explicit_value_the_runtime_rewrote_is_reported(self):
+        """SGLang force-disables the field to -1 under some configurations;
+        that rewrite is exactly what an operator needs to see."""
+        resolutions = capture_runtime_resolutions(
+            {"chunked_prefill_size": 4096},
+            server_args(chunked_prefill_size=-1),
+        )
+        assert [(r.configured, r.resolved) for r in resolutions] == [(4096, -1)]
+
+    def test_missing_attribute_is_skipped(self):
+        assert capture_runtime_resolutions({}, server_args()) == []
+
+    def test_origin_names_the_resolver(self):
+        (resolution,) = capture_runtime_resolutions(
+            {}, server_args(mem_fraction_static=0.85)
+        )
+        assert resolution.origin == HARDWARE
+
+
+class TestRequireResolved:
+    def test_passes_a_concrete_value_through(self):
+        assert require_resolved(2048, field_name="chunked_prefill_size") == 2048
+
+    def test_refuses_auto_and_names_the_safe_site(self):
+        with pytest.raises(ValueError, match="finalize_runtime_derived"):
+            require_resolved(None, field_name="chunked_prefill_size")
+
+    def test_error_names_the_field(self):
+        with pytest.raises(ValueError, match="chunked_prefill_size"):
+            require_resolved(None, field_name="chunked_prefill_size")
+
+
+class TestRecord:
+    def test_record_and_get(self):
+        record = RuntimeResolutionRecord()
+        record.record("thinker", [runtime("chunked_prefill_size", 2048)])
+        assert record.get("thinker")[0].resolved == 2048
+
+    def test_unknown_stage_is_empty(self):
+        assert RuntimeResolutionRecord().get("talker") == []
+
+    def test_get_returns_a_copy(self):
+        record = RuntimeResolutionRecord()
+        record.record("thinker", [runtime("chunked_prefill_size", 2048)])
+        record.get("thinker").clear()
+        assert len(record.get("thinker")) == 1
+
+
+class TestNeverAPatch:
+    def test_runtime_source_has_no_layer(self):
+        """The structural guarantee: SourceKind.RUNTIME is deliberately
+        absent from the layer table, so a runtime observation cannot be
+        turned into a patch and can never enter precedence."""
+        with pytest.raises(KeyError):
+            ConfigSource(SourceKind.RUNTIME, "launch").layer
+
+
+class TestProvenanceRuntimeChannel:
+    def resolved_with_patch(self, pipeline_config: PipelineConfig):
+        patch = ConfigPatch.create(MEM_FRACTION, "0.8", CLI, root=type(pipeline_config))
+        return ConfigResolver(pipeline_config).resolve(ConfigPatchSet([patch]))
+
+    def test_untouched_path_no_longer_key_errors(self):
+        provenance = ProvenanceMap()
+        provenance.record_runtime(CHUNK, runtime(CHUNK, 2048))
+        text = provenance.explain(CHUNK)
+        assert f"{CHUNK} = 2048" in text
+        assert "runtime (sglang ServerArgs hardware resolution)" in text
+
+    def test_unknown_path_still_key_errors(self):
+        with pytest.raises(KeyError):
+            ProvenanceMap().explain(CHUNK)
+
+    def test_paths_includes_runtime_only_paths(self):
+        provenance = ProvenanceMap()
+        provenance.record_runtime(CHUNK, runtime(CHUNK, 2048))
+        assert provenance.paths() == [CHUNK]
+        assert provenance.runtime_resolved(CHUNK)
+        assert not provenance.touched(CHUNK)
+
+    def test_touched_path_appends_a_runtime_line(self, pipeline_config: PipelineConfig):
+        resolved = self.resolved_with_patch(pipeline_config)
+        resolved.provenance.record_runtime(
+            MEM_FRACTION, runtime(MEM_FRACTION, 0.85, configured=0.8)
+        )
+        text = resolved.provenance.explain(MEM_FRACTION)
+        lines = text.splitlines()
+        # The launch has the last word: headline and final line report it,
+        # with the patch history intact in between.
+        assert lines[0] == f"{MEM_FRACTION} = 0.85"
+        assert "[winner]" in text
+        assert lines[-1].strip() == (
+            "0.85  <- runtime (sglang ServerArgs hardware resolution)"
+        )
+
+    def test_no_runtime_line_without_a_runtime_entry(
+        self, pipeline_config: PipelineConfig
+    ):
+        resolved = self.resolved_with_patch(pipeline_config)
+        assert "runtime" not in resolved.provenance.explain(MEM_FRACTION)

--- a/tests/unit_test/qwen3_asr/test_pipeline.py
+++ b/tests/unit_test/qwen3_asr/test_pipeline.py
@@ -657,9 +657,12 @@ def test_qwen3_asr_auto_chunked_prefill_uses_the_sglang_ladder(
     )
     assert attested.cuda_graph_config.prefill.max_bs == resolved_chunked_prefill_size
     assert (
-        "Qwen3-ASR: chunked_prefill_size was unset, SGLang resolved "
-        f"{resolved_chunked_prefill_size}, prefill CUDA graph cap "
+        "Qwen3-ASR: runtime-resolved chunked_prefill_size: auto -> "
         f"{resolved_chunked_prefill_size}"
+    ) in caplog.text
+    assert (
+        "Qwen3-ASR: prefill CUDA graph cap follows the resolved "
+        f"chunked_prefill_size: {resolved_chunked_prefill_size}"
     ) in caplog.text
     assert "cannot be scheduled" not in caplog.text
 

--- a/tests/unit_test/scheduling/test_engine_factory.py
+++ b/tests/unit_test/scheduling/test_engine_factory.py
@@ -784,3 +784,71 @@ def test_tts_engine_builder_base_scheduler_preserves_abort_with_extra_kwargs(
     assert captured_kwargs["tp_worker"] == "worker"
     assert captured_kwargs["request_builder"] == "request_builder"
     assert captured_kwargs["result_adapter"] == "result_adapter"
+
+
+def test_runtime_resolutions_captured_and_finalize_hook_runs_after_construction(
+    monkeypatch, caplog
+) -> None:
+    """The build must read hardware-resolved fields back off the constructed
+    ServerArgs, record them, and only then call finalize_runtime_derived —
+    the one place a derivation from those fields reads a real value."""
+    import logging
+
+    from sglang_omni.config.runtime_resolution import RuntimeResolution
+    from sglang_omni.scheduling import engine_factory, sglang_backend
+
+    MinimalBuilder, build_kwargs, consumed = _build_minimal_tts_builder_harness(
+        monkeypatch
+    )
+    del build_kwargs, consumed
+
+    # The harness leaves chunked_prefill_size unset (auto); simulate SGLang
+    # resolving it from GPU memory inside construction.
+    harness_fake = sglang_backend.build_sglang_server_args
+
+    def resolving_server_args(*args: Any, **kwargs: Any) -> Any:
+        server_args = harness_fake(*args, **kwargs)
+        server_args.chunked_prefill_size = 2048
+        return server_args
+
+    monkeypatch.setattr(
+        sglang_backend, "build_sglang_server_args", resolving_server_args
+    )
+
+    seen: dict[str, Any] = {}
+
+    class FinalizingBuilder(MinimalBuilder):
+        def customize_server_args(self, server_args: Any) -> None:
+            del server_args
+            seen["customize_ran"] = True
+
+        def finalize_runtime_derived(
+            self, server_args: Any, resolutions: list[RuntimeResolution]
+        ) -> None:
+            assert seen.get("customize_ran"), "hook must run after customize"
+            seen["chunk"] = server_args.chunked_prefill_size
+            seen["resolutions"] = resolutions
+
+    with caplog.at_level(logging.INFO, logger=engine_factory.logger.name):
+        builder = FinalizingBuilder()
+        builder.build("model", device="cuda:0", gpu_id=0)
+
+    assert seen["chunk"] == 2048
+    by_path = {r.path: r for r in seen["resolutions"]}
+    assert by_path["chunked_prefill_size"].configured is None
+    assert by_path["chunked_prefill_size"].resolved == 2048
+    assert builder.runtime_resolutions == seen["resolutions"]
+    assert "runtime-resolved chunked_prefill_size: auto -> 2048" in caplog.text
+
+
+def test_finalize_runtime_derived_default_is_a_no_op(monkeypatch) -> None:
+    """Existing builders that override nothing must build exactly as before,
+    with the captured resolutions recorded on the builder."""
+    MinimalBuilder, build_kwargs, consumed = _build_minimal_tts_builder_harness(
+        monkeypatch
+    )
+    del build_kwargs, consumed
+
+    builder = MinimalBuilder()
+    builder.build("model", device="cuda:0", gpu_id=0)
+    assert isinstance(builder.runtime_resolutions, list)

--- a/tests/unit_test/scheduling/test_engine_factory.py
+++ b/tests/unit_test/scheduling/test_engine_factory.py
@@ -841,6 +841,40 @@ def test_runtime_resolutions_captured_and_finalize_hook_runs_after_construction(
     assert "runtime-resolved chunked_prefill_size: auto -> 2048" in caplog.text
 
 
+def test_capture_runs_before_customize_server_args(monkeypatch) -> None:
+    """A builder's customize_server_args write (zonos2 forces
+    chunked_prefill_size=0) must not be recorded as the hardware's
+    resolution — capture reads the constructed args, not the customized
+    ones."""
+    from sglang_omni.scheduling import sglang_backend
+
+    MinimalBuilder, build_kwargs, consumed = _build_minimal_tts_builder_harness(
+        monkeypatch
+    )
+    del build_kwargs, consumed
+
+    harness_fake = sglang_backend.build_sglang_server_args
+
+    def resolving_server_args(*args: Any, **kwargs: Any) -> Any:
+        server_args = harness_fake(*args, **kwargs)
+        server_args.chunked_prefill_size = 2048
+        return server_args
+
+    monkeypatch.setattr(
+        sglang_backend, "build_sglang_server_args", resolving_server_args
+    )
+
+    class ForcingBuilder(MinimalBuilder):
+        def customize_server_args(self, server_args: Any) -> None:
+            server_args.chunked_prefill_size = 0
+
+    builder = ForcingBuilder()
+    builder.build("model", device="cuda:0", gpu_id=0)
+
+    by_path = {r.path: r for r in builder.runtime_resolutions}
+    assert by_path["chunked_prefill_size"].resolved == 2048
+
+
 def test_finalize_runtime_derived_default_is_a_no_op(monkeypatch) -> None:
     """Existing builders that override nothing must build exactly as before,
     with the captured resolutions recorded on the builder."""


### PR DESCRIPTION
Stacked on #1915 (base is `Yuhao/defer-prefill-cuda-graph-buckets`; retarget to `main` once it merges).

## Motivation

Several SGLang engine fields mean "auto" when left `null` — `chunked_prefill_size`, `mem_fraction_static`, `cuda_graph_max_bs`, `max_total_tokens`. SGLang only resolves them from GPU memory inside `ServerArgs` construction (`_handle_gpu_memory_settings`), on whatever card the stage lands on.

Any builder code that derives dependent values from these fields *before* `ServerArgs` construction (e.g. in `adjust_overrides()`) reads a value that does not exist yet. That is the ordering bug class behind #1915: prefill CUDA graph buckets built from a still-`None` `chunked_prefill_size` can exceed the value SGLang later resolves, and the launch fails on a self-contradiction. The config resolver's contract ("downstream must not write back") is correct for user config, but these launch-settled values are not user config — they had no representation at all.

This PR gives them one: a **runtime-resolution channel**, structurally separate from patches.

## What this adds

**`sglang_omni/config/runtime_resolution.py`** (new)
- `RuntimeResolution(path, configured, resolved, origin)` — one observed resolution.
- `capture_runtime_resolutions(configured, server_args)` — diffs the pre-construction overrides against the constructed `ServerArgs` for the four auto fields; only changes are recorded, echoes are not.
- `require_resolved(value, field_name=...)` — a guardrail derivation code can call to refuse an unresolved "auto" with an actionable error. Provided, not yet wired into any call site.
- `RuntimeResolutionRecord` — process-local per-stage registry.

**`config/patch.py`, `config/provenance.py`, `config/resolver.py`**
- `SourceKind.RUNTIME`, deliberately absent from the layer table: a runtime observation cannot be turned into a patch and can never enter precedence. `ConfigSource.layer` raising `KeyError` for it is the structural guarantee.
- `ProvenanceMap` gains a `runtime` dict, `record_runtime()` and `runtime_resolved()`; `explain()` renders launch-settled values, including on paths no patch touched (previously a `KeyError`).
- Resolver docstring now states where launch-settled values go: the runtime channel, never write-back.

**`scheduling/engine_factory.py`**
- After `ServerArgs` construction and `customize_server_args`, `build()` captures the resolutions, records them, logs each at INFO (`thinker: runtime-resolved chunked_prefill_size: auto -> 2048 (...)`), and calls a new builder hook `finalize_runtime_derived(server_args, resolutions)` (default no-op) — the documented safe place for derivations that need resolved values. `adjust_overrides` now warns about this in its docstring.

**`cli/config.py`**
- `config resolve --show provenance` and `config explain` run without a GPU, so auto hardware-resolved engine fields render as an honest pending entry instead of nothing:

  ```
  stages.tts_engine.engine.chunked_prefill_size = auto (resolved from GPU memory at launch)  <- runtime (sglang hardware resolution at launch)
  ```

## Behavior differences

- `config explain` / `--show provenance` list auto engine fields with a pending runtime line; explicitly configured values render as before.
- Engine builds log one INFO line per field the runtime filled in or rewrote.
- No behavior change to any launch decision: the hook defaults to no-op and `require_resolved` has no call sites yet.

## Non-goals

- No declared-dependency engine between config fields.
- No move of any model's prefill CUDA graph ladder generation into the new hook — that is the targeted fix territory of #1915; this PR touches none of the files it rewrites, so the two merge independently. Migrating ladder derivation into `finalize_runtime_derived` is natural follow-up work.

## Tests

- `tests/unit_test/config/test_runtime_resolution.py` (new): capture semantics, `require_resolved`, the never-a-patch structural guarantee, provenance runtime rendering.
- `tests/unit_test/scheduling/test_engine_factory.py`: the hook runs after construction and sees resolved values; default is a no-op.
- `tests/unit_test/config/test_cli_config.py`: pending line rendering, explicit values unaffected, no-arg explain listing survives runtime-only paths.

`pytest tests/unit_test/config`: 162 passed (3 pre-existing `TestServeErrors` failures unrelated to this change, reproduced on a clean checkout).

## On top of #1915

The last commit connects the fix to the channel: #1915's ad-hoc `chunked_prefill_size was unset, SGLang resolved N` INFO line and the channel's `runtime-resolved chunked_prefill_size: auto -> N` reported the same resolution twice. The channel line is kept as the record; the ad-hoc line is reduced to its one extra fact (the prefill CUDA graph cap that followed the resolved chunk), logged right after it. `require_resolved` stays unwired: with #1915's pre-derivation gone, no code path reads an auto field before ServerArgs construction anymore — the guard is for the next derivation someone writes in `finalize_runtime_derived`.
