### PR TITLE
fix(zonos2): bound speaker resampler cache

### DIFF
--- a/sglang_omni/models/zonos2/components/speaker_encoder.py
+++ b/sglang_omni/models/zonos2/components/speaker_encoder.py
@@ -13,9 +13,9 @@ import subprocess
 import threading
 import wave
 from dataclasses import dataclass
-from functools import cache
+from functools import lru_cache
 from pathlib import Path
-from typing import Any
+from typing import Any, Callable
 
 import torch
 import torch.nn as nn
@@ -29,6 +29,21 @@ from sglang_omni.scheduling.reference_encoder import (
 )
 
 SPEAKER_EMBEDDING_DIM = 2048
+# Source sample rates come from caller-provided reference audio. Keep enough common
+# rates hot without allowing device-resident resamplers to grow without bound.
+_RESAMPLER_CACHE_MAX_ITEMS = 8
+
+
+def _make_resampler_getter(
+    *, target_sample_rate: int, device: str
+) -> Callable[[int], nn.Module]:
+    @lru_cache(maxsize=_RESAMPLER_CACHE_MAX_ITEMS)
+    def _get_resampler(orig_sample_rate: int) -> nn.Module:
+        return torchaudio.transforms.Resample(orig_sample_rate, target_sample_rate).to(
+            device
+        )
+
+    return _get_resampler
 
 
 class Qwen3SpeakerEmbedding(nn.Module):
@@ -59,6 +74,11 @@ class Qwen3SpeakerEmbedding(nn.Module):
         self.model.to(device)
         self.model.eval()
 
+        self._get_resampler = _make_resampler_getter(
+            target_sample_rate=self.TARGET_SAMPLE_RATE,
+            device=device,
+        )
+
         self.mel_transform = torchaudio.transforms.MelSpectrogram(
             sample_rate=self.TARGET_SAMPLE_RATE,
             n_fft=self.N_FFT,
@@ -78,12 +98,6 @@ class Qwen3SpeakerEmbedding(nn.Module):
     @property
     def dtype(self):
         return next(self.model.parameters()).dtype
-
-    @cache
-    def _get_resampler(self, orig_sample_rate: int):
-        return torchaudio.transforms.Resample(
-            orig_sample_rate, self.TARGET_SAMPLE_RATE
-        ).to(self.device)
 
     def prepare_input(self, wav: torch.Tensor, sample_rate: int) -> torch.Tensor:
         assert wav.ndim < 3

--- a/tests/unit_test/zonos2/test_speaker_cache.py
+++ b/tests/unit_test/zonos2/test_speaker_cache.py
@@ -1,11 +1,12 @@
 # SPDX-License-Identifier: Apache-2.0
-"""GPU-free tests for the SpeakerEncoder content-hash cache.
+"""GPU-free tests for the SpeakerEncoder caches.
 
 The LRU mechanics live in the shared StageOutputCache (covered by its own tests);
 these cover ZONOS2's model-local glue now routed through it: content-hash keying,
 a cache hit avoiding a second forward, recency-ordered eviction at the count cap,
-and clone isolation of returned embeddings. The Qwen3 embedder is stubbed, so no
-model checkpoint or GPU is needed (the module still imports torchaudio/transformers).
+clone isolation of returned embeddings, and the bounded resampler cache. The Qwen3
+embedder is stubbed, so no model checkpoint or GPU is needed (the module still
+imports torchaudio/transformers).
 """
 
 import threading
@@ -19,8 +20,10 @@ pytest.importorskip("transformers")
 import torch  # noqa: E402
 
 from sglang_omni.models.zonos2.components.speaker_encoder import (  # noqa: E402
+    _RESAMPLER_CACHE_MAX_ITEMS,
     SPEAKER_EMBEDDING_DIM,
     SpeakerEncoder,
+    _make_resampler_getter,
 )
 
 
@@ -130,3 +133,38 @@ def test_returned_embedding_is_isolated_clone() -> None:
 def test_rejects_non_positive_cache_size() -> None:
     with pytest.raises(ValueError):
         SpeakerEncoder(device="cpu", cache_max_items=0)
+
+
+def test_speaker_resampler_cache_is_bounded_and_recency_ordered(monkeypatch) -> None:
+    created = []
+
+    class _FakeResampler(torch.nn.Module):
+        def __init__(self, orig_sample_rate: int, target_sample_rate: int) -> None:
+            super().__init__()
+            self.orig_sample_rate = orig_sample_rate
+            self.target_sample_rate = target_sample_rate
+            created.append(self)
+
+    monkeypatch.setattr(
+        "sglang_omni.models.zonos2.components.speaker_encoder."
+        "torchaudio.transforms.Resample",
+        _FakeResampler,
+    )
+
+    get_resampler = _make_resampler_getter(
+        target_sample_rate=24000,
+        device="cpu",
+    )
+
+    sample_rates = [8000 + index for index in range(_RESAMPLER_CACHE_MAX_ITEMS)]
+    for sample_rate in sample_rates:
+        get_resampler(sample_rate)
+
+    first = get_resampler(sample_rates[0])
+    overflow_rate = 48000
+    get_resampler(overflow_rate)
+
+    assert get_resampler(sample_rates[0]) is first
+    assert len(created) == _RESAMPLER_CACHE_MAX_ITEMS + 1
+    get_resampler(sample_rates[1])
+    assert len(created) == _RESAMPLER_CACHE_MAX_ITEMS + 2


### PR DESCRIPTION
## Motivation

ZONOS2 speaker-reference audio may arrive with caller-provided sample rates. The speaker encoder previously used an unbounded functools cache for torchaudio Resample modules, so every distinct source rate retained another device-resident resampler for the lifetime of the process. The method-level cache also retained encoder instances through its keys.

Bound the cache so uncommon or adversarial source rates cannot cause persistent GPU-memory growth while common rates still reuse their resampling kernels.

## Modifications

- Replace the unbounded method cache with a per-embedder LRU cache capped at eight resamplers.
- Capture the target sample rate and device in the per-instance cache factory so entries are keyed only by source sample rate and are not shared across embedder instances.
- Add a GPU-free regression test covering the cache bound, hit recency, and least-recently-used eviction.

## Related Issues

Related to #775, which introduced ZONOS2 support. This PR addresses a follow-up cache-lifetime issue and does not close #775.

## Accuracy Test

The resampling operation and model math are unchanged; eviction only causes the same torchaudio Resample module to be recreated when a rate becomes active again.

- Targeted speaker-cache suite: 7 passed.
- Full ZONOS2 unit suite: 57 passed.
- Real-model smoke test on an NVIDIA GeForce RTX 4070 Ti using marksverdhei/Qwen3-Voice-Embedding-12Hz-1.7B:
  - exercised ten distinct source sample rates;
  - observed cache maxsize=8, currsize=8, misses=10;
  - produced a finite speaker embedding with shape [1, 2048].

## Benchmark & Profiling

This is a memory-bounding change rather than a throughput optimization. The real-model smoke test observed approximately 46 MiB of model allocation and 66 MiB peak allocated VRAM for the speaker-encoder process. The steady-state cache-hit path remains an LRU lookup followed by the existing resampler call.

## Checklist

- [x] Format your code according with pre-commit.
- [x] Add unit tests.
- [x] Update documentation / docstrings / example tutorials as needed.
- [x] Provide throughput / latency benchmark results and accuracy evaluation results as needed.
- [ ] For reviewers: If you haven't made any contributions to this PR and are only assisting with merging the main branch, please remove yourself as a co-author when merging the PR.

## CI

Pre-commit passed locally on both changed files. Draft PRs do not run the repository's self-hosted GPU CI; request the appropriate maintainer label and CI selection when the PR is ready for review.