### PR TITLE
[Perf] Freeze Python GC after startup

### DIFF
--- a/docs/developer_reference/rl_admin_control.md
+++ b/docs/developer_reference/rl_admin_control.md
@@ -59,10 +59,12 @@ updated the model weights; recover by reloading or otherwise repairing the
 worker before calling `continue_generation`.
 
 `/freeze_gc` calls `gc.freeze()` in the API process and in every targeted stage
-process (all TP ranks). The launcher already does this once automatically when
-the pipeline becomes ready (disable with `SGLANG_OMNI_FREEZE_GC_AFTER_STARTUP=0`);
-call the endpoint again after your own warmup traffic so lazily created objects
-join the frozen set. Freezing is idempotent and only affects GC scan cost, never
+process (all TP ranks). The launcher already does this automatically: once when
+the pipeline becomes ready and once more after the first
+`SGLANG_OMNI_FREEZE_GC_AFTER_REQUESTS` (default 64) requests complete, so the
+state the first requests build lazily joins the frozen set. Disable both with
+`SGLANG_OMNI_FREEZE_GC_AFTER_STARTUP=0`, or only the second with
+`..._AFTER_REQUESTS=0`; call the endpoint yourself after any further warmup. Freezing is idempotent and only affects GC scan cost, never
 correctness. The response carries per-stage generation counts and the API
 server's own counts under `api_server`.
 

--- a/docs/developer_reference/rl_admin_control.md
+++ b/docs/developer_reference/rl_admin_control.md
@@ -37,6 +37,7 @@ The worker server supports:
 - `POST /destroy_weights_update_group`
 - `POST /update_weights_from_distributed`
 - `GET|POST /weights_checker`
+- `POST /freeze_gc`
 
 `/update_weights_from_disk` is the primary implemented update path. It pauses
 the target scheduler, optionally aborts active requests, calls the underlying
@@ -56,6 +57,14 @@ aborted or safely retracted, cache is flushed by default, and the visible
 update fails, the scheduler remains paused because SGLang may have partially
 updated the model weights; recover by reloading or otherwise repairing the
 worker before calling `continue_generation`.
+
+`/freeze_gc` calls `gc.freeze()` in the API process and in every targeted stage
+process (all TP ranks). The launcher already does this once automatically when
+the pipeline becomes ready (disable with `SGLANG_OMNI_FREEZE_GC_AFTER_STARTUP=0`);
+call the endpoint again after your own warmup traffic so lazily created objects
+join the frozen set. Freezing is idempotent and only affects GC scan cost, never
+correctness. The response carries per-stage generation counts and the API
+server's own counts under `api_server`.
 
 `/update_weights_from_tensor` is still reserved for a future tensor data-plane
 integration and returns HTTP 501 from the worker and router HTTP APIs. Once

--- a/sglang_omni/client/client.py
+++ b/sglang_omni/client/client.py
@@ -31,7 +31,7 @@ from sglang_omni.client.types import (
     UsageInfo,
 )
 from sglang_omni.pipeline.coordinator import Coordinator
-from sglang_omni.proto import OmniRequest, RequestState, StreamMessage
+from sglang_omni.proto import ADMIN_FREEZE_GC, OmniRequest, RequestState, StreamMessage
 
 
 class Client:
@@ -303,6 +303,19 @@ class Client:
         return await self._coordinator.admin(
             action,
             payload,
+            stages=stages,
+            timeout_s=timeout_s,
+        )
+
+    async def freeze_gc(
+        self,
+        *,
+        stages: list[str] | None = None,
+        timeout_s: float = 30.0,
+    ) -> dict[str, Any]:
+        """Freeze the Python cyclic GC in every targeted stage process."""
+        return await self._coordinator.admin(
+            ADMIN_FREEZE_GC,
             stages=stages,
             timeout_s=timeout_s,
         )

--- a/sglang_omni/pipeline/coordinator.py
+++ b/sglang_omni/pipeline/coordinator.py
@@ -116,6 +116,10 @@ class Coordinator:
 
         # Request tracking
         self._requests: dict[str, RequestInfo] = {}
+        # Monotonic count of requests that reached a terminal completion
+        # (success or error). Read by the launcher to time the post-warmup
+        # GC freeze; never reset.
+        self.completed_requests = 0
         self._completion_futures: dict[str, asyncio.Future] = {}
         self._stream_queues: dict[
             str, asyncio.Queue[CompleteMessage | StreamMessage]
@@ -667,6 +671,7 @@ class Coordinator:
             if stream_queue is not None:
                 await stream_queue.put(msg)
             self._requests.pop(request_id, None)
+            self.completed_requests += 1
             return
 
         expected_terminal_stages = self._expected_terminal_stages(request_id)
@@ -691,6 +696,7 @@ class Coordinator:
             if request_id in self._stream_queues:
                 await self._stream_queues[request_id].put(msg)
             self._requests.pop(request_id, None)
+            self.completed_requests += 1
             return
 
         # Multi-terminal: collect partial results
@@ -715,6 +721,7 @@ class Coordinator:
             if not future.done():
                 future.set_result(merged)
         self._requests.pop(request_id, None)
+        self.completed_requests += 1
 
     async def _handle_stream(self, msg: StreamMessage) -> None:
         """Handle a stream chunk from a stage."""

--- a/sglang_omni/pipeline/stage/runtime.py
+++ b/sglang_omni/pipeline/stage/runtime.py
@@ -35,6 +35,7 @@ from sglang_omni.profiler.event_recorder import get_recorder as _get_recorder
 from sglang_omni.profiler.event_recorder import set_active_stage as _set_active_stage
 from sglang_omni.profiler.torch_profiler import TorchProfiler
 from sglang_omni.proto import (
+    ADMIN_FREEZE_GC,
     AdminMessage,
     AdminResult,
     AdminResultMessage,
@@ -51,6 +52,7 @@ from sglang_omni.proto import (
 )
 from sglang_omni.relay.base import Relay
 from sglang_omni.scheduling.messages import IncomingMessage
+from sglang_omni.utils.gc_control import freeze_gc
 
 logger = logging.getLogger(__name__)
 
@@ -1012,6 +1014,15 @@ class Stage:
 
     async def _run_admin_operation(self, operation: Any) -> AdminResult:
         try:
+            if operation.action == ADMIN_FREEZE_GC:
+                # Process-wide, independent of the scheduler: every stage
+                # process and every TP rank freezes its own interpreter.
+                return self._admin_result(
+                    operation,
+                    success=True,
+                    message="gc frozen",
+                    data=freeze_gc(f"stage {self.name}"),
+                )
             handler = getattr(self.scheduler, "admin", None)
             if handler is None:
                 return self._admin_result(

--- a/sglang_omni/pipeline/stage_workers.py
+++ b/sglang_omni/pipeline/stage_workers.py
@@ -26,6 +26,7 @@ from sglang_omni.pipeline.stage.runtime import Stage
 from sglang_omni.pipeline.stage.stream_queue import StreamQueue
 from sglang_omni.pipeline.tp_control import TPFollowerControlPlane, TPLeaderFanout
 from sglang_omni.platforms import current_platform, get_platform_spec
+from sglang_omni.utils.gc_control import install_gc_stats_if_enabled
 from sglang_omni.utils.gpu_compat import (
     apply_gpu_compat_env_defaults,
     get_gpu_compat_env_defaults,
@@ -410,6 +411,7 @@ def stage_process_main(
     if not spec.stage_specs:
         raise ValueError(f"Process {spec.process_name!r} requires at least one stage")
     log = logging.getLogger(f"stage_workers.{spec.process_name}")
+    install_gc_stats_if_enabled(f"stage process {spec.process_name}")
 
     try:
         for stage_spec in spec.stage_specs:

--- a/sglang_omni/proto/__init__.py
+++ b/sglang_omni/proto/__init__.py
@@ -2,6 +2,7 @@
 from .admin import (
     ADMIN_CONTINUE_GENERATION,
     ADMIN_DESTROY_WEIGHTS_UPDATE_GROUP,
+    ADMIN_FREEZE_GC,
     ADMIN_INIT_WEIGHTS_UPDATE_GROUP,
     ADMIN_MODEL_INFO,
     ADMIN_PAUSE_GENERATION,
@@ -47,6 +48,7 @@ __all__ = [
     "AdminResult",
     "AdminMessage",
     "AdminResultMessage",
+    "ADMIN_FREEZE_GC",
     "ADMIN_MODEL_INFO",
     "ADMIN_PAUSE_GENERATION",
     "ADMIN_CONTINUE_GENERATION",

--- a/sglang_omni/proto/admin.py
+++ b/sglang_omni/proto/admin.py
@@ -15,6 +15,7 @@ ADMIN_UPDATE_WEIGHTS_FROM_DISTRIBUTED = "update_weights_from_distributed"
 ADMIN_INIT_WEIGHTS_UPDATE_GROUP = "init_weights_update_group"
 ADMIN_DESTROY_WEIGHTS_UPDATE_GROUP = "destroy_weights_update_group"
 ADMIN_WEIGHTS_CHECKER = "weights_checker"
+ADMIN_FREEZE_GC = "freeze_gc"
 
 
 @dataclass

--- a/sglang_omni/serve/launcher.py
+++ b/sglang_omni/serve/launcher.py
@@ -51,6 +51,7 @@ from sglang_omni.utils.gc_control import (
     FREEZE_GC_AFTER_STARTUP_ENV,
     freeze_gc,
     freeze_gc_after_startup_enabled,
+    install_gc_stats_if_enabled,
 )
 from sglang_omni.utils.gpu_compat import apply_gpu_compat_env_defaults
 from sglang_omni.utils.gpu_memory import (
@@ -396,6 +397,7 @@ async def _run_server(
     """
     # 0. Check port availability before loading models
     port = _find_available_port(host, port)
+    install_gc_stats_if_enabled("api server")
 
     mp_runner = MultiProcessPipelineRunner(pipeline_config)
     startup_timeout = float(os.environ.get("SGLANG_OMNI_STARTUP_TIMEOUT", "600"))

--- a/sglang_omni/serve/launcher.py
+++ b/sglang_omni/serve/launcher.py
@@ -47,6 +47,11 @@ from sglang_omni.profiler.event_recorder import get_recorder as _get_event_recor
 from sglang_omni.profiler.profiler_control import ProfilerControlClient
 from sglang_omni.serve.openai_api import create_app
 from sglang_omni.serve.protocol import DEFAULT_TTS_BATCH_MAX_ITEMS
+from sglang_omni.utils.gc_control import (
+    FREEZE_GC_AFTER_STARTUP_ENV,
+    freeze_gc,
+    freeze_gc_after_startup_enabled,
+)
 from sglang_omni.utils.gpu_compat import apply_gpu_compat_env_defaults
 from sglang_omni.utils.gpu_memory import (
     GpuDeviceInfo,
@@ -456,6 +461,8 @@ async def _run_server(
         profiler_ctl = ProfilerControlClient(mp_runner.stage_control_endpoints)
         _mount_profiler_routes(app, profiler_ctl, profiler_dir)
 
+        await _freeze_gc_after_startup(client)
+
         config = uvicorn.Config(
             app,
             host=host,
@@ -469,6 +476,31 @@ async def _run_server(
         logger.info("Shutting down pipeline …")
         await mp_runner.stop()
         logger.info("Pipeline stopped.")
+
+
+async def _freeze_gc_after_startup(client: Client) -> None:
+    """Freeze the cyclic GC in every pipeline process once startup is complete.
+
+    Stage processes have finished model load and CUDA graph capture by the time
+    ``mp_runner.start()`` returns, so the static object set is in place.  The
+    freeze is process-local and idempotent; ``POST /freeze_gc`` can repeat it
+    after operator warmup traffic.  Disable with
+    ``SGLANG_OMNI_FREEZE_GC_AFTER_STARTUP=0``.
+    """
+    if not freeze_gc_after_startup_enabled():
+        logger.info(
+            "Skipping post-startup GC freeze (%s disabled it)",
+            FREEZE_GC_AFTER_STARTUP_ENV,
+        )
+        return
+    try:
+        result = await client.freeze_gc(timeout_s=30.0)
+    except Exception:
+        logger.warning("Post-startup GC freeze failed on the stages", exc_info=True)
+    else:
+        if not result.get("success", False):
+            logger.warning("Post-startup GC freeze reported failure: %s", result)
+    freeze_gc("api server")
 
 
 async def _serve_with_failure_watch(

--- a/sglang_omni/serve/launcher.py
+++ b/sglang_omni/serve/launcher.py
@@ -50,6 +50,7 @@ from sglang_omni.serve.protocol import DEFAULT_TTS_BATCH_MAX_ITEMS
 from sglang_omni.utils.gc_control import (
     FREEZE_GC_AFTER_STARTUP_ENV,
     freeze_gc,
+    freeze_gc_after_requests,
     freeze_gc_after_startup_enabled,
     install_gc_stats_if_enabled,
 )
@@ -425,6 +426,7 @@ async def _run_server(
         len(gpu_ids),
     )
 
+    warmup_freeze_task: asyncio.Task[None] | None = None
     try:
         cl_kwargs = client_kwargs or {}
         client = Client(coordinator, **cl_kwargs)
@@ -463,7 +465,7 @@ async def _run_server(
         profiler_ctl = ProfilerControlClient(mp_runner.stage_control_endpoints)
         _mount_profiler_routes(app, profiler_ctl, profiler_dir)
 
-        await _freeze_gc_after_startup(client)
+        warmup_freeze_task = await _freeze_gc_after_startup(client, coordinator)
 
         config = uvicorn.Config(
             app,
@@ -475,34 +477,58 @@ async def _run_server(
         server = _PipelineUvicornServer(config)
         await _serve_with_failure_watch(server, [mp_runner.wait_failed()])
     finally:
+        if warmup_freeze_task is not None:
+            warmup_freeze_task.cancel()
         logger.info("Shutting down pipeline …")
         await mp_runner.stop()
         logger.info("Pipeline stopped.")
 
 
-async def _freeze_gc_after_startup(client: Client) -> None:
-    """Freeze the cyclic GC in every pipeline process once startup is complete.
+_WARMUP_FREEZE_POLL_S = 5.0
 
-    Stage processes have finished model load and CUDA graph capture by the time
-    ``mp_runner.start()`` returns, so the static object set is in place.  The
-    freeze is process-local and idempotent; ``POST /freeze_gc`` can repeat it
-    after operator warmup traffic.  Disable with
-    ``SGLANG_OMNI_FREEZE_GC_AFTER_STARTUP=0``.
+
+async def _freeze_all(client: Client, context: str) -> None:
+    try:
+        result = await client.freeze_gc(timeout_s=30.0)
+    except Exception:
+        logger.warning("%s GC freeze failed on the stages", context, exc_info=True)
+    else:
+        if not result.get("success", False):
+            logger.warning("%s GC freeze reported failure: %s", context, result)
+    freeze_gc(f"api server ({context})")
+
+
+async def _freeze_gc_after_startup(
+    client: Client, coordinator: Any
+) -> asyncio.Task[None] | None:
+    """Freeze the cyclic GC in every pipeline process, twice.
+
+    Once right away: stage processes have finished model load and CUDA graph
+    capture by the time ``mp_runner.start()`` returns.  Once more after the
+    first ``SGLANG_OMNI_FREEZE_GC_AFTER_REQUESTS`` (default 64) requests
+    complete, so the state that the first requests build lazily joins the
+    frozen set too.  Both freezes are process-local and idempotent;
+    ``POST /freeze_gc`` repeats them on demand.  Disable everything with
+    ``SGLANG_OMNI_FREEZE_GC_AFTER_STARTUP=0``; ``..._AFTER_REQUESTS=0`` keeps
+    only the startup freeze.
     """
     if not freeze_gc_after_startup_enabled():
         logger.info(
             "Skipping post-startup GC freeze (%s disabled it)",
             FREEZE_GC_AFTER_STARTUP_ENV,
         )
-        return
-    try:
-        result = await client.freeze_gc(timeout_s=30.0)
-    except Exception:
-        logger.warning("Post-startup GC freeze failed on the stages", exc_info=True)
-    else:
-        if not result.get("success", False):
-            logger.warning("Post-startup GC freeze reported failure: %s", result)
-    freeze_gc("api server")
+        return None
+    await _freeze_all(client, "post-startup")
+    threshold = freeze_gc_after_requests()
+    if threshold == 0:
+        return None
+
+    async def _after_requests() -> None:
+        while coordinator.completed_requests < threshold:
+            await asyncio.sleep(_WARMUP_FREEZE_POLL_S)
+        await _freeze_all(client, f"post-warmup ({threshold} requests)")
+
+    return asyncio.create_task(_after_requests())
 
 
 async def _serve_with_failure_watch(

--- a/sglang_omni/serve/openai_api.py
+++ b/sglang_omni/serve/openai_api.py
@@ -123,6 +123,7 @@ from sglang_omni.serve.streaming import (
 )
 from sglang_omni.serve.transcriptions import register_transcriptions
 from sglang_omni.serve.translations import register_translations
+from sglang_omni.utils.gc_control import freeze_gc
 
 logger = logging.getLogger(__name__)
 HTTP_DISCONNECT_POLL_INTERVAL_S = 0.05
@@ -565,6 +566,23 @@ def _register_admin(app: FastAPI, admin_api_key: str | None = None) -> None:
                 timeout_s=_timeout_or_default(req.timeout_s, 120.0),
             )
         )
+
+    @app.post("/freeze_gc", dependencies=[Depends(_auth)])
+    async def freeze_gc_post(req: AdminRequestBase | None = None) -> JSONResponse:
+        """Freeze the Python GC in the API process and every targeted stage.
+
+        Mirrors SGLang's ``/freeze_gc``: call it after your own warmup traffic
+        so the objects created lazily on first use join the frozen set too.
+        """
+        client: Client = app.state.client
+        req = req or AdminRequestBase()
+        result = await client.freeze_gc(
+            stages=req.stages,
+            timeout_s=_timeout_or_default(req.timeout_s, 30.0),
+        )
+        result = dict(result)
+        result["api_server"] = freeze_gc("api server")
+        return _admin_response(result)
 
 
 def _timeout_or_default(timeout_s: float | None, default: float) -> float:

--- a/sglang_omni/utils/gc_control.py
+++ b/sglang_omni/utils/gc_control.py
@@ -1,0 +1,64 @@
+# SPDX-License-Identifier: Apache-2.0
+"""Python GC control helpers shared by the launcher, stage runtime and admin path.
+
+``gc.freeze()`` moves every object currently tracked by the cyclic collector
+into a permanent generation that later collections skip.  After model load and
+CUDA graph capture a serving process holds millions of long-lived objects
+(weights, graph runners, tokenizer tables); freezing them keeps gen2 collections
+from re-scanning that static set on every request, which shows up as tail
+latency on the scheduler thread.  Freezing is idempotent and never affects
+correctness: objects created afterwards stay in the regular generations.
+"""
+
+from __future__ import annotations
+
+import gc
+import logging
+import os
+from typing import Any
+
+logger = logging.getLogger(__name__)
+
+FREEZE_GC_AFTER_STARTUP_ENV = "SGLANG_OMNI_FREEZE_GC_AFTER_STARTUP"
+
+
+def freeze_gc_after_startup_enabled() -> bool:
+    """Return whether the launcher should freeze GC once the pipeline is ready.
+
+    Enabled by default; set ``SGLANG_OMNI_FREEZE_GC_AFTER_STARTUP=0`` to keep the
+    pre-existing behaviour (no freeze).  ``POST /freeze_gc`` stays available
+    either way.
+    """
+    raw = os.environ.get(FREEZE_GC_AFTER_STARTUP_ENV, "1").strip().lower()
+    return raw not in {"0", "false", "no", "off"}
+
+
+def gc_object_counts() -> tuple[int, int, int]:
+    return tuple(len(gc.get_objects(generation=i)) for i in range(3))  # type: ignore[return-value]
+
+
+def freeze_gc(context: str) -> dict[str, Any]:
+    """Freeze the cyclic GC in this process and return before/after generation sizes."""
+    before = gc_object_counts()
+    gc.freeze()
+    after = gc_object_counts()
+    frozen = gc.get_freeze_count()
+    logger.info(
+        "Freezing GC in %s process (pid=%d): gen0 %d->%d, gen1 %d->%d, gen2 %d->%d, frozen=%d",
+        context,
+        os.getpid(),
+        before[0],
+        after[0],
+        before[1],
+        after[1],
+        before[2],
+        after[2],
+        frozen,
+    )
+    return {
+        "context": context,
+        "pid": os.getpid(),
+        "before": {"gen0": before[0], "gen1": before[1], "gen2": before[2]},
+        "after": {"gen0": after[0], "gen1": after[1], "gen2": after[2]},
+        "frozen": frozen,
+    }

--- a/sglang_omni/utils/gc_control.py
+++ b/sglang_omni/utils/gc_control.py
@@ -62,3 +62,78 @@ def freeze_gc(context: str) -> dict[str, Any]:
         "after": {"gen0": after[0], "gen1": after[1], "gen2": after[2]},
         "frozen": frozen,
     }
+
+
+GC_STATS_ENV = "SGLANG_OMNI_GC_STATS"
+_GC_STATS_SUMMARY_INTERVAL_S = 30.0
+_GC_STATS_SLOW_GEN2_S = 0.05
+
+
+def gc_stats_enabled() -> bool:
+    raw = os.environ.get(GC_STATS_ENV, "0").strip().lower()
+    return raw not in {"", "0", "false", "no", "off"}
+
+
+def install_gc_stats_if_enabled(context: str) -> bool:
+    """Opt-in diagnostic: count cyclic GC passes per generation in this process.
+
+    With ``SGLANG_OMNI_GC_STATS=1`` a ``gc.callbacks`` hook accumulates the
+    number, total and maximum duration of collections per generation, logs one
+    summary line every 30 s of GC activity, and logs every gen2 pass slower
+    than 50 ms on its own.  This is the evidence path for the post-startup
+    freeze: compare gen2 count / stall time with and without it.  Off by
+    default; the hook costs one ``time.monotonic()`` per collection.
+    """
+    if not gc_stats_enabled():
+        return False
+    import time
+
+    state = {
+        "start": {},
+        "count": [0, 0, 0],
+        "total": [0.0, 0.0, 0.0],
+        "max": [0.0, 0.0, 0.0],
+        "last_log": time.monotonic(),
+    }
+
+    def _cb(phase: str, info: dict[str, Any]) -> None:
+        gen = int(info.get("generation", 0))
+        now = time.monotonic()
+        if phase == "start":
+            state["start"][gen] = now
+            return
+        dur = now - state["start"].pop(gen, now)
+        state["count"][gen] += 1
+        state["total"][gen] += dur
+        state["max"][gen] = max(state["max"][gen], dur)
+        if gen == 2 and dur >= _GC_STATS_SLOW_GEN2_S:
+            logger.info(
+                "GC gen2 pass in %s (pid=%d): %.1f ms, collected=%s, frozen=%d",
+                context,
+                os.getpid(),
+                dur * 1000.0,
+                info.get("collected"),
+                gc.get_freeze_count(),
+            )
+        if now - state["last_log"] >= _GC_STATS_SUMMARY_INTERVAL_S:
+            state["last_log"] = now
+            logger.info(
+                "GC stats %s (pid=%d): gen0 n=%d tot=%.0fms max=%.1fms | "
+                "gen1 n=%d tot=%.0fms max=%.1fms | gen2 n=%d tot=%.0fms max=%.1fms | frozen=%d",
+                context,
+                os.getpid(),
+                state["count"][0],
+                state["total"][0] * 1000.0,
+                state["max"][0] * 1000.0,
+                state["count"][1],
+                state["total"][1] * 1000.0,
+                state["max"][1] * 1000.0,
+                state["count"][2],
+                state["total"][2] * 1000.0,
+                state["max"][2] * 1000.0,
+                gc.get_freeze_count(),
+            )
+
+    gc.callbacks.append(_cb)
+    logger.info("GC stats enabled in %s process (pid=%d)", context, os.getpid())
+    return True

--- a/sglang_omni/utils/gc_control.py
+++ b/sglang_omni/utils/gc_control.py
@@ -33,6 +33,27 @@ def freeze_gc_after_startup_enabled() -> bool:
     return raw not in {"0", "false", "no", "off"}
 
 
+FREEZE_GC_AFTER_REQUESTS_ENV = "SGLANG_OMNI_FREEZE_GC_AFTER_REQUESTS"
+DEFAULT_FREEZE_GC_AFTER_REQUESTS = 64
+
+
+def freeze_gc_after_requests() -> int:
+    """How many completed requests to wait for before the second freeze.
+
+    The first requests lazily build kernels, caches and per-model state that
+    the startup freeze cannot see; freezing once more after they complete
+    moves that set into the permanent generation as well.  ``0`` disables the
+    second freeze.
+    """
+    raw = os.environ.get(FREEZE_GC_AFTER_REQUESTS_ENV, "").strip()
+    if not raw:
+        return DEFAULT_FREEZE_GC_AFTER_REQUESTS
+    value = int(raw)
+    if value < 0:
+        raise ValueError(f"{FREEZE_GC_AFTER_REQUESTS_ENV} must be >= 0, got {value}")
+    return value
+
+
 def gc_object_counts() -> tuple[int, int, int]:
     return tuple(len(gc.get_objects(generation=i)) for i in range(3))  # type: ignore[return-value]
 

--- a/tests/unit_test/pipeline/test_admin_control.py
+++ b/tests/unit_test/pipeline/test_admin_control.py
@@ -565,3 +565,34 @@ def test_stage_admin_dispatches_to_scheduler() -> None:
         assert result_msg.result.data["action"] == "pause_generation"
 
     asyncio.run(_run())
+
+
+def test_stage_admin_freeze_gc_runs_without_scheduler_support() -> None:
+    async def _run() -> None:
+        scheduler = FakeScheduler()  # no ``admin`` method on purpose
+        control_plane = RecordingStageControlPlane()
+        stage = Stage(
+            name="decode",
+            role="single",
+            get_next=lambda request_id, output: None,
+            gpu_id=None,
+            endpoints={},
+            control_plane=control_plane,
+            relay=FakeRelay(),
+            scheduler=scheduler,
+        )
+
+        await stage._on_admin(
+            AdminMessage(AdminOperation(op_id="op-gc", action="freeze_gc"))
+        )
+
+        assert len(control_plane.completions) == 1
+        result_msg = control_plane.completions[0]
+        assert isinstance(result_msg, AdminResultMessage)
+        result = result_msg.result
+        assert result.success is True
+        assert result.action == "freeze_gc"
+        assert result.data["frozen"] > 0
+        assert result.data["after"]["gen2"] <= result.data["before"]["gen2"]
+
+    asyncio.run(_run())

--- a/tests/unit_test/pipeline/test_coordinator.py
+++ b/tests/unit_test/pipeline/test_coordinator.py
@@ -1074,3 +1074,33 @@ def test_coordinator_without_replicas_sends_no_bindings() -> None:
         assert control_plane.submitted[0][2].replica_bindings is None
 
     asyncio.run(_run())
+
+
+def test_coordinator_counts_completed_requests() -> None:
+    async def _run() -> None:
+        coordinator = Coordinator(
+            "inproc://complete",
+            "inproc://abort",
+            entry_stage="preprocess",
+            terminal_stages=["decode"],
+        )
+        coordinator.control_plane = RecordingCoordinatorControlPlane()
+        coordinator.register_stage("preprocess", "inproc://preprocess")
+        assert coordinator.completed_requests == 0
+
+        await coordinator._submit_request("ok", "hello")
+        await coordinator._handle_completion(
+            CompleteMessage("ok", "decode", True, result={"text": "hi"})
+        )
+        assert coordinator.completed_requests == 1
+
+        await coordinator._submit_request("err", "hello")
+        failed = coordinator._completion_futures["err"]
+        await coordinator._handle_completion(
+            CompleteMessage("err", "decode", False, error="boom")
+        )
+        assert coordinator.completed_requests == 2
+        with pytest.raises(Exception):
+            await failed
+
+    asyncio.run(_run())

--- a/tests/unit_test/serve/test_launcher_gc_freeze.py
+++ b/tests/unit_test/serve/test_launcher_gc_freeze.py
@@ -1,0 +1,75 @@
+# SPDX-License-Identifier: Apache-2.0
+from __future__ import annotations
+
+import asyncio
+import gc
+
+from sglang_omni.serve import launcher
+from sglang_omni.utils.gc_control import (
+    FREEZE_GC_AFTER_REQUESTS_ENV,
+    FREEZE_GC_AFTER_STARTUP_ENV,
+)
+
+
+class _FakeClient:
+    def __init__(self) -> None:
+        self.calls: list[float] = []
+
+    async def freeze_gc(self, *, timeout_s: float = 30.0) -> dict:
+        self.calls.append(timeout_s)
+        return {"success": True}
+
+
+class _FakeCoordinator:
+    completed_requests = 0
+
+
+def test_two_phase_freeze_waits_for_completed_requests(monkeypatch) -> None:
+    monkeypatch.delenv(FREEZE_GC_AFTER_STARTUP_ENV, raising=False)
+    monkeypatch.setenv(FREEZE_GC_AFTER_REQUESTS_ENV, "3")
+    monkeypatch.setattr(launcher, "_WARMUP_FREEZE_POLL_S", 0.01)
+
+    async def _run() -> None:
+        client, coordinator = _FakeClient(), _FakeCoordinator()
+        task = await launcher._freeze_gc_after_startup(client, coordinator)
+        assert len(client.calls) == 1  # startup freeze is immediate
+        assert task is not None and not task.done()
+        await asyncio.sleep(0.05)
+        assert len(client.calls) == 1  # still waiting for requests
+        coordinator.completed_requests = 3
+        await asyncio.wait_for(task, timeout=2.0)
+        assert len(client.calls) == 2
+
+    try:
+        asyncio.run(_run())
+    finally:
+        gc.unfreeze()
+
+
+def test_second_freeze_disabled_by_zero(monkeypatch) -> None:
+    monkeypatch.delenv(FREEZE_GC_AFTER_STARTUP_ENV, raising=False)
+    monkeypatch.setenv(FREEZE_GC_AFTER_REQUESTS_ENV, "0")
+
+    async def _run() -> None:
+        client = _FakeClient()
+        task = await launcher._freeze_gc_after_startup(client, _FakeCoordinator())
+        assert task is None
+        assert len(client.calls) == 1
+
+    try:
+        asyncio.run(_run())
+    finally:
+        gc.unfreeze()
+
+
+def test_startup_freeze_opt_out(monkeypatch) -> None:
+    monkeypatch.setenv(FREEZE_GC_AFTER_STARTUP_ENV, "0")
+
+    async def _run() -> None:
+        client = _FakeClient()
+        assert (
+            await launcher._freeze_gc_after_startup(client, _FakeCoordinator()) is None
+        )
+        assert client.calls == []
+
+    asyncio.run(_run())

--- a/tests/unit_test/utils/test_gc_control.py
+++ b/tests/unit_test/utils/test_gc_control.py
@@ -32,3 +32,17 @@ def test_freeze_gc_after_startup_env_parsing(monkeypatch) -> None:
         assert freeze_gc_after_startup_enabled() is False
     monkeypatch.setenv(FREEZE_GC_AFTER_STARTUP_ENV, "1")
     assert freeze_gc_after_startup_enabled() is True
+
+
+def test_gc_stats_hook_counts_collections(monkeypatch) -> None:
+    from sglang_omni.utils.gc_control import GC_STATS_ENV, install_gc_stats_if_enabled
+
+    monkeypatch.setenv(GC_STATS_ENV, "0")
+    assert install_gc_stats_if_enabled("t") is False
+    monkeypatch.setenv(GC_STATS_ENV, "1")
+    before = len(gc.callbacks)
+    assert install_gc_stats_if_enabled("t") is True
+    try:
+        gc.collect(2)  # exercises start/stop without raising
+    finally:
+        del gc.callbacks[before:]

--- a/tests/unit_test/utils/test_gc_control.py
+++ b/tests/unit_test/utils/test_gc_control.py
@@ -46,3 +46,23 @@ def test_gc_stats_hook_counts_collections(monkeypatch) -> None:
         gc.collect(2)  # exercises start/stop without raising
     finally:
         del gc.callbacks[before:]
+
+
+def test_freeze_gc_after_requests_env(monkeypatch) -> None:
+    import pytest
+
+    from sglang_omni.utils.gc_control import (
+        DEFAULT_FREEZE_GC_AFTER_REQUESTS,
+        FREEZE_GC_AFTER_REQUESTS_ENV,
+        freeze_gc_after_requests,
+    )
+
+    monkeypatch.delenv(FREEZE_GC_AFTER_REQUESTS_ENV, raising=False)
+    assert freeze_gc_after_requests() == DEFAULT_FREEZE_GC_AFTER_REQUESTS
+    monkeypatch.setenv(FREEZE_GC_AFTER_REQUESTS_ENV, "0")
+    assert freeze_gc_after_requests() == 0
+    monkeypatch.setenv(FREEZE_GC_AFTER_REQUESTS_ENV, "128")
+    assert freeze_gc_after_requests() == 128
+    monkeypatch.setenv(FREEZE_GC_AFTER_REQUESTS_ENV, "-1")
+    with pytest.raises(ValueError):
+        freeze_gc_after_requests()

--- a/tests/unit_test/utils/test_gc_control.py
+++ b/tests/unit_test/utils/test_gc_control.py
@@ -1,0 +1,34 @@
+# SPDX-License-Identifier: Apache-2.0
+from __future__ import annotations
+
+import gc
+
+from sglang_omni.utils.gc_control import (
+    FREEZE_GC_AFTER_STARTUP_ENV,
+    freeze_gc,
+    freeze_gc_after_startup_enabled,
+)
+
+
+def test_freeze_gc_reports_counts_and_is_idempotent() -> None:
+    junk = [[i] for i in range(1000)]  # tracked containers in gen0
+    first = freeze_gc("test")
+    # The interpreter may track/untrack a handful of its own objects between
+    # the freeze and the readback; only the order of magnitude is meaningful.
+    assert first["frozen"] > 0
+    assert abs(first["frozen"] - gc.get_freeze_count()) < 100
+    assert first["after"]["gen0"] <= first["before"]["gen0"]
+    second = freeze_gc("test")
+    assert second["frozen"] >= first["frozen"]
+    del junk
+    gc.unfreeze()
+
+
+def test_freeze_gc_after_startup_env_parsing(monkeypatch) -> None:
+    monkeypatch.delenv(FREEZE_GC_AFTER_STARTUP_ENV, raising=False)
+    assert freeze_gc_after_startup_enabled() is True
+    for raw in ("0", "false", "NO", " off "):
+        monkeypatch.setenv(FREEZE_GC_AFTER_STARTUP_ENV, raw)
+        assert freeze_gc_after_startup_enabled() is False
+    monkeypatch.setenv(FREEZE_GC_AFTER_STARTUP_ENV, "1")
+    assert freeze_gc_after_startup_enabled() is True


### PR DESCRIPTION
## Motivation

Python's cyclic GC scans every tracked object; in a serving process the long-lived population (engine, pools, cache tree) makes full gen2 passes expensive, and those pauses land on request tail latency. `gc.freeze()` after startup moves the long-lived set into the permanent generation so recurring collections only scan per-request garbage.

**Parked**: 
* #1724 removed the dominant gen2 allocation source, and the freeze no longer shows a measurable benefit on current main. 
* Residual value could be the `/freeze_gc` admin endpoint and the opt-in GC stats as observability

## Modifications

- `utils/gc_control.py`: freeze/stats plumbing. Three controls: `SGLANG_OMNI_FREEZE_GC_AFTER_STARTUP` (default on), `SGLANG_OMNI_FREEZE_GC_AFTER_REQUESTS` (default 64 -- a second automatic freeze after the first completed requests), `SGLANG_OMNI_GC_STATS` (opt-in counters). Both automatic freezes are default-on in this preview; given the verdict below, they are not recommended for adoption as-is.
- Launcher broadcasts freeze at readiness; API process self-freezes; `POST /freeze_gc` admin endpoint + `Client.freeze_gc`; TP followers handled at runtime layer.

## Related Issues

Part of #1754 (T-PR19).

## Accuracy Test

Not applicable (no model-side change). 

## Benchmark & Profiling

Measured on commit `15c4568` with this pr. 
* Radix is left ON at its default: the radix tree is the largest long-lived Python object population, so GC effects are most visible there. 
* Qwen3-TTS; Freeze vs no-freeze; same-window pairs; two runs; L=14 clone traffic; c=32, pre+post windows:

| run | window | freeze qps | no-freeze qps | ratio | p95 ratio |
|---|---|---:|---:|---:|---:|
| 1 | pre | 8.332 | 8.369 | 0.996 | 1.002 |
| 1 | post | 7.905 | 7.348 | 1.076 | 1.006 |
| 2 | pre | 7.440 | 8.326 | 0.894 | 0.997 |
| 2 | post | 7.015 | 7.201 | 0.974 | 1.006 |


The gen2 pressure came from the classic evict path's per-call O(L) full-heap rebuild, and #1724 replaced it with a persistent lazy heap, removing that allocation source; 

## Checklist

- [x] Format your code according with pre-commit.
- [x] Add unit tests.
- [x] Update documentation / docstrings / example tutorials as needed.
- [x] Provide throughput / latency benchmark results and accuracy evaluation results as needed.

## CI

Not labeled (parked preview; not proposed for merge).

