### PR TITLE
ci(xpu): scope the PR trigger to the paths the XPU suites exercise

### DIFF
--- a/.github/workflows/omni-xpu-ci.yaml
+++ b/.github/workflows/omni-xpu-ci.yaml
@@ -63,7 +63,12 @@ jobs:
         with:
           filters: |
             xpu:
-              - 'sglang_omni/**'
+              # The XPU suites import sglang_omni.platforms and
+              # sglang_omni.utils.device only; scope the trigger to that
+              # surface so unrelated model or docs changes do not occupy an
+              # XPU runner.
+              - 'sglang_omni/platforms/**'
+              - 'sglang_omni/utils/device.py'
               - 'tests/unit_test/xpu/**'
               - 'pyproject_xpu.toml'
               - 'scripts/xpu/**'


### PR DESCRIPTION
## What

The XPU CI paths filter matches `sglang_omni/**`, so any change anywhere in the package runs the XPU device-layer suite. The two suites import only `sglang_omni.platforms` and `sglang_omni.utils.device`:

```
tests/unit_test/xpu/test_device_layer.py:    from sglang_omni.platforms import ...
tests/unit_test/xpu/test_install_script.py: import sglang_omni.utils.device
```

This narrows the filter to that surface plus the XPU-specific files already listed (`tests/unit_test/xpu/**`, `pyproject_xpu.toml`, `scripts/xpu/**`, the Dockerfile, the workflow itself). Anything touching the real dependency surface still triggers everything, and the `workflow_dispatch` force-true path for manual runs is untouched.

## Why

#1807 changes one model's request builder and its cookbook, and still occupied an XPU runner — where it collected a failing check from a `Checkout PR code` step that had nothing to do with the change (twice, including a re-run). Scarce accelerator runners spending time on PRs that cannot affect them is the same queue problem the H100 side manages with `run-*` labels.

@pavansivaram you added this workflow in #1749 — if the broad filter was intentional (device-layer suite as a smoke test for every omni change), happy to close this; in that case a `run-xpu` label gate like omni-ci's might be worth considering instead.

Collaborated with Claude Code.