### PR TITLE
[AMD][ROCm] Support Qwen3-Omni speech and HIP-visible TP placement on gfx950

### DIFF
--- a/examples/README.md
+++ b/examples/README.md
@@ -59,6 +59,16 @@ sgl-omni serve \
   --port 8000
 ```
 
+Qwen3-Omni BF16, one-GPU colocated AMD MI355X (gfx950, ROCm):
+
+```bash
+sgl-omni serve \
+  --config examples/configs/qwen3_omni_colocated_gfx950_bf16.yaml \
+  --colocate \
+  --model-name qwen3-omni \
+  --port 8000
+```
+
 ## Ming-Omni Server
 
 Text output:

--- a/examples/configs/qwen3_omni_colocated_gfx950_bf16.yaml
+++ b/examples/configs/qwen3_omni_colocated_gfx950_bf16.yaml
@@ -1,0 +1,21 @@
+# SPDX-License-Identifier: Apache-2.0
+# BF16 colocated profile for AMD MI355X (gfx950).
+config_cls: Qwen3OmniSpeechColocatedPipelineConfig
+name: qwen3-omni-colocated-gfx950-bf16
+model_path: Qwen/Qwen3-Omni-30B-A3B-Instruct
+
+stages:
+  image_encoder:
+    gpu_memory_fraction: 0.02
+  audio_encoder:
+    gpu_memory_fraction: 0.02
+  thinker:
+    gpu_memory_fraction: 0.78
+    engine:
+      # The breakable prefill graph enabled by the H100 profile is not yet
+      # qualified on gfx950; keep sglang's default (decode graph only).
+      cuda_graph_backend_prefill: disabled
+  talker_ar:
+    gpu_memory_fraction: 0.10
+  code2wav:
+    gpu_memory_fraction: 0.02

--- a/sglang_omni/models/qwen3_omni/components/audio_layer_graph.py
+++ b/sglang_omni/models/qwen3_omni/components/audio_layer_graph.py
@@ -28,12 +28,18 @@ class _Captured:
 _HOPPER = 9
 
 
-def _packed_attention_backend(capability: tuple[int, int]) -> str:
-    """FA3 on Hopper, Triton on every other CUDA device.
+def _packed_attention_backend(capability: tuple[int, int], *, is_hip: bool) -> str:
+    """FA3 on NVIDIA Hopper, Triton on every other supported device.
 
     sglang's VisionAttention rule also picks FA4 on Blackwell. Omni validates
     Hopper only, and Triton is the arm sglang itself uses on the other parts.
     """
+    if is_hip:
+        # PyTorch HIP reports AMD gfx950 as capability (9, 5). The Hopper check
+        # below would pick FA3, whose sglang impl raises on HIP ("only
+        # available for cuda or musa") and leaves the encoder eager. These
+        # graphs wire only the FA3 and Triton impls, so HIP takes Triton.
+        return "triton_attn"
     major, _ = capability
     return "fa3" if major == _HOPPER else "triton_attn"
 
@@ -42,7 +48,10 @@ def _resolve_packed_attention(device: torch.device) -> tuple[nn.Module, str]:
     # Local import: only a process that requests the graphs loads sglang's kernels.
     from sglang.srt.layers.attention import vision
 
-    backend = _packed_attention_backend(torch.cuda.get_device_capability(device))
+    backend = _packed_attention_backend(
+        torch.cuda.get_device_capability(device),
+        is_hip=torch.version.hip is not None,
+    )
     if backend == "fa3":
         impl_class = vision.VisionFlash3Attention
     else:

--- a/sglang_omni/models/qwen3_omni/components/audio_layer_graph.py
+++ b/sglang_omni/models/qwen3_omni/components/audio_layer_graph.py
@@ -35,10 +35,8 @@ def _packed_attention_backend(capability: tuple[int, int], *, is_hip: bool) -> s
     Hopper only, and Triton is the arm sglang itself uses on the other parts.
     """
     if is_hip:
-        # PyTorch HIP reports AMD gfx950 as capability (9, 5). The Hopper check
-        # below would pick FA3, whose sglang impl raises on HIP ("only
-        # available for cuda or musa") and leaves the encoder eager. These
-        # graphs wire only the FA3 and Triton impls, so HIP takes Triton.
+        # Note (zijiecode): HIP reports gfx950 as (9, 5), which the Hopper check
+        # would send to FA3; FA3 does not exist on HIP.
         return "triton_attn"
     major, _ = capability
     return "fa3" if major == _HOPPER else "triton_attn"

--- a/sglang_omni/models/qwen3_omni/components/talker.py
+++ b/sglang_omni/models/qwen3_omni/components/talker.py
@@ -90,14 +90,10 @@ class _PredictorDecodeGraph:
         self.summed_embeddings: torch.Tensor | None = None
         self._capture()
 
-    # Capture under inference mode like replay. torch's CUDA generator keeps
-    # seed/offset tensors that are allocated when the first live graph
-    # registers with it; SGLang's outer decode graph registers them from
-    # inference mode, so they are inference tensors. capture_begin() then
-    # fills them in place, which a plain no_grad capture is not allowed to do
-    # on torch 2.9 ("Inplace update to inference tensor outside
-    # InferenceMode"); the aborted capture also leaves the generator broken.
-    # torch 2.13 tolerates it, so this is neutral on CUDA CI.
+    # Note (zijiecode): capture in the same mode as replay. SGLang registers the
+    # CUDA generator from inference mode, so on torch 2.9 (ROCm) a no_grad
+    # capture_begin() is refused as an inplace update to an inference tensor
+    # and the aborted capture breaks every later graph in the process.
     @torch.inference_mode()
     def _capture(self) -> None:
         device = self.layer0_codes.device
@@ -1470,10 +1466,14 @@ class Qwen3OmniTalker(nn.Module):
             return False
         if not layer0_codes.is_cuda or not talker_hidden.is_cuda:
             return False
-        # SGLang's decode-graph capture runs warmup forwards before the stream
-        # capture itself; get_is_capture_mode() covers that whole window, so the
-        # predictor never captures its own graph inside the enclosing capture.
-        if get_is_capture_mode() or torch.cuda.is_current_stream_capturing():
+        if torch.cuda.is_current_stream_capturing():
+            return False
+        # Note (zijiecode): SGLang's decode-graph warmup runs this forward before
+        # its own capture. On ROCm (torch 2.9) the predictor must not register
+        # the CUDA generator first, or SGLang's no_grad capture_begin() fails
+        # on the inference tensors it left behind. CUDA keeps the startup-time
+        # capture.
+        if current_platform.is_rocm() and get_is_capture_mode():
             return False
         return True
 

--- a/sglang_omni/models/qwen3_omni/components/talker.py
+++ b/sglang_omni/models/qwen3_omni/components/talker.py
@@ -9,6 +9,7 @@ from typing import Iterable, Optional, Tuple
 
 import torch
 from sglang.srt.layers.logits_processor import LogitsProcessorOutput
+from sglang.srt.model_executor.runner_utils.capture_mode import get_is_capture_mode
 from sglang.srt.model_loader.weight_utils import default_weight_loader
 from sglang.srt.sampling.sampling_batch_info import SamplingBatchInfo
 from sglang.srt.utils import add_prefix
@@ -89,7 +90,15 @@ class _PredictorDecodeGraph:
         self.summed_embeddings: torch.Tensor | None = None
         self._capture()
 
-    @torch.no_grad()
+    # Capture under inference mode like replay. torch's CUDA generator keeps
+    # seed/offset tensors that are allocated when the first live graph
+    # registers with it; SGLang's outer decode graph registers them from
+    # inference mode, so they are inference tensors. capture_begin() then
+    # fills them in place, which a plain no_grad capture is not allowed to do
+    # on torch 2.9 ("Inplace update to inference tensor outside
+    # InferenceMode"); the aborted capture also leaves the generator broken.
+    # torch 2.13 tolerates it, so this is neutral on CUDA CI.
+    @torch.inference_mode()
     def _capture(self) -> None:
         device = self.layer0_codes.device
         with torch.cuda.device(device):
@@ -1461,7 +1470,10 @@ class Qwen3OmniTalker(nn.Module):
             return False
         if not layer0_codes.is_cuda or not talker_hidden.is_cuda:
             return False
-        if torch.cuda.is_current_stream_capturing():
+        # SGLang's decode-graph capture runs warmup forwards before the stream
+        # capture itself; get_is_capture_mode() covers that whole window, so the
+        # predictor never captures its own graph inside the enclosing capture.
+        if get_is_capture_mode() or torch.cuda.is_current_stream_capturing():
             return False
         return True
 

--- a/sglang_omni/models/qwen3_omni/config.py
+++ b/sglang_omni/models/qwen3_omni/config.py
@@ -185,13 +185,9 @@ def _decode_stage(*, process: str) -> StageConfig:
 def _talker_stage_env() -> dict[str, str]:
     if not current_platform.is_rocm():
         return {}
-    # sglang's ROCm sampler routes all-greedy batches to aiter's greedy_sample,
-    # which returns wrong token ids for vocabularies below 16384 entries
-    # (measured on gfx950 with aiter c16d44b9); the Talker codec head has 3072.
-    # A greedy Talker request (talker_temperature=0) would feed a corrupt first
-    # codec token into the code predictor, so keep this stage on torch.argmax.
-    # Only greedy token selection changes; attention and MoE kernels stay on
-    # the configured ROCm backends.
+    # Note (zijiecode): aiter.greedy_sample returns wrong ids for vocab sizes below
+    # 16384 (gfx950, aiter c16d44b9) and the Talker codec head has 3072, so a
+    # greedy Talker request would corrupt its first codec token.
     return {"SGLANG_DISABLE_AITER_GREEDY_SAMPLE": "1"}
 
 

--- a/sglang_omni/models/qwen3_omni/config.py
+++ b/sglang_omni/models/qwen3_omni/config.py
@@ -182,6 +182,19 @@ def _decode_stage(*, process: str) -> StageConfig:
     )
 
 
+def _talker_stage_env() -> dict[str, str]:
+    if not current_platform.is_rocm():
+        return {}
+    # sglang's ROCm sampler routes all-greedy batches to aiter's greedy_sample,
+    # which returns wrong token ids for vocabularies below 16384 entries
+    # (measured on gfx950 with aiter c16d44b9); the Talker codec head has 3072.
+    # A greedy Talker request (talker_temperature=0) would feed a corrupt first
+    # codec token into the code predictor, so keep this stage on torch.argmax.
+    # Only greedy token selection changes; attention and MoE kernels stay on
+    # the configured ROCm backends.
+    return {"SGLANG_DISABLE_AITER_GREEDY_SAMPLE": "1"}
+
+
 def _talker_stage(
     *,
     gpu: int,
@@ -191,6 +204,7 @@ def _talker_stage(
     return EngineStageConfig(
         name="talker_ar",
         process=process,
+        env=_talker_stage_env(),
         wait_for=["preprocessing", "image_encoder", "audio_encoder"],
         wait_for_fn=f"{_PKG}.request_builders.resolve_mm_aggregate_wait_sources",
         merge_fn=f"{_PKG}.request_builders.merge_for_talker",

--- a/sglang_omni/pipeline/stage_workers.py
+++ b/sglang_omni/pipeline/stage_workers.py
@@ -903,12 +903,18 @@ def _prepare_accelerator_environment(
             # A CPU stage colocated in a GPU-narrowed process keeps its
             # identity; normalizing it would bind it to the local device.
             return
-        mapped_gpu = os.environ.get("CUDA_VISIBLE_DEVICES", str(spec.gpu_id))
+        visibility_var = (
+            "HIP_VISIBLE_DEVICES"
+            if current_platform.is_rocm() and os.environ.get("HIP_VISIBLE_DEVICES")
+            else "CUDA_VISIBLE_DEVICES"
+        )
+        mapped_gpu = os.environ.get(visibility_var, str(spec.gpu_id))
         _normalize_spec_gpu_id_to_local_device(spec)
         log.info(
-            "TP stage %s rank %d sees CUDA_VISIBLE_DEVICES=%s (local gpu_id=0)",
+            "TP stage %s rank %d sees %s=%s (local gpu_id=0)",
             spec.stage_name,
             spec.tp_rank,
+            visibility_var,
             mapped_gpu,
         )
         return
@@ -920,8 +926,15 @@ def _prepare_accelerator_environment(
     for key, value in env_updates.items():
         os.environ[key] = value
 
-    mapped_gpu = env_updates.get("CUDA_VISIBLE_DEVICES")
-    if mapped_gpu is None:
+    mapped_visibility = next(
+        (
+            (key, env_updates[key])
+            for key in ("HIP_VISIBLE_DEVICES", "CUDA_VISIBLE_DEVICES")
+            if env_updates.get(key)
+        ),
+        None,
+    )
+    if mapped_visibility is None:
         log.info(
             "TP stage %s rank %d keeps every card visible, using gpu_id=%s",
             spec.stage_name,
@@ -930,11 +943,13 @@ def _prepare_accelerator_environment(
         )
         return
 
+    visibility_var, mapped_gpu = mapped_visibility
     _normalize_spec_gpu_id_to_local_device(spec)
     log.info(
-        "Mapped TP stage %s rank %d to CUDA_VISIBLE_DEVICES=%s (local gpu_id=0)",
+        "Mapped TP stage %s rank %d to %s=%s (local gpu_id=0)",
         spec.stage_name,
         spec.tp_rank,
+        visibility_var,
         mapped_gpu,
     )
 

--- a/sglang_omni/pipeline/stage_workers.py
+++ b/sglang_omni/pipeline/stage_workers.py
@@ -903,18 +903,12 @@ def _prepare_accelerator_environment(
             # A CPU stage colocated in a GPU-narrowed process keeps its
             # identity; normalizing it would bind it to the local device.
             return
-        visibility_var = (
-            "HIP_VISIBLE_DEVICES"
-            if current_platform.is_rocm() and os.environ.get("HIP_VISIBLE_DEVICES")
-            else "CUDA_VISIBLE_DEVICES"
-        )
-        mapped_gpu = os.environ.get(visibility_var, str(spec.gpu_id))
+        mapped_gpu = os.environ.get("CUDA_VISIBLE_DEVICES", str(spec.gpu_id))
         _normalize_spec_gpu_id_to_local_device(spec)
         log.info(
-            "TP stage %s rank %d sees %s=%s (local gpu_id=0)",
+            "TP stage %s rank %d sees CUDA_VISIBLE_DEVICES=%s (local gpu_id=0)",
             spec.stage_name,
             spec.tp_rank,
-            visibility_var,
             mapped_gpu,
         )
         return
@@ -926,15 +920,8 @@ def _prepare_accelerator_environment(
     for key, value in env_updates.items():
         os.environ[key] = value
 
-    mapped_visibility = next(
-        (
-            (key, env_updates[key])
-            for key in ("HIP_VISIBLE_DEVICES", "CUDA_VISIBLE_DEVICES")
-            if env_updates.get(key)
-        ),
-        None,
-    )
-    if mapped_visibility is None:
+    mapped_gpu = env_updates.get("CUDA_VISIBLE_DEVICES")
+    if mapped_gpu is None:
         log.info(
             "TP stage %s rank %d keeps every card visible, using gpu_id=%s",
             spec.stage_name,
@@ -943,13 +930,11 @@ def _prepare_accelerator_environment(
         )
         return
 
-    visibility_var, mapped_gpu = mapped_visibility
     _normalize_spec_gpu_id_to_local_device(spec)
     log.info(
-        "Mapped TP stage %s rank %d to %s=%s (local gpu_id=0)",
+        "Mapped TP stage %s rank %d to CUDA_VISIBLE_DEVICES=%s (local gpu_id=0)",
         spec.stage_name,
         spec.tp_rank,
-        visibility_var,
         mapped_gpu,
     )
 

--- a/sglang_omni/platforms/rocm.py
+++ b/sglang_omni/platforms/rocm.py
@@ -51,11 +51,9 @@ class ROCMOmniPlatform(RocmDeviceMixin, OmniPlatform):
             "SGLANG_ENABLE_TP_MEMORY_INBALANCE_CHECK": "false",
         }
         if hip_visible:
-            # The HIP runtime honors HIP_VISIBLE_DEVICES over the CUDA alias, so
-            # a HIP-narrowed parent must narrow the child through it as well.
-            # The CUDA alias still carries the same physical id: the startup
-            # lock and sglang's physical-device helpers resolve the card
-            # through CUDA_VISIBLE_DEVICES.
+            # Note (zijiecode): the HIP runtime prefers HIP_VISIBLE_DEVICES over the
+            # CUDA alias, so the child must be narrowed through it; the alias
+            # is kept for the startup lock and SGLang's physical-device helpers.
             env_updates["HIP_VISIBLE_DEVICES"] = mapped_gpu
         return env_updates
 

--- a/sglang_omni/platforms/rocm.py
+++ b/sglang_omni/platforms/rocm.py
@@ -27,7 +27,11 @@ class ROCMOmniPlatform(RocmDeviceMixin, OmniPlatform):
             return {}
 
         source_env = env if env is not None else os.environ
-        original_visible = source_env.get("CUDA_VISIBLE_DEVICES")
+        hip_visible = source_env.get("HIP_VISIBLE_DEVICES")
+        visibility_var = (
+            "HIP_VISIBLE_DEVICES" if hip_visible else "CUDA_VISIBLE_DEVICES"
+        )
+        original_visible = source_env.get(visibility_var)
         if spec.gpu_id is None:
             raise ValueError(f"tp stage {spec.stage_name!r} requires a GPU id")
         if original_visible:
@@ -35,17 +39,25 @@ class ROCMOmniPlatform(RocmDeviceMixin, OmniPlatform):
             if spec.gpu_id >= len(visible_devices):
                 raise ValueError(
                     f"tp stage {spec.stage_name!r} assigned gpu_id={spec.gpu_id}, "
-                    f"but CUDA_VISIBLE_DEVICES only exposes {visible_devices}"
+                    f"but {visibility_var} only exposes {visible_devices}"
                 )
             mapped_gpu = visible_devices[spec.gpu_id]
         else:
             mapped_gpu = str(spec.gpu_id)
 
-        return {
+        env_updates = {
             "CUDA_VISIBLE_DEVICES": mapped_gpu,
             "SGLANG_ONE_VISIBLE_DEVICE_PER_PROCESS": "true",
             "SGLANG_ENABLE_TP_MEMORY_INBALANCE_CHECK": "false",
         }
+        if hip_visible:
+            # The HIP runtime honors HIP_VISIBLE_DEVICES over the CUDA alias, so
+            # a HIP-narrowed parent must narrow the child through it as well.
+            # The CUDA alias still carries the same physical id: the startup
+            # lock and sglang's physical-device helpers resolve the card
+            # through CUDA_VISIBLE_DEVICES.
+            env_updates["HIP_VISIBLE_DEVICES"] = mapped_gpu
+        return env_updates
 
     def get_intra_node_transport(self):
         from sglang_omni.comm.data_ref import TransportKind

--- a/tests/unit_test/pipeline/test_stage_process_env.py
+++ b/tests/unit_test/pipeline/test_stage_process_env.py
@@ -234,9 +234,7 @@ def test_rocm_tp_child_keeps_parent_mapped_hip_visible_device(monkeypatch) -> No
     assert spec.comm_config["gpu_id"] == 0
     assert os.environ["HIP_VISIBLE_DEVICES"] == "5"
     assert os.environ["CUDA_VISIBLE_DEVICES"] == "5"
-    assert any("HIP_VISIBLE_DEVICES=5" in message for message in log.messages)
-    # The startup lock keys on the physical card, resolved through the CUDA
-    # alias from the child's local gpu_id.
+    assert any("CUDA_VISIBLE_DEVICES=5" in message for message in log.messages)
     assert get_gpu_startup_lock_path(spec.gpu_id).name.endswith("_gpu_5_startup.lock")
 
 

--- a/tests/unit_test/pipeline/test_stage_process_env.py
+++ b/tests/unit_test/pipeline/test_stage_process_env.py
@@ -16,6 +16,8 @@ from sglang_omni.pipeline.stage_workers import (
     _patched_spawn_env,
 )
 from sglang_omni.platforms.cuda import CUDAOmniPlatform
+from sglang_omni.platforms.rocm import ROCMOmniPlatform
+from sglang_omni.utils.gpu_memory import get_gpu_startup_lock_path
 from tests.unit_test.fixtures.pipeline_fakes import FakeScheduler, fake_factory_path
 
 cuda_platform = CUDAOmniPlatform()
@@ -207,6 +209,37 @@ def test_tp_child_keeps_parent_mapped_visible_device(monkeypatch) -> None:
     assert os.environ["CUDA_VISIBLE_DEVICES"] == "4"
 
 
+def test_rocm_tp_child_keeps_parent_mapped_hip_visible_device(monkeypatch) -> None:
+    """ROCm TP children normalize the single HIP-visible card to local cuda:0."""
+    monkeypatch.setattr(stage_workers, "current_platform", ROCMOmniPlatform())
+    monkeypatch.setenv("HIP_VISIBLE_DEVICES", "5")
+    monkeypatch.setenv("CUDA_VISIBLE_DEVICES", "5")
+    monkeypatch.setenv("SGLANG_ONE_VISIBLE_DEVICE_PER_PROCESS", "true")
+    spec = StageLaunchConfig(
+        stage_name="thinker",
+        role="follower",
+        tp_rank=1,
+        tp_size=2,
+        gpu_id=1,
+        factory_arg_defaults={"gpu_id": 1},
+        comm_config={"gpu_id": 1},
+    )
+    log = _RecordingLog()
+
+    stage_workers._prepare_accelerator_environment(spec, log)
+
+    assert spec.gpu_id == 0
+    assert spec.placement_gpu_id == 1
+    assert spec.factory_arg_defaults["gpu_id"] == 0
+    assert spec.comm_config["gpu_id"] == 0
+    assert os.environ["HIP_VISIBLE_DEVICES"] == "5"
+    assert os.environ["CUDA_VISIBLE_DEVICES"] == "5"
+    assert any("HIP_VISIBLE_DEVICES=5" in message for message in log.messages)
+    # The startup lock keys on the physical card, resolved through the CUDA
+    # alias from the child's local gpu_id.
+    assert get_gpu_startup_lock_path(spec.gpu_id).name.endswith("_gpu_5_startup.lock")
+
+
 def test_spawn_env_applies_stage_defaults_before_child_start(monkeypatch) -> None:
     monkeypatch.delenv("SGLANG_TEST_STAGE_ENV", raising=False)
     spec = StageLaunchConfig(
@@ -247,6 +280,20 @@ def test_spawn_env_combines_stage_defaults_with_tp_visible_device(monkeypatch) -
 
     assert "SGLANG_TEST_STAGE_ENV" not in os.environ
     assert os.environ["CUDA_VISIBLE_DEVICES"] == "3,4"
+
+
+def test_rocm_spawn_env_maps_rank_through_hip_visible_devices(monkeypatch) -> None:
+    monkeypatch.setenv("HIP_VISIBLE_DEVICES", "3,5")
+    monkeypatch.delenv("CUDA_VISIBLE_DEVICES", raising=False)
+    monkeypatch.setattr(stage_workers, "current_platform", ROCMOmniPlatform())
+
+    with _patched_spawn_env(_worker_spec(_tp_spec(gpu_id=1))):
+        assert os.environ["HIP_VISIBLE_DEVICES"] == "5"
+        assert os.environ["CUDA_VISIBLE_DEVICES"] == "5"
+        assert os.environ["SGLANG_ONE_VISIBLE_DEVICE_PER_PROCESS"] == "true"
+
+    assert os.environ["HIP_VISIBLE_DEVICES"] == "3,5"
+    assert "CUDA_VISIBLE_DEVICES" not in os.environ
 
 
 class _RecordingLog:
@@ -371,6 +418,40 @@ def test_construct_stage_uses_placement_gpu_id_for_device_and_startup_lock(
     assert [stage.scheduler.gpu_id for stage in stages] == [0, 0]
     assert set_device_calls == [0, 0]
     assert seen_gpu_ids == [0, 0]
+
+
+def test_narrowed_tp_child_locks_its_local_device(monkeypatch) -> None:
+    """A TP child narrowed to one card locks through its local gpu_id.
+
+    The lock path resolves the physical card via CUDA_VISIBLE_DEVICES, so the
+    pre-narrowing placement id must not be used: it would index past the
+    single visible device.
+    """
+    monkeypatch.setenv("CUDA_VISIBLE_DEVICES", "4")
+    seen_gpu_ids: list[int] = []
+
+    @contextmanager
+    def _fake_lock(gpu_id: int):
+        seen_gpu_ids.append(gpu_id)
+        yield get_gpu_startup_lock_path(gpu_id)
+
+    monkeypatch.setattr(stage_workers, "gpu_startup_lock", _fake_lock)
+    spec = StageLaunchConfig(
+        stage_name="thinker",
+        role="follower",
+        tp_rank=1,
+        tp_size=2,
+        placement_gpu_id=1,
+        gpu_id=0,
+        factory=fake_factory_path("make_scheduler_accepting_gpu_id"),
+        factory_arg_defaults={"gpu_id": 0},
+    )
+
+    scheduler = stage_workers._construct_scheduler(spec, 0, _RecordingLog())
+
+    assert scheduler.gpu_id == 0
+    assert seen_gpu_ids == [0]
+    assert get_gpu_startup_lock_path(0).name.endswith("_gpu_4_startup.lock")
 
 
 def test_cpu_scheduler_construction_skips_startup_lock(monkeypatch) -> None:

--- a/tests/unit_test/qwen3_omni/test_audio_layer_graph.py
+++ b/tests/unit_test/qwen3_omni/test_audio_layer_graph.py
@@ -143,7 +143,13 @@ def test_disabled_runner_declines_even_with_graphs() -> None:
 def test_packed_attention_backend_follows_the_device_capability(
     capability: tuple[int, int], backend: str
 ) -> None:
-    assert _packed_attention_backend(capability) == backend
+    assert _packed_attention_backend(capability, is_hip=False) == backend
+
+
+def test_packed_attention_backend_keeps_hip_off_fa3() -> None:
+    """PyTorch HIP reports gfx950 as (9, 5); that is not NVIDIA Hopper."""
+    assert _packed_attention_backend((9, 5), is_hip=True) == "triton_attn"
+    assert _packed_attention_backend((9, 0), is_hip=True) == "triton_attn"
 
 
 def test_an_unresolvable_kernel_stack_stays_eager_with_a_reason(

--- a/tests/unit_test/qwen3_omni/test_config_manager.py
+++ b/tests/unit_test/qwen3_omni/test_config_manager.py
@@ -7,9 +7,11 @@ import pytest
 
 from sglang_omni.config import build_stage_placement_plan, resolve_stage_factory_args
 from sglang_omni.config.manager import ConfigManager
+from sglang_omni.models.qwen3_omni import config as qwen3_omni_config
 from sglang_omni.models.qwen3_omni.config import (
     Qwen3OmniPipelineConfig,
     Qwen3OmniSpeechColocatedPipelineConfig,
+    Qwen3OmniSpeechPipelineConfig,
 )
 from tests.unit_test.pipeline.helpers import build_compiled_process_topology
 
@@ -247,3 +249,61 @@ def test_qwen3_omni_h100_bf16_config_enables_speech_prefill_graph() -> None:
     assert overrides["cuda_graph_backend_prefill"] == "breakable"
     assert "cuda_graph_bs_prefill" not in overrides
     assert overrides["cuda_graph_max_bs_prefill"] == 2048
+
+
+def test_qwen3_omni_gfx950_bf16_config_uses_colocated_budgets() -> None:
+    config_path = (
+        _REPO_ROOT / "examples" / "configs" / "qwen3_omni_colocated_gfx950_bf16.yaml"
+    )
+
+    config = ConfigManager.from_file(str(config_path)).config
+    plan = build_stage_placement_plan(config)
+    overrides = _stage(config, "thinker").engine.overrides()
+
+    assert isinstance(config, Qwen3OmniSpeechColocatedPipelineConfig)
+    assert config.name == "qwen3-omni-colocated-gfx950-bf16"
+    assert "prefill_attention_backend" not in overrides
+    assert overrides["cuda_graph_backend_prefill"] == "disabled"
+    assert plan.gpus[0].total_gpu_memory_fraction == pytest.approx(0.94)
+    assert {
+        name: _stage(config, name).gpu_memory_fraction
+        for name in (
+            "image_encoder",
+            "audio_encoder",
+            "thinker",
+            "talker_ar",
+            "code2wav",
+        )
+    } == {
+        "image_encoder": pytest.approx(0.02),
+        "audio_encoder": pytest.approx(0.02),
+        "thinker": pytest.approx(0.78),
+        "talker_ar": pytest.approx(0.10),
+        "code2wav": pytest.approx(0.02),
+    }
+
+
+@pytest.mark.parametrize(
+    ("is_rocm", "expected_env"),
+    [
+        (True, {"SGLANG_DISABLE_AITER_GREEDY_SAMPLE": "1"}),
+        (False, {}),
+    ],
+)
+def test_qwen3_omni_talker_stage_keeps_greedy_selection_off_aiter_on_rocm(
+    monkeypatch: pytest.MonkeyPatch,
+    is_rocm: bool,
+    expected_env: dict[str, str],
+) -> None:
+    """aiter's greedy_sample is wrong below 16384 vocab entries; the Talker
+    codec head has 3072, so the ROCm Talker process falls back to torch.argmax."""
+    monkeypatch.setattr(qwen3_omni_config.current_platform, "is_rocm", lambda: is_rocm)
+
+    for config_cls in (
+        Qwen3OmniSpeechPipelineConfig,
+        Qwen3OmniSpeechColocatedPipelineConfig,
+    ):
+        config = config_cls(model_path="dummy")
+
+        assert _stage(config, "talker_ar").env == expected_env
+        assert _stage(config, "thinker").env == {}

--- a/tests/unit_test/qwen3_omni/test_talker.py
+++ b/tests/unit_test/qwen3_omni/test_talker.py
@@ -640,9 +640,8 @@ def test_qwen_predictor_decode_graph_matches_eager(monkeypatch: pytest.MonkeyPat
     layer0_codes = torch.tensor([[1], [7]], dtype=torch.int, device=device)
     talker_hidden = torch.randn(2, 1, 8, device=device)
 
-    # SGLang constructs nested model buffers while its outer runner is in
-    # inference mode, so graph capture and replay must both run in that mode;
-    # torch 2.9/ROCm refuses a no_grad capture_begin() over inference tensors.
+    # Note (zijiecode): SGLang runs the predictor from inference mode, so capture
+    # and replay are exercised in that mode here as well.
     with torch.inference_mode():
         talker.code_predictor_forward(layer0_codes, talker_hidden)
         torch.cuda.synchronize()
@@ -2412,27 +2411,23 @@ def test_talker_prefill_forward_invalidates_next_decode_reuse() -> None:
     assert float(fake._sampling_temperatures[0, 0]) == pytest.approx(0.8)
 
 
-def test_qwen_predictor_decode_graph_skips_outer_sglang_capture(
-    monkeypatch: pytest.MonkeyPatch,
+@pytest.mark.parametrize(("is_rocm", "expected"), [(True, False), (False, True)])
+def test_qwen_predictor_decode_graph_skips_outer_sglang_capture_on_rocm(
+    monkeypatch: pytest.MonkeyPatch, is_rocm: bool, expected: bool
 ) -> None:
-    """Keep the predictor eager while SGLang captures its enclosing decode graph.
-
-    SGLang runs warmup forwards inside model_capture_mode() before the stream
-    capture starts, so the capture-mode flag must short-circuit the stream query.
-    """
+    """SGLang's warmup forwards run inside model_capture_mode() before the
+    stream capture starts; ROCm keeps the predictor eager there, CUDA does not."""
     monkeypatch.setattr(talker_module, "get_is_capture_mode", lambda: True)
+    monkeypatch.setattr(talker_module.current_platform, "is_rocm", lambda: is_rocm)
     monkeypatch.setattr(torch.cuda, "is_available", lambda: True)
-
-    def fail_stream_capture_query() -> bool:
-        pytest.fail("SGLang capture mode should short-circuit the stream query")
-
-    monkeypatch.setattr(
-        torch.cuda, "is_current_stream_capturing", fail_stream_capture_query
-    )
+    monkeypatch.setattr(torch.cuda, "is_current_stream_capturing", lambda: False)
     talker = object.__new__(Qwen3OmniTalker)
 
-    assert not talker._can_use_predictor_decode_graph(
-        layer0_codes=SimpleNamespace(dtype=torch.int, is_cuda=True),
-        talker_hidden=SimpleNamespace(is_cuda=True),
-        seq_len=1,
+    assert (
+        talker._can_use_predictor_decode_graph(
+            layer0_codes=SimpleNamespace(dtype=torch.int, is_cuda=True),
+            talker_hidden=SimpleNamespace(is_cuda=True),
+            seq_len=1,
+        )
+        is expected
     )

--- a/tests/unit_test/qwen3_omni/test_talker.py
+++ b/tests/unit_test/qwen3_omni/test_talker.py
@@ -640,9 +640,9 @@ def test_qwen_predictor_decode_graph_matches_eager(monkeypatch: pytest.MonkeyPat
     layer0_codes = torch.tensor([[1], [7]], dtype=torch.int, device=device)
     talker_hidden = torch.randn(2, 1, 8, device=device)
 
-    # SGLang 0.5.15 constructs nested model buffers while its outer runner is
-    # in inference mode. Replaying later from a no-grad capture must still be
-    # allowed to update those inference tensors in place.
+    # SGLang constructs nested model buffers while its outer runner is in
+    # inference mode, so graph capture and replay must both run in that mode;
+    # torch 2.9/ROCm refuses a no_grad capture_begin() over inference tensors.
     with torch.inference_mode():
         talker.code_predictor_forward(layer0_codes, talker_hidden)
         torch.cuda.synchronize()
@@ -2410,3 +2410,29 @@ def test_talker_prefill_forward_invalidates_next_decode_reuse() -> None:
     )
 
     assert float(fake._sampling_temperatures[0, 0]) == pytest.approx(0.8)
+
+
+def test_qwen_predictor_decode_graph_skips_outer_sglang_capture(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """Keep the predictor eager while SGLang captures its enclosing decode graph.
+
+    SGLang runs warmup forwards inside model_capture_mode() before the stream
+    capture starts, so the capture-mode flag must short-circuit the stream query.
+    """
+    monkeypatch.setattr(talker_module, "get_is_capture_mode", lambda: True)
+    monkeypatch.setattr(torch.cuda, "is_available", lambda: True)
+
+    def fail_stream_capture_query() -> bool:
+        pytest.fail("SGLang capture mode should short-circuit the stream query")
+
+    monkeypatch.setattr(
+        torch.cuda, "is_current_stream_capturing", fail_stream_capture_query
+    )
+    talker = object.__new__(Qwen3OmniTalker)
+
+    assert not talker._can_use_predictor_decode_graph(
+        layer0_codes=SimpleNamespace(dtype=torch.int, is_cuda=True),
+        talker_hidden=SimpleNamespace(is_cuda=True),
+        seq_len=1,
+    )

--- a/tests/unit_test/test_platforms.py
+++ b/tests/unit_test/test_platforms.py
@@ -62,6 +62,43 @@ def test_rocm_platform_keeps_cuda_compatible_tp_mapping() -> None:
     )
 
 
+def test_rocm_platform_maps_tp_rank_through_hip_visible_devices() -> None:
+    platform = ROCMOmniPlatform()
+    spec = SimpleNamespace(stage_name="thinker", tp_size=2, gpu_id=1)
+
+    mapped_env = platform.get_stage_process_env(spec, {"HIP_VISIBLE_DEVICES": "3,4"})
+
+    assert mapped_env["HIP_VISIBLE_DEVICES"] == "4"
+    assert mapped_env["CUDA_VISIBLE_DEVICES"] == "4"
+    assert mapped_env["SGLANG_ONE_VISIBLE_DEVICE_PER_PROCESS"] == "true"
+
+
+def test_rocm_platform_prefers_hip_visibility_over_cuda_alias() -> None:
+    """HIP_VISIBLE_DEVICES wins in the HIP runtime, so the rank maps through it;
+    the CUDA alias mirrors the same physical id for the CUDA-named helpers."""
+    platform = ROCMOmniPlatform()
+    spec = SimpleNamespace(stage_name="thinker", tp_size=2, gpu_id=1)
+
+    mapped_env = platform.get_stage_process_env(
+        spec,
+        {
+            "HIP_VISIBLE_DEVICES": "3,5",
+            "CUDA_VISIBLE_DEVICES": "6,7",
+        },
+    )
+
+    assert mapped_env["HIP_VISIBLE_DEVICES"] == "5"
+    assert mapped_env["CUDA_VISIBLE_DEVICES"] == "5"
+
+
+def test_rocm_platform_without_hip_visibility_sets_only_the_cuda_alias() -> None:
+    platform = ROCMOmniPlatform()
+    spec = SimpleNamespace(stage_name="thinker", tp_size=2, gpu_id=0)
+
+    assert "HIP_VISIBLE_DEVICES" not in platform.get_stage_process_env(spec, {})
+    assert platform.get_stage_process_env(spec, {})["CUDA_VISIBLE_DEVICES"] == "0"
+
+
 def test_rocm_platform_uses_conservative_omni_capabilities() -> None:
     from sglang_omni.comm.data_ref import TransportKind
 


### PR DESCRIPTION
<!-- Suggested title: [AMD][ROCm] Support Qwen3-Omni speech and HIP-visible TP placement on gfx950 -->

## Motivation


- TP placement when the user sets `HIP_VISIBLE_DEVICES`. SGLang-Omni pins each Thinker TP rank to one card through `CUDA_VISIBLE_DEVICES`. The HIP runtime prefers `HIP_VISIBLE_DEVICES` over that alias, so with `HIP_VISIBLE_DEVICES=0,1` every rank still saw both cards and all ranks landed on card 0.
- Qwen3-Omni speech (Talker + audio output) on gfx950. The audio encoder graphs, the Talker predictor graph, and greedy Talker sampling each hit a ROCm-specific problem.


## Modifications

TP placement:

- When the parent process uses `HIP_VISIBLE_DEVICES`, map each TP rank through it, and also set `CUDA_VISIBLE_DEVICES` to the same card. HIP picks the card; the CUDA alias is what the startup lock and SGLang's device helpers read.

Speech:

- Audio encoder graphs: gfx950 reports capability `(9, 5)`, so the `major == 9` check picked FA3, which does not exist on HIP. Use Triton on HIP.
- Talker predictor graph: do not capture it while SGLang is capturing the Talker decode graph (`get_is_capture_mode()` also covers SGLang's warmup runs), and capture under `inference_mode` like replay. 
- Greedy Talker sampling: `aiter.greedy_sample` returns wrong ids for vocab sizes below 16384 (0/30 correct up to 12288, 30/30 from 16384). The Talker codec head is 3072, so the Talker stage on ROCm sets `SGLANG_DISABLE_AITER_GREEDY_SAMPLE=1` and greedy picks fall back to `torch.argmax`. The Thinker keeps aiter.

## Accuracy Test

All runs used one AMD Instinct MI355X with rocm sglang-omni image. 

SeedTTS EN, 50 samples, concurrency 16, single card with the gfx950 profile:

| Metric | Result |
|---|---:|
| Completed / failed requests | 50 / 0 |
| Corpus WER | 0.71% |
| Per-sample WER max | 14.3% (none above 50%) |
| Mean latency | 2.232 s |
| P95 latency | 3.551 s |
| Mean RTF | 0.716 |
| Mean audio duration | 3.47 s |

Video-AMME, 10 samples, Thinker TP=2 with 32K context, speech output on: 10/10 completed, transcribed audio WER 0.95% corpus, 3.4% max.

40 repeated speech requests plus 5 greedy Talker requests (`talker_temperature=0`) all returned normal-length audio. The server log shows the audio-layer graphs on `triton_attn`, the Thinker/Talker decode graphs, and the Talker predictor graph captured on the first request.


The launch command:

```bash
sgl-omni serve \
  --config examples/configs/qwen3_omni_colocated_gfx950_bf16.yaml \
  --colocate \
  --model-path Qwen/Qwen3-Omni-30B-A3B-Instruct \
  --model-name qwen3-omni \
  --port 8000
```

## Unit Test

There is no ROCm CI yet, so these were run in the same ROCm container. 

- `test_rocm_platform_maps_tp_rank_through_hip_visible_devices`, `test_rocm_platform_prefers_hip_visibility_over_cuda_alias`, `test_rocm_platform_without_hip_visibility_sets_only_the_cuda_alias`: the rank maps through `HIP_VISIBLE_DEVICES` when present, mirrors it into `CUDA_VISIBLE_DEVICES`, and is unchanged otherwise.
- `test_rocm_spawn_env_maps_rank_through_hip_visible_devices`, `test_rocm_tp_child_keeps_parent_mapped_hip_visible_device`: the spawn hook and the child normalization see both variables, and the lock resolves to the physical card.
- `test_narrowed_tp_child_locks_its_local_device`: a narrowed TP child locks through its local `gpu_id`; the pre-narrowing placement id would index past the single visible device.
- `test_packed_attention_backend_keeps_hip_off_fa3`: capability `(9, 5)` on HIP selects Triton, not FA3.
- `test_qwen_predictor_decode_graph_skips_outer_sglang_capture`: the predictor stays eager while SGLang's capture mode is active, without touching the stream query.
- `test_qwen3_omni_talker_stage_keeps_greedy_selection_off_aiter_on_rocm`: only the Talker stage, and only on ROCm, sets `SGLANG_DISABLE_AITER_GREEDY_SAMPLE=1`.
- `test_qwen3_omni_gfx950_bf16_config_uses_colocated_budgets`: the new profile loads, keeps the ROCm attention backend, disables the prefill graph, and sums to 94% of the card.

## Checklist

- [x] Format your code according with pre-commit.
- [x] Add unit tests.
- [x] Update documentation / docstrings / example tutorials as needed.
- [x] Provide throughput / latency benchmark results and accuracy evaluation results as needed.
- [ ] For reviewers: If you haven't made any contributions to this PR and are only assisting with merging the main branch, please remove yourself as a co-author when merging the PR.
