### PR TITLE
[Perf][MOSS-TTS] One batched full-sequence offline decode for Local/Delay and retire offline slots

### DIFF
--- a/sglang_omni/models/moss_tts/vocoder.py
+++ b/sglang_omni/models/moss_tts/vocoder.py
@@ -148,8 +148,8 @@ def decode_codes_batch(
     ``[channels, samples_i]`` per item.
 
     ``interleaved_channels`` mirrors the codec's channel-interleave restore:
-    the decoder emits ``[B, 1, T * C]`` with channels packed into the sample
-    axis, which is de-interleaved into ``[B, C, T]`` before slicing.
+    the decoder emits ``[B, 1, T * C]`` with channels interleaved into the
+    sample axis, which is de-interleaved into ``[B, C, T]`` before slicing.
     """
     if not codes_rows:
         return []
@@ -196,7 +196,14 @@ def decode_codes_batch(
         if interleaved_channels > 1:
             # note (Zhang Yiyang): de-interleave [B, 1, T * C] -> [B, C, T];
             # same math as the codec's _restore_channels_from_codec
-            # channel-interleave branch.
+            # channel-interleave branch (including its floor length division —
+            # interleaved lengths are per-channel lengths * C by construction).
+            if audio.ndim != 3 or int(audio.shape[1]) != 1:
+                raise ValueError(
+                    "MOSS batched decoder must emit interleaved audio "
+                    f"[B, 1, T * {interleaved_channels}], got "
+                    f"{tuple(audio.shape)}"
+                )
             audio = (
                 audio.squeeze(1)
                 .contiguous()

--- a/sglang_omni/models/moss_tts/vocoder.py
+++ b/sglang_omni/models/moss_tts/vocoder.py
@@ -5,7 +5,7 @@ from __future__ import annotations
 
 import logging
 import traceback
-from collections.abc import Iterator
+from collections.abc import Callable, Iterator, Sequence
 from contextlib import contextmanager
 from itertools import accumulate
 from typing import Any, cast
@@ -77,13 +77,22 @@ def _join_waveforms(waveforms: list[torch.Tensor]) -> torch.Tensor:
     return waveforms[0] if len(waveforms) == 1 else torch.cat(waveforms, dim=0)
 
 
+def _mono_waveform(wav: torch.Tensor) -> torch.Tensor:
+    if wav.ndim != 2 or int(wav.shape[0]) != 1:
+        raise ValueError(
+            f"MOSS-TTS Delay batched decode must yield mono audio [1, T], got "
+            f"{tuple(wav.shape)}"
+        )
+    return wav[0]
+
+
 def _copy_valid_waveforms_to_cpu(
     audio: torch.Tensor,
     output_lengths: list[int],
 ) -> list[torch.Tensor]:
-    if audio.ndim != 3 or int(audio.shape[1]) != 1:
+    if audio.ndim != 3:
         raise ValueError(
-            "MOSS-TTS Delay decoder audio must have shape [B, 1, T], got "
+            "MOSS batched decoder audio must have shape [B, C, T], got "
             f"{tuple(audio.shape)}"
         )
     if len(output_lengths) != int(audio.shape[0]):
@@ -93,9 +102,9 @@ def _copy_valid_waveforms_to_cpu(
         raise ValueError("output_lengths must be within the decoded waveform")
 
     valid_waveforms = [
-        audio[index, 0, :length] for index, length in enumerate(output_lengths)
+        audio[index, :, :length] for index, length in enumerate(output_lengths)
     ]
-    flat_audio = _join_waveforms(valid_waveforms)
+    flat_audio = torch.cat(valid_waveforms, dim=-1)
     if flat_audio.device.type == "cuda":
         try:
             flat_cpu = torch.empty(
@@ -113,9 +122,94 @@ def _copy_valid_waveforms_to_cpu(
         flat_cpu = flat_audio.detach().to(device="cpu", dtype=torch.float32)
     offsets = [0, *accumulate(output_lengths)]
     return [
-        flat_cpu[start:end].contiguous()
+        flat_cpu[:, start:end].contiguous()
         for start, end in zip(offsets[:-1], offsets[1:], strict=True)
     ]
+
+
+def decode_codes_batch(
+    codes_rows: Sequence[torch.Tensor],
+    *,
+    quantizer_decode: Callable[[torch.Tensor], torch.Tensor],
+    decoder: MossAudioTokenizerVocoderDecoder,
+    device: torch.device,
+    compute_dtype: torch.dtype | None,
+    max_batch_size: int,
+    interleaved_channels: int = 1,
+) -> list[torch.Tensor]:
+    """Batched non-streaming decode of code rows, shared by MOSS-TTS models.
+
+    Each item is ``[T_i, n_vq]`` code rows. Waves of at most ``max_batch_size``
+    items are zero-padded into one ``[n_vq, B, T_max]`` batch; the quantizer
+    runs in FP32 with autocast disabled and ``decoder`` runs under the
+    compute-dtype autocast with host-side lengths (no GPU sync). The attention
+    backend is the decoder's own resolution, so this path works with any
+    backend the decoder supports. Returns one CPU fp32 waveform
+    ``[channels, samples_i]`` per item.
+
+    ``interleaved_channels`` mirrors the codec's channel-interleave restore:
+    the decoder emits ``[B, 1, T * C]`` with channels packed into the sample
+    axis, which is de-interleaved into ``[B, C, T]`` before slicing.
+    """
+    if not codes_rows:
+        return []
+    if any(rows.ndim != 2 for rows in codes_rows):
+        raise ValueError("batched vocode rows must be 2-D [T, n_vq]")
+    n_vq = int(codes_rows[0].shape[1])
+    if n_vq <= 0 or any(int(rows.shape[1]) != n_vq for rows in codes_rows):
+        raise ValueError("batched vocode rows must share one n_vq")
+
+    decoded: list[torch.Tensor] = []
+    wave_size = max(int(max_batch_size), 1)
+    for start in range(0, len(codes_rows), wave_size):
+        wave = codes_rows[start : start + wave_size]
+        host_rows = [rows.to(device="cpu", dtype=torch.long) for rows in wave]
+        input_lengths_cpu = [int(rows.shape[0]) for rows in host_rows]
+        audio_codes = (
+            pad_sequence(host_rows, batch_first=True, padding_value=0)
+            .permute(2, 0, 1)
+            .contiguous()
+            .to(device=device, non_blocking=True)
+        )
+        input_lengths = torch.tensor(
+            input_lengths_cpu,
+            device=device,
+            dtype=torch.int32,
+        )
+        output_lengths_cpu = decoder.output_lengths(input_lengths_cpu)
+        with torch.inference_mode():
+            # note (Zhang Yiyang): keep codebook math in FP32; only decoder
+            # stages run under the configured compute autocast, independent of
+            # the attention backend.
+            with torch.autocast(device_type=device.type, enabled=False):
+                decoder_hidden_states = quantizer_decode(audio_codes).float()
+            with _autocast_if_supported(device, compute_dtype):
+                audio, audio_lengths = decoder(
+                    decoder_hidden_states,
+                    input_lengths,
+                    input_lengths_cpu=input_lengths_cpu,
+                )
+        if audio is None or audio_lengths is None:
+            raise RuntimeError(
+                "MOSS audio tokenizer returned empty audio/audio_lengths"
+            )
+        if interleaved_channels > 1:
+            # note (Zhang Yiyang): de-interleave [B, 1, T * C] -> [B, C, T];
+            # same math as the codec's _restore_channels_from_codec
+            # channel-interleave branch.
+            audio = (
+                audio.squeeze(1)
+                .contiguous()
+                .view(int(audio.shape[0]), -1, interleaved_channels)
+                .transpose(1, 2)
+                .contiguous()
+                .float()
+            )
+            output_lengths_cpu = [
+                length // interleaved_channels for length in output_lengths_cpu
+            ]
+        decoded.extend(_copy_valid_waveforms_to_cpu(audio, output_lengths_cpu))
+    return decoded
 
 
 class MossTTSVocoder(BatchVocoderBase):
@@ -234,91 +328,39 @@ class MossTTSVocoder(BatchVocoderBase):
             or 24000
         )
 
-    def _decode_segments_batch(
+    def _decode_segment_batches(
         self,
         segments: list[torch.Tensor],
     ) -> list[torch.Tensor]:
+        if not segments:
+            return []
         codec = self._codec
         if codec is None:
             raise RuntimeError("batched MOSS-TTS Delay codec path is unavailable")
-        packed_decoder = self._nonstream_decoder
-        if packed_decoder is None:
+        if self._nonstream_decoder is None:
             raise RuntimeError("packed MOSS-TTS Delay codec path is unavailable")
-        if not segments:
-            return []
-
-        if any(segment.ndim != 2 for segment in segments):
-            raise ValueError("MOSS-TTS Delay codec segments must be 2D")
-        device = _codec_device(codec, self._device)
-        n_vq = int(segments[0].shape[1])
-        if n_vq <= 0 or any(int(segment.shape[1]) != n_vq for segment in segments):
-            raise ValueError("MOSS-TTS Delay codec segments must share one n_vq")
-
-        host_segments = [
-            segment.to(device="cpu", dtype=torch.long) for segment in segments
-        ]
-        input_lengths_cpu = [int(segment.shape[0]) for segment in host_segments]
-        padded_codes = pad_sequence(
-            host_segments,
-            batch_first=True,
-            padding_value=0,
-        )
-        audio_codes = (
-            padded_codes.permute(2, 0, 1)
-            .contiguous()
-            .to(device=device, non_blocking=True)
-        )
-        input_lengths = torch.tensor(
-            input_lengths_cpu,
-            device=device,
-            dtype=torch.int32,
-        )
-        output_lengths_cpu = packed_decoder.output_lengths(input_lengths_cpu)
-
         quantizer = self._quantizer
         if quantizer is None or not callable(getattr(quantizer, "decode_codes", None)):
             raise RuntimeError(
                 "MOSS-TTS Delay audio tokenizer has no supported "
                 "quantizer.decode_codes"
             )
-        with torch.inference_mode():
-            # Keep codebook math in FP32. Only decoder stages run under the
-            # configured compute autocast, independent of the attention backend.
-            with torch.autocast(device_type=device.type, enabled=False):
-                quantizer_decoder = self._quantizer_decoder
-                decoder_hidden_states = (
-                    quantizer.decode_codes(audio_codes)
-                    if quantizer_decoder is None
-                    else quantizer_decoder.decode_codes(audio_codes)
-                ).float()
-            with _autocast_if_supported(device, self._compute_dtype):
-                audio, audio_lengths = packed_decoder(
-                    decoder_hidden_states,
-                    input_lengths,
-                    input_lengths_cpu=input_lengths_cpu,
-                )
-        if audio is None or audio_lengths is None:
-            raise RuntimeError(
-                "MOSS-TTS Delay audio tokenizer returned empty audio/audio_lengths"
-            )
-        if len(output_lengths_cpu) != int(audio.shape[0]):
-            raise RuntimeError(
-                "MOSS-TTS Delay decoder returned an unexpected output batch size"
-            )
-        return _copy_valid_waveforms_to_cpu(audio, output_lengths_cpu)
-
-    def _decode_segment_batches(
-        self,
-        segments: list[torch.Tensor],
-    ) -> list[torch.Tensor]:
-        decoded: list[torch.Tensor] = []
-        for start in range(0, len(segments), self._max_segment_batch_size):
-            decoded.extend(
-                self._decode_segments_batch(
-                    segments[start : start + self._max_segment_batch_size],
-                )
-            )
-        return decoded
+        quantizer_decoder = self._quantizer_decoder
+        wavs = decode_codes_batch(
+            segments,
+            quantizer_decode=(
+                quantizer_decoder.decode_codes
+                if quantizer_decoder is not None
+                else quantizer.decode_codes
+            ),
+            decoder=self._nonstream_decoder,
+            device=_codec_device(codec, self._device),
+            compute_dtype=self._compute_dtype,
+            max_batch_size=self._max_segment_batch_size,
+        )
+        # note (Zhang Yiyang): the Delay codec is mono: [1, samples] ->
+        # [samples].
+        return [_mono_waveform(wav) for wav in wavs]
 
     async def decode_batch(
         self, items: list[tuple[MossTTSState, torch.Tensor]]
@@ -390,4 +432,4 @@ class MossTTSVocoder(BatchVocoderBase):
         return payload
 
 
-__all__ = ["MossTTSVocoder"]
+__all__ = ["MossTTSVocoder", "decode_codes_batch"]

--- a/sglang_omni/models/moss_tts_local/stages.py
+++ b/sglang_omni/models/moss_tts_local/stages.py
@@ -661,7 +661,7 @@ def create_vocoder_executor(
     codec_model_path: str | None = None,
     max_batch_size: int = 8,
     max_batch_wait_ms: int = 2,
-    stream_slots: int = 15,
+    stream_slots: int = 16,
     stream_chunk_frames: int = 25,
     initial_chunk_frames: int = 5,
     coalesce_floor_frames: int = 5,

--- a/sglang_omni/models/moss_tts_local/streaming_vocoder.py
+++ b/sglang_omni/models/moss_tts_local/streaming_vocoder.py
@@ -3,9 +3,9 @@
 
 Streaming requests share one persistent batched ``codec.streaming()`` session.
 The remote codec uses SDPA for the lifetime of that session because its
-FlashAttention streaming path is unreliable. Pure non-streaming traffic uses
-the MOSS decoder with packed SGLang FlashAttention when no live streaming
-session owns the codec state.
+FlashAttention streaming path is unreliable. Non-streaming traffic always runs
+the batched full-sequence decode (decode_codes_batch); it never holds session
+slots.
 """
 
 from __future__ import annotations
@@ -23,6 +23,10 @@ from sglang_omni.models.moss_tts.attention import (
     SDPA_ATTENTION_BACKEND,
 )
 from sglang_omni.models.moss_tts.audio_tokenizer import MossAudioTokenizerVocoderDecoder
+from sglang_omni.models.moss_tts.vocoder import decode_codes_batch
+from sglang_omni.models.moss_tts.vocoder_quantizer import (
+    MossAudioTokenizerQuantizerDecoder,
+)
 from sglang_omni.models.moss_tts_local.payload_types import MossTTSLocalState
 from sglang_omni.proto import StagePayload
 from sglang_omni.scheduling.pipeline_state import build_usage
@@ -35,14 +39,13 @@ from sglang_omni.utils.audio_payload import audio_waveform_payload
 logger = logging.getLogger(__name__)
 
 _SOURCE_HINT = "MOSS-TTS Local"
-_SESSION_RESERVED_OFFLINE_SLOTS = 1
 
 
 class _CodecStreamSession:
     """Persistent batched ``codec.streaming()`` session with slot bookkeeping.
 
-    Live requests hold stream slots for their lifetime. Offline work always has
-    reserved slots and can also borrow currently idle stream slots. All methods
+    Live requests hold stream slots for their lifetime. Non-streaming work never
+    enters the session; it uses the batched full-sequence decode path. All methods
     run on the scheduler-loop thread.
     """
 
@@ -51,13 +54,11 @@ class _CodecStreamSession:
         codec: Any,
         *,
         stream_slots: int,
-        offline_slots: int,
         n_vq: int,
     ) -> None:
         self._codec = codec
         self._stream_slots = int(stream_slots)
-        self._offline_slots = int(offline_slots)
-        self._batch_size = self._stream_slots + self._offline_slots
+        self._batch_size = self._stream_slots
         self._n_vq = int(n_vq)
         self._device = next(codec.parameters()).device
         self._free_stream_slots = list(range(self._stream_slots))
@@ -276,79 +277,6 @@ class _CodecStreamSession:
             out[slot] = audio_cpu[index, :, :n_samples]
         return out
 
-    def decode_offline(
-        self,
-        codes_list: list[torch.Tensor],
-        *,
-        max_step_frames: int,
-        max_batch_size: int,
-    ) -> list[torch.Tensor]:
-        """Decode complete utterances ``[n_vq, T]`` through offline slots in the
-        persistent codec session."""
-        if not codes_list:
-            return []
-        wavs: list[torch.Tensor] = []
-        reserved = list(range(self._stream_slots, self._batch_size))
-        requested_wave_size = min(max(int(max_batch_size), 1), len(codes_list))
-        borrow_count = min(
-            max(requested_wave_size - len(reserved), 0),
-            len(self._free_stream_slots),
-        )
-        borrowed = self._free_stream_slots[-borrow_count:] if borrow_count else []
-        if borrowed:
-            del self._free_stream_slots[-borrow_count:]
-        available = reserved + borrowed
-        # Note(Chenchen Hong): Under stream saturation, offline batches degrade
-        # to serial waves and block the scheduler pump until decoding completes.
-        wave_size = min(requested_wave_size, len(available))
-        decode_succeeded = False
-        try:
-            for wave_start in range(0, len(codes_list), wave_size):
-                wave = codes_list[wave_start : wave_start + wave_size]
-                slots = available[: len(wave)]
-                self._reset_slots(slots)
-                cursors = [0] * len(wave)
-                chunks: list[list[torch.Tensor]] = [[] for _ in wave]
-                while True:
-                    remaining = [
-                        int(codes.shape[1]) - cur for codes, cur in zip(wave, cursors)
-                    ]
-                    positive = [r for r in remaining if r > 0]
-                    if not positive:
-                        break
-                    if any(r >= max_step_frames for r in positive):
-                        step_t = max_step_frames
-                    else:
-                        step_t = min(positive)
-                    plan = {
-                        slots[i]: wave[i][:, cursors[i] : cursors[i] + step_t]
-                        for i, rem in enumerate(remaining)
-                        if rem >= step_t
-                    }
-                    decoded = self.step(plan)
-                    for i in range(len(wave)):
-                        if slots[i] in plan:
-                            chunks[i].append(decoded[slots[i]])
-                            cursors[i] += step_t
-                for item_chunks in chunks:
-                    wavs.append(torch.cat(item_chunks, dim=-1))
-            decode_succeeded = True
-        finally:
-            if borrowed:
-                try:
-                    self._reset_slots(borrowed)
-                except Exception:
-                    logger.exception(
-                        "MOSS vocoder failed to reset borrowed stream slots %s; "
-                        "quarantining them",
-                        borrowed,
-                    )
-                    if decode_succeeded:
-                        raise
-                else:
-                    self._free_stream_slots.extend(borrowed)
-        return wavs
-
 
 @dataclass
 class _LocalStreamState:
@@ -379,7 +307,7 @@ class MossTTSLocalStreamingVocoderScheduler(
         *,
         n_vq: int,
         sample_rate: int,
-        stream_slots: int = 15,
+        stream_slots: int = 16,
         stream_chunk_frames: int = 25,
         attention_backend: str = AUTO_ATTENTION_BACKEND,
         initial_chunk_frames: int = 5,
@@ -426,6 +354,36 @@ class MossTTSLocalStreamingVocoderScheduler(
         )
         self._codec = codec
         self._nonstream_decoder = nonstream_decoder
+        quantizer = getattr(codec, "quantizer", None)
+        if quantizer is None or not callable(getattr(quantizer, "decode_codes", None)):
+            raise RuntimeError(
+                "MOSS-TTS Local audio tokenizer has no quantizer.decode_codes; "
+                "the batched non-streaming decode path is unavailable"
+            )
+        try:
+            quantizer_decoder = MossAudioTokenizerQuantizerDecoder(quantizer)
+        except (AttributeError, RuntimeError, TypeError, ValueError):
+            logger.exception(
+                "MOSS-TTS Local quantizer is incompatible with the cached FP32 "
+                "decoder; using source quantizer decode"
+            )
+            quantizer_decoder = None
+        self._quantizer_decode = (
+            quantizer_decoder.decode_codes
+            if quantizer_decoder is not None
+            else quantizer.decode_codes
+        )
+        self._compute_dtype = getattr(codec, "compute_dtype", None)
+        # note (Zhang Yiyang): matches the codec's _restore_channels_from_codec:
+        # stereo v2 decoders interleave channels into the sample axis, so packed
+        # outputs must be de-interleaved before slicing.
+        number_channels = int(getattr(codec, "number_channels", 1) or 1)
+        self._interleaved_channels = (
+            number_channels
+            if number_channels > 1
+            and bool(getattr(codec, "enable_channel_interleave", False))
+            else 1
+        )
         self._attention_backend = attention_backend
         self._stream_slots = int(stream_slots)
         # Coalesce up to one full set of streaming lanes per pump, not the offline batch width.
@@ -438,13 +396,8 @@ class MossTTSLocalStreamingVocoderScheduler(
             0, min(int(coalesce_floor_frames), int(stream_chunk_frames))
         )
         self._max_step_frames = int(max_step_frames)
-        # Pure non-streaming traffic closes the idle session and uses the packed
-        # batch path. Keep one overflow lane for progress while streams are live
-        # instead of reserving half of every streaming CUDA graph for that case.
-        self._offline_slots = _SESSION_RESERVED_OFFLINE_SLOTS
         self._n_vq = int(n_vq)
         self._session: _CodecStreamSession | None = None
-        self._session_used_by_streaming = False
         self._cuda_graph = bool(cuda_graph)
         self._cuda_graph_frames = (
             [int(t) for t in cuda_graph_frames] if cuda_graph_frames else None
@@ -472,7 +425,6 @@ class MossTTSLocalStreamingVocoderScheduler(
         if self._session is not None:
             self._session.close()
             self._session = None
-        self._session_used_by_streaming = False
 
     def create_stream_state(self, request_id: str) -> _LocalStreamState:
         del request_id
@@ -545,21 +497,18 @@ class MossTTSLocalStreamingVocoderScheduler(
         self, request_id: str, state: _LocalStreamState, *, is_final: bool
     ) -> torch.Tensor | None:
         """Stream-done drain: pending frames go through the request's session
-        slot (released afterwards) or the offline lane when slot-starved;
-        steady-state chunks decode through the coalesced step hooks instead."""
+        slot (released afterwards) or the batched non-streaming path when
+        slot-starved; steady-state chunks decode through the coalesced step
+        hooks instead."""
         del request_id, is_final
         audio_parts: list[torch.Tensor] = []
         if state.slot is None and state.pending:
-            # Slot-starved: every frame is still buffered, decode offline.
-            codes = torch.stack(state.pending, dim=1)
+            # note (Zhang Yiyang): slot-starved — every frame is still
+            # buffered; decode batched in one full-sequence call
+            # (non-streaming route).
+            codes = torch.stack(state.pending, dim=1).transpose(0, 1).contiguous()
             state.pending = []
-            audio_parts.extend(
-                self._ensure_session_graphed().decode_offline(
-                    [codes],
-                    max_step_frames=self._max_step_frames,
-                    max_batch_size=self._max_batch_size,
-                )
-            )
+            audio_parts.append(self._decode_codes_rows([codes])[0])
         elif state.slot is not None:
             session = self._ensure_session_graphed()
             while state.pending:
@@ -682,20 +631,9 @@ class MossTTSLocalStreamingVocoderScheduler(
             self._session = _CodecStreamSession(
                 self._codec,
                 stream_slots=self._stream_slots,
-                offline_slots=self._offline_slots,
                 n_vq=self._n_vq,
             )
         return self._session
-
-    def _close_idle_startup_session_locked(self) -> None:
-        if (
-            self._session is not None
-            and not self._session_used_by_streaming
-            and not self._stream_states
-            and not self._stream_payloads
-        ):
-            self._session.close()
-            self._session = None
 
     def _cuda_graph_capture_frames(self) -> list[int]:
         """Step lengths T to capture. Config ``cuda_graph_frames`` overrides the default."""
@@ -712,13 +650,10 @@ class MossTTSLocalStreamingVocoderScheduler(
             return False
 
     def _ensure_session_graphed(self) -> _CodecStreamSession:
-        """Live session with CUDA graphs captured (at most once). Streaming paths call this instead
-        of _ensure_session so a session created after non-streaming traffic closed the graphed
-        startup session is re-captured; a low-VRAM skip is remembered (no per-step re-probe).
-
-        That first post-non-streaming streaming request pays a one-time warmup latency (the recapture
-        runs synchronously here, fail-safe to eager on low VRAM); streaming-only traffic uses the
-        factory session and never hits this path.
+        """Live session with CUDA graphs captured (at most once per session). Streaming paths
+        call this instead of _ensure_session so a lazily created session (factory warmup
+        skipped, e.g. non-CUDA codec) still gets its one capture attempt here, synchronously,
+        fail-safe to eager on low VRAM; a low-VRAM skip is remembered (no per-step re-probe).
         """
         with self._state_lock:
             session = self._ensure_session()
@@ -757,7 +692,6 @@ class MossTTSLocalStreamingVocoderScheduler(
 
     def _ensure_slot(self, state: _LocalStreamState) -> None:
         if state.slot is None:
-            self._session_used_by_streaming = True
             state.slot = self._ensure_session_graphed().acquire()
 
     def _latch_thresholds(
@@ -783,13 +717,7 @@ class MossTTSLocalStreamingVocoderScheduler(
         rows = torch.as_tensor(state.audio_codes, dtype=torch.long)
         if rows.numel() == 0:
             return None
-        codes = rows[:, : self._n_vq].transpose(0, 1).contiguous()
-        self._session_used_by_streaming = True
-        return self._ensure_session_graphed().decode_offline(
-            [codes],
-            max_step_frames=self._max_step_frames,
-            max_batch_size=self._max_batch_size,
-        )[0]
+        return self._decode_codes_rows([rows])[0]
 
     def _prepare_codes(
         self, payload: StagePayload
@@ -824,80 +752,21 @@ class MossTTSLocalStreamingVocoderScheduler(
             payload.data["usage"] = usage
         return payload
 
-    def _decode_codes_rows_nonstream(
-        self, codes_list: list[torch.Tensor]
-    ) -> list[torch.Tensor]:
-        n_vq = self._n_vq
-        device = next(self._codec.parameters()).device
-        codes_channels_first = [
-            codes[:, :n_vq]
-            .transpose(0, 1)
-            .contiguous()
-            .to(device=device, dtype=torch.long)
-            for codes in codes_list
-        ]
-        max_len = max(int(codes.shape[1]) for codes in codes_channels_first)
-        audio_codes = torch.zeros(
-            n_vq,
-            len(codes_channels_first),
-            max_len,
-            device=device,
-            dtype=torch.long,
-        )
-        padding_mask = torch.zeros(
-            len(codes_channels_first), max_len, device=device, dtype=torch.bool
-        )
-        for index, codes in enumerate(codes_channels_first):
-            length = int(codes.shape[1])
-            audio_codes[:, index, :length] = codes
-            padding_mask[index, :length] = True
-
-        decoded = self._codec.decode(
-            audio_codes,
-            padding_mask=padding_mask,
-            num_quantizers=n_vq,
-            return_dict=True,
-            chunk_duration=None,
-        )
-        audio = decoded.audio
-        audio_lengths = decoded.audio_lengths
-        if audio is None or audio_lengths is None:
-            raise RuntimeError(
-                "audio_tokenizer.decode did not return audio/audio_lengths."
-            )
-        audio_cpu = audio.detach().to("cpu", torch.float32)
-        lengths_cpu = audio_lengths.detach().to("cpu")
-        return [
-            audio_cpu[index, :, : int(lengths_cpu[index])].contiguous()
-            for index in range(int(audio_cpu.shape[0]))
-        ]
-
     def _decode_codes_rows(self, codes_list: list[torch.Tensor]) -> list[torch.Tensor]:
-        """Decode ``[T, >=n_vq]`` row tensors to fp32 CPU waveforms."""
-        with self._state_lock:
-            self._close_idle_startup_session_locked()
-        if self._session is None:
-            # The processor helper forces chunk_duration=8 and enters the
-            # tokenizer streaming loop. This decoder is non-streaming, so it must
-            # run through the tokenizer's full-sequence decode path.
-            original_decoder = self._codec.decoder
-            self._codec.decoder = self._nonstream_decoder
-            try:
-                return self._decode_codes_rows_nonstream(codes_list)
-            finally:
-                self._codec.decoder = original_decoder
-        channels_first = [
-            codes[:, : self._n_vq].transpose(0, 1).contiguous() for codes in codes_list
-        ]
-        # abort() resets slots under _state_lock from other threads; serialize
-        # every session access on the same lock.
-        with self._state_lock:
-            wavs = self._session.decode_offline(
-                channels_first,
-                max_step_frames=self._max_step_frames,
-                max_batch_size=self._max_batch_size,
-            )
-        return [wav.detach().to("cpu", torch.float32).contiguous() for wav in wavs]
+        """Decode ``[T, >=n_vq]`` row tensors to fp32 CPU waveforms via the
+        batched full-sequence path shared with MOSS-TTS Delay (decode_codes_batch);
+        non-streaming work never enters the streaming session and touches no
+        session-owned state."""
+        rows = [codes[:, : self._n_vq] for codes in codes_list]
+        return decode_codes_batch(
+            rows,
+            quantizer_decode=self._quantizer_decode,
+            decoder=self._nonstream_decoder,
+            device=next(self._codec.parameters()).device,
+            compute_dtype=self._compute_dtype,
+            max_batch_size=self._max_batch_size,
+            interleaved_channels=self._interleaved_channels,
+        )
 
     def _vocode_batch(self, payloads: list[StagePayload]) -> list[StagePayload]:
         prepared = [self._prepare_codes(payload) for payload in payloads]

--- a/sglang_omni/models/moss_tts_local/streaming_vocoder.py
+++ b/sglang_omni/models/moss_tts_local/streaming_vocoder.py
@@ -375,8 +375,8 @@ class MossTTSLocalStreamingVocoderScheduler(
         )
         self._compute_dtype = getattr(codec, "compute_dtype", None)
         # note (Zhang Yiyang): matches the codec's _restore_channels_from_codec:
-        # stereo v2 decoders interleave channels into the sample axis, so packed
-        # outputs must be de-interleaved before slicing.
+        # stereo v2 decoders interleave channels into the sample axis, so the
+        # interleaved layout must be restored before slicing.
         number_channels = int(getattr(codec, "number_channels", 1) or 1)
         self._interleaved_channels = (
             number_channels

--- a/tests/unit_test/moss_tts/test_vocoder.py
+++ b/tests/unit_test/moss_tts/test_vocoder.py
@@ -147,8 +147,8 @@ def test_moss_tts_vocoder_copies_only_valid_waveforms() -> None:
         torch.float32,
     ]
     assert [waveform.tolist() for waveform in waveforms] == [
-        [1.0, 2.0],
-        [3.0, 4.0, 5.0],
+        [[1.0, 2.0]],
+        [[3.0, 4.0, 5.0]],
     ]
 
 

--- a/tests/unit_test/moss_tts_local/test_streaming_vocoder.py
+++ b/tests/unit_test/moss_tts_local/test_streaming_vocoder.py
@@ -1590,7 +1590,9 @@ def test_factory_captures_graphs_before_returning(monkeypatch) -> None:
 
 
 @pytest.mark.parametrize("trigger", ["chunk", "slot_starved", "no_chunk_done"])
-def test_streaming_reuses_graphed_session_after_nonstreaming(monkeypatch, trigger) -> None:
+def test_streaming_reuses_graphed_session_after_nonstreaming(
+    monkeypatch, trigger
+) -> None:
     """Non-streaming traffic leaves the graphed startup session intact; later streaming work
     reuses it with no re-capture. Streaming sessions are created by the first-chunk path
     (_ensure_slot), or by the factory warmup; a slot-starved finish and a no-chunk finish use

--- a/tests/unit_test/moss_tts_local/test_streaming_vocoder.py
+++ b/tests/unit_test/moss_tts_local/test_streaming_vocoder.py
@@ -56,16 +56,38 @@ class _FakeStreamingState:
         self.exec_mask[reset_mask] = True
 
 
+class FakeQuantizer:
+    """Batched-path quantizer: [N, B, T] codes -> [B, 1, T] hidden values
+    ``sum(codes[:, b, t]) + 1000 * t`` (the other half of ``reference_waveform``)."""
+
+    def __init__(self) -> None:
+        self.calls = 0
+
+    def decode_codes(self, codes: torch.Tensor) -> torch.Tensor:
+        self.calls += 1
+        values = codes.to(torch.float64).sum(dim=0)
+        offsets = torch.arange(int(codes.shape[2]), dtype=torch.float64) * 1000.0
+        return (values + offsets).to(torch.float32).unsqueeze(1)
+
+
 class _FakeDecoderStage(nn.Module):
     module_type = "PatchedPretransform"
-    patch_size = 1
+    patch_size = SAMPLES_PER_FRAME
+    is_downsample = False
 
     def forward(
         self,
         x: torch.Tensor,
         input_lengths: torch.Tensor,
     ) -> tuple[torch.Tensor, torch.Tensor]:
-        return x, input_lengths
+        # note (Zhang Yiyang): [B, 1, T] -> [B, 2, T * SAMPLES_PER_FRAME]:
+        # replicate per-frame values over the frame's samples (negated on the
+        # second channel).
+        audio = x.repeat_interleave(SAMPLES_PER_FRAME, dim=-1)
+        return (
+            torch.cat([audio, -audio], dim=1),
+            input_lengths * SAMPLES_PER_FRAME,
+        )
 
 
 class FakeCodec(nn.Module):
@@ -85,6 +107,7 @@ class FakeCodec(nn.Module):
         self.attention_implementation = "flash_attention_2"
         self.attention_implementation_calls: list[str] = []
         self.decoder = nn.ModuleList([_FakeDecoderStage()])
+        self.quantizer = FakeQuantizer()
         self.frame_calls = 0
         self.decode_calls = 0
         self.decode_chunk_durations: list[float | None] = []
@@ -156,7 +179,22 @@ class FakeCodec(nn.Module):
             )
         else:
             lengths = padding_mask.sum(dim=-1).long()
-        return self._decode_frame(audio_codes, lengths)
+        # note (Zhang Yiyang): full-sequence decode is stateless in the real
+        # codec — production runs it through the shared batched path
+        # (decode_codes_batch), which never consults a live streaming session's
+        # exec_mask/offsets; the fake mirrors that by ignoring _streaming_state.
+        _, batch_size, total = audio_codes.shape
+        audio = torch.zeros(batch_size, 2, total * SAMPLES_PER_FRAME)
+        audio_lengths = torch.zeros(batch_size, dtype=torch.long)
+        for b in range(batch_size):
+            t_len = int(lengths[b])
+            for t in range(t_len):
+                value = float(audio_codes[:, b, t].sum()) + 1000.0 * t
+                start = t * SAMPLES_PER_FRAME
+                audio[b, 0, start : start + SAMPLES_PER_FRAME] = value
+                audio[b, 1, start : start + SAMPLES_PER_FRAME] = -value
+            audio_lengths[b] = t_len * SAMPLES_PER_FRAME
+        return SimpleNamespace(audio=audio, audio_lengths=audio_lengths)
 
 
 class FakeProcessor:
@@ -391,13 +429,15 @@ def test_stream_concatenates_to_offline_decode(monkeypatch) -> None:
     }
 
 
-def test_default_session_preserves_batch_width_for_streaming_lanes(monkeypatch) -> None:
+def test_default_session_streaming_lane_capacity(monkeypatch) -> None:
     scheduler = _make_scheduler(monkeypatch, FakeProcessor())
     session = scheduler._ensure_session()
 
     assert scheduler._max_batch_size == 8
-    assert scheduler._stream_slots == 15
-    assert session._offline_slots == 1
+    # note (Zhang Yiyang): 15 streaming lanes + the 1 lane freed by removing the
+    # offline reserve = 16; the freed lane goes to streaming, not the trash.
+    assert scheduler._stream_slots == 16
+    assert not hasattr(session, "_offline_slots")
     assert session._batch_size == 16
 
 
@@ -406,7 +446,6 @@ def test_streaming_session_forces_sdpa_and_restores_codec_backend() -> None:
     session = _CodecStreamSession(
         codec,
         stream_slots=2,
-        offline_slots=1,
         n_vq=N_VQ,
     )
 
@@ -427,7 +466,7 @@ def test_streaming_session_restores_backend_when_streaming_setup_fails() -> None
 
     codec = FailingCodec()
     with pytest.raises(RuntimeError, match="streaming setup failed"):
-        _CodecStreamSession(codec, stream_slots=1, offline_slots=1, n_vq=N_VQ)
+        _CodecStreamSession(codec, stream_slots=1, n_vq=N_VQ)
 
     assert codec.attention_implementation == "flash_attention_2"
     assert codec.attention_implementation_calls == ["sdpa", "flash_attention_2"]
@@ -932,7 +971,7 @@ def test_slot_reacquisition_preserves_initial_chunk_boundary(monkeypatch) -> Non
     )
 
 
-def test_slot_exhaustion_falls_back_to_offline_decode(monkeypatch) -> None:
+def test_slot_exhaustion_falls_back_to_batched_decode(monkeypatch) -> None:
     processor = FakeProcessor()
     scheduler = _make_scheduler(
         monkeypatch,
@@ -960,12 +999,13 @@ def test_slot_exhaustion_falls_back_to_offline_decode(monkeypatch) -> None:
         for m in messages_b
         if m.type == "stream"
     ]
-    assert sizes_b == [8]  # one catch-up chunk decoded through the offline lane
+    # note (Zhang Yiyang): the whole buffer decodes in one batched call.
+    assert sizes_b == [8]
     np.testing.assert_array_equal(
         _concat_stream_audio(messages_b, "b"),
         reference_waveform(rows_b[:, 1:]).numpy(),
     )
-    # "a" is unaffected by b's offline-lane decode.
+    # note (Zhang Yiyang): "a" is unaffected by b's batched decode.
     for index, row in enumerate(rows_a[5:], start=5):
         scheduler._on_chunk("a", _stream_item(row, metadata, index))
     scheduler._on_done("a")
@@ -1014,11 +1054,10 @@ def test_abort_releases_slot(monkeypatch) -> None:
     )
 
 
-def test_non_streaming_path_ignores_idle_startup_session(monkeypatch) -> None:
+def test_non_streaming_path_leaves_startup_session_untouched(monkeypatch) -> None:
     processor = FakeProcessor()
     scheduler = _make_scheduler(monkeypatch, processor)
-    scheduler._ensure_session()
-    assert scheduler._session is not None
+    startup_session = scheduler._ensure_session()
     assert scheduler._codec._streaming_state is not None
 
     rows = _rows(11, seed=59)
@@ -1026,12 +1065,14 @@ def test_non_streaming_path_ignores_idle_startup_session(monkeypatch) -> None:
     (result,) = scheduler._vocode_batch([_offline_payload(rows, "r1")])
 
     assert processor.decode_calls == 0
-    assert scheduler._codec.decode_calls == 1
-    assert scheduler._codec.decode_chunk_durations == [None]
-    assert scheduler._codec.decode_decoders == [scheduler._nonstream_decoder]
+    # note (Zhang Yiyang): the batched path bypasses codec.decode entirely (no
+    # decoder swap, no streaming-loop entry): quantizer decode happens once,
+    # under no session, and never touches the startup session.
+    assert scheduler._codec.decode_calls == 0
+    assert scheduler._codec.quantizer.calls == 1
     assert scheduler._codec.decoder is original_decoder
-    assert scheduler._session is None
-    assert scheduler._codec._streaming_state is None
+    assert scheduler._session is startup_session
+    assert scheduler._codec._streaming_state is not None
     np.testing.assert_array_equal(
         _decode_audio(result.data), reference_waveform(rows[:, 1:]).numpy()
     )
@@ -1058,15 +1099,14 @@ def test_non_streaming_path_with_and_without_live_session(monkeypatch) -> None:
     rows_2 = _rows(4, seed=61)
     original_decoder = scheduler._codec.decoder
 
-    # Before any stream: use the full-sequence tokenizer path with the packed
-    # non-streaming decoder installed.
+    # note (Zhang Yiyang): before any stream, use the batched full-sequence
+    # path (quantizer + batched decoder), never codec.decode.
     results = scheduler._vocode_batch(
         [_offline_payload(rows_1, "r1"), _offline_payload(rows_2, "r2")]
     )
     assert processor.decode_calls == 0
-    assert scheduler._codec.decode_calls == 1
-    assert scheduler._codec.decode_chunk_durations == [None]
-    assert scheduler._codec.decode_decoders == [scheduler._nonstream_decoder]
+    assert scheduler._codec.decode_calls == 0
+    assert scheduler._codec.quantizer.calls == 1
     assert scheduler._codec.decoder is original_decoder
     waves_before = [_decode_audio(result.data) for result in results]
     for result in results:
@@ -1078,14 +1118,15 @@ def test_non_streaming_path_with_and_without_live_session(monkeypatch) -> None:
     _run_stream(scheduler, _rows(6, seed=62))
     assert scheduler._session is not None
 
-    # ...after which the processor path would raise ("already streaming"), so
-    # offline decodes must go through the session's offline lane and still
-    # produce identical audio.
+    # note (Zhang Yiyang): ...after which offline decodes still use the batched
+    # full-sequence path (non-streaming work never enters the streaming
+    # session), producing identical audio.
     results = scheduler._vocode_batch(
         [_offline_payload(rows_1, "r3"), _offline_payload(rows_2, "r4")]
     )
     assert processor.decode_calls == 0
-    assert scheduler._codec.decode_calls == 1
+    assert scheduler._codec.decode_calls == 0
+    assert scheduler._codec.quantizer.calls == 2
     waves_after = [_decode_audio(result.data) for result in results]
     for before, after in zip(waves_before, waves_after):
         np.testing.assert_array_equal(before, after)
@@ -1094,7 +1135,7 @@ def test_non_streaming_path_with_and_without_live_session(monkeypatch) -> None:
     )
 
 
-def test_offline_lane_waves_split_across_slots(monkeypatch) -> None:
+def test_offline_batch_uses_batched_path_with_live_session(monkeypatch) -> None:
     del monkeypatch
     processor = FakeProcessor()
     # Constructed directly: max_step_frames is not a factory knob.
@@ -1119,13 +1160,20 @@ def test_offline_lane_waves_split_across_slots(monkeypatch) -> None:
             )
         )
     results = scheduler._vocode_batch(payloads)
+    codec = processor.audio_tokenizer
+    # note (Zhang Yiyang): two batched waves (3 items, max_batch_size=2); no
+    # session stepping.
+    assert codec.decode_calls == 0
+    assert codec.quantizer.calls == 2
     for rows, result in zip(rows_list, results):
         np.testing.assert_array_equal(
             _decode_audio(result.data), reference_waveform(rows[:, 1:]).numpy()
         )
 
 
-def test_mixed_offline_batch_borrows_idle_stream_slots(monkeypatch) -> None:
+def test_offline_batch_leaves_stream_slots_untouched(monkeypatch) -> None:
+    """With streams holding slots, an offline batch decodes via the batched path
+    without borrowing or resetting any stream slot."""
     processor = FakeProcessor()
     codec = processor.audio_tokenizer
     scheduler = _make_scheduler(
@@ -1142,6 +1190,9 @@ def test_mixed_offline_batch_borrows_idle_stream_slots(monkeypatch) -> None:
             request_id, _stream_item(_rows(1, seed=seed)[0], _metadata())
         )
     assert codec.frame_calls == 0
+    session = scheduler._session
+    assert session is not None
+    assert len(session._free_stream_slots) == 1
 
     offline_rows = [_rows(2, seed=82), _rows(2, seed=83)]
     results = scheduler._vocode_batch(
@@ -1150,95 +1201,23 @@ def test_mixed_offline_batch_borrows_idle_stream_slots(monkeypatch) -> None:
             _offline_payload(offline_rows[1], "offline-b"),
         ]
     )
-    assert codec.frame_calls == 1
+    assert codec.decode_calls == 0
+    assert codec.quantizer.calls == 1
+    # note (Zhang Yiyang): the batched path never runs streaming steps.
+    assert codec.frame_calls == 0
+    assert scheduler._session is session
+    assert len(session._free_stream_slots) == 1
     for rows, result in zip(offline_rows, results):
         np.testing.assert_array_equal(
             _decode_audio(result.data), reference_waveform(rows[:, 1:]).numpy()
         )
 
     rows = _rows(2, seed=84)
-    messages = _run_stream(scheduler, rows, request_id="borrowed-slot-stream")
+    messages = _run_stream(scheduler, rows, request_id="stream-after-offline")
     np.testing.assert_array_equal(
-        _concat_stream_audio(messages, "borrowed-slot-stream"),
+        _concat_stream_audio(messages, "stream-after-offline"),
         reference_waveform(rows[:, 1:]).numpy(),
     )
-
-
-def test_offline_borrowed_slot_is_leased_and_reset_after_failure(monkeypatch) -> None:
-    processor = FakeProcessor()
-    scheduler = _make_scheduler(
-        monkeypatch,
-        processor,
-        stream_slots=2,
-        max_batch_size=2,
-        stream_chunk_frames=3,
-        initial_chunk_frames=3,
-    )
-    scheduler._on_chunk("held", _stream_item(_rows(1, seed=85)[0], _metadata()))
-    session = scheduler._ensure_session()
-    borrowed_slot = session._free_stream_slots[-1]
-    original_step = session.step
-
-    def fail_after_step(slot_codes):
-        assert borrowed_slot not in session._free_stream_slots
-        original_step(slot_codes)
-        raise RuntimeError("injected offline decode failure")
-
-    monkeypatch.setattr(session, "step", fail_after_step)
-    offline_codes = [
-        rows[:, 1:].transpose(0, 1).contiguous()
-        for rows in (_rows(2, seed=86), _rows(2, seed=87))
-    ]
-    with pytest.raises(RuntimeError, match="injected offline decode failure"):
-        session.decode_offline(offline_codes, max_step_frames=3, max_batch_size=2)
-
-    monkeypatch.setattr(session, "step", original_step)
-    assert session._free_stream_slots == [borrowed_slot]
-    rows = _rows(2, seed=88)
-    messages = _run_stream(scheduler, rows, request_id="after-failure")
-    np.testing.assert_array_equal(
-        _concat_stream_audio(messages, "after-failure"),
-        reference_waveform(rows[:, 1:]).numpy(),
-    )
-
-
-def test_offline_borrowed_slot_is_quarantined_without_masking_failure(
-    monkeypatch,
-) -> None:
-    processor = FakeProcessor()
-    scheduler = _make_scheduler(
-        monkeypatch,
-        processor,
-        stream_slots=2,
-        max_batch_size=2,
-    )
-    session = scheduler._ensure_session()
-    borrowed_slot = session._free_stream_slots[-1]
-    original_step = session.step
-    original_reset = session._reset_slots
-    reset_calls = 0
-
-    def fail_after_step(slot_codes):
-        original_step(slot_codes)
-        raise ValueError("injected decode failure")
-
-    def fail_cleanup_reset(slots):
-        nonlocal reset_calls
-        reset_calls += 1
-        if reset_calls == 2:
-            raise RuntimeError("injected reset failure")
-        original_reset(slots)
-
-    monkeypatch.setattr(session, "step", fail_after_step)
-    monkeypatch.setattr(session, "_reset_slots", fail_cleanup_reset)
-    offline_codes = [
-        rows[:, 1:].transpose(0, 1).contiguous()
-        for rows in (_rows(2, seed=89), _rows(2, seed=90))
-    ]
-    with pytest.raises(ValueError, match="injected decode failure"):
-        session.decode_offline(offline_codes, max_step_frames=3, max_batch_size=2)
-
-    assert borrowed_slot not in session._free_stream_slots
 
 
 def test_stop_closes_persistent_streaming_session(monkeypatch) -> None:
@@ -1474,8 +1453,8 @@ def test_create_vocoder_executor_uses_separate_codec(monkeypatch) -> None:
 
     assert processor.decode_calls == 0
     assert processor.audio_tokenizer.decode_calls == 0
-    assert codec.decode_calls == 1
-    assert codec.decode_decoders == [scheduler._nonstream_decoder]
+    assert codec.decode_calls == 0
+    assert codec.quantizer.calls == 1
     np.testing.assert_array_equal(
         _decode_audio(result.data), reference_waveform(rows[:, 1:]).numpy()
     )
@@ -1611,10 +1590,11 @@ def test_factory_captures_graphs_before_returning(monkeypatch) -> None:
 
 
 @pytest.mark.parametrize("trigger", ["chunk", "slot_starved", "no_chunk_done"])
-def test_streaming_recaptures_graph_after_nonstreaming(monkeypatch, trigger) -> None:
-    """Non-streaming traffic closes the graphed startup session; the next streaming session must be
-    re-captured. Covers all three streaming session-creation paths: a first chunk (_ensure_slot), a
-    slot-starved finish (on_stream_done offline lane), a no-chunk finish (_decode_payload_codes).
+def test_streaming_reuses_graphed_session_after_nonstreaming(monkeypatch, trigger) -> None:
+    """Non-streaming traffic leaves the graphed startup session intact; later streaming work
+    reuses it with no re-capture. Streaming sessions are created by the first-chunk path
+    (_ensure_slot), or by the factory warmup; a slot-starved finish and a no-chunk finish use
+    the batched non-streaming route and never create a session by themselves.
     """
     calls: list = []
     _install_fake_capture(monkeypatch, calls, seal=True)
@@ -1628,15 +1608,15 @@ def test_streaming_recaptures_graph_after_nonstreaming(monkeypatch, trigger) -> 
     )
     assert scheduler._session is not None
     assert scheduler._session.has_cuda_graph_runner()
-    # Hold the object, not id(): a GC'd session's address can be reused, so an id()
-    # check risks a false negative. `is not` on the retained ref is reliable.
     startup_session = scheduler._session
 
-    # Non-streaming traffic closes the idle startup session.
+    # note (Zhang Yiyang): non-streaming decode uses the batched path and
+    # leaves the startup session untouched.
     nonstream_rows = _rows(5, seed=1)
     (result,) = scheduler._vocode_batch([_offline_payload(nonstream_rows, "n1")])
-    assert scheduler._session is None
-    assert startup_session._closed
+    assert scheduler._session is startup_session
+    assert not startup_session._closed
+    assert len(calls) == 1
     np.testing.assert_array_equal(
         _decode_audio(result.data), reference_waveform(nonstream_rows[:, 1:]).numpy()
     )
@@ -1644,7 +1624,9 @@ def test_streaming_recaptures_graph_after_nonstreaming(monkeypatch, trigger) -> 
     if trigger == "chunk":
         scheduler._on_chunk("s", _stream_item(_rows(6, seed=2)[0], _metadata()))
     elif trigger == "slot_starved":
-        # "hold" takes the only slot; "starve" buffers without a slot, then finishes offline.
+        # note (Zhang Yiyang): "hold" takes the persistent session's only
+        # slot; "starve" buffers without a slot, then finishes through the
+        # batched path.
         for i, row in enumerate(_rows(5, seed=3)):
             scheduler._on_chunk("hold", _stream_item(row, _metadata(), i))
         for i, row in enumerate(_rows(6, seed=4)):
@@ -1659,17 +1641,25 @@ def test_streaming_recaptures_graph_after_nonstreaming(monkeypatch, trigger) -> 
             "nc", _terminal_payload(_rows(5, seed=5), request_id="nc")
         )
 
-    assert scheduler._session is not None
+    if trigger == "no_chunk_done":
+        # note (Zhang Yiyang): batched non-streaming decode creates no session;
+        # the factory-captured startup session stays the only one.
+        assert scheduler._session is startup_session
+        assert len(calls) == 1
+        messages = _drain(scheduler)
+        np.testing.assert_array_equal(
+            _concat_stream_audio(messages, "nc"),
+            reference_waveform(_rows(5, seed=5)[:, 1:]).numpy(),
+        )
+        return
+
+    # note (Zhang Yiyang): streaming work reuses the factory-captured session —
+    # no re-capture.
+    assert scheduler._session is startup_session
     assert (
-        scheduler._session is not startup_session
-    ), "a fresh session must have been created, not the closed startup one"
-    # Factory warmup (1) + this recapture (1): exactly one recapture happened.
-    assert (
-        len(calls) == 2
-    ), f"{trigger}: expected 2 warmups (factory + recapture), got {len(calls)}"
-    assert (
-        scheduler._session.has_cuda_graph_runner()
-    ), f"{trigger}: the new streaming session must be re-captured"
+        len(calls) == 1
+    ), f"{trigger}: expected 1 warmup (factory only, no recapture), got {len(calls)}"
+    assert scheduler._session.has_cuda_graph_runner()
 
 
 def test_low_vram_capture_attempted_once_no_reprobe(monkeypatch) -> None:

--- a/tests/unit_test/moss_tts_local/test_vocoder_cuda_graph.py
+++ b/tests/unit_test/moss_tts_local/test_vocoder_cuda_graph.py
@@ -15,7 +15,6 @@ pytestmark = pytest.mark.accelerator
 CODEC_MODEL_ID = "OpenMOSS-Team/MOSS-Audio-Tokenizer-v2"
 N_VQ = 12  # MOSS-TTS-Local v1.5 uses the first 12 RVQ codebooks
 STREAM_SLOTS = 8
-OFFLINE_SLOTS = 8
 # T values the gate exercises (chunk sizes); warmup captures these + remainders.
 CHUNK_TS = [1, 5, 25, 100]
 _HAS_CUDA = torch.cuda.is_available()
@@ -58,9 +57,7 @@ def session_bundle():
     )
     n_vq = N_VQ
     vocab = _codebook_size(codec)
-    session = _CodecStreamSession(
-        codec, stream_slots=STREAM_SLOTS, offline_slots=OFFLINE_SLOTS, n_vq=n_vq
-    )
+    session = _CodecStreamSession(codec, stream_slots=STREAM_SLOTS, n_vq=n_vq)
     # Capture every length the test emits (each chunk_t and its remainder) once, sealed.
     wanted = set()
     for chunk_t in CHUNK_TS:
@@ -232,7 +229,7 @@ def test_vram_guard_skips_capture_and_falls_back_to_eager(session_bundle):
     session, n_vq, vocab, captured = session_bundle
     guarded = MossVocoderCudaGraphRunner(
         session._codec,
-        batch_size=STREAM_SLOTS + OFFLINE_SLOTS,
+        batch_size=STREAM_SLOTS,
         n_vq=n_vq,
         min_free_gb=100000.0,  # 100 TB headroom -> always trips
     )
@@ -251,7 +248,7 @@ def test_capture_failure_falls_back_to_eager(session_bundle):
 
     session, n_vq, vocab, captured = session_bundle
     runner = MossVocoderCudaGraphRunner(
-        session._codec, batch_size=STREAM_SLOTS + OFFLINE_SLOTS, n_vq=n_vq
+        session._codec, batch_size=STREAM_SLOTS, n_vq=n_vq
     )
 
     def boom(frame_count):


### PR DESCRIPTION
## Motivation

MOSS-TTS-Local's non-streaming (offline) vocode currently rides the **streaming** codec session: one reserved offline slot plus opportunistic borrowing of idle stream slots, decoded in chunks of `max_step_frames` (default 100). Measured against a batched full-sequence decode of the same codes, the slot/chunked route loses badly at the component level (packed is ~5–9x faster; the default CUDA graph capture set covers only the small-T streaming shapes and never catches the T=100 offline step), and under mixed streaming+offline traffic the offline decode contends with live streams for session lanes.

This PR retires the slot-based offline route entirely and moves both MOSS-TTS model families onto one shared batched full-sequence decode.

## Modifications

- **`sglang_omni/models/moss_tts/vocoder.py`: new shared `decode_codes_batch`.** Batched full-sequence decode of code rows: zero-pad waves of at most `max_batch_size` items into `[n_vq, B, T_max]`, quantizer decode in FP32 with autocast disabled, decoder stages under the configured compute-dtype autocast, host-side input/output lengths (no GPU sync), and the codec's channel-interleave restore (`[B,1,T*C] -> [B,C,T]`) for the stereo v2 tokenizer. The decoder resolves its own attention backend, so this path is backend-agnostic. `_copy_valid_waveforms_to_cpu` is generalized to `[B,C,T]` batched waves; `_mono_waveform` added.
- **MOSS-TTS-Local:** all three non-streaming entries (`_vocode_batch`, slot-starved drain, terminal-payload full decode) route through the shared path. The offline reserved slot is gone; the persistent session is streaming-only (`session width = stream_slots`), and non-streaming decodes hold no scheduler lock. The streaming session lifecycle is untouched (per-slot CUDA graphs, coalesced stepping).
- **MOSS-TTS (Delay):** `_decode_segment_batches` is now a thin shell over the same shared function (mono unwrap), deleting its private copy of the same algorithm.
- **Removed the idle-startup-session close heuristic** (`_close_idle_startup_session_locked` / `_session_used_by_streaming`, introduced in #798): the framework was inferring the traffic mix at runtime (closing the graph-captured startup session after pure offline traffic, then re-capturing on the next stream — a one-time TTFA spike). Serving now keeps one decision: graphs are captured at startup, or not at all via the existing pipeline-config `cuda_graph: false` (which also skips creating the session).
- **Default `stream_slots` 15 -> 16:** the lane freed by removing the offline reserve is donated to streaming concurrency (the session was already 16 wide).

Offline decode no longer shares any state with live streams: no slot borrow, no session lock, no decoder swap.

## Related Issues

#1233 

## Accuracy Test

Non-streaming decode used to run chunked through the session (chunk = `max_step_frames`); it now runs full-sequence batched. The codec is chunk-boundary dependent, so Local non-streaming audio is **not bit-identical** to the old output; the Delay side **is** bit-identical (its previous offline decode was the same full-sequence algorithm, merely extracted).

### Codec numerical parity and tests

Bit checks on the real codecs (one NVIDIA H200), shared path vs a verbatim executor-state replica of the pre-refactor implementations:

| Side | Coverage | Result |
|---|---|---|
| MOSS-TTS-Local (MOSS-Audio-Tokenizer-v2) | B1_T125, B1_T1000, B4_T250, B8_T500, B8_mixed | 5/5 workloads bitwise identical (`torch.equal`, maxdelta 0.0) |
| MOSS-TTS Delay (v1 codec) | segments T={1,3,25,100,40} incl. multi-wave mixed-length batching | 5/5 bitwise identical (`torch.equal`, maxdelta 0.0) |

Tests: 482/482 (`tests/unit_test/moss_tts_local/` + `tests/unit_test/moss_tts/`), plus 15/15 GPU cuda-graph tests.

### SeedTTS-Eval EN quality (5 paired rounds, 1088 samples per side per round)

Both sides ran the identical 5-round sequence (round 1 is the server-warmup round on both sides, so pairing by round index cancels it); all 5 rounds retained, none screened as outliers. `Base` = main `d6670de4`, `Current` = this PR. Raw results are shown as `Base / Current`:

#### MOSS-TTS Local non-streaming

| Round | Corpus WER | Corpus WER, excluding samples above 50% WER | Speaker Similarity | UTMOS |
|---:|---:|---:|---:|---:|
| 1 | 2.4031% / 1.9091% | 1.5450% / 1.5881% | 65.3796 / 65.2890 | 3.9672 / 3.9596 |
| 2 | 2.0933% / 2.0765% | 1.6156% / 1.7059% | 65.0697 / 65.0979 | 3.9646 / 3.9604 |
| 3 | 2.4784% / 2.2859% | 1.6544% / 1.5439% | 65.3178 / 65.3672 | 3.9552 / 3.9696 |
| 4 | 2.1938% / 2.2272% | 1.6591% / 1.8170% | 65.3417 / 65.1969 | 3.9652 / 3.9637 |
| 5 | 2.3110% / 2.2189% | 1.7522% / 1.5848% | 65.2964 / 65.2890 | 3.9632 / 3.9538 |

| Metric | Base mean | Current mean | Change | Current - Base paired 95% CI |
|---|---:|---:|---:|---:|
| Corpus WER | 2.2959% | 2.1435% | -6.64% | `[-0.4120, +0.1072]` pp |
| Corpus WER, excluding samples above 50% WER | 1.6453% | 1.6479% | +0.16% | `[-0.1675, +0.1728]` pp |
| Speaker Similarity | 65.2811 | 65.2480 | -0.05% | `[-0.1351, +0.0689]` |
| UTMOS | 3.9631 | 3.9614 | -0.04% | `[-0.0134, +0.0101]` |

#### MOSS-TTS Local streaming

| Round | Corpus WER | Corpus WER, excluding samples above 50% WER | Speaker Similarity | UTMOS |
|---:|---:|---:|---:|---:|
| 1 | 2.3110% / 2.3277% | 1.7189% / 1.5624% | 65.3201 / 65.4030 | 3.9678 / 3.9593 |
| 2 | 2.1268% / 2.1268% | 1.5250% / 1.5916% | 65.2850 / 65.4294 | 3.9631 / 3.9739 |
| 3 | 2.2440% / 2.2356% | 1.6923% / 1.5007% | 65.4285 / 65.2804 | 3.9603 / 3.9633 |
| 4 | 2.2189% / 1.9426% | 1.5941% / 1.4313% | 65.1596 / 65.2342 | 3.9720 / 3.9621 |
| 5 | 2.1184% / 2.5036% | 1.5328% / 1.6805% | 65.0025 / 65.3299 | 3.9643 / 3.9573 |

| Metric | Base mean | Current mean | Change | Current - Base paired 95% CI |
|---|---:|---:|---:|---:|
| Corpus WER | 2.2038% | 2.2272% | +1.06% | `[-0.2692, +0.3161]` pp |
| Corpus WER, excluding samples above 50% WER | 1.6126% | 1.5533% | -3.68% | `[-0.2520, +0.1334]` pp |
| Speaker Similarity | 65.2391 | 65.3354 | +0.15% | `[-0.1153, +0.3077]` |
| UTMOS | 3.9655 | 3.9632 | -0.06% | `[-0.0134, +0.0087]` |

#### MOSS-TTS Delay non-streaming

| Round | Corpus WER | Corpus WER, excluding samples above 50% WER | Speaker Similarity | UTMOS |
|---:|---:|---:|---:|---:|
| 1 | 1.6662% / 1.7081% | 1.3277% / 1.3118% | 68.8895 / 69.0532 | 3.9349 / 3.9394 |
| 2 | 1.9007% / 1.6746% | 1.2725% / 1.2365% | 69.0454 / 68.9923 | 3.9384 / 3.9366 |
| 3 | 1.5323% / 1.5072% | 1.2842% / 1.2425% | 68.9099 / 68.8030 | 3.9463 / 3.9408 |
| 4 | 1.6830% / 1.8337% | 1.2450% / 1.4465% | 68.8969 / 68.7271 | 3.9395 / 3.9246 |
| 5 | 1.6746% / 1.6076% | 1.4282% / 1.3014% | 68.9231 / 68.8509 | 3.9383 / 3.9486 |

| Metric | Base mean | Current mean | Change | Current - Base paired 95% CI |
|---|---:|---:|---:|---:|
| Corpus WER | 1.6914% | 1.6662% | -1.49% | `[-0.1980, +0.1477]` pp |
| Corpus WER, excluding samples above 50% WER | 1.3115% | 1.3078% | -0.29% | `[-0.1557, +0.1481]` pp |
| Speaker Similarity | 68.9330 | 68.8853 | -0.07% | `[-0.2044, +0.1090]` |
| UTMOS | 3.9395 | 3.9380 | -0.04% | `[-0.0134, +0.0105]` |

Every paired confidence interval above includes zero — no statistically detectable quality change in any of the three routes. (The mixed streaming+non-streaming mode was also evaluated per round; its ranges — WER 2.1–2.8% / SIM 64.6–65.9 / UTMOS 3.95–3.99 — fully overlap between sides and carry no additional signal over the tables above.)

## Benchmark & Profiling

### Benchmark configuration

- Device: one NVIDIA H200 (physical GPU5, NUMA1); client+server under a cgroup hard quota of 24 logical CPUs on NUMA1.
- Models: `OpenMOSS-Team/MOSS-TTS-Local-Transformer-v1.5` (local modes), `OpenMOSS-Team/MOSS-TTS-v1.5` (delay mode).
- Workload: full SeedTTS-Eval EN, 1088/1088 requests per side per round, concurrency 16, `references` ref format, token count `auto`, default warmup (= concurrency), zero failed requests in every round.
- A/B method: same host, serial; `Base` = main `d6670de4` with the PR stashed away, `Current` = the PR; a fresh server per (side, mode).
- Modes: non-streaming per model, streaming Local, and a mixed mode that fires two concurrent clients (c8 streaming + c8 non-streaming) on disjoint corpus halves.
- Analysis: 5 paired rounds per mode; paired 95% CI of `Current - Base` (t, df=4). No outlier screening was needed — round 1 is the warmup round on both sides symmetrically, so pairing cancels it.

### MOSS-TTS Local non-streaming

Raw results as `Base / Current`:

| Round | Throughput QPS | Mean latency (s) | P95 latency (s) | Mean RTF |
|---:|---:|---:|---:|---:|
| 1 | 14.640 / 15.108 | 1.087 / 1.053 | 1.488 / 1.470 | 0.2511 / 0.2427 |
| 2 | 17.075 / 17.902 | 0.931 / 0.888 | 1.294 / 1.252 | 0.2135 / 0.2030 |
| 3 | 17.108 / 17.853 | 0.930 / 0.890 | 1.300 / 1.248 | 0.2133 / 0.2037 |
| 4 | 17.130 / 17.892 | 0.929 / 0.889 | 1.292 / 1.247 | 0.2131 / 0.2035 |
| 5 | 17.005 / 17.886 | 0.934 / 0.888 | 1.309 / 1.249 | 0.2142 / 0.2036 |

| Metric | Base mean | Current mean | Change | Current - Base paired 95% CI |
|---|---:|---:|---:|---:|
| Throughput QPS | 16.592 | 17.328 | **+4.44%** | `[+0.538, +0.935]` QPS |
| Mean latency | 0.962 s | 0.922 s | **-4.22%** | `[-0.046, -0.035]` s |
| P95 latency | 1.337 s | 1.293 s | **-3.25%** | `[-0.063, -0.024]` s |
| Mean RTF | 0.2210 | 0.2113 | **-4.41%** | `[-0.0108, -0.0086]` |

All four paired CIs exclude zero: the non-streaming route change is a real, if modest, end-to-end win (the component-level vocoder gap is ~5–9x and is amortized by the AR stage).

### MOSS-TTS Local streaming

| Round | Throughput QPS | Mean latency (s) | P95 latency (s) | Mean RTF | Mean TTFA (s) | P95 TTFA (s) |
|---:|---:|---:|---:|---:|---:|---:|
| 1 | 8.331 / 8.379 | 1.909 / 1.899 | 2.638 / 2.568 | 0.4429 / 0.4395 | 0.5809 / 0.5916 | 1.0233 / 0.9630 |
| 2 | 8.958 / 9.047 | 1.776 / 1.760 | 2.409 / 2.432 | 0.4107 / 0.4075 | 0.5433 / 0.4753 | 0.8438 / 1.0120 |
| 3 | 9.218 / 9.450 | 1.724 / 1.682 | 2.384 / 2.343 | 0.3973 / 0.3869 | 0.4356 / 0.3507 | 0.7218 / 0.5756 |
| 4 | 9.418 / 9.457 | 1.689 / 1.682 | 2.356 / 2.346 | 0.3884 / 0.3862 | 0.3861 / 0.3316 | 0.6518 / 0.4969 |
| 5 | 9.593 / 9.436 | 1.658 / 1.686 | 2.341 / 2.336 | 0.3807 / 0.3875 | 0.3238 / 0.3453 | 0.4918 / 0.5268 |

| Metric | Base mean | Current mean | Change | Current - Base paired 95% CI |
|---|---:|---:|---:|---:|
| Throughput QPS | 9.104 | 9.154 | +0.55% | `[-0.123, +0.223]` QPS |
| Mean latency | 1.751 s | 1.742 s | -0.54% | `[-0.041, +0.022]` s |
| P95 latency | 2.426 s | 2.405 s | -0.85% | `[-0.065, +0.024]` s |
| Mean RTF | 0.4040 | 0.4015 | -0.61% | `[-0.0101, +0.0051]` |
| Mean TTFA | 0.4539 s | 0.4189 s | -7.72% | `[-0.0947, +0.0246]` s |
| P95 TTFA | 0.7465 s | 0.7149 s | -4.24% | `[-0.1999, +0.1367]` s |

Unchanged within round noise, as intended: the streaming decode path (session CUDA graphs, coalesced steps) is untouched. The `stream_slots` 15->16 widening included here shows no measurable effect on the pure-streaming c16 workload; it matters under contention (mixed mode below).

### MOSS-TTS Delay non-streaming

| Round | Throughput QPS | Mean latency (s) | P95 latency (s) | Mean RTF |
|---:|---:|---:|---:|---:|
| 1 | 8.158 / 8.123 | 1.952 / 1.959 | 2.504 / 2.496 | 0.4491 / 0.4512 |
| 2 | 8.784 / 8.711 | 1.814 / 1.829 | 2.328 / 2.339 | 0.4173 / 0.4206 |
| 3 | 8.672 / 8.677 | 1.837 / 1.835 | 2.330 / 2.346 | 0.4222 / 0.4222 |
| 4 | 8.767 / 8.715 | 1.818 / 1.827 | 2.323 / 2.311 | 0.4178 / 0.4198 |
| 5 | 8.743 / 8.791 | 1.821 / 1.810 | 2.306 / 2.305 | 0.4188 / 0.4159 |

| Metric | Base mean | Current mean | Change | Current - Base paired 95% CI |
|---|---:|---:|---:|---:|
| Throughput QPS | 8.625 | 8.603 | -0.25% | `[-0.081, +0.038]` QPS |
| Mean latency | 1.848 s | 1.852 s | +0.19% | `[-0.009, +0.016]` s |
| P95 latency | 2.358 s | 2.359 s | +0.05% | `[-0.014, +0.016]` s |
| Mean RTF | 0.4250 | 0.4259 | +0.21% | `[-0.0021, +0.0039]` |

Flat within noise, as expected for a same-algorithm extraction.

### Mixed traffic (c8 streaming + c8 non-streaming, one Local server)

Streaming client:

| Round | Throughput QPS | Mean latency (s) | P95 latency (s) | Mean RTF | Mean TTFA (s) | P95 TTFA (s) |
|---:|---:|---:|---:|---:|---:|---:|
| 1 | 2.748 / 5.126 | 2.892 / 1.551 | 3.732 / 2.130 | 0.6925 / 0.3595 | 1.6857 / 0.3702 | 2.6971 / 0.5511 |
| 2 | 2.945 / 5.610 | 2.700 / 1.417 | 3.312 / 1.956 | 0.6417 / 0.3271 | 1.5118 / 0.2766 | 1.8961 / 0.4075 |
| 3 | 2.910 / 5.649 | 2.720 / 1.406 | 3.361 / 1.932 | 0.6474 / 0.3241 | 1.5496 / 0.2535 | 1.8992 / 0.3729 |
| 4 | 2.944 / 5.599 | 2.690 / 1.417 | 3.390 / 1.958 | 0.6411 / 0.3272 | 1.4910 / 0.2660 | 1.9194 / 0.3850 |
| 5 | 2.999 / 5.604 | 2.643 / 1.417 | 3.246 / 1.951 | 0.6293 / 0.3268 | 1.4242 / 0.2664 | 1.8102 / 0.3925 |

| Metric | Base mean | Current mean | Change | Current - Base paired 95% CI |
|---|---:|---:|---:|---:|
| Throughput QPS | 2.909 | 5.518 | **+89.66%** | `[+2.438, +2.779]` QPS |
| Mean latency | 2.729 s | 1.442 s | **-47.17%** | `[-1.341, -1.233]` s |
| P95 latency | 3.408 s | 1.985 s | **-41.75%** | `[-1.566, -1.280]` s |
| Mean RTF | 0.6504 | 0.3329 | **-48.81%** | `[-0.3316, -0.3033]` |
| Mean TTFA | 1.5325 s | 0.2865 s | **-81.30%** | `[-1.324, -1.168]` s |
| P95 TTFA | 2.0444 s | 0.4218 s | **-79.37%** | `[-1.990, -1.255]` s |

Non-streaming client:

| Round | Throughput QPS | Mean latency (s) | P95 latency (s) | Mean RTF |
|---:|---:|---:|---:|---:|
| 1 | 2.721 / 5.104 | 2.934 / 1.563 | 3.849 / 2.170 | 0.6871 / 0.3571 |
| 2 | 2.911 / 5.586 | 2.742 / 1.428 | 3.387 / 1.974 | 0.6436 / 0.3260 |
| 3 | 2.874 / 5.616 | 2.778 / 1.421 | 3.431 / 1.985 | 0.6535 / 0.3236 |
| 4 | 2.904 / 5.577 | 2.748 / 1.431 | 3.499 / 1.991 | 0.6437 / 0.3265 |
| 5 | 2.960 / 5.583 | 2.697 / 1.429 | 3.373 / 1.987 | 0.6322 / 0.3260 |

| Metric | Base mean | Current mean | Change | Current - Base paired 95% CI |
|---|---:|---:|---:|---:|
| Throughput QPS | 2.874 | 5.493 | **+91.13%** | `[+2.447, +2.791]` QPS |
| Mean latency | 2.780 s | 1.454 s | **-47.68%** | `[-1.376, -1.275]` s |
| P95 latency | 3.508 s | 2.021 s | **-42.37%** | `[-1.632, -1.341]` s |
| Mean RTF | 0.6520 | 0.3318 | **-49.11%** | `[-0.3326, -0.3077]` |

This is the scenario the PR exists for: before, every offline decode entered the chunked session decode and contended with live streams; after, offline never touches the session. Both request classes roughly double their throughput, and stream TTFA drops ~5x under coexistence.

### Caveats

- Single shared host (cgroup-pinned); absolute QPS is box-sensitive. Trust the paired same-host deltas and their per-round consistency, not the absolute numbers.
- Mixed gains are measured at c8+c8; other mixes shift the point, not the direction. Long-audio (2/5/10 min) end-to-end was benchmarked earlier on this branch family: flat (AR dominates; the vocoder route is ~1% of e2e there).

## Configuration and lifecycle

- Streaming behavior is unchanged by default; offline always uses the batched full-sequence path.
- `cuda_graph: false` fully opts out of the graph-captured startup session (no capture, no session created at startup) — the supported switch for pure-offline deployments that want the graph pool's few-GB VRAM back (previously reclaimed lazily by the removed idle-close heuristic).
- `cuda_graph_frames` / `cuda_graph_min_free_gb` semantics unchanged.

## Checklist

- [x] Format your code according with pre-commit.
- [x] Add unit tests.
- [x] Update documentation / docstrings / example tutorials as needed.
- [x] Provide throughput / latency benchmark results and accuracy evaluation results as needed.
- [ ] For reviewers: If you haven't made any contributions to this PR and are only assisting with merging the main branch, please remove yourself as a co-author when merging the PR.

## CI

CI runs on self-hosted GPU runners and requires a maintainer to add the
`run-ci` label. Once labeled, every subsequent push re-triggers CI as
long as the label remains. Use `/tag-and-rerun-ci higgs` or
`/tag-and-rerun-ci moss` or `/tag-and-rerun-ci qwen3-tts` to select a TTS CI
model, and
`/tag-and-rerun-ci fun-asr`, `/tag-and-rerun-ci qwen3-asr` or
`/tag-and-rerun-ci whisper-asr` to select an ASR CI model. One selector from
each family can be combined, for example `/tag-and-rerun-ci moss fun-asr`.
Draft PRs are skipped even if labeled.
