### PR TITLE
[Scheduler] Fold the resolved-chunk log into the runtime-resolution lines

### DIFF
--- a/sglang_omni/scheduling/engine_factory.py
+++ b/sglang_omni/scheduling/engine_factory.py
@@ -166,15 +166,6 @@ class SGLangGenerationEngineBuilder(ABC):
             **overrides,
         )
         self.customize_server_args(server_args)
-        if (
-            overrides.get("chunked_prefill_size") is None
-            and get_prefill_cuda_graph_backend(server_args) != CudaGraphBackend.DISABLED
-        ):
-            logger.info(
-                f"{self.model_name}: chunked_prefill_size was unset, SGLang resolved "
-                f"{server_args.chunked_prefill_size}, prefill CUDA graph cap "
-                f"{server_args.cuda_graph_config.prefill.max_bs}"
-            )
         self.validate_before_infrastructure(server_args)
 
         # ServerArgs construction is where "auto" fields become concrete
@@ -186,6 +177,17 @@ class SGLangGenerationEngineBuilder(ABC):
         RUNTIME_RESOLUTION_RECORD.record(self.model_name, self.runtime_resolutions)
         for resolution in self.runtime_resolutions:
             logger.info(f"{self.model_name}: runtime-resolved {resolution.describe()}")
+        if (
+            overrides.get("chunked_prefill_size") is None
+            and get_prefill_cuda_graph_backend(server_args) != CudaGraphBackend.DISABLED
+        ):
+            # The consumer of the resolved chunk: SGLang capped its prefill
+            # graph ladder by it. Logged next to the resolution lines above so
+            # the value and its consequence read together.
+            logger.info(
+                f"{self.model_name}: prefill CUDA graph cap follows the resolved "
+                f"chunked_prefill_size: {server_args.cuda_graph_config.prefill.max_bs}"
+            )
         self.finalize_runtime_derived(server_args, self.runtime_resolutions)
 
         infra_kwargs = dict(self.infra_kwargs())

--- a/tests/unit_test/qwen3_asr/test_pipeline.py
+++ b/tests/unit_test/qwen3_asr/test_pipeline.py
@@ -657,9 +657,12 @@ def test_qwen3_asr_auto_chunked_prefill_uses_the_sglang_ladder(
     )
     assert attested.cuda_graph_config.prefill.max_bs == resolved_chunked_prefill_size
     assert (
-        "Qwen3-ASR: chunked_prefill_size was unset, SGLang resolved "
-        f"{resolved_chunked_prefill_size}, prefill CUDA graph cap "
+        "Qwen3-ASR: runtime-resolved chunked_prefill_size: auto -> "
         f"{resolved_chunked_prefill_size}"
+    ) in caplog.text
+    assert (
+        "Qwen3-ASR: prefill CUDA graph cap follows the resolved "
+        f"chunked_prefill_size: {resolved_chunked_prefill_size}"
     ) in caplog.text
     assert "cannot be scheduled" not in caplog.text
 


### PR DESCRIPTION
Top of the stack #1915 ← #1932 ← this. Retarget to `main` as the PRs below merge.

## What

With both the fix (#1915) and the runtime-resolution channel (#1932) in place, the same resolution was reported twice, one construction apart: #1915's ad-hoc `chunked_prefill_size was unset, SGLang resolved N, prefill CUDA graph cap M` INFO line, and the channel's `runtime-resolved chunked_prefill_size: auto -> N`.

Keep the channel line as the record of the value; reduce the ad-hoc line to its one extra fact — the prefill CUDA graph cap that followed the resolved chunk — logged immediately after, so the resolution and its consequence read together:

```
Qwen3-ASR: runtime-resolved chunked_prefill_size: auto -> 2048 (sglang ServerArgs hardware resolution)
Qwen3-ASR: prefill CUDA graph cap follows the resolved chunked_prefill_size: 2048
```

The log-asserting test from #1915 is updated to the two-line form.

## Why require_resolved stays unwired

#1932 ships `require_resolved()` for derivation code that reads auto fields too early. After #1915 removed the ladder pre-derivation, no code path reads an auto field before ServerArgs construction anymore, so there is nothing to guard; the guard is for the next derivation someone writes, in `finalize_runtime_derived`.
