### PR TITLE
[XPU] Serve Qwen3-Omni speech on Intel XPU, talker and Code2Wav with XPUGraphs

### DIFF
--- a/examples/configs/qwen3_omni_speech_xpu_b60.yaml
+++ b/examples/configs/qwen3_omni_speech_xpu_b60.yaml
@@ -1,0 +1,35 @@
+# SPDX-License-Identifier: Apache-2.0
+#
+# Qwen3-Omni speech on 8x Intel Arc Pro B60 (24 GB each).
+#
+#   sgl-omni serve --config examples/configs/qwen3_omni_speech_xpu_b60.yaml
+#
+# TP=8 because the 30B-A3B thinker does not fit one 24 GB card, and at TP=4 its
+# per-rank weights leave the KV pool no room.
+
+config_cls: Qwen3OmniSpeechPipelineConfig
+name: qwen3-omni-speech-xpu-b60
+model_path: Qwen/Qwen3-Omni-30B-A3B-Instruct
+
+stages:
+  image_encoder:
+    gpu: 0
+  audio_encoder:
+    gpu: 0
+
+  thinker:
+    gpu: [0, 1, 2, 3, 4, 5, 6, 7]
+    tp_size: 8
+    engine:
+      mem_fraction_static: 0.55
+
+  # 0.55 + 0.35 reserves 0.90 of card 6, the tightest card here.
+  talker_ar:
+    gpu: 6
+    engine:
+      mem_fraction_static: 0.35
+
+  code2wav:
+    gpu: 7
+    # 0.02 of a 24 GB card leaves less graph budget than the capture keys need.
+    gpu_memory_fraction: 0.05

--- a/sglang_omni/model_runner/sglang_model_runner.py
+++ b/sglang_omni/model_runner/sglang_model_runner.py
@@ -1,5 +1,6 @@
 from __future__ import annotations
 
+import contextlib
 import dataclasses
 import logging
 from collections.abc import Iterator
@@ -451,6 +452,9 @@ class SGLModelRunner(ModelRunner):
         deferred graph-capture call sites, so finalize here at the common
         capture boundary instead of relying on every stage to mirror the
         scheduler's post-capture hook.
+
+        On XPU the capture is wrapped to pin SDPA, which the engines reach through
+        model code SGLang's capture does not wrap.
         """
         record = self._weight_share_record
         if record is not None:
@@ -463,7 +467,13 @@ class SGLModelRunner(ModelRunner):
 
         get_flags().capture.enable_torch_compile = get_exec().graph.enable_torch_compile
         _install_prefill_runner_dispatch()
-        result = super().init_cuda_graphs(capture_decode_cuda_graph)
+
+        from sglang_omni.platforms import current_platform
+
+        with contextlib.ExitStack() as pins:
+            if current_platform.is_xpu():
+                pins.enter_context(current_platform.graph_capture_attention())
+            result = super().init_cuda_graphs(capture_decode_cuda_graph)
         if self.token_to_kv_pool.post_capture_active:
             self.post_capture_resize_kv_pool()
         return result

--- a/sglang_omni/models/qwen3_omni/components/code2wav_cuda_graph.py
+++ b/sglang_omni/models/qwen3_omni/components/code2wav_cuda_graph.py
@@ -1,12 +1,14 @@
 # SPDX-License-Identifier: Apache-2.0
-"""Exact-shape CUDA graphs for the Qwen3-Omni Code2Wav component."""
+"""Exact-shape device graphs for the Qwen3-Omni Code2Wav component."""
 
 from __future__ import annotations
 
+import contextlib
 import gc
 import logging
 import math
 import os
+import threading
 from collections import Counter
 from contextlib import AbstractContextManager
 from copy import deepcopy
@@ -15,7 +17,11 @@ from typing import Any
 
 import torch
 
+from sglang_omni.platforms import current_platform
+
 logger = logging.getLogger(__name__)
+
+_MASK_SWAP_LOCK = threading.Lock()
 
 
 @dataclass(frozen=True, slots=True)
@@ -30,13 +36,12 @@ class GraphKey:
 class Code2WavRunResult:
     """Result metadata for either an exact graph replay or eager fallback.
 
-    A ``cuda_graph`` output is a borrowed static buffer. Before the next replay,
-    the caller must either finish every read or enqueue every dependent read and
-    copy on the same CUDA stream so replay cannot overtake them. The tensor
-    itself must not be retained or consumed concurrently; asynchronous host
-    transfer must retain its destination and completion event until
-    materialization finishes. This runner deliberately does not clone the
-    output.
+    A replayed output is a borrowed static buffer. Before the next replay, the
+    caller must either finish every read or enqueue every dependent read and copy
+    on the same device stream so replay cannot overtake them. The tensor itself
+    must not be retained or consumed concurrently; asynchronous host transfer must
+    retain its destination and completion event until materialization finishes.
+    This runner deliberately does not clone the output.
     """
 
     output: torch.Tensor
@@ -56,32 +61,68 @@ class _BuildFailure(RuntimeError):
     pass
 
 
-class _TorchCudaApi:
-    """Small injectable boundary around CUDA-only operations."""
+@contextlib.contextmanager
+def _unpacked_sequence_mask() -> Any:
+    from transformers import masking_utils
+
+    if not _MASK_SWAP_LOCK.acquire(blocking=False):
+        raise RuntimeError(
+            "Code2Wav mask pin is already held; capture must stay single-threaded "
+            "because it swaps a transformers global"
+        )
+    try:
+        original = masking_utils.find_packed_sequence_indices
+        masking_utils.find_packed_sequence_indices = lambda *args, **kwargs: None
+        try:
+            yield
+        finally:
+            masking_utils.find_packed_sequence_indices = original
+    finally:
+        _MASK_SWAP_LOCK.release()
+
+
+@contextlib.contextmanager
+def _xpu_capture_pins() -> Any:
+    if not current_platform.is_xpu():
+        yield
+        return
+    with current_platform.graph_capture_attention(), _unpacked_sequence_mask():
+        yield
+
+
+class _TorchDeviceApi:
+
+    @staticmethod
+    def _module(device: torch.device) -> Any:
+        return torch.get_device_module(device)
+
+    def graph_backend(self, device: torch.device) -> Any | None:
+        return current_platform.get_device_graph_backend(device)
 
     def device_context(self, device: torch.device) -> AbstractContextManager[Any]:
-        return torch.cuda.device(device)
+        return self._module(device).device(device)
 
     def memory_stats(self, device: torch.device) -> dict[str, int]:
-        free_bytes, total_bytes = torch.cuda.mem_get_info(device)
+        module = self._module(device)
+        free_bytes, total_bytes = module.mem_get_info(device)
         return {
-            "allocated_bytes": int(torch.cuda.memory_allocated(device)),
-            "reserved_bytes": int(torch.cuda.memory_reserved(device)),
-            "max_reserved_bytes": int(torch.cuda.max_memory_reserved(device)),
+            "allocated_bytes": int(module.memory_allocated(device)),
+            "reserved_bytes": int(module.memory_reserved(device)),
+            "max_reserved_bytes": int(module.max_memory_reserved(device)),
             "free_bytes": int(free_bytes),
             "total_bytes": int(total_bytes),
         }
 
-    def empty_cache(self) -> None:
-        torch.cuda.empty_cache()
+    def empty_cache(self, device: torch.device) -> None:
+        self._module(device).empty_cache()
 
     def new_static_input(
         self, shape: tuple[int, int, int], *, device: torch.device
     ) -> torch.Tensor:
         return torch.zeros(shape, dtype=torch.long, device=device)
 
-    def new_stream(self, device: torch.device) -> torch.cuda.Stream:
-        return torch.cuda.Stream(device=device)
+    def new_stream(self, device: torch.device) -> Any:
+        return self._module(device).Stream(device=device)
 
     def warmup(
         self,
@@ -90,17 +131,18 @@ class _TorchCudaApi:
         *,
         iterations: int,
         device: torch.device,
-        stream: torch.cuda.Stream,
+        stream: Any,
     ) -> None:
-        current_stream = torch.cuda.current_stream(device)
+        module = self._module(device)
+        current_stream = module.current_stream(device)
         stream.wait_stream(current_stream)
-        with torch.cuda.stream(stream), torch.inference_mode():
+        with module.stream(stream), torch.inference_mode():
             for _ in range(iterations):
                 model(static_input)
         current_stream.wait_stream(stream)
 
-    def graph_pool_handle(self) -> Any:
-        return torch.cuda.graph_pool_handle()
+    def graph_pool_handle(self, device: torch.device) -> Any:
+        return self._module(device).graph_pool_handle()
 
     def capture(
         self,
@@ -108,42 +150,40 @@ class _TorchCudaApi:
         static_input: torch.Tensor,
         *,
         pool: Any,
-        stream: torch.cuda.Stream,
-    ) -> tuple[torch.cuda.CUDAGraph, torch.Tensor]:
-        current_stream = torch.cuda.current_stream(static_input.device)
+        stream: Any,
+    ) -> tuple[Any, torch.Tensor]:
+        device = static_input.device
+        module = self._module(device)
+        current_stream = module.current_stream(device)
         stream.wait_stream(current_stream)
-        graph = torch.cuda.CUDAGraph()
+        backend = self.graph_backend(device)
         try:
             with torch.inference_mode():
-                with torch.cuda.graph(
-                    graph,
-                    pool=pool,
-                    stream=stream,
-                    capture_error_mode="thread_local",
-                ):
+                with backend.capture(
+                    pool=pool, stream=stream, thread_local_errors=True
+                ) as graph:
                     static_output = model(static_input)
         finally:
-            # torch.cuda.graph.__exit__ calls capture_end before restoring its
-            # stream context. If capture_end raises, restore explicitly using
-            # the original stream's device-aware identity.
-            torch.cuda.set_stream(current_stream)
+            # graph.__exit__ restores its stream context only after capture_end,
+            # which may raise, so restore explicitly.
+            module.set_stream(current_stream)
         current_stream.wait_stream(stream)
         return graph, static_output
 
     def synchronize(self, device: torch.device) -> None:
-        torch.cuda.synchronize(device)
+        self._module(device).synchronize(device)
 
-    def is_cuda_tensor(self, tensor: torch.Tensor) -> bool:
-        return tensor.is_cuda
+    def is_accelerator_tensor(self, tensor: torch.Tensor, device: torch.device) -> bool:
+        return tensor.device.type == device.type
 
     def tensor_device_matches(self, tensor: torch.Tensor, device: torch.device) -> bool:
         return tensor.device == device
 
 
 class Code2WavCudaGraphRunner:
-    """Exact-shape CUDA graph runner for ``[B, Q, T]`` long codes.
+    """Exact-shape device graph runner for ``[B, Q, T]`` long codes.
 
-    One instance is permanently bound to one model, CUDA device, quantizer
+    One instance is permanently bound to one model, device, quantizer
     count, ``torch.long`` input dtype, and owner process. ``batch_size == 1``
     keys form an atomic tier with the original semantics: any failure there
     disables the complete runner and leaves no partial matrix published.
@@ -166,20 +206,27 @@ class Code2WavCudaGraphRunner:
         device: str | torch.device,
         num_quantizers: int,
         graph_keys: tuple[GraphKey, ...],
-        cuda_api: Any,
+        device_api: Any,
     ) -> None:
         self._model = model
         self._device = torch.device(device)
-        if self._device.type not in ("cuda", "musa") or self._device.index is None:
-            raise ValueError("Code2Wav CUDA graphs require a concrete CUDA/MUSA device")
+        self._device_api = device_api
+        if self._device.index is None:
+            raise ValueError(
+                f"Code2Wav graphs require a concrete device, got {self._device}"
+            )
+        if self._device_api.graph_backend(self._device) is None:
+            raise ValueError(
+                f"{current_platform.device_type} names no device graph backend, "
+                f"so Code2Wav cannot capture on {self._device}"
+            )
         self._num_quantizers = int(num_quantizers)
         if self._num_quantizers <= 0:
-            raise ValueError("Code2Wav CUDA graphs require a positive quantizer count")
+            raise ValueError("Code2Wav graphs require a positive quantizer count")
         self._graph_keys = graph_keys
         self._tier0_keys = tuple(k for k in graph_keys if k.batch_size == 1)
         self._tier1_keys = tuple(k for k in graph_keys if k.batch_size > 1)
         self._owner_pid = os.getpid()
-        self._cuda = cuda_api
         self._graphs: dict[GraphKey, _CapturedGraph] = {}
         # Note (ruoyu): the scheduler reads the published sizes several times
         # per step, so they are cached and refreshed where the key set changes
@@ -207,7 +254,7 @@ class Code2WavCudaGraphRunner:
         num_quantizers: int,
         total_gpu_memory_fraction: float | None,
         graph_keys: tuple[GraphKey, ...],
-        cuda_api: Any | None = None,
+        device_api: Any | None = None,
     ) -> Code2WavCudaGraphRunner:
         """Build the configured serving-reachable serial graphs."""
 
@@ -216,7 +263,7 @@ class Code2WavCudaGraphRunner:
             device=device,
             num_quantizers=num_quantizers,
             graph_keys=graph_keys,
-            cuda_api=_TorchCudaApi() if cuda_api is None else cuda_api,
+            device_api=_TorchDeviceApi() if device_api is None else device_api,
         )
         runner._build(total_gpu_memory_fraction)
         return runner
@@ -240,8 +287,8 @@ class Code2WavCudaGraphRunner:
             self._memory_stats["tier1"] = tier1_info
 
         try:
-            with self._cuda.device_context(self._device):
-                before = self._cuda.memory_stats(self._device)
+            with self._device_api.device_context(self._device):
+                before = self._device_api.memory_stats(self._device)
         except Exception as exc:
             self._rollback_build(
                 temporary={},
@@ -314,7 +361,7 @@ class Code2WavCudaGraphRunner:
                 )
         self._enabled = True
         logger.info(
-            "Code2Wav CUDA graph runner published %d exact graphs on %s",
+            "Code2Wav device graph runner published %d exact graphs on %s",
             len(self._graphs),
             self._device,
         )
@@ -351,24 +398,27 @@ class Code2WavCudaGraphRunner:
         tier1_abandoned = False
         error_reason: str | None = None
         tier0_started = False
+        capturing: tuple[GraphKey, str] | None = None
         try:
-            with self._cuda.device_context(self._device):
-                pool = self._cuda.graph_pool_handle()
-                capture_stream = self._cuda.new_stream(self._device)
+            with self._device_api.device_context(self._device):
+                pool = self._device_api.graph_pool_handle(self._device)
+                capture_stream = self._device_api.new_stream(self._device)
                 if tier1_keys:
                     previous_footprint = self._footprint_since(before)
                 for index, key in enumerate(tier1_keys):
                     self._build_stats["attempted_graph_count"] += 1
+                    capturing = (key, "capturing")
                     temporary[key] = self._capture_graph(
                         key,
                         pool=pool,
                         stream=capture_stream,
                     )
-                    self._cuda.synchronize(self._device)
+                    capturing = (key, "measuring after")
+                    self._device_api.synchronize(self._device)
                     # Warmup's eager activations linger in the allocator cache
                     # and would count as reserved footprint, dwarfing the pool
                     # itself; release them so the check measures what is kept.
-                    self._cuda.empty_cache()
+                    self._device_api.empty_cache(self._device)
                     footprint = self._footprint_since(before)
                     tier1_info["per_key_footprint_bytes"][self._key_name(key)] = (
                         footprint - previous_footprint
@@ -381,18 +431,20 @@ class Code2WavCudaGraphRunner:
                     tier0_started = True
                     for key in self._priority_order(self._tier0_keys):
                         self._build_stats["attempted_graph_count"] += 1
+                        capturing = (key, "capturing")
                         temporary[key] = self._capture_graph(
                             key,
                             pool=pool,
                             stream=capture_stream,
                         )
-                    # Capture, replay and equivalence checks enqueue CUDA
+                        capturing = (key, "measuring after")
+                    # Capture, replay and equivalence checks enqueue device
                     # work. Do not make the graph matrix visible until every
                     # key has completed on the bound device.
-                    self._cuda.synchronize(self._device)
+                    self._device_api.synchronize(self._device)
                     gc.collect()
-                    self._cuda.empty_cache()
-                    after = self._cuda.memory_stats(self._device)
+                    self._device_api.empty_cache(self._device)
+                    after = self._device_api.memory_stats(self._device)
                     self._memory_stats["after"] = after
                     graph_footprint = max(
                         0,
@@ -422,6 +474,17 @@ class Code2WavCudaGraphRunner:
                 if isinstance(exc, _BuildFailure)
                 else f"capture_failed: {type(exc).__name__}: {exc}"
             )
+            if not isinstance(exc, _BuildFailure):
+                logger.warning(
+                    "Code2Wav graph build failed on %s while %s",
+                    self._device,
+                    (
+                        f"{capturing[1]} key={self._key_name(capturing[0])}"
+                        if capturing
+                        else "setting up the capture pool"
+                    ),
+                    exc_info=True,
+                )
             if tier1_keys and not tier0_started:
                 tier1_info["disable_reason"] = reason
                 tier1_abandoned = True
@@ -440,8 +503,8 @@ class Code2WavCudaGraphRunner:
         capture_stream = None
         gc.collect()
         try:
-            with self._cuda.device_context(self._device):
-                self._cuda.empty_cache()
+            with self._device_api.device_context(self._device):
+                self._device_api.empty_cache(self._device)
         except Exception as cleanup_exc:
             logger.warning(
                 "Code2Wav graph attempt rollback cleanup failed: %s",
@@ -458,7 +521,7 @@ class Code2WavCudaGraphRunner:
         return "shrink", remaining
 
     def _footprint_since(self, before: dict[str, int]) -> int:
-        snapshot = self._cuda.memory_stats(self._device)
+        snapshot = self._device_api.memory_stats(self._device)
         return max(
             0,
             snapshot["allocated_bytes"] - before["allocated_bytes"],
@@ -487,26 +550,29 @@ class Code2WavCudaGraphRunner:
         pool: Any,
         stream: Any,
     ) -> _CapturedGraph:
-        static_input = self._cuda.new_static_input(
+        static_input = self._device_api.new_static_input(
             (key.batch_size, self._num_quantizers, key.frames),
             device=self._device,
         )
-        self._cuda.warmup(
-            self._model,
-            static_input,
-            iterations=self._WARMUP_ITERATIONS,
-            device=self._device,
-            stream=stream,
-        )
-        graph, static_output = self._cuda.capture(
-            self._model,
-            static_input,
-            pool=pool,
-            stream=stream,
-        )
-        with torch.inference_mode():
-            eager_output = self._model(static_input).detach().clone()
-            graph.replay()
+        # _verify_equivalence compares with torch.equal, so the eager reference
+        # below has to see the kernels the graph recorded, not a fresh choice.
+        with _xpu_capture_pins():
+            self._device_api.warmup(
+                self._model,
+                static_input,
+                iterations=self._WARMUP_ITERATIONS,
+                device=self._device,
+                stream=stream,
+            )
+            graph, static_output = self._device_api.capture(
+                self._model,
+                static_input,
+                pool=pool,
+                stream=stream,
+            )
+            with torch.inference_mode():
+                eager_output = self._model(static_input).detach().clone()
+                graph.replay()
         self._verify_equivalence(
             key=key,
             eager_output=eager_output,
@@ -551,17 +617,19 @@ class Code2WavCudaGraphRunner:
     ) -> None:
         if "after" not in self._memory_stats:
             try:
-                self._cuda.synchronize(self._device)
+                self._device_api.synchronize(self._device)
             except Exception as synchronize_exc:
                 logger.warning(
-                    "Code2Wav CUDA graph rollback synchronize failed: %s",
+                    "Code2Wav device graph rollback synchronize failed: %s",
                     synchronize_exc,
                 )
             try:
-                self._memory_stats["after"] = self._cuda.memory_stats(self._device)
+                self._memory_stats["after"] = self._device_api.memory_stats(
+                    self._device
+                )
             except Exception as snapshot_exc:
                 logger.warning(
-                    "Code2Wav CUDA graph rollback snapshot failed: %s",
+                    "Code2Wav device graph rollback snapshot failed: %s",
                     snapshot_exc,
                 )
         self._graphs.clear()
@@ -573,17 +641,17 @@ class Code2WavCudaGraphRunner:
         self._disable_reason = reason
         gc.collect()
         try:
-            with self._cuda.device_context(self._device):
-                self._cuda.empty_cache()
-                self._memory_stats["after_rollback"] = self._cuda.memory_stats(
+            with self._device_api.device_context(self._device):
+                self._device_api.empty_cache(self._device)
+                self._memory_stats["after_rollback"] = self._device_api.memory_stats(
                     self._device
                 )
         except Exception as cleanup_exc:
             logger.warning(
-                "Code2Wav CUDA graph rollback cleanup failed: %s",
+                "Code2Wav device graph rollback cleanup failed: %s",
                 cleanup_exc,
             )
-        logger.warning("Code2Wav CUDA graph runner disabled: %s", reason)
+        logger.warning("Code2Wav device graph runner disabled: %s", reason)
 
     def run(
         self,
@@ -600,7 +668,7 @@ class Code2WavCudaGraphRunner:
         current_pid = os.getpid()
         if current_pid != self._owner_pid:
             raise RuntimeError(
-                "Code2Wav CUDA graph runner/model belongs to PID "
+                "Code2Wav device graph runner/model belongs to PID "
                 f"{self._owner_pid}, but was used in PID {current_pid}; it must "
                 "be rebuilt in a spawned process before inference"
             )
@@ -637,11 +705,14 @@ class Code2WavCudaGraphRunner:
         )
 
     def _validate_codes(self, codes: torch.Tensor) -> None:
-        if not self._cuda.is_cuda_tensor(codes):
-            raise TypeError("Code2Wav graph input must be a CUDA tensor")
+        if not self._device_api.is_accelerator_tensor(codes, self._device):
+            raise TypeError(
+                f"Code2Wav graph input must be on device type "
+                f"{self._device.type!r}, got {codes.device.type!r}"
+            )
         if codes.dtype != torch.long:
             raise TypeError("Code2Wav graph input must use torch.long")
-        if not self._cuda.tensor_device_matches(codes, self._device):
+        if not self._device_api.tensor_device_matches(codes, self._device):
             raise ValueError(f"Code2Wav graph input must be on {self._device}")
         if codes.ndim != 3:
             raise ValueError("Code2Wav graph input must have shape [B, Q, T]")
@@ -676,14 +747,14 @@ class Code2WavCudaGraphRunner:
         self._disable_reason = reason
         gc.collect()
         try:
-            with self._cuda.device_context(self._device):
-                self._cuda.empty_cache()
+            with self._device_api.device_context(self._device):
+                self._device_api.empty_cache(self._device)
         except Exception as cleanup_exc:
             logger.warning(
-                "Code2Wav CUDA graph runtime cleanup failed: %s",
+                "Code2Wav device graph runtime cleanup failed: %s",
                 cleanup_exc,
             )
-        logger.exception("Code2Wav CUDA graph replay disabled the runner")
+        logger.exception("Code2Wav device graph replay disabled the runner")
 
     def stats(self) -> dict[str, Any]:
         """Return a strict JSON-safe snapshot of build and runtime state."""

--- a/sglang_omni/models/qwen3_omni/components/code2wav_scheduler.py
+++ b/sglang_omni/models/qwen3_omni/components/code2wav_scheduler.py
@@ -974,8 +974,8 @@ def create_code2wav_scheduler(
     """Factory: returns Code2WavScheduler."""
     if enable_cuda_graph and total_gpu_memory_fraction is None:
         raise ValueError(
-            "Code2Wav CUDA graph requires "
-            "runtime.resources.total_gpu_memory_fraction"
+            "Code2Wav device graph requires gpu_memory_fraction "
+            "on the code2wav stage"
         )
     concrete_device = torch.device(resolve_device_spec(device, gpu_id))
     if concrete_device.type != "cpu" and concrete_device.index is None:
@@ -1018,7 +1018,7 @@ def create_code2wav_scheduler(
             )
             enable_batching = False
         logger.info(
-            "Code2Wav CUDA graph startup stats=%s",
+            "Code2Wav device graph startup stats=%s",
             json.dumps(
                 cuda_graph_runner.stats(),
                 sort_keys=True,

--- a/sglang_omni/platforms/interface.py
+++ b/sglang_omni/platforms/interface.py
@@ -3,6 +3,7 @@
 from __future__ import annotations
 
 from collections.abc import Mapping
+from contextlib import AbstractContextManager, nullcontext
 from typing import TYPE_CHECKING
 
 from sglang.srt.platforms.device_mixin import DeviceMixin
@@ -11,6 +12,7 @@ from sglang_omni.utils.misc import normalize_quantization
 
 if TYPE_CHECKING:
     import torch
+    from torch.nn.attention import SDPBackend
 
     from sglang_omni.comm.data_ref import TransportKind
     from sglang_omni.pipeline.stage_workers import StageLaunchConfig
@@ -91,3 +93,16 @@ class OmniPlatform(DeviceMixin):
     def supports_torchaudio_resample(self) -> bool:
         """Check if current platform support torchaudio.functional.resample"""
         return True
+
+    def get_graph_capture_sdpa_backends(self) -> tuple["SDPBackend", ...]:
+        """Empty leaves dispatch alone."""
+        return ()
+
+    def graph_capture_attention(self) -> AbstractContextManager[object]:
+        backends = self.get_graph_capture_sdpa_backends()
+        if not backends:
+            return nullcontext()
+
+        from torch.nn.attention import sdpa_kernel
+
+        return sdpa_kernel(list(backends))

--- a/sglang_omni/platforms/xpu.py
+++ b/sglang_omni/platforms/xpu.py
@@ -15,6 +15,7 @@ logger = logging.getLogger(__name__)
 if TYPE_CHECKING:
     from sglang.srt.configs.model_config import ModelConfig
     from sglang.srt.server_args import ServerArgs
+    from torch.nn.attention import SDPBackend
 
     from sglang_omni.pipeline.stage_workers import StageLaunchConfig
     from sglang_omni.platforms.device_graph import DeviceGraphBackend
@@ -33,7 +34,7 @@ class XPUOmniPlatform(OmniPlatform):
         torch.xpu.set_device(0 if index is None else index)
 
     def enable_code2wav_graph(self):
-        return False
+        return True
 
     def get_fused_qk_norm_rope_with_cos_sin_cache(self):
         try:
@@ -47,8 +48,7 @@ class XPUOmniPlatform(OmniPlatform):
         return fused_inplace_qknorm_rope
 
     def enable_talker_graph(self) -> bool:
-        # The predictor's default SDPA dispatch is not capturable here.
-        return False
+        return True
 
     def enable_thinker_decode_graph(self) -> bool:
         # Capture leaves the scheduler thread's stream recording; host reads fail.
@@ -64,6 +64,13 @@ class XPUOmniPlatform(OmniPlatform):
         from sglang.srt.model_executor.cuda_graph_config import Backend
 
         return Backend.FULL
+
+    def get_graph_capture_sdpa_backends(self) -> tuple["SDPBackend", ...]:
+        """Efficient attention is left out: XPU reaches math before its
+        unsupported efficient branch, so naming it changes nothing."""
+        from torch.nn.attention import SDPBackend
+
+        return (SDPBackend.FLASH_ATTENTION, SDPBackend.MATH)
 
     def apply_model_worker_backend_policy(
         self,

--- a/tests/unit_test/model_runner/test_weight_share_load_path.py
+++ b/tests/unit_test/model_runner/test_weight_share_load_path.py
@@ -12,6 +12,7 @@ Requires sglang to be importable.
 from __future__ import annotations
 
 import os
+from contextlib import contextmanager
 from types import SimpleNamespace
 from unittest import mock
 
@@ -205,6 +206,59 @@ def test_graph_capture_finalizes_post_capture_kv_pool():
         runner.init_cuda_graphs()
 
     assert calls == ["capture", "resize"]
+
+
+def test_graph_capture_pins_sdpa_around_the_upstream_capture():
+    from sglang_omni.platforms import current_platform
+
+    runner = _bare_runner()
+    calls = []
+
+    @contextmanager
+    def fake_pin():
+        calls.append("pin_enter")
+        try:
+            yield
+        finally:
+            calls.append("pin_exit")
+
+    with (
+        get_context().override_server_args(),
+        mock.patch.object(current_platform, "is_xpu", lambda: True),
+        mock.patch.object(current_platform, "graph_capture_attention", fake_pin),
+        mock.patch.object(
+            ModelRunner,
+            "init_cuda_graphs",
+            lambda self, capture_decode_cuda_graph=True: calls.append("capture"),
+        ),
+    ):
+        runner.init_cuda_graphs()
+
+    assert calls == ["pin_enter", "capture", "pin_exit"]
+
+
+def test_a_non_xpu_platform_captures_unwrapped():
+    from sglang_omni.platforms import current_platform
+
+    runner = _bare_runner()
+    calls = []
+
+    def fail_if_entered():
+        raise AssertionError("the pin must not be built off XPU")
+
+    with (
+        get_context().override_server_args(),
+        mock.patch.object(current_platform, "is_xpu", lambda: False),
+        mock.patch.object(current_platform, "graph_capture_attention", fail_if_entered),
+        mock.patch.object(
+            ModelRunner,
+            "init_cuda_graphs",
+            lambda self, capture_decode_cuda_graph=True: calls.append("capture"),
+        ),
+    ):
+        runner.init_cuda_graphs()
+
+    assert calls == ["capture"]
 
 
 def test_graph_capture_reseeds_torch_compile_from_the_exec_bag():

--- a/tests/unit_test/qwen3_omni/test_code2wav.py
+++ b/tests/unit_test/qwen3_omni/test_code2wav.py
@@ -11,6 +11,7 @@ import numpy as np
 import pytest
 import torch
 
+from sglang_omni.config.schema import StageConfig
 from sglang_omni.models.qwen3_omni.components import code2wav_scheduler
 from sglang_omni.models.qwen3_omni.components.code2wav_cuda_graph import (
     Code2WavRunResult,
@@ -131,7 +132,7 @@ def test_qwen_code2wav_factory_default_does_not_build_cuda_graphs(monkeypatch) -
     )
 
     def _unexpected_build(*args, **kwargs):
-        raise AssertionError("disabled default must not build CUDA graphs")
+        raise AssertionError("disabled default must not build device graphs")
 
     monkeypatch.setattr(
         code2wav_scheduler.Code2WavCudaGraphRunner,
@@ -147,21 +148,17 @@ def test_qwen_code2wav_factory_default_does_not_build_cuda_graphs(monkeypatch) -
     assert scheduler._cuda_graph_runner is None
 
 
-def test_non_cuda_platforms_disable_the_code2wav_graph() -> None:
-    """The runner is CUDA-only, and the platform owns that decision rather than the
-    factory re-deriving it from the device type. A platform inheriting the base True
-    would reach the CUDA-only runner, so every non-CUDA platform declares itself.
-    """
+def test_only_graph_capable_platforms_enable_the_code2wav_graph() -> None:
     from sglang_omni.platforms.cpu import CPUOmniPlatform
     from sglang_omni.platforms.cuda import CUDAOmniPlatform
     from sglang_omni.platforms.npu import NPUOmniPlatform
     from sglang_omni.platforms.rocm import ROCMOmniPlatform
     from sglang_omni.platforms.xpu import XPUOmniPlatform
 
-    assert XPUOmniPlatform().enable_code2wav_graph() is False
+    assert XPUOmniPlatform().enable_code2wav_graph() is True
+    assert CUDAOmniPlatform().enable_code2wav_graph() is True
     assert NPUOmniPlatform().enable_code2wav_graph() is False
     assert CPUOmniPlatform().enable_code2wav_graph() is False
-    assert CUDAOmniPlatform().enable_code2wav_graph() is True
     assert ROCMOmniPlatform().enable_code2wav_graph() is False
 
 
@@ -190,7 +187,7 @@ def test_qwen_code2wav_enabled_factory_rejects_missing_typed_budget_before_load(
 
     monkeypatch.setattr(code2wav_scheduler, "load_code2wav_model", _load)
 
-    with pytest.raises(ValueError, match="total_gpu_memory_fraction"):
+    with pytest.raises(ValueError, match="gpu_memory_fraction") as excinfo:
         code2wav_scheduler.create_code2wav_scheduler(
             "dummy",
             device="cuda:0",
@@ -198,6 +195,9 @@ def test_qwen_code2wav_enabled_factory_rejects_missing_typed_budget_before_load(
         )
 
     assert load_calls == 0
+    # The message aborts startup, so the key it names has to be settable.
+    named = {word.strip("'\".,:") for word in str(excinfo.value).split()}
+    assert named & set(StageConfig.model_fields), str(excinfo.value)
 
 
 def test_qwen_code2wav_factory_allows_batching_with_cuda_graph(
@@ -421,7 +421,7 @@ def test_qwen_code2wav_enabled_factory_normalizes_device_and_derives_graph_keys(
     stats_record = next(
         record
         for record in caplog.records
-        if "CUDA graph startup stats=" in record.message
+        if "device graph startup stats=" in record.message
     )
     assert json.loads(stats_record.message.split("stats=", 1)[1]) == runner.stats()
 
@@ -469,7 +469,7 @@ def test_qwen_code2wav_enabled_factory_logs_disabled_build_reason(
     stats_record = next(
         record
         for record in caplog.records
-        if "CUDA graph startup stats=" in record.message
+        if "device graph startup stats=" in record.message
     )
     assert json.loads(stats_record.message.split("stats=", 1)[1]) == {
         "disable_reason": "capture_failed: RuntimeError: capture failed",

--- a/tests/unit_test/qwen3_omni/test_code2wav_cuda_graph.py
+++ b/tests/unit_test/qwen3_omni/test_code2wav_cuda_graph.py
@@ -4,7 +4,8 @@ from __future__ import annotations
 
 import json
 from collections.abc import Callable
-from contextlib import nullcontext
+from contextlib import contextmanager, nullcontext
+from types import SimpleNamespace
 from typing import Any
 
 import pytest
@@ -108,6 +109,10 @@ class _FakeCudaBackend:
         ]
         self._memory_index = 0
 
+    def graph_backend(self, device: torch.device) -> object:
+        del device
+        return object()
+
     def device_context(self, device: torch.device):
         del device
         return nullcontext()
@@ -118,7 +123,8 @@ class _FakeCudaBackend:
         self._memory_index += 1
         return dict(self._memory_snapshots[index])
 
-    def empty_cache(self) -> None:
+    def empty_cache(self, device: torch.device) -> None:
+        del device
         self.empty_cache_calls += 1
 
     def new_static_input(
@@ -143,7 +149,8 @@ class _FakeCudaBackend:
         for _ in range(iterations):
             model(static_input)
 
-    def graph_pool_handle(self) -> object:
+    def graph_pool_handle(self, device: torch.device) -> object:
+        del device
         self.pool_calls += 1
         return object()
 
@@ -181,8 +188,9 @@ class _FakeCudaBackend:
         del device
         self.synchronize_calls += 1
 
-    def is_cuda_tensor(self, tensor: torch.Tensor) -> bool:
-        return id(tensor) in self._tensor_devices
+    def is_accelerator_tensor(self, tensor: torch.Tensor, device: torch.device) -> bool:
+        marked = self._tensor_devices.get(id(tensor))
+        return marked is not None and marked.type == device.type
 
     def tensor_device_matches(self, tensor: torch.Tensor, device: torch.device) -> bool:
         return self._tensor_devices.get(id(tensor)) == device
@@ -208,7 +216,7 @@ def _build_runner(
         num_quantizers=16,
         total_gpu_memory_fraction=total_gpu_memory_fraction,
         graph_keys=_DEFAULT_GRAPH_KEYS,
-        cuda_api=backend,
+        device_api=backend,
     )
     return runner, backend, model
 
@@ -238,7 +246,7 @@ def test_build_captures_only_the_explicit_graph_keys() -> None:
         num_quantizers=16,
         total_gpu_memory_fraction=0.5,
         graph_keys=graph_keys,
-        cuda_api=backend,
+        device_api=backend,
     )
 
     assert [tuple(graph.static_input.shape) for graph in backend.graphs] == [
@@ -357,9 +365,11 @@ def test_all_serving_keys_hit_while_batch_two_misses() -> None:
     }
 
 
-def test_cuda_api_restores_original_stream_when_capture_exit_raises(
+def test_device_api_restores_original_stream_when_capture_exit_raises(
     monkeypatch: pytest.MonkeyPatch,
 ) -> None:
+    from sglang_omni import platforms
+
     original_stream = object()
     current = {"stream": original_stream}
 
@@ -376,29 +386,29 @@ def test_cuda_api_restores_original_stream_when_capture_exit_raises(
         def __exit__(self, *_args: object) -> None:
             raise RuntimeError("fake capture_end failed")
 
-    def graph_context(*_args: object, **kwargs: object) -> _FailingCaptureContext:
+    def capture(**kwargs: object) -> _FailingCaptureContext:
         assert kwargs["stream"] is side_stream
+        assert kwargs["thread_local_errors"] is True
         return _FailingCaptureContext()
 
-    monkeypatch.setattr(
-        code2wav_cuda_graph.torch.cuda,
-        "current_stream",
-        lambda _device: current["stream"],
+    fake_module = SimpleNamespace(
+        __name__="fake",
+        current_stream=lambda _device: current["stream"],
+        set_stream=lambda stream: current.update(stream=stream),
     )
     monkeypatch.setattr(
-        code2wav_cuda_graph.torch.cuda,
-        "set_stream",
-        lambda stream: current.update(stream=stream),
+        code2wav_cuda_graph.torch,
+        "get_device_module",
+        lambda *_args, **_kwargs: fake_module,
     )
     monkeypatch.setattr(
-        code2wav_cuda_graph.torch.cuda,
-        "CUDAGraph",
-        lambda: object(),
+        platforms.current_platform,
+        "get_device_graph_backend",
+        lambda _device: SimpleNamespace(capture=capture),
     )
-    monkeypatch.setattr(code2wav_cuda_graph.torch.cuda, "graph", graph_context)
 
     with pytest.raises(RuntimeError, match="fake capture_end failed"):
-        code2wav_cuda_graph._TorchCudaApi().capture(
+        code2wav_cuda_graph._TorchDeviceApi().capture(
             _FakeModel(),
             torch.zeros((1, 16, 10), dtype=torch.long),
             pool=object(),
@@ -411,7 +421,7 @@ def test_cuda_api_restores_original_stream_when_capture_exit_raises(
 @pytest.mark.accelerator
 @pytest.mark.skipif(not torch.cuda.is_available(), reason="CUDA is unavailable")
 def test_real_cuda_invalid_capture_preserves_current_stream() -> None:
-    api = code2wav_cuda_graph._TorchCudaApi()
+    api = code2wav_cuda_graph._TorchDeviceApi()
     device = torch.device("cuda", torch.cuda.current_device())
     original_stream = torch.cuda.current_stream(device)
     side_stream = api.new_stream(device)
@@ -621,7 +631,7 @@ def test_intentional_eager_fallbacks(
 @pytest.mark.parametrize(
     ("case", "expected_error", "message"),
     [
-        ("non_cuda", TypeError, "CUDA tensor"),
+        ("non_cuda", TypeError, "must be on device type 'cuda'"),
         ("wrong_dtype", TypeError, "torch.long"),
         ("wrong_device", ValueError, "cuda:0"),
         ("wrong_shape", ValueError, "shape"),
@@ -818,7 +828,7 @@ def _build_tiered_runner(
         num_quantizers=16,
         total_gpu_memory_fraction=0.5,
         graph_keys=_TIERED_GRAPH_KEYS,
-        cuda_api=backend,
+        device_api=backend,
     )
 
 
@@ -1048,3 +1058,160 @@ def test_runtime_disable_clears_tier1_availability() -> None:
 
     assert runner.available_batch_sizes(10) == ()
     assert runner.stats()["enabled"] is False
+
+
+def test_the_mask_pin_refuses_a_concurrent_holder() -> None:
+    import threading
+
+    held = threading.Event()
+    release = threading.Event()
+    outcome: list[str] = []
+
+    def holder() -> None:
+        with code2wav_cuda_graph._unpacked_sequence_mask():
+            held.set()
+            release.wait(timeout=5)
+
+    worker = threading.Thread(target=holder)
+    worker.start()
+    try:
+        assert held.wait(timeout=5), "holder never acquired the pin"
+        try:
+            with code2wav_cuda_graph._unpacked_sequence_mask():
+                outcome.append("acquired")
+        except RuntimeError:
+            outcome.append("refused")
+    finally:
+        release.set()
+        worker.join(timeout=5)
+
+    assert outcome == ["refused"]
+    with code2wav_cuda_graph._unpacked_sequence_mask():
+        pass
+
+
+def test_a_failure_reading_the_mask_global_does_not_leak_the_lock(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    from transformers import masking_utils
+
+    monkeypatch.delattr(masking_utils, "find_packed_sequence_indices")
+
+    with pytest.raises(AttributeError):
+        with code2wav_cuda_graph._unpacked_sequence_mask():
+            pass
+
+    monkeypatch.undo()
+    with code2wav_cuda_graph._unpacked_sequence_mask():
+        assert masking_utils.find_packed_sequence_indices([1, 2]) is None
+
+
+def test_a_device_whose_platform_names_no_graph_backend_is_refused_at_build() -> None:
+
+    class _NoBackend(_FakeCudaBackend):
+        def graph_backend(self, device: torch.device) -> None:
+            del device
+            return None
+
+    with pytest.raises(ValueError, match="names no device graph backend"):
+        Code2WavCudaGraphRunner.build(
+            _FakeModel(),
+            device="cuda:0",
+            num_quantizers=16,
+            total_gpu_memory_fraction=0.5,
+            graph_keys=_DEFAULT_GRAPH_KEYS,
+            device_api=_NoBackend(),
+        )
+
+
+def test_an_indexless_device_is_refused_at_build() -> None:
+    with pytest.raises(ValueError, match="concrete device"):
+        Code2WavCudaGraphRunner.build(
+            _FakeModel(),
+            device="cuda",
+            num_quantizers=16,
+            total_gpu_memory_fraction=0.5,
+            graph_keys=_DEFAULT_GRAPH_KEYS,
+            device_api=_FakeCudaBackend(),
+        )
+
+
+class _PhaseRecordingBackend(_FakeCudaBackend):
+
+    def __init__(self, phase: list[str]) -> None:
+        super().__init__()
+        self._phase = phase
+
+    def warmup(self, model, static_input, **kwargs):
+        parent = super().warmup
+        return self._during("warmup", lambda: parent(model, static_input, **kwargs))
+
+    def capture(self, model, static_input, **kwargs):
+        parent = super().capture
+        graph, output = self._during(
+            "capture", lambda: parent(model, static_input, **kwargs)
+        )
+        inner_replay = graph.replay
+        graph.replay = lambda: self._during("replay", inner_replay)
+        return graph, output
+
+    def _during(self, phase: str, call):
+        previous, self._phase[0] = self._phase[0], phase
+        try:
+            return call()
+        finally:
+            self._phase[0] = previous
+
+
+@pytest.mark.parametrize("is_xpu", [False, True], ids=["non_xpu", "xpu"])
+def test_capture_pins_cover_warmup_capture_and_the_equivalence_check(
+    monkeypatch: pytest.MonkeyPatch, is_xpu: bool
+) -> None:
+    """_verify_equivalence compares with torch.equal, so an eager reference taken
+    outside the pins can reject a good capture and disable the runner."""
+    from transformers import masking_utils
+
+    from sglang_omni import platforms
+
+    events: list[str] = []
+    phase = ["eager"]
+
+    @contextmanager
+    def recording_pin():
+        events.append("pin_enter")
+        try:
+            yield
+        finally:
+            events.append("pin_exit")
+
+    monkeypatch.setattr(platforms.current_platform, "is_xpu", lambda: is_xpu)
+    monkeypatch.setattr(
+        platforms.current_platform, "graph_capture_attention", recording_pin
+    )
+    original_probe = masking_utils.find_packed_sequence_indices
+    seen_probe: list[object] = []
+    model = _FakeModel()
+
+    def recording_model(codes: torch.Tensor) -> torch.Tensor:
+        events.append(phase[0])
+        seen_probe.append(masking_utils.find_packed_sequence_indices)
+        return model(codes)
+
+    runner = Code2WavCudaGraphRunner.build(
+        recording_model,
+        device="cuda:0",
+        num_quantizers=16,
+        total_gpu_memory_fraction=0.5,
+        graph_keys=(GraphKey(batch_size=1, frames=10),),
+        device_api=_PhaseRecordingBackend(phase),
+    )
+
+    assert runner.stats()["build"]["published_graph_count"] == 1
+    inner = ["warmup"] * 3 + ["capture", "eager", "replay"]
+    if is_xpu:
+        assert events == ["pin_enter", *inner, "pin_exit"]
+        assert all(probe is not original_probe for probe in seen_probe)
+    else:
+        assert events == inner, "no pin may be entered off XPU"
+        assert all(probe is original_probe for probe in seen_probe)
+    assert masking_utils.find_packed_sequence_indices is original_probe

--- a/tests/unit_test/qwen3_omni/test_config_manager.py
+++ b/tests/unit_test/qwen3_omni/test_config_manager.py
@@ -307,3 +307,36 @@ def test_qwen3_omni_talker_stage_keeps_greedy_selection_off_aiter_on_rocm(
 
         assert _stage(config, "talker_ar").env == expected_env
         assert _stage(config, "thinker").env == {}
+
+
+def test_qwen3_omni_xpu_b60_example_config_loads_and_plans() -> None:
+    config_path = _REPO_ROOT / "examples" / "configs" / "qwen3_omni_speech_xpu_b60.yaml"
+
+    manager = ConfigManager.from_file(str(config_path))
+    config = manager.config
+    plan = build_stage_placement_plan(config)
+    topology = build_compiled_process_topology(config)
+
+    assert isinstance(config, Qwen3OmniSpeechPipelineConfig)
+    assert config.name == "qwen3-omni-speech-xpu-b60"
+    assert [group.name for group in topology.groups] == [
+        "preprocessing",
+        "image_encoder",
+        "audio_encoder",
+        "decode",
+        "talker_ar",
+        "code2wav",
+    ]
+
+    thinker = _stage(config, "thinker")
+    assert thinker.tp_size == 8
+    assert thinker.gpu == [0, 1, 2, 3, 4, 5, 6, 7]
+    assert thinker.engine.mem_fraction_static == pytest.approx(0.55)
+    assert _stage(config, "talker_ar").engine.mem_fraction_static == pytest.approx(0.35)
+
+    assert _stage(config, "talker_ar").gpu == 6
+    assert _stage(config, "code2wav").gpu == 7
+    assert _stage(config, "code2wav").gpu_memory_fraction == pytest.approx(0.05)
+    assert plan.stages["thinker"].gpu_ids == tuple(range(8))
+    assert plan.stages["talker_ar"].gpu_ids == (6,)
+    assert plan.stages["code2wav"].gpu_ids == (7,)

--- a/tests/unit_test/test_platforms.py
+++ b/tests/unit_test/test_platforms.py
@@ -1,6 +1,7 @@
 # SPDX-License-Identifier: Apache-2.0
 from __future__ import annotations
 
+from contextlib import nullcontext
 from types import SimpleNamespace
 
 import pytest
@@ -194,8 +195,8 @@ def test_xpu_names_the_decode_graph_backend_sglang_leaves_off() -> None:
     assert CPUOmniPlatform().get_decode_cuda_graph_backend() is None
 
 
-def test_xpu_keeps_the_qwen3_omni_talker_decode_eager() -> None:
-    assert xpu_platform.XPUOmniPlatform().enable_talker_graph() is False
+def test_xpu_captures_the_qwen3_omni_talker_decode() -> None:
+    assert xpu_platform.XPUOmniPlatform().enable_talker_graph() is True
     assert OmniPlatform().enable_talker_graph() is True
     assert CPUOmniPlatform().enable_talker_graph() is True
 
@@ -247,3 +248,55 @@ def test_a_platform_declines_a_device_that_is_not_its_own() -> None:
     assert platform.get_device_graph_backend(torch.device("xpu", 0)) is None
     assert platform.get_device_graph_backend(torch.device("meta")) is None
     assert platform.get_device_graph_backend(torch.device("cpu")) is None
+
+
+def test_xpu_names_the_sdpa_backends_a_graph_capture_can_use() -> None:
+    from torch.nn.attention import SDPBackend
+
+    backends = xpu_platform.XPUOmniPlatform().get_graph_capture_sdpa_backends()
+
+    assert set(backends) == {SDPBackend.FLASH_ATTENTION, SDPBackend.MATH}
+    assert SDPBackend.MATH in backends, "no fallback for shapes flash declines"
+    for platform in (OmniPlatform(), CPUOmniPlatform(), CUDAOmniPlatform()):
+        assert platform.get_graph_capture_sdpa_backends() == ()
+
+
+def test_a_platform_that_names_no_sdpa_backend_never_pins(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    import torch.nn.attention as attention
+
+    calls: list[object] = []
+
+    def recording_pin(backends):
+        calls.append(backends)
+        return nullcontext()
+
+    monkeypatch.setattr(attention, "sdpa_kernel", recording_pin)
+
+    with OmniPlatform().graph_capture_attention():
+        pass
+
+    assert calls == []
+
+
+def test_the_pin_receives_exactly_the_backends_the_hook_names(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    import torch.nn.attention as attention
+    from torch.nn.attention import SDPBackend
+
+    calls: list[list[SDPBackend]] = []
+
+    def recording_pin(backends):
+        calls.append(list(backends))
+        return nullcontext()
+
+    monkeypatch.setattr(attention, "sdpa_kernel", recording_pin)
+    platform = xpu_platform.XPUOmniPlatform()
+
+    with platform.graph_capture_attention():
+        pass
+
+    assert calls == [list(platform.get_graph_capture_sdpa_backends())]
+    assert calls[0], "an empty set would leave dispatch on the uncapturable default"


### PR DESCRIPTION
## Motivation

Support Qwen3-Omni speech — talker and Code2Wav — with XPUGraphs on Intel XPU.

Both speech-stage graph gates answered `False` on XPU, so the thinker could only
run `--text-only`. The talker graph is what puts the pipeline under realtime:
eager decode runs at RTF 1.45, slower than the audio it produces; the graph brings
that to 0.73.

## Modifications

1. **`enable_code2wav_graph()` and `enable_talker_graph()`: `False` → `True`** in
   `XPUOmniPlatform`.
2. **`SGLangModelRunner.init_cuda_graphs` pins SDPA around the capture on XPU.**
   The talker's capture died at startup with *"Graph nodes cannot depend on events
   from outside the graph"* — XPU's default SDPA dispatch records an event the graph
   did not create. The engines reach SDPA through model code SGLang's capture does
   not wrap, so the choice is made around the whole capture.
3. **`code2wav.gpu_memory_fraction: 0.02` → `0.05`** in the XPU profile. The
   fraction is of the whole card: 2.8 GiB on a 141 GiB H200, but 490 MiB on a
   24 GB B60, which left less graph budget than the capture keys need.

The Code2Wav runner also stops naming `torch.cuda` directly and asks the platform
for the graph backend #1911 landed. New config:
`examples/configs/qwen3_omni_speech_xpu_b60.yaml` (thinker TP=8, talker on card 6,
code2wav on card 7).

10 files, +702/−127.

**Non-XPU platforms are untouched, structurally.** Both capture pins — the SDPA
backend choice and transformers' packed-sequence probe — sit behind an `is_xpu()`
gate, and `init_cuda_graphs` enters nothing off XPU. CUDA, ROCm, MUSA and NPU reach
the same capture, with the same interpreter state, as before this PR. Asserted by
tests parametrised over `is_xpu`.

## Related Issues

- Tracking issue #1588.
- Builds on #1679 (XPU decode-graph backend opt-in).
- Depends on #1911 (merged), which landed `sglang_omni/platforms/device_graph.py`;
  this PR consumes its `DeviceGraphBackend` rather than keeping a private
  graph-type lookup.

## Accuracy Test

| | result |
|---|---|
| Round-trip WER, Qwen3-ASR judge | **0.0%** |
| Code2Wav graph replay vs eager | **bit-exact** at all four keys |

Replay is compared against eager under the same SDPA pin. Against *unpinned* eager
it would measure which attention kernel ran, not whether capture recorded
faithfully — on XPU the SDPA backends differ from each other in bf16 at these
shapes, and the default dispatch switches backend with the frame count.

## Benchmark & Profiling

8× Intel Arc Pro B60, weights warm. Talker decode graph A/B, two arms with only
`talker_ar.engine.disable_cuda_graph` changing and Code2Wav publishing 4/4 keys in
both, so the delta is the talker alone:

| run | graph (min) | eager (min) | speedup | RTF |
|---|---|---|---|---|
| quiet host | 1.88 s | 3.73 s | **1.98×** | 0.73 vs 1.45 |
| contended host | 2.01 s | 4.29 s | **2.14×** | 0.82 vs 1.58 |

Per-arm minimum, 4 warm requests per arm. The minima agree within ~8% across runs
while medians swing 1.65–2.02× with host load, so the floor is the statistic that
survives a shared machine. n=4 is thin; a CI-gating number wants the 5-run protocol
on a quiet host.

Code2Wav's own step goes 23.4–25.4 ms → 18.5–18.7 ms (1.24–1.37× on that step).
That is ~20 ms of a ~1.9 s request and the stage overlaps talker generation, so it
buys per-chunk jitter rather than throughput.

**Reproduce:**

```bash
sgl-omni serve --config examples/configs/qwen3_omni_speech_xpu_b60.yaml \
    --model-path <Qwen3-Omni-30B-A3B-Instruct> --port 8114

# eager arm
sgl-omni serve --config examples/configs/qwen3_omni_speech_xpu_b60.yaml \
    --model-path <model> --talker_ar.engine.disable_cuda_graph true
```

Confirm the graphs engaged rather than assuming:

```bash
grep "Capture target decode XPU graph end" <serve.log>   # talker
grep -o '"published_graph_count":[0-9]*' <serve.log>      # code2wav -> 4
```

## Checklist

- [x] Format your code according with pre-commit.
- [x] Add unit tests.
- [x] Update documentation / docstrings / example tutorials as needed.
- [x] Provide throughput / latency benchmark results and accuracy evaluation results as needed.
- [ ] For reviewers: If you haven't made any contributions to this PR and are only assisting with merging the main branch, please remove yourself as a co-author when merging the PR.

## CI

`/tag-and-rerun-ci qwen3-tts qwen3-asr`
