### PR TITLE
[Qwen3-TTS] Capture the code predictor CUDA graphs at startup

### DIFF
--- a/sglang_omni/models/qwen3_tts/engine_builder.py
+++ b/sglang_omni/models/qwen3_tts/engine_builder.py
@@ -131,12 +131,11 @@ class Qwen3TtsEngineBuilder(TtsEngineBuilder):
         subtalker = request_builders.resolve_subtalker_sampling(
             self.wrapper._merge_generate_kwargs()
         )
-        signature = model.uniform_predictor_graph_signature(
+        model.capture_predictor_graphs(
             do_sample=subtalker.do_sample,
             top_k=subtalker.top_k,
             top_p=subtalker.top_p,
         )
-        model.capture_predictor_graphs(signature)
 
     def make_model_runner(self, model_worker: Any, output_proc: Any) -> Any:
         model_runner_mod = importlib.import_module(

--- a/sglang_omni/models/qwen3_tts/engine_builder.py
+++ b/sglang_omni/models/qwen3_tts/engine_builder.py
@@ -116,6 +116,28 @@ class Qwen3TtsEngineBuilder(TtsEngineBuilder):
         if _is_truthy(overrides.get("enable_torch_compile", False)):
             raise ValueError("Qwen3-TTS torch.compile is not supported")
 
+    def setup_model_resources(
+        self,
+        model: Any,
+        server_args: Any,
+        *,
+        generation_cuda_graph_enabled: bool,
+    ) -> None:
+        del server_args
+        if not generation_cuda_graph_enabled:
+            return
+        # note(ratish): the bucket warmups also build cuDNN's attention plans,
+        # which otherwise land inside the first serving step of each batch size.
+        subtalker = request_builders.resolve_subtalker_sampling(
+            self.wrapper._merge_generate_kwargs()
+        )
+        signature = model.uniform_predictor_graph_signature(
+            do_sample=subtalker.do_sample,
+            top_k=subtalker.top_k,
+            top_p=subtalker.top_p,
+        )
+        model.capture_predictor_graphs(signature)
+
     def make_model_runner(self, model_worker: Any, output_proc: Any) -> Any:
         model_runner_mod = importlib.import_module(
             "sglang_omni.models.qwen3_tts.model_runner"

--- a/sglang_omni/models/qwen3_tts/request_builders.py
+++ b/sglang_omni/models/qwen3_tts/request_builders.py
@@ -101,6 +101,25 @@ def derive_qwen3_tts_sampling_seeds(seed: int) -> tuple[int, int]:
     )
 
 
+@dataclass(frozen=True)
+class SubtalkerSampling:
+    do_sample: bool
+    temperature: float
+    top_p: float
+    top_k: int
+
+
+def resolve_subtalker_sampling(gen_kwargs: dict[str, Any]) -> SubtalkerSampling:
+    """Subtalker sampling from merged generate kwargs, with the fallbacks used
+    when the checkpoint ships no generation config."""
+    return SubtalkerSampling(
+        do_sample=bool(gen_kwargs.get("subtalker_dosample", True)),
+        temperature=float(gen_kwargs.get("subtalker_temperature", 0.9)),
+        top_p=float(gen_kwargs.get("subtalker_top_p", 1.0)),
+        top_k=int(gen_kwargs.get("subtalker_top_k", 50)),
+    )
+
+
 @dataclass
 class Qwen3TTSSGLangRequestData(SGLangARRequestData):
     """Qwen3-TTS scheduler-owned request state."""
@@ -1339,6 +1358,7 @@ def build_sglang_qwen3_tts_request(
     ref_code_len = (
         int(prepared.ref_code.shape[0]) if prepared.ref_code is not None else 0
     )
+    subtalker = resolve_subtalker_sampling(gen_kwargs)
     data = Qwen3TTSSGLangRequestData(
         input_ids=prepared.input_ids,
         attention_mask=prepared.attention_mask,
@@ -1353,10 +1373,10 @@ def build_sglang_qwen3_tts_request(
         prompt_input_embeds=prepared.prompt_input_embeds,
         prefill_input_embeds=prepared.prompt_input_embeds,
         semantic_sampling_seed=semantic_sampling_seed,
-        subtalker_dosample=bool(gen_kwargs.get("subtalker_dosample", True)),
-        subtalker_temperature=float(gen_kwargs.get("subtalker_temperature", 0.9)),
-        subtalker_top_p=float(gen_kwargs.get("subtalker_top_p", 1.0)),
-        subtalker_top_k=int(gen_kwargs.get("subtalker_top_k", 50)),
+        subtalker_dosample=subtalker.do_sample,
+        subtalker_temperature=subtalker.temperature,
+        subtalker_top_p=subtalker.top_p,
+        subtalker_top_k=subtalker.top_k,
         subtalker_sampling_seed=subtalker_sampling_seed,
         stream_codec_output=state.stream_codec_output,
         engine_start_s=time.perf_counter(),

--- a/sglang_omni/models/qwen3_tts/sglang_model.py
+++ b/sglang_omni/models/qwen3_tts/sglang_model.py
@@ -6,6 +6,7 @@ from __future__ import annotations
 import gc
 import logging
 import os
+import time
 from contextlib import contextmanager
 from typing import Any, Iterable, Optional, Tuple
 
@@ -959,8 +960,8 @@ class Qwen3TTSTalker(Qwen3TTSPromptBuilderMixin, nn.Module):
         )
         self._predictor_graphs: dict[tuple, _PredictorDecodeGraph] = {}
         self._predictor_graph_disabled: set[tuple] = set()
-        # Note: (Jiaxin Deng) None = resolved at decode time; the bootstrap
-        # defers graph capture past init, so nothing is decided here.
+        # note(ratish): None until the startup capture or the first decode
+        # resolves it, after the bootstrap has built sglang's graphs.
         self._predictor_graph_enabled: bool | None = None
         self._predictor_graph_failure_count = 0
         self._predictor_graph_capacity_fallback_count = 0
@@ -1241,6 +1242,51 @@ class Qwen3TTSTalker(Qwen3TTSPromptBuilderMixin, nn.Module):
         # Note: (Jiaxin Deng) capture under TP would record collectives; the
         # graphed chain is only validated single-rank, so TP stays eager.
         return int(server_args.tp_size) == 1
+
+    def uniform_predictor_graph_signature(
+        self,
+        *,
+        do_sample: bool,
+        top_k: int,
+        top_p: float,
+    ) -> tuple:
+        """Graph signature of a batch whose rows all sample with these values."""
+        if not do_sample:
+            return ("argmax", 0, False, False)
+        max_top_k, has_top_p, has_unbounded_top_k = _predictor_signature_terms(
+            [int(top_k)],
+            [float(top_p)],
+            int(self.config.code_predictor_config.vocab_size),
+        )
+        return ("sampled", max_top_k, has_top_p, has_unbounded_top_k)
+
+    def capture_predictor_graphs(self, signature: tuple) -> int:
+        """Buckets go in descending order so the smaller ones reuse the pool of
+        the larger ones."""
+        if self._predictor_graph_enabled is None:
+            self._predictor_graph_enabled = self._resolve_predictor_graph_enabled()
+        if not self._predictor_graph_enabled:
+            return 0
+        started = time.perf_counter()
+        captured_before = len(self._predictor_graphs)
+        with self._predictor_capture_session():
+            for bucket_size in reversed(self._predictor_graph_batch_sizes):
+                key = (bucket_size, *signature)
+                if key in self._predictor_graphs:
+                    continue
+                if len(self._predictor_graphs) >= _PREDICTOR_GRAPH_MAX_KEYS:
+                    break
+                self._predictor_graphs[key] = self._capture_predictor_graph(
+                    bucket_size, signature
+                )
+                self._predictor_graph_capture_count += 1
+        captured = len(self._predictor_graphs) - captured_before
+        elapsed_s = time.perf_counter() - started
+        logger.info(
+            f"Captured {captured} Qwen3-TTS predictor CUDA graphs for "
+            f"signature={signature} in {elapsed_s:.1f} s"
+        )
+        return captured
 
     @contextmanager
     def _predictor_capture_session(self):

--- a/sglang_omni/models/qwen3_tts/sglang_model.py
+++ b/sglang_omni/models/qwen3_tts/sglang_model.py
@@ -1243,30 +1243,29 @@ class Qwen3TTSTalker(Qwen3TTSPromptBuilderMixin, nn.Module):
         # graphed chain is only validated single-rank, so TP stays eager.
         return int(server_args.tp_size) == 1
 
-    def uniform_predictor_graph_signature(
+    def capture_predictor_graphs(
         self,
         *,
         do_sample: bool,
         top_k: int,
         top_p: float,
-    ) -> tuple:
-        """Graph signature of a batch whose rows all sample with these values."""
-        if not do_sample:
-            return ("argmax", 0, False, False)
-        max_top_k, has_top_p, has_unbounded_top_k = _predictor_signature_terms(
-            [int(top_k)],
-            [float(top_p)],
-            int(self.config.code_predictor_config.vocab_size),
-        )
-        return ("sampled", max_top_k, has_top_p, has_unbounded_top_k)
-
-    def capture_predictor_graphs(self, signature: tuple) -> int:
-        """Buckets go in descending order so the smaller ones reuse the pool of
-        the larger ones."""
+    ) -> int:
+        """Capture the bucket ladder of the signature a batch gets when every row
+        samples with these values. Buckets go in descending order so the smaller
+        ones reuse the pool of the larger ones."""
         if self._predictor_graph_enabled is None:
             self._predictor_graph_enabled = self._resolve_predictor_graph_enabled()
         if not self._predictor_graph_enabled:
             return 0
+        if do_sample:
+            max_top_k, has_top_p, has_unbounded_top_k = _predictor_signature_terms(
+                [int(top_k)],
+                [float(top_p)],
+                int(self.config.code_predictor_config.vocab_size),
+            )
+            signature = ("sampled", max_top_k, has_top_p, has_unbounded_top_k)
+        else:
+            signature = ("argmax", 0, False, False)
         started = time.perf_counter()
         captured_before = len(self._predictor_graphs)
         for bucket_size in reversed(self._predictor_graph_batch_sizes):

--- a/sglang_omni/models/qwen3_tts/sglang_model.py
+++ b/sglang_omni/models/qwen3_tts/sglang_model.py
@@ -1269,17 +1269,16 @@ class Qwen3TTSTalker(Qwen3TTSPromptBuilderMixin, nn.Module):
             return 0
         started = time.perf_counter()
         captured_before = len(self._predictor_graphs)
-        with self._predictor_capture_session():
-            for bucket_size in reversed(self._predictor_graph_batch_sizes):
-                key = (bucket_size, *signature)
-                if key in self._predictor_graphs:
-                    continue
-                if len(self._predictor_graphs) >= _PREDICTOR_GRAPH_MAX_KEYS:
-                    break
-                self._predictor_graphs[key] = self._capture_predictor_graph(
-                    bucket_size, signature
-                )
-                self._predictor_graph_capture_count += 1
+        for bucket_size in reversed(self._predictor_graph_batch_sizes):
+            key = (bucket_size, *signature)
+            if key in self._predictor_graphs:
+                continue
+            if len(self._predictor_graphs) >= _PREDICTOR_GRAPH_MAX_KEYS:
+                break
+            self._predictor_graphs[key] = self._capture_predictor_graph(
+                bucket_size, signature
+            )
+            self._predictor_graph_capture_count += 1
         captured = len(self._predictor_graphs) - captured_before
         elapsed_s = time.perf_counter() - started
         logger.info(
@@ -1288,11 +1287,15 @@ class Qwen3TTSTalker(Qwen3TTSPromptBuilderMixin, nn.Module):
         )
         return captured
 
-    @contextmanager
-    def _predictor_capture_session(self):
+    @torch.no_grad()
+    def _capture_predictor_graph(
+        self,
+        bucket_size: int,
+        signature: tuple,
+    ) -> _PredictorDecodeGraph:
         """One stream per talker for warmups and captures: the allocator only
         reuses a pool block on the stream that freed it. Automatic collection
-        is off for the window because a CUDAGraph finalizer reached by the
+        is off for the capture because a CUDAGraph finalizer reached by the
         cyclic collector while a stream is capturing destroys its pool inside
         the capture."""
         device = self._predictor_k_cache.device
@@ -1300,26 +1303,6 @@ class Qwen3TTSTalker(Qwen3TTSPromptBuilderMixin, nn.Module):
             self._predictor_capture_stream = torch.cuda.Stream(device=device)
         capture_stream = self._predictor_capture_stream
         current_stream = torch.cuda.current_stream(device=device)
-        capture_stream.wait_stream(current_stream)
-        gc_was_enabled = gc.isenabled()
-        gc.disable()
-        try:
-            with torch.cuda.device(device):
-                yield
-        finally:
-            current_stream.wait_stream(capture_stream)
-            if gc_was_enabled:
-                gc.enable()
-
-    @torch.no_grad()
-    def _capture_predictor_graph(
-        self,
-        bucket_size: int,
-        signature: tuple,
-    ) -> _PredictorDecodeGraph:
-        capture_stream = self._predictor_capture_stream
-        assert capture_stream is not None, "capture outside a capture session"
-        device = self._predictor_k_cache.device
         graph = _PredictorDecodeGraph(
             bucket_size,
             signature,
@@ -1329,7 +1312,7 @@ class Qwen3TTSTalker(Qwen3TTSPromptBuilderMixin, nn.Module):
         )
         # note(ratish): the buffers are zero filled on the current stream and
         # layer0_codes is an embedding index, so the capture stream waits here.
-        capture_stream.wait_stream(torch.cuda.current_stream(device=device))
+        capture_stream.wait_stream(current_stream)
 
         def run_once() -> Tuple[torch.Tensor, torch.Tensor]:
             return self._code_predictor_forward_incremental(
@@ -1338,11 +1321,14 @@ class Qwen3TTSTalker(Qwen3TTSPromptBuilderMixin, nn.Module):
                 semantic_positions=graph.semantic_positions,
             )
 
+        gc_was_enabled = gc.isenabled()
+        gc.disable()
         try:
             # note(ratish): the outer stream context restores the current stream
             # when a failed capture raises from capture_end before torch.cuda.graph
             # restores it.
             with (
+                torch.cuda.device(device),
                 self._predictor_graph_capture_state(bucket_size, signature),
                 torch.cuda.stream(capture_stream),
             ):
@@ -1363,6 +1349,10 @@ class Qwen3TTSTalker(Qwen3TTSPromptBuilderMixin, nn.Module):
             except Exception:
                 pass
             raise
+        finally:
+            current_stream.wait_stream(capture_stream)
+            if gc_was_enabled:
+                gc.enable()
         if graph.result_codes is None or graph.summed_embeddings is None:
             raise RuntimeError("Qwen3-TTS predictor CUDA graph captured no outputs")
         return graph
@@ -1411,8 +1401,7 @@ class Qwen3TTSTalker(Qwen3TTSPromptBuilderMixin, nn.Module):
                     )
                 return None
             try:
-                with self._predictor_capture_session():
-                    graph = self._capture_predictor_graph(bucket_size, signature)
+                graph = self._capture_predictor_graph(bucket_size, signature)
             except Exception:
                 self._predictor_graph_disabled.add(key)
                 self._predictor_graph_failure_count += 1

--- a/sglang_omni/models/qwen3_tts/sglang_model.py
+++ b/sglang_omni/models/qwen3_tts/sglang_model.py
@@ -9,8 +9,12 @@ from contextlib import contextmanager
 from typing import Any, Iterable, Optional, Tuple
 
 import torch
+from sglang.srt.batch_invariant_ops import is_batch_invariant_mode_enabled
 from sglang.srt.layers.logits_processor import LogitsProcessorOutput
-from sglang.srt.layers.quantization.unquant import UnquantizedLinearMethod
+from sglang.srt.layers.quantization.unquant import (
+    UnquantizedLinearMethod,
+    get_bf16_gemm_backend,
+)
 from sglang.srt.layers.sampler import multinomial_with_seed
 from sglang.srt.model_executor.runner_backend_utils.breakable_cuda_graph import (
     eager_on_graph,
@@ -1658,10 +1662,14 @@ class Qwen3TTSTalker(Qwen3TTSPromptBuilderMixin, nn.Module):
         """Run the Predictor attention output projection and residual add."""
 
         weight = getattr(o_proj, "weight", None)
+        # note(ratish): the fusion stands in for sglang's linear only where that
+        # linear is torch's GEMM: batch invariant mode overrides aten::addmm but
+        # not the out variant, and the cutedsl backend replaces F.linear on sm100.
         use_fused_addmm = (
             attn_input.is_cuda
+            and not is_batch_invariant_mode_enabled()
+            and not get_bf16_gemm_backend().is_cutedsl()
             and not torch.is_grad_enabled()
-            and torch.cuda.get_device_capability(attn_input.device) == (9, 0)
             and isinstance(
                 getattr(o_proj, "quant_method", None), UnquantizedLinearMethod
             )

--- a/sglang_omni/models/qwen3_tts/sglang_model.py
+++ b/sglang_omni/models/qwen3_tts/sglang_model.py
@@ -1367,22 +1367,6 @@ class Qwen3TTSTalker(Qwen3TTSPromptBuilderMixin, nn.Module):
             raise RuntimeError("Qwen3-TTS predictor CUDA graph captured no outputs")
         return graph
 
-    def _record_predictor_graph_failure(self, key: tuple) -> None:
-        self._predictor_graph_disabled.add(key)
-        self._predictor_graph_failure_count += 1
-        logger.warning(
-            "Disabling Qwen3-TTS predictor CUDA graph for key=%s",
-            key,
-            exc_info=True,
-        )
-        if self._predictor_graph_failure_count >= _PREDICTOR_GRAPH_MAX_FAILURES:
-            self._predictor_graph_enabled = False
-            logger.warning(
-                "Disabling Qwen3-TTS predictor CUDA graphs entirely "
-                "after %d capture failures",
-                self._predictor_graph_failure_count,
-            )
-
     def _predictor_forward_graphed(
         self,
         layer0_codes: torch.Tensor,
@@ -1430,7 +1414,20 @@ class Qwen3TTSTalker(Qwen3TTSPromptBuilderMixin, nn.Module):
                 with self._predictor_capture_session():
                     graph = self._capture_predictor_graph(bucket_size, signature)
             except Exception:
-                self._record_predictor_graph_failure(key)
+                self._predictor_graph_disabled.add(key)
+                self._predictor_graph_failure_count += 1
+                logger.warning(
+                    "Disabling Qwen3-TTS predictor CUDA graph for key=%s",
+                    key,
+                    exc_info=True,
+                )
+                if self._predictor_graph_failure_count >= _PREDICTOR_GRAPH_MAX_FAILURES:
+                    self._predictor_graph_enabled = False
+                    logger.warning(
+                        "Disabling Qwen3-TTS predictor CUDA graphs entirely "
+                        "after %d capture failures",
+                        self._predictor_graph_failure_count,
+                    )
                 return None
             self._predictor_graphs[key] = graph
             self._predictor_graph_capture_count += 1

--- a/sglang_omni/models/qwen3_tts/sglang_model.py
+++ b/sglang_omni/models/qwen3_tts/sglang_model.py
@@ -1289,6 +1289,22 @@ class Qwen3TTSTalker(Qwen3TTSPromptBuilderMixin, nn.Module):
         # graphed chain is only validated single-rank, so TP stays eager.
         return int(server_args.tp_size) == 1
 
+    def _record_predictor_graph_failure(self, key: tuple) -> None:
+        self._predictor_graph_disabled.add(key)
+        self._predictor_graph_failure_count += 1
+        logger.warning(
+            "Disabling Qwen3-TTS predictor CUDA graph for key=%s",
+            key,
+            exc_info=True,
+        )
+        if self._predictor_graph_failure_count >= _PREDICTOR_GRAPH_MAX_FAILURES:
+            self._predictor_graph_enabled = False
+            logger.warning(
+                "Disabling Qwen3-TTS predictor CUDA graphs entirely "
+                "after %d capture failures",
+                self._predictor_graph_failure_count,
+            )
+
     def _predictor_forward_graphed(
         self,
         layer0_codes: torch.Tensor,
@@ -1341,20 +1357,7 @@ class Qwen3TTSTalker(Qwen3TTSPromptBuilderMixin, nn.Module):
                     hidden_dtype=talker_hidden.dtype,
                 )
             except Exception:
-                self._predictor_graph_disabled.add(key)
-                self._predictor_graph_failure_count += 1
-                logger.warning(
-                    "Disabling Qwen3-TTS predictor CUDA graph for key=%s",
-                    key,
-                    exc_info=True,
-                )
-                if self._predictor_graph_failure_count >= _PREDICTOR_GRAPH_MAX_FAILURES:
-                    self._predictor_graph_enabled = False
-                    logger.warning(
-                        "Disabling Qwen3-TTS predictor CUDA graphs entirely "
-                        "after %d capture failures",
-                        self._predictor_graph_failure_count,
-                    )
+                self._record_predictor_graph_failure(key)
                 return None
             self._predictor_graphs[key] = graph
             self._predictor_graph_capture_count += 1

--- a/sglang_omni/models/qwen3_tts/sglang_model.py
+++ b/sglang_omni/models/qwen3_tts/sglang_model.py
@@ -69,6 +69,30 @@ def _quantize_predictor_top_k(max_top_k: int, vocab_size: int) -> int | None:
     return None
 
 
+def _predictor_signature_terms(
+    sampled_top_ks: list[int],
+    sampled_top_ps: list[float],
+    vocab_size: int,
+) -> tuple[int, bool, bool]:
+    """The one signature rule, shared by the batch path and the startup capture."""
+    bounded_top_ks = [
+        int(top_k) for top_k in sampled_top_ks if 0 < int(top_k) < vocab_size
+    ]
+    has_top_p = any(0.0 < float(top_p) < 1.0 for top_p in sampled_top_ps)
+    has_unbounded_top_k = len(bounded_top_ks) != len(sampled_top_ks)
+    max_top_k = 0
+    max_bounded_top_k = max(bounded_top_ks, default=0)
+    if max_bounded_top_k > 0 and not has_unbounded_top_k:
+        # Note: (Jiaxin Deng) ladder-quantized so predictor-graph keys are
+        # shared across request top_k values; per-row masks keep true k.
+        quantized = _quantize_predictor_top_k(max_bounded_top_k, vocab_size)
+        if quantized is None:
+            has_unbounded_top_k = True
+        else:
+            max_top_k = quantized
+    return max_top_k, has_top_p, has_unbounded_top_k
+
+
 def _sample_seeded_categorical(
     logprobs: torch.Tensor,
     seeds: torch.Tensor,
@@ -1063,30 +1087,16 @@ class Qwen3TTSTalker(Qwen3TTSPromptBuilderMixin, nn.Module):
                 sample_rows.append(row_idx)
 
         predictor_vocab_size = int(self.config.code_predictor_config.vocab_size)
-        sampled_top_ks = [sub_top_ks[row_idx] for row_idx in sample_rows]
-        bounded_top_ks = [
-            top_k for top_k in sampled_top_ks if 0 < int(top_k) < predictor_vocab_size
-        ]
+        max_top_k, has_top_p, has_unbounded_top_k = _predictor_signature_terms(
+            [sub_top_ks[row_idx] for row_idx in sample_rows],
+            [sub_top_ps[row_idx] for row_idx in sample_rows],
+            predictor_vocab_size,
+        )
         self._sub_batch_size = batch_size
         self._sub_sample_count = len(sample_rows)
         self._sub_sample_max_row_index = sample_rows[-1] if sample_rows else -1
         self._sub_has_sampled_rows = bool(sample_rows)
-        self._sub_sampled_has_top_p = any(
-            0.0 < float(sub_top_ps[row_idx]) < 1.0 for row_idx in sample_rows
-        )
-        has_unbounded_top_k = len(bounded_top_ks) != len(sampled_top_ks)
-        max_top_k = 0
-        max_bounded_top_k = max(bounded_top_ks, default=0)
-        if max_bounded_top_k > 0 and not has_unbounded_top_k:
-            # Note: (Jiaxin Deng) ladder-quantized so predictor-graph keys are
-            # shared across request top_k values; per-row masks keep true k.
-            quantized = _quantize_predictor_top_k(
-                max_bounded_top_k, predictor_vocab_size
-            )
-            if quantized is None:
-                has_unbounded_top_k = True
-            else:
-                max_top_k = quantized
+        self._sub_sampled_has_top_p = has_top_p
         self._sub_sampled_max_top_k = max_top_k
         self._sub_sampled_has_unbounded_top_k = has_unbounded_top_k
 

--- a/sglang_omni/models/qwen3_tts/sglang_model.py
+++ b/sglang_omni/models/qwen3_tts/sglang_model.py
@@ -109,25 +109,25 @@ class _PredictorDecodeGraph:
     """CUDA graph over the full per-token predictor chain for one batch bucket.
 
     One graph per (bucket, sampling signature): the signature pins the host
-    branches of the eager sampling path (argmax vs sampled, top-k bound,
-    top-p presence), so replay reproduces the eager sampling bits.
+    branches of the sampling path (argmax vs sampled, top-k bound, top-p
+    presence), so replay reproduces the bits of the eager pass.
     Per-step inputs reach the captured region through persistent device
-    buffers written with device-side copies before replay.
+    buffers written with device-side copies before replay. Holds no reference
+    to the talker: a cycle would put the CUDAGraph finalizer behind the
+    cyclic collector.
     """
 
     def __init__(
         self,
-        model: "Qwen3TTSTalker",
         batch_size: int,
         signature: tuple,
         *,
+        device: torch.device,
         hidden_size: int,
         hidden_dtype: torch.dtype,
     ) -> None:
-        self.model = model
         self.batch_size = batch_size
         self.signature = signature
-        device = model._predictor_k_cache.device
         self.layer0_codes = torch.zeros(batch_size, 1, dtype=torch.long, device=device)
         self.talker_hidden = torch.zeros(
             batch_size, 1, hidden_size, dtype=hidden_dtype, device=device
@@ -138,56 +138,6 @@ class _PredictorDecodeGraph:
         self.graph = torch.cuda.CUDAGraph()
         self.result_codes: torch.Tensor | None = None
         self.summed_embeddings: torch.Tensor | None = None
-        try:
-            self._capture()
-        except Exception:
-            # Note: (Jiaxin Deng) release the graph's private memory pool
-            # eagerly; the raising object may linger on traceback frames.
-            try:
-                self.graph.reset()
-            except Exception:
-                pass
-            raise
-
-    @torch.no_grad()
-    def _capture(self) -> None:
-        model = self.model
-        device = self.layer0_codes.device
-        with (
-            torch.cuda.device(device),
-            model._predictor_graph_capture_state(self.batch_size, self.signature),
-        ):
-            current_stream = torch.cuda.current_stream(device=device)
-            warmup_stream = torch.cuda.Stream(device=device)
-            warmup_stream.wait_stream(current_stream)
-            with torch.cuda.stream(warmup_stream):
-                for _ in range(2):
-                    model._code_predictor_forward_incremental(
-                        self.layer0_codes,
-                        self.talker_hidden,
-                        semantic_positions=self.semantic_positions,
-                    )
-            current_stream.wait_stream(warmup_stream)
-
-            capture_stream = torch.cuda.Stream(device=device)
-            capture_stream.wait_stream(current_stream)
-            with torch.cuda.graph(
-                self.graph,
-                pool=model._predictor_graph_memory_pool(),
-                stream=capture_stream,
-                capture_error_mode="thread_local",
-            ):
-                self.result_codes, self.summed_embeddings = (
-                    model._code_predictor_forward_incremental(
-                        self.layer0_codes,
-                        self.talker_hidden,
-                        semantic_positions=self.semantic_positions,
-                    )
-                )
-            current_stream.wait_stream(capture_stream)
-
-        if self.result_codes is None or self.summed_embeddings is None:
-            raise RuntimeError("Qwen3-TTS predictor CUDA graph captured no outputs")
 
     @torch.no_grad()
     def replay(
@@ -1289,6 +1239,63 @@ class Qwen3TTSTalker(Qwen3TTSPromptBuilderMixin, nn.Module):
         # graphed chain is only validated single-rank, so TP stays eager.
         return int(server_args.tp_size) == 1
 
+    @torch.no_grad()
+    def _capture_predictor_graph(
+        self,
+        bucket_size: int,
+        signature: tuple,
+    ) -> _PredictorDecodeGraph:
+        device = self._predictor_k_cache.device
+        graph = _PredictorDecodeGraph(
+            bucket_size,
+            signature,
+            device=device,
+            hidden_size=int(self._output_embeds.shape[-1]),
+            hidden_dtype=self._output_embeds.dtype,
+        )
+
+        def run_once() -> Tuple[torch.Tensor, torch.Tensor]:
+            return self._code_predictor_forward_incremental(
+                graph.layer0_codes,
+                graph.talker_hidden,
+                semantic_positions=graph.semantic_positions,
+            )
+
+        try:
+            with (
+                torch.cuda.device(device),
+                self._predictor_graph_capture_state(bucket_size, signature),
+            ):
+                current_stream = torch.cuda.current_stream(device=device)
+                warmup_stream = torch.cuda.Stream(device=device)
+                warmup_stream.wait_stream(current_stream)
+                with torch.cuda.stream(warmup_stream):
+                    for _ in range(2):
+                        run_once()
+                current_stream.wait_stream(warmup_stream)
+
+                capture_stream = torch.cuda.Stream(device=device)
+                capture_stream.wait_stream(current_stream)
+                with torch.cuda.graph(
+                    graph.graph,
+                    pool=self._predictor_graph_memory_pool(),
+                    stream=capture_stream,
+                    capture_error_mode="thread_local",
+                ):
+                    graph.result_codes, graph.summed_embeddings = run_once()
+                current_stream.wait_stream(capture_stream)
+        except Exception:
+            # Note: (Jiaxin Deng) release the graph's private memory pool
+            # eagerly; the raising object may linger on traceback frames.
+            try:
+                graph.graph.reset()
+            except Exception:
+                pass
+            raise
+        if graph.result_codes is None or graph.summed_embeddings is None:
+            raise RuntimeError("Qwen3-TTS predictor CUDA graph captured no outputs")
+        return graph
+
     def _record_predictor_graph_failure(self, key: tuple) -> None:
         self._predictor_graph_disabled.add(key)
         self._predictor_graph_failure_count += 1
@@ -1349,13 +1356,7 @@ class Qwen3TTSTalker(Qwen3TTSPromptBuilderMixin, nn.Module):
                     )
                 return None
             try:
-                graph = _PredictorDecodeGraph(
-                    self,
-                    bucket_size,
-                    signature,
-                    hidden_size=int(talker_hidden.shape[-1]),
-                    hidden_dtype=talker_hidden.dtype,
-                )
+                graph = self._capture_predictor_graph(bucket_size, signature)
             except Exception:
                 self._record_predictor_graph_failure(key)
                 return None

--- a/sglang_omni/models/qwen3_tts/sglang_model.py
+++ b/sglang_omni/models/qwen3_tts/sglang_model.py
@@ -162,7 +162,6 @@ class _PredictorDecodeGraph:
                         self.layer0_codes,
                         self.talker_hidden,
                         semantic_positions=self.semantic_positions,
-                        for_capture=True,
                     )
             current_stream.wait_stream(warmup_stream)
 
@@ -179,7 +178,6 @@ class _PredictorDecodeGraph:
                         self.layer0_codes,
                         self.talker_hidden,
                         semantic_positions=self.semantic_positions,
-                        for_capture=True,
                     )
                 )
             current_stream.wait_stream(capture_stream)
@@ -973,7 +971,6 @@ class Qwen3TTSTalker(Qwen3TTSPromptBuilderMixin, nn.Module):
             max_batch_size, hidden_size, device=device, dtype=dtype
         )
         self._sub_batch_size = 0
-        self._sub_sample_max_row_index = -1
         self._sub_temperature_tensor = torch.full(
             (max_batch_size,), 0.9, device=device, dtype=torch.float32
         )
@@ -995,10 +992,6 @@ class Qwen3TTSTalker(Qwen3TTSPromptBuilderMixin, nn.Module):
         self._sub_identity_row_indices_tensor = torch.arange(
             max_batch_size, device=device, dtype=torch.long
         )
-        self._sub_sample_row_indices_tensor = torch.zeros(
-            max_batch_size, device=device, dtype=torch.long
-        )
-        self._sub_sample_count = 0
         self._sub_has_sampled_rows = False
         self._sub_sampled_has_top_p = False
         self._sub_sampled_max_top_k = 0
@@ -1093,8 +1086,6 @@ class Qwen3TTSTalker(Qwen3TTSPromptBuilderMixin, nn.Module):
             predictor_vocab_size,
         )
         self._sub_batch_size = batch_size
-        self._sub_sample_count = len(sample_rows)
-        self._sub_sample_max_row_index = sample_rows[-1] if sample_rows else -1
         self._sub_has_sampled_rows = bool(sample_rows)
         self._sub_sampled_has_top_p = has_top_p
         self._sub_sampled_max_top_k = max_top_k
@@ -1125,10 +1116,6 @@ class Qwen3TTSTalker(Qwen3TTSPromptBuilderMixin, nn.Module):
         self._sub_do_sample_tensor[:batch_size] = torch.tensor(
             sub_do_samples, device=device, dtype=torch.bool
         )
-        if sample_rows:
-            self._sub_sample_row_indices_tensor[: len(sample_rows)] = torch.tensor(
-                sample_rows, device=device, dtype=torch.long
-            )
         self._decode_prep_rids = rids
 
     @torch.no_grad()
@@ -1258,7 +1245,6 @@ class Qwen3TTSTalker(Qwen3TTSPromptBuilderMixin, nn.Module):
     def _predictor_graph_capture_state(self, bucket_size: int, signature: tuple):
         saved = (
             self._sub_batch_size,
-            self._sub_sample_count,
             self._sub_has_sampled_rows,
             self._sub_sampled_has_top_p,
             self._sub_sampled_max_top_k,
@@ -1268,7 +1254,6 @@ class Qwen3TTSTalker(Qwen3TTSPromptBuilderMixin, nn.Module):
         try:
             self._sub_batch_size = bucket_size
             self._sub_has_sampled_rows = sampled
-            self._sub_sample_count = bucket_size if sampled else 0
             _, max_top_k, has_top_p, has_unbounded_top_k = signature
             self._sub_sampled_max_top_k = max_top_k
             self._sub_sampled_has_top_p = has_top_p
@@ -1277,7 +1262,6 @@ class Qwen3TTSTalker(Qwen3TTSPromptBuilderMixin, nn.Module):
         finally:
             (
                 self._sub_batch_size,
-                self._sub_sample_count,
                 self._sub_has_sampled_rows,
                 self._sub_sampled_has_top_p,
                 self._sub_sampled_max_top_k,
@@ -1379,8 +1363,6 @@ class Qwen3TTSTalker(Qwen3TTSPromptBuilderMixin, nn.Module):
         layer0_codes: torch.Tensor,
         talker_hidden: torch.Tensor,
         semantic_positions: torch.Tensor | None = None,
-        *,
-        for_capture: bool = False,
     ) -> Tuple[torch.Tensor, torch.Tensor]:
         if layer0_codes.ndim == 1:
             layer0_codes = layer0_codes.unsqueeze(1)
@@ -1403,13 +1385,7 @@ class Qwen3TTSTalker(Qwen3TTSPromptBuilderMixin, nn.Module):
         embedding_buffer = getattr(self, "_predictor_embedding_buffer", None)
         if embedding_buffer is not None:
             embedding_buffer = embedding_buffer[:batch_size]
-        # Note (Jun Liu): Capture P2 into a graph; a standalone Triton launch
-        # loses to ATen.
-        use_fused_embedding = (
-            embedding_buffer is not None
-            and layer0_codes.is_cuda
-            and torch.cuda.is_current_stream_capturing()
-        )
+        use_fused_embedding = embedding_buffer is not None and layer0_codes.is_cuda
 
         for pos in range(seq_len):
             layer0_code = layer0_codes[:, pos : pos + 1]
@@ -1420,9 +1396,14 @@ class Qwen3TTSTalker(Qwen3TTSPromptBuilderMixin, nn.Module):
             pos_codes = result_codes[:, :, pos]
             pos_summed = summed_embeddings[:, pos, :]
             pos_summed.zero_()
-            talker_predictor_embed = self.code_predictor.project_input(
-                talker_hidden[:, pos : pos + 1, :]
-            ).to(dtype=predictor_dtype)
+            talker_slice = talker_hidden[:, pos : pos + 1, :]
+            talker_predictor_embed = self.code_predictor.project_input(talker_slice).to(
+                dtype=predictor_dtype
+            )
+            if talker_predictor_embed is talker_slice:
+                # note(ratish): the fused o_proj epilogue overwrites its residual,
+                # which on the first layer is this tensor.
+                talker_predictor_embed = talker_slice.clone()
             pos_codes[:, 0].copy_(layer0_code[:, 0])
             pos_summed.add_(layer0_embed[:, 0, :])
 
@@ -1446,7 +1427,6 @@ class Qwen3TTSTalker(Qwen3TTSPromptBuilderMixin, nn.Module):
                     logits[:, -1, :],
                     layer_idx,
                     semantic_positions=semantic_positions[:, pos],
-                    for_capture=for_capture,
                 )
                 pos_codes[:, layer_idx + 1].copy_(next_code)
                 codec_embedding = self.code_predictor.model.codec_embedding[layer_idx]
@@ -1499,55 +1479,6 @@ class Qwen3TTSTalker(Qwen3TTSPromptBuilderMixin, nn.Module):
         return base.unsqueeze(1) + offsets.unsqueeze(0)
 
     def _sample_subtalker_token(
-        self,
-        logits: torch.Tensor,
-        layer_idx: int = 0,
-        *,
-        semantic_positions: torch.Tensor | None = None,
-        for_capture: bool = False,
-    ) -> torch.Tensor:
-        if for_capture:
-            return self._sample_subtalker_token_graph_safe(
-                logits, layer_idx, semantic_positions=semantic_positions
-            )
-
-        if logits.shape[0] == 0:
-            return torch.empty((0,), device=logits.device, dtype=torch.long)
-        batch_size = int(logits.shape[0])
-        if batch_size > self._sub_batch_size:
-            raise RuntimeError("Qwen3-TTS subtalker sampling buffers are too small")
-
-        if not self._sub_has_sampled_rows:
-            return torch.argmax(logits, dim=-1).to(dtype=torch.long)
-
-        if self._sub_sample_max_row_index >= batch_size:
-            raise RuntimeError("Qwen3-TTS sampled row index exceeds batch size")
-        sampled_rows = self._sub_sample_row_indices_tensor[: self._sub_sample_count]
-        sampled_positions = self._select_semantic_positions(
-            semantic_positions,
-            batch_size,
-            logits.device,
-        ).index_select(0, sampled_rows)
-
-        if self._sub_sample_count == batch_size:
-            return self._sample_subtalker_token_seeded(
-                logits,
-                layer_idx,
-                row_indices=sampled_rows,
-                semantic_positions=sampled_positions,
-            )
-
-        tokens = torch.argmax(logits, dim=-1).to(dtype=torch.long)
-        sampled_logits = logits.index_select(0, sampled_rows)
-        tokens[sampled_rows] = self._sample_subtalker_token_seeded(
-            sampled_logits,
-            layer_idx,
-            row_indices=sampled_rows,
-            semantic_positions=sampled_positions,
-        )
-        return tokens
-
-    def _sample_subtalker_token_graph_safe(
         self,
         logits: torch.Tensor,
         layer_idx: int = 0,
@@ -1621,10 +1552,7 @@ class Qwen3TTSTalker(Qwen3TTSPromptBuilderMixin, nn.Module):
             + 1
         )
 
-        # Note (Jun Liu): The raw-logit fusion has a favorable launch-count
-        # tradeoff only in the predictor CUDA graph. The eager path keeps the
-        # mature ATen sequence, including all of its shape coverage.
-        if logits.is_cuda and torch.cuda.is_current_stream_capturing():
+        if logits.is_cuda:
             fused_sampled = sample_from_logits_with_seed_top_k_top_p(
                 logits,
                 temperatures,
@@ -1732,7 +1660,6 @@ class Qwen3TTSTalker(Qwen3TTSPromptBuilderMixin, nn.Module):
         weight = getattr(o_proj, "weight", None)
         use_fused_addmm = (
             attn_input.is_cuda
-            and torch.cuda.is_current_stream_capturing()
             and not torch.is_grad_enabled()
             and torch.cuda.get_device_capability(attn_input.device) == (9, 0)
             and isinstance(

--- a/sglang_omni/models/qwen3_tts/sglang_model.py
+++ b/sglang_omni/models/qwen3_tts/sglang_model.py
@@ -3,6 +3,7 @@
 
 from __future__ import annotations
 
+import gc
 import logging
 import os
 from contextlib import contextmanager
@@ -50,6 +51,7 @@ logger = logging.getLogger(__name__)
 QTTS_PREDICTOR_GRAPH_ENV = "SGLANG_OMNI_QTTS_PREDICTOR_GRAPH"
 _PREDICTOR_GRAPH_MAX_KEYS = 32
 _PREDICTOR_GRAPH_MAX_FAILURES = 8
+_PREDICTOR_GRAPH_WARMUP_PASSES = 2
 # Note: (Jiaxin Deng) 50 is on the ladder because it is the family checkpoint
 # default, keeping the dominant signature's kernel width exactly as before.
 _PREDICTOR_TOP_K_LADDER = (4, 8, 16, 32, 50, 64, 128, 256, 512, 1024)
@@ -965,6 +967,7 @@ class Qwen3TTSTalker(Qwen3TTSPromptBuilderMixin, nn.Module):
         self._predictor_graph_capacity_warned = False
         self._predictor_graph_capture_count = 0
         self._predictor_graph_pool = None
+        self._predictor_capture_stream: torch.cuda.Stream | None = None
         _bind_default_weight_loaders(self)
         self._cached_params_dict = dict(self.named_parameters())
         self._sampler = None
@@ -1239,12 +1242,37 @@ class Qwen3TTSTalker(Qwen3TTSPromptBuilderMixin, nn.Module):
         # graphed chain is only validated single-rank, so TP stays eager.
         return int(server_args.tp_size) == 1
 
+    @contextmanager
+    def _predictor_capture_session(self):
+        """One stream per talker for warmups and captures: the allocator only
+        reuses a pool block on the stream that freed it. Automatic collection
+        is off for the window because a CUDAGraph finalizer reached by the
+        cyclic collector while a stream is capturing destroys its pool inside
+        the capture."""
+        device = self._predictor_k_cache.device
+        if self._predictor_capture_stream is None:
+            self._predictor_capture_stream = torch.cuda.Stream(device=device)
+        capture_stream = self._predictor_capture_stream
+        current_stream = torch.cuda.current_stream(device=device)
+        capture_stream.wait_stream(current_stream)
+        gc_was_enabled = gc.isenabled()
+        gc.disable()
+        try:
+            with torch.cuda.device(device):
+                yield
+        finally:
+            current_stream.wait_stream(capture_stream)
+            if gc_was_enabled:
+                gc.enable()
+
     @torch.no_grad()
     def _capture_predictor_graph(
         self,
         bucket_size: int,
         signature: tuple,
     ) -> _PredictorDecodeGraph:
+        capture_stream = self._predictor_capture_stream
+        assert capture_stream is not None, "capture outside a capture session"
         device = self._predictor_k_cache.device
         graph = _PredictorDecodeGraph(
             bucket_size,
@@ -1253,6 +1281,9 @@ class Qwen3TTSTalker(Qwen3TTSPromptBuilderMixin, nn.Module):
             hidden_size=int(self._output_embeds.shape[-1]),
             hidden_dtype=self._output_embeds.dtype,
         )
+        # note(ratish): the buffers are zero filled on the current stream and
+        # layer0_codes is an embedding index, so the capture stream waits here.
+        capture_stream.wait_stream(torch.cuda.current_stream(device=device))
 
         def run_once() -> Tuple[torch.Tensor, torch.Tensor]:
             return self._code_predictor_forward_incremental(
@@ -1262,20 +1293,15 @@ class Qwen3TTSTalker(Qwen3TTSPromptBuilderMixin, nn.Module):
             )
 
         try:
+            # note(ratish): the outer stream context restores the current stream
+            # when a failed capture raises from capture_end before torch.cuda.graph
+            # restores it.
             with (
-                torch.cuda.device(device),
                 self._predictor_graph_capture_state(bucket_size, signature),
+                torch.cuda.stream(capture_stream),
             ):
-                current_stream = torch.cuda.current_stream(device=device)
-                warmup_stream = torch.cuda.Stream(device=device)
-                warmup_stream.wait_stream(current_stream)
-                with torch.cuda.stream(warmup_stream):
-                    for _ in range(2):
-                        run_once()
-                current_stream.wait_stream(warmup_stream)
-
-                capture_stream = torch.cuda.Stream(device=device)
-                capture_stream.wait_stream(current_stream)
+                for _ in range(_PREDICTOR_GRAPH_WARMUP_PASSES):
+                    run_once()
                 with torch.cuda.graph(
                     graph.graph,
                     pool=self._predictor_graph_memory_pool(),
@@ -1283,7 +1309,6 @@ class Qwen3TTSTalker(Qwen3TTSPromptBuilderMixin, nn.Module):
                     capture_error_mode="thread_local",
                 ):
                     graph.result_codes, graph.summed_embeddings = run_once()
-                current_stream.wait_stream(capture_stream)
         except Exception:
             # Note: (Jiaxin Deng) release the graph's private memory pool
             # eagerly; the raising object may linger on traceback frames.
@@ -1356,7 +1381,8 @@ class Qwen3TTSTalker(Qwen3TTSPromptBuilderMixin, nn.Module):
                     )
                 return None
             try:
-                graph = self._capture_predictor_graph(bucket_size, signature)
+                with self._predictor_capture_session():
+                    graph = self._capture_predictor_graph(bucket_size, signature)
             except Exception:
                 self._record_predictor_graph_failure(key)
                 return None

--- a/tests/unit_test/qwen3_tts/test_pipeline.py
+++ b/tests/unit_test/qwen3_tts/test_pipeline.py
@@ -5245,6 +5245,7 @@ def test_qwen3_tts_engine_accepts_64_batch_policy_and_enables_cuda_graph(
     from sglang_omni.models.qwen3_tts.request_builders import (
         clear_qwen3_tts_preprocessing_context,
     )
+    from sglang_omni.models.qwen3_tts.sglang_model import Qwen3TTSTalker
     from sglang_omni.scheduling import bootstrap as bootstrap_mod
     from sglang_omni.scheduling import omni_scheduler as scheduler_mod
     from sglang_omni.scheduling import sglang_backend
@@ -5277,10 +5278,20 @@ def test_qwen3_tts_engine_accepts_64_batch_policy_and_enables_cuda_graph(
     build_kwargs: dict = {}
     infrastructure_saw_deferred_capture: list[bool] = []
     init_graph_calls: list[bool] = []
+    predictor_captures: list[tuple] = []
 
     class FakeModel:
+        config = SimpleNamespace(code_predictor_config=SimpleNamespace(vocab_size=2048))
+        uniform_predictor_graph_signature = (
+            Qwen3TTSTalker.uniform_predictor_graph_signature
+        )
+
         def load_speech_tokenizer(self, tokenizer) -> None:
             self.speech_tokenizer = tokenizer
+
+        def capture_predictor_graphs(self, signature: tuple) -> int:
+            predictor_captures.append(signature)
+            return 6
 
     class FakeSGLangRunner:
         def __init__(self, server_args) -> None:
@@ -5300,6 +5311,9 @@ def test_qwen3_tts_engine_accepts_64_batch_policy_and_enables_cuda_graph(
     class FakeQwen3TTSModel:
         def __init__(self, **kwargs) -> None:
             self.kwargs = kwargs
+
+        def _merge_generate_kwargs(self, **kwargs):
+            return {**self.kwargs["generate_defaults"], **kwargs}
 
     qwen_tts_module = types.ModuleType("qwen_tts")
     qwen_tts_module.Qwen3TTSModel = FakeQwen3TTSModel
@@ -5480,6 +5494,7 @@ def test_qwen3_tts_engine_accepts_64_batch_policy_and_enables_cuda_graph(
 
     assert infrastructure_saw_deferred_capture == [True]
     assert init_graph_calls == [True]
+    assert predictor_captures == [("sampled", 50, False, False)]
     assert scheduler.server_args.cuda_graph_bs == expected_cuda_graph_bs
     assert scheduler.server_args.cuda_graph_max_bs == 64
     assert scheduler.server_args.disable_cuda_graph is False

--- a/tests/unit_test/qwen3_tts/test_pipeline.py
+++ b/tests/unit_test/qwen3_tts/test_pipeline.py
@@ -4998,7 +4998,6 @@ def test_qwen3_tts_prepare_decode_buffers_collects_private_subtalker_seeds(
     talker._sub_sampling_seed_tensor = torch.empty(2, dtype=torch.long)
     talker._sub_do_sample_tensor = torch.empty(2, dtype=torch.bool)
     talker._sub_identity_row_indices_tensor = torch.arange(2, dtype=torch.long)
-    talker._sub_sample_row_indices_tensor = torch.empty(2, dtype=torch.long)
     requests = [
         SimpleNamespace(
             data=Qwen3TTSSGLangRequestData(
@@ -5030,7 +5029,6 @@ def test_qwen3_tts_prepare_decode_buffers_collects_private_subtalker_seeds(
     assert talker._sub_temperature_tensor[:2].tolist() == pytest.approx([0.8, 1.0])
     assert talker._sub_top_k_tensor[:2].tolist() == [40, 1]
     assert talker._sub_do_sample_tensor[:2].tolist() == [True, False]
-    assert talker._sub_sample_count == 1
     assert talker._sub_identity_row_indices_tensor.tolist() == [0, 1]
     assert talker._sub_has_sampled_rows is True
     assert talker._sub_sampled_has_top_p is True
@@ -5088,9 +5086,6 @@ def test_qwen3_tts_subtalker_sampling_batches_sampled_path_without_global_rng(
     talker._sub_sampling_seed_tensor = torch.tensor([17, 23])
     talker._sub_do_sample_tensor = torch.tensor([True, True])
     talker._sub_identity_row_indices_tensor = torch.tensor([0, 1])
-    talker._sub_sample_row_indices_tensor = torch.tensor([0, 1])
-    talker._sub_sample_max_row_index = 1
-    talker._sub_sample_count = 2
     talker._sub_has_sampled_rows = True
     talker._sub_sampled_has_top_p = False
     talker._sub_sampled_max_top_k = 0
@@ -5121,12 +5116,6 @@ def test_qwen3_tts_subtalker_sampling_batches_sampled_path_without_global_rng(
         raise AssertionError("sampled subtalker path must not use global RNG")
 
     monkeypatch.setattr(torch, "multinomial", fail_multinomial)
-
-    def fail_argmax(*args, **kwargs):
-        del args, kwargs
-        raise AssertionError("all-sampled subtalker path must not compute argmax")
-
-    monkeypatch.setattr(torch, "argmax", fail_argmax)
 
     tokens = Qwen3TTSTalker._sample_subtalker_token(
         talker,
@@ -5206,9 +5195,6 @@ def test_qwen3_tts_sampled_subtalker_requires_semantic_positions(
     talker._sub_sampling_seed_tensor = torch.tensor([17])
     talker._sub_do_sample_tensor = torch.tensor([True])
     talker._sub_identity_row_indices_tensor = torch.tensor([0])
-    talker._sub_sample_row_indices_tensor = torch.tensor([0])
-    talker._sub_sample_max_row_index = 0
-    talker._sub_sample_count = 1
     talker._sub_has_sampled_rows = True
     talker._sub_sampled_has_top_p = False
     talker._sub_sampled_max_top_k = 0
@@ -5646,7 +5632,6 @@ def _make_prep_talker(monkeypatch):
     talker._sub_sampling_seed_tensor = torch.empty(2, dtype=torch.long)
     talker._sub_do_sample_tensor = torch.empty(2, dtype=torch.bool)
     talker._sub_identity_row_indices_tensor = torch.arange(2, dtype=torch.long)
-    talker._sub_sample_row_indices_tensor = torch.empty(2, dtype=torch.long)
     return Qwen3TTSTalker, talker
 
 

--- a/tests/unit_test/qwen3_tts/test_pipeline.py
+++ b/tests/unit_test/qwen3_tts/test_pipeline.py
@@ -5245,7 +5245,6 @@ def test_qwen3_tts_engine_accepts_64_batch_policy_and_enables_cuda_graph(
     from sglang_omni.models.qwen3_tts.request_builders import (
         clear_qwen3_tts_preprocessing_context,
     )
-    from sglang_omni.models.qwen3_tts.sglang_model import Qwen3TTSTalker
     from sglang_omni.scheduling import bootstrap as bootstrap_mod
     from sglang_omni.scheduling import omni_scheduler as scheduler_mod
     from sglang_omni.scheduling import sglang_backend
@@ -5281,16 +5280,13 @@ def test_qwen3_tts_engine_accepts_64_batch_policy_and_enables_cuda_graph(
     predictor_captures: list[tuple] = []
 
     class FakeModel:
-        config = SimpleNamespace(code_predictor_config=SimpleNamespace(vocab_size=2048))
-        uniform_predictor_graph_signature = (
-            Qwen3TTSTalker.uniform_predictor_graph_signature
-        )
-
         def load_speech_tokenizer(self, tokenizer) -> None:
             self.speech_tokenizer = tokenizer
 
-        def capture_predictor_graphs(self, signature: tuple) -> int:
-            predictor_captures.append(signature)
+        def capture_predictor_graphs(
+            self, *, do_sample: bool, top_k: int, top_p: float
+        ) -> int:
+            predictor_captures.append((do_sample, top_k, top_p))
             return 6
 
     class FakeSGLangRunner:
@@ -5494,7 +5490,7 @@ def test_qwen3_tts_engine_accepts_64_batch_policy_and_enables_cuda_graph(
 
     assert infrastructure_saw_deferred_capture == [True]
     assert init_graph_calls == [True]
-    assert predictor_captures == [("sampled", 50, False, False)]
+    assert predictor_captures == [(True, 50, 1.0)]
     assert scheduler.server_args.cuda_graph_bs == expected_cuda_graph_bs
     assert scheduler.server_args.cuda_graph_max_bs == 64
     assert scheduler.server_args.disable_cuda_graph is False

--- a/tests/unit_test/qwen3_tts/test_predictor_cuda_graph.py
+++ b/tests/unit_test/qwen3_tts/test_predictor_cuda_graph.py
@@ -1097,9 +1097,11 @@ def test_startup_capture_builds_the_ladder_for_one_signature():
     talker = _build_talker(device)
     signature = ("sampled", 8, False, False)
 
-    assert talker.capture_predictor_graphs(signature) == len(BUCKETS)
+    assert talker.capture_predictor_graphs(do_sample=True, top_k=5, top_p=1.0) == len(
+        BUCKETS
+    )
     assert set(talker._predictor_graphs) == {(bucket, *signature) for bucket in BUCKETS}
-    assert talker.capture_predictor_graphs(signature) == 0
+    assert talker.capture_predictor_graphs(do_sample=True, top_k=5, top_p=1.0) == 0
 
     for batch_size in BUCKETS:
         talker.prepare_decode_buffers(_uniform_requests(batch_size, top_k=5))
@@ -1130,15 +1132,24 @@ def test_startup_capture_failure_raises_and_restores_state(
     )
 
     with pytest.raises(RuntimeError, match="simulated capture failure"):
-        talker.capture_predictor_graphs(("sampled", 8, False, False))
+        talker.capture_predictor_graphs(do_sample=True, top_k=8, top_p=1.0)
 
     assert not talker._predictor_graphs
     assert talker._sub_batch_size == 0
     assert gc.isenabled()
 
 
-def test_signature_rule_is_shared_by_batch_and_startup_paths():
+def test_signature_rule_is_shared_by_batch_and_startup_paths(
+    monkeypatch: pytest.MonkeyPatch,
+):
     talker = _build_talker(torch.device("cpu"))
+    startup_keys: list[tuple] = []
+
+    def _record_capture(self, bucket_size, signature):
+        startup_keys.append((bucket_size, *signature))
+        return object()
+
+    monkeypatch.setattr(Qwen3TTSTalker, "_capture_predictor_graph", _record_capture)
     cases = [
         (True, 5, 1.0),
         (True, 5, 0.9),
@@ -1162,12 +1173,9 @@ def test_signature_rule_is_shared_by_batch_and_startup_paths():
             )
         else:
             expected = ("argmax", 0, False, False)
-        assert (
-            talker.uniform_predictor_graph_signature(
-                do_sample=dosample, top_k=top_k, top_p=top_p
-            )
-            == expected
-        ), (dosample, top_k, top_p)
+        talker._predictor_graphs.clear()
+        talker.capture_predictor_graphs(do_sample=dosample, top_k=top_k, top_p=top_p)
+        assert startup_keys[-1][1:] == expected, (dosample, top_k, top_p)
 
 
 @pytest.mark.accelerator

--- a/tests/unit_test/qwen3_tts/test_predictor_cuda_graph.py
+++ b/tests/unit_test/qwen3_tts/test_predictor_cuda_graph.py
@@ -187,6 +187,7 @@ def _build_talker(device: torch.device) -> Qwen3TTSTalker:
     talker._predictor_graph_capacity_warned = False
     talker._predictor_graph_capture_count = 0
     talker._predictor_graph_pool = None
+    talker._predictor_capture_stream = None
     return talker
 
 
@@ -1057,6 +1058,34 @@ def test_server_disable_cuda_graph_gates_predictor(monkeypatch: pytest.MonkeyPat
 
     assert not talker._predictor_graphs
     assert talker._predictor_graph_enabled is False
+    assert torch.equal(graph_codes, eager_codes)
+    assert torch.equal(graph_embeds, eager_embeds)
+
+
+@pytest.mark.accelerator
+def test_failed_capture_restores_the_current_stream(monkeypatch: pytest.MonkeyPatch):
+    device = torch.device("cuda")
+    talker = _build_talker(device)
+    real_forward = Qwen3TTSTalker._code_predictor_forward_incremental
+
+    def _sync_inside_capture(self, *args, **kwargs):
+        if torch.cuda.is_current_stream_capturing():
+            torch.cuda.synchronize()
+        return real_forward(self, *args, **kwargs)
+
+    monkeypatch.setattr(
+        Qwen3TTSTalker, "_code_predictor_forward_incremental", _sync_inside_capture
+    )
+    talker.prepare_decode_buffers(_uniform_requests(2))
+    layer0, hidden, positions = _step_inputs(2, device)
+    eager_codes, eager_embeds = _run_eager(talker, layer0, hidden, positions)
+
+    graph_codes, graph_embeds = _run_forward(talker, layer0, hidden, positions)
+
+    assert torch.cuda.current_stream(device) == torch.cuda.default_stream(device)
+    assert gc.isenabled()
+    assert not talker._predictor_graphs
+    assert talker._predictor_graph_failure_count == 1
     assert torch.equal(graph_codes, eager_codes)
     assert torch.equal(graph_embeds, eager_embeds)
 

--- a/tests/unit_test/qwen3_tts/test_predictor_cuda_graph.py
+++ b/tests/unit_test/qwen3_tts/test_predictor_cuda_graph.py
@@ -17,6 +17,7 @@ from types import SimpleNamespace
 
 import pytest
 import torch
+from sglang.srt.layers.quantization.unquant import Bf16GemmBackend
 from torch import nn
 
 import sglang_omni.models.qwen3_tts.sglang_model as sglang_model_module
@@ -1050,6 +1051,41 @@ def test_server_disable_cuda_graph_gates_predictor(monkeypatch: pytest.MonkeyPat
 
     assert not talker._predictor_graphs
     assert talker._predictor_graph_enabled is False
+    assert torch.equal(graph_codes, eager_codes)
+    assert torch.equal(graph_embeds, eager_embeds)
+
+
+@pytest.mark.accelerator
+@pytest.mark.parametrize(
+    "sglang_gemm_override",
+    [
+        ("is_batch_invariant_mode_enabled", lambda: True),
+        ("get_bf16_gemm_backend", lambda: Bf16GemmBackend.CUTEDSL),
+    ],
+    ids=["batch-invariant", "optimized-backend"],
+)
+def test_sglang_gemm_overrides_keep_the_eager_gemm_on_both_paths(
+    monkeypatch: pytest.MonkeyPatch, sglang_gemm_override
+):
+    device = torch.device("cuda")
+    talker = _build_talker(device)
+    monkeypatch.setattr(sglang_model_module, *sglang_gemm_override)
+    original_addmm = torch.addmm
+    calls = []
+
+    def _record_addmm(*args, **kwargs):
+        calls.append(None)
+        return original_addmm(*args, **kwargs)
+
+    monkeypatch.setattr(torch, "addmm", _record_addmm)
+    talker.prepare_decode_buffers(_uniform_requests(2))
+    layer0, hidden, positions = _step_inputs(2, device)
+
+    eager_codes, eager_embeds = _run_eager(talker, layer0, hidden, positions)
+    graph_codes, graph_embeds = _run_forward(talker, layer0, hidden, positions)
+
+    assert talker._predictor_graphs
+    assert not calls
     assert torch.equal(graph_codes, eager_codes)
     assert torch.equal(graph_embeds, eager_embeds)
 

--- a/tests/unit_test/qwen3_tts/test_predictor_cuda_graph.py
+++ b/tests/unit_test/qwen3_tts/test_predictor_cuda_graph.py
@@ -1091,6 +1091,86 @@ def test_failed_capture_restores_the_current_stream(monkeypatch: pytest.MonkeyPa
 
 
 @pytest.mark.accelerator
+@pytest.mark.accelerator
+def test_startup_capture_builds_the_ladder_for_one_signature():
+    device = torch.device("cuda")
+    talker = _build_talker(device)
+    signature = ("sampled", 8, False, False)
+
+    assert talker.capture_predictor_graphs(signature) == len(BUCKETS)
+    assert set(talker._predictor_graphs) == {(bucket, *signature) for bucket in BUCKETS}
+    assert talker.capture_predictor_graphs(signature) == 0
+
+    for batch_size in BUCKETS:
+        talker.prepare_decode_buffers(_uniform_requests(batch_size, top_k=5))
+        layer0, hidden, positions = _step_inputs(batch_size, device)
+        eager_codes, eager_embeds = _run_eager(talker, layer0, hidden, positions)
+        graph_codes, graph_embeds = _run_forward(talker, layer0, hidden, positions)
+        assert torch.equal(graph_codes, eager_codes)
+        assert torch.equal(graph_embeds, eager_embeds)
+
+    assert len(talker._predictor_graphs) == len(BUCKETS)
+
+
+@pytest.mark.accelerator
+def test_startup_capture_failure_raises_and_restores_state(
+    monkeypatch: pytest.MonkeyPatch,
+):
+    device = torch.device("cuda")
+    talker = _build_talker(device)
+    real_forward = Qwen3TTSTalker._code_predictor_forward_incremental
+
+    def _boom_forward(self, *args, **kwargs):
+        if torch.cuda.current_stream(device) != torch.cuda.default_stream(device):
+            raise RuntimeError("simulated capture failure")
+        return real_forward(self, *args, **kwargs)
+
+    monkeypatch.setattr(
+        Qwen3TTSTalker, "_code_predictor_forward_incremental", _boom_forward
+    )
+
+    with pytest.raises(RuntimeError, match="simulated capture failure"):
+        talker.capture_predictor_graphs(("sampled", 8, False, False))
+
+    assert not talker._predictor_graphs
+    assert talker._sub_batch_size == 0
+    assert gc.isenabled()
+
+
+def test_signature_rule_is_shared_by_batch_and_startup_paths():
+    talker = _build_talker(torch.device("cpu"))
+    cases = [
+        (True, 5, 1.0),
+        (True, 5, 0.9),
+        (True, 0, 1.0),
+        (True, 3, 0.5),
+        (True, PRED_VOCAB, 1.0),
+        (True, 4, 1.0),
+        (True, 9, 1.0),
+        (False, 5, 1.0),
+    ]
+    for dosample, top_k, top_p in cases:
+        talker.prepare_decode_buffers(
+            _uniform_requests(3, dosample=dosample, top_k=top_k, top_p=top_p)
+        )
+        if talker._sub_has_sampled_rows:
+            expected = (
+                "sampled",
+                talker._sub_sampled_max_top_k,
+                talker._sub_sampled_has_top_p,
+                talker._sub_sampled_has_unbounded_top_k,
+            )
+        else:
+            expected = ("argmax", 0, False, False)
+        assert (
+            talker.uniform_predictor_graph_signature(
+                do_sample=dosample, top_k=top_k, top_p=top_p
+            )
+            == expected
+        ), (dosample, top_k, top_p)
+
+
+@pytest.mark.accelerator
 def test_graph_object_holds_no_reference_to_the_talker():
     device = torch.device("cuda")
     talker = _build_talker(device)

--- a/tests/unit_test/qwen3_tts/test_predictor_cuda_graph.py
+++ b/tests/unit_test/qwen3_tts/test_predictor_cuda_graph.py
@@ -11,6 +11,8 @@ bucket-exact batch sizes, and the dispatch/replay path must never host-sync.
 from __future__ import annotations
 
 import ast
+import gc
+import weakref
 from contextlib import contextmanager
 from pathlib import Path
 from types import SimpleNamespace
@@ -603,15 +605,19 @@ def test_capture_failure_restores_live_sub_state(monkeypatch: pytest.MonkeyPatch
     )
     layer0, hidden, positions = _step_inputs(2, device)
 
-    class _BoomGraph:
-        def __init__(self, model, bucket_size, signature, **kwargs) -> None:
-            del kwargs
-            with model._predictor_graph_capture_state(bucket_size, signature):
-                raise RuntimeError("simulated capture failure")
+    real_forward = Qwen3TTSTalker._code_predictor_forward_incremental
 
-    monkeypatch.setattr(sglang_model_module, "_PredictorDecodeGraph", _BoomGraph)
+    def _boom_forward(self, *args, **kwargs):
+        if torch.cuda.current_stream(device) != torch.cuda.default_stream(device):
+            raise RuntimeError("simulated capture failure")
+        return real_forward(self, *args, **kwargs)
+
+    monkeypatch.setattr(
+        Qwen3TTSTalker, "_code_predictor_forward_incremental", _boom_forward
+    )
     _run_forward(talker, layer0, hidden, positions)
 
+    assert talker._predictor_graph_disabled
     assert talker._sub_batch_size == 2
     assert talker._sub_has_sampled_rows is True
     assert talker._sub_do_sample_tensor[:2].tolist() == [True, False]
@@ -1053,6 +1059,24 @@ def test_server_disable_cuda_graph_gates_predictor(monkeypatch: pytest.MonkeyPat
     assert talker._predictor_graph_enabled is False
     assert torch.equal(graph_codes, eager_codes)
     assert torch.equal(graph_embeds, eager_embeds)
+
+
+@pytest.mark.accelerator
+def test_graph_object_holds_no_reference_to_the_talker():
+    device = torch.device("cuda")
+    talker = _build_talker(device)
+    talker.prepare_decode_buffers(_uniform_requests(2))
+    layer0, hidden, positions = _step_inputs(2, device)
+    _run_forward(talker, layer0, hidden, positions)
+    (graph,) = talker._predictor_graphs.values()
+
+    assert all(value is not talker for value in vars(graph).values())
+    assert talker not in gc.get_referents(graph)
+
+    graph_ref = weakref.ref(graph)
+    talker._predictor_graphs.clear()
+    del graph
+    assert graph_ref() is None
 
 
 @pytest.mark.accelerator

--- a/tests/unit_test/qwen3_tts/test_predictor_cuda_graph.py
+++ b/tests/unit_test/qwen3_tts/test_predictor_cuda_graph.py
@@ -127,10 +127,6 @@ def _build_talker(device: torch.device) -> Qwen3TTSTalker:
     talker._sub_identity_row_indices_tensor = torch.arange(
         MAX_BS, device=device, dtype=torch.long
     )
-    talker._sub_sample_row_indices_tensor = torch.zeros(
-        MAX_BS, device=device, dtype=torch.long
-    )
-    talker._sub_sample_count = 0
     talker._sub_has_sampled_rows = False
     talker._sub_sampled_has_top_p = False
     talker._sub_sampled_max_top_k = 0
@@ -319,61 +315,17 @@ def test_missing_embedding_buffer_uses_original_graph_path():
 
 
 @pytest.mark.accelerator
-def test_fused_embedding_runs_only_during_cuda_graph_capture(
-    monkeypatch: pytest.MonkeyPatch,
-):
+def test_eager_predictor_leaves_the_talker_hidden_untouched_for_an_identity_projection():
     device = torch.device("cuda")
     talker = _build_talker(device)
+    talker.code_predictor.project_input = lambda hidden: hidden
     talker.prepare_decode_buffers(_uniform_requests(2))
     layer0, hidden, positions = _step_inputs(2, device)
-    original_kernel = sglang_model_module.gather_codec_embedding_and_add
-    calls = []
+    hidden_before = hidden.clone()
 
-    def _record_kernel(*args):
-        calls.append(None)
-        return original_kernel(*args)
+    _run_eager(talker, layer0, hidden, positions)
 
-    monkeypatch.setattr(
-        sglang_model_module,
-        "gather_codec_embedding_and_add",
-        _record_kernel,
-    )
-    eager_codes, eager_embeds = _run_eager(talker, layer0, hidden, positions)
-    assert not calls
-
-    graph_codes, graph_embeds = _run_forward(talker, layer0, hidden, positions)
-    assert len(calls) == NUM_CODE_GROUPS - 1
-    assert torch.equal(graph_codes, eager_codes)
-    assert torch.equal(graph_embeds, eager_embeds)
-
-
-@pytest.mark.accelerator
-@pytest.mark.parametrize("batch_size", [1, 4, 8, 16])
-def test_fused_o_proj_residual_runs_only_during_cuda_graph_capture(
-    monkeypatch: pytest.MonkeyPatch,
-    batch_size: int,
-):
-    device = torch.device("cuda")
-    talker = _build_talker(device)
-    talker.prepare_decode_buffers(_uniform_requests(batch_size))
-    layer0, hidden, positions = _step_inputs(batch_size, device)
-    original_addmm = torch.addmm
-    calls = []
-
-    def _record_addmm(input, *args, **kwargs):
-        assert kwargs["out"] is input
-        calls.append(None)
-        return original_addmm(input, *args, **kwargs)
-
-    monkeypatch.setattr(torch, "addmm", _record_addmm)
-
-    eager_codes, eager_embeds = _run_eager(talker, layer0, hidden, positions)
-    assert not calls
-
-    graph_codes, graph_embeds = _run_forward(talker, layer0, hidden, positions)
-    assert len(calls) == NUM_CODE_GROUPS
-    assert torch.equal(graph_codes, eager_codes)
-    assert torch.equal(graph_embeds, eager_embeds)
+    assert torch.equal(hidden, hidden_before)
 
 
 @pytest.mark.accelerator
@@ -660,7 +612,6 @@ def test_capture_failure_restores_live_sub_state(monkeypatch: pytest.MonkeyPatch
     _run_forward(talker, layer0, hidden, positions)
 
     assert talker._sub_batch_size == 2
-    assert talker._sub_sample_count == 1
     assert talker._sub_has_sampled_rows is True
     assert talker._sub_do_sample_tensor[:2].tolist() == [True, False]
 
@@ -1038,7 +989,6 @@ def test_capture_state_body_failure_restores_state():
     talker.prepare_decode_buffers(_uniform_requests(3, dosample=False))
     saved = (
         talker._sub_batch_size,
-        talker._sub_sample_count,
         talker._sub_has_sampled_rows,
         talker._sub_sampled_has_top_p,
         talker._sub_sampled_max_top_k,
@@ -1048,7 +998,6 @@ def test_capture_state_body_failure_restores_state():
     with pytest.raises(RuntimeError, match="simulated capture failure"):
         with talker._predictor_graph_capture_state(4, ("sampled", 8, True, False)):
             assert talker._sub_batch_size == 4
-            assert talker._sub_sample_count == 4
             assert talker._sub_has_sampled_rows is True
             assert talker._sub_sampled_has_top_p is True
             assert talker._sub_sampled_max_top_k == 8
@@ -1057,7 +1006,6 @@ def test_capture_state_body_failure_restores_state():
 
     assert (
         talker._sub_batch_size,
-        talker._sub_sample_count,
         talker._sub_has_sampled_rows,
         talker._sub_sampled_has_top_p,
         talker._sub_sampled_max_top_k,

--- a/tests/unit_test/qwen3_tts/test_sampling_kernels.py
+++ b/tests/unit_test/qwen3_tts/test_sampling_kernels.py
@@ -4,6 +4,7 @@
 from __future__ import annotations
 
 from types import SimpleNamespace
+from unittest import mock
 
 import pytest
 import torch
@@ -11,6 +12,7 @@ from sglang.kernels.ops.sampling.murmur_hash import murmur_hash32
 from sglang.srt.layers.sampler import multinomial_with_seed
 
 from sglang_omni.models.qwen3_tts import sampling_kernels as sampling_kernels_module
+from sglang_omni.models.qwen3_tts import sglang_model as sglang_model_module
 from sglang_omni.models.qwen3_tts.sampling_kernels import (
     sample_from_logits_with_seed_top_k_top_p,
     sample_from_sorted_logprobs_with_seed_small_k,
@@ -227,6 +229,26 @@ def _production_seeded_tokens(
     )
 
 
+def _reference_seeded_tokens(
+    talker: Qwen3TTSTalker,
+    logits: torch.Tensor,
+    *,
+    layer_idx: int,
+    semantic_positions: torch.Tensor,
+) -> torch.Tensor:
+    with mock.patch.object(
+        sglang_model_module,
+        "sample_from_logits_with_seed_top_k_top_p",
+        return_value=None,
+    ):
+        return _production_seeded_tokens(
+            talker,
+            logits,
+            layer_idx=layer_idx,
+            semantic_positions=semantic_positions,
+        )
+
+
 def _fused_seeded_tokens(
     talker: Qwen3TTSTalker,
     logits: torch.Tensor,
@@ -268,7 +290,7 @@ def _fused_seeded_tokens(
         (1, 1024, 0.95),
     ],
 )
-def test_fused_raw_logit_sampler_matches_production_reference(
+def test_fused_raw_logit_sampler_matches_reference(
     batch_size: int,
     max_top_k: int,
     top_p: float,
@@ -304,7 +326,7 @@ def test_fused_raw_logit_sampler_matches_production_reference(
         max_top_k=max_top_k,
     )
 
-    expected = _production_seeded_tokens(
+    expected = _reference_seeded_tokens(
         talker,
         logits,
         layer_idx=3,
@@ -339,7 +361,7 @@ def test_fused_raw_logit_sampler_matches_reference_for_equal_logits(
             seeds,
             max_top_k=max_top_k,
         )
-        expected = _production_seeded_tokens(
+        expected = _reference_seeded_tokens(
             talker,
             logits,
             layer_idx=2,
@@ -391,7 +413,7 @@ def test_fused_raw_logit_sampler_matches_reference_for_threshold_ties(
             seeds,
             max_top_k=max_top_k,
         )
-        expected = _production_seeded_tokens(
+        expected = _reference_seeded_tokens(
             talker,
             logits,
             layer_idx=5,
@@ -447,7 +469,7 @@ def test_fused_raw_logit_sampler_matches_reference_for_signed_zero_order(
             seeds,
             max_top_k=max_top_k,
         )
-        expected = _production_seeded_tokens(
+        expected = _reference_seeded_tokens(
             talker,
             logits,
             layer_idx=6,
@@ -487,7 +509,7 @@ def test_fused_raw_logit_sampler_captures_without_reference_top_k(
         max_top_k=32,
     )
 
-    expected = _production_seeded_tokens(
+    expected = _reference_seeded_tokens(
         talker,
         logits,
         layer_idx=4,
@@ -545,7 +567,7 @@ def test_fused_raw_logit_sampler_capture_falls_back_without_triton_gather(
         seeds,
         max_top_k=32,
     )
-    expected = _production_seeded_tokens(
+    expected = _reference_seeded_tokens(
         talker,
         logits,
         layer_idx=5,


### PR DESCRIPTION
## Summary

The Qwen3-TTS code predictor runs 16 one-token forwards per talker token over its own five-layer KV cache, replayed through one CUDA graph per (batch bucket, sampling signature). Those graphs were captured lazily, inside the first serving step that produced each batch size, and each capture stalled the running batch by about 350 ms on H100, most of it cuDNN building an attention plan for the new shape. A single warmup request only covers batch size 1, so the other buckets kept capturing under live traffic.

This branch captures the graphs of the checkpoint's default sampling signature at startup, after SGLang's own graphs and before the stage reports ready, and cleans up the capture mechanics on the way. Steady state is unchanged: the replayed kernels are the same, the eager fallback now runs the same kernels as the graph, and the startup cost is about 3 s.

## Changes

- `_predictor_signature_terms` holds the one rule that maps a batch's sampling values to its graph signature. `prepare_decode_buffers` and the new startup path both call it.
- The eager predictor path runs the same three kernels the graph replays: the fused embedding gather, the fused seeded sampler with its ATen fallback, and the fused output projection with the residual add. The capture-only gating, the second eager sampler and its three staging fields are removed. When the talker and predictor hidden sizes match, the input projection is the identity, so the first layer's input is cloned before the fused epilogue writes into it.
- The fused output projection is used only where SGLang's linear would run torch's GEMM: not under batch-invariant mode, which overrides `aten::addmm` but not its out variant, and not when the cuteDSL bf16 backend is selected. This replaces the sm90 pin. A request under `--enable-deterministic-inference` used to fail with a CUBLAS error at this call.
- Capture moves onto the talker as `_capture_predictor_graph`. `_PredictorDecodeGraph` holds the buffers, the graph and its outputs, and no reference to the talker.
- The capture routine runs warmups and capture on one stream per talker, as torch requires when several captures share one memory pool, keeps the cyclic collector off for the capture so a graph finalizer cannot run inside it, and restores the current stream if `capture_end` raises, which torch's context does not do on its own.
- `resolve_subtalker_sampling` holds the subtalker sampling fallbacks used when a checkpoint ships no generation config. The request path and the builder share it.
- `Qwen3TtsEngineBuilder.setup_model_resources` passes the sampling values of the merged generation defaults to `capture_predictor_graphs`, which derives the signature, captures the bucket ladder in descending order into one pool and logs `Captured 6 Qwen3-TTS predictor CUDA graphs for signature=(...) in 2.9 s`. A startup capture failure fails the boot. Batches whose signature differs from the default still capture lazily, bounded as before.

## Test results

H100, `Qwen/Qwen3-TTS-12Hz-1.7B-Base`, SGLang 0.5.18, torch 2.13.0. `pytest tests/unit_test/qwen3_tts -q`: 348 passed.

Full-corpus A/B on the seed-tts-eval English split (1088 samples), one fresh server per arm, `--seed 1234`, no warmup requests, arms alternated. A is main, B is this branch.

c1:

| Metric | A | B | Delta |
| --- | ---: | ---: | ---: |
| Mean latency | 0.443 s | 0.440 s | -0.003 s (-0.7%) |
| Median latency | 0.430 s | 0.427 s | -0.003 s |
| p95 latency | 0.644 s | 0.641 s | -0.003 s |
| p99 latency | 0.766 s | 0.763 s | -0.003 s |
| First request latency | | | -0.672 s |
| QPS | 2.254 | 2.270 | +0.016 (+0.7%) |
| WER | 1.01315% | 1.01315% | 0 |
| Speaker similarity | 71.30515 | 71.30515 | 0 |

c16:

| Metric | A | B | Delta |
| --- | ---: | ---: | ---: |
| Mean latency | 1.077 s | 1.035 s | -0.042 s (-3.9%) |
| Median latency | 1.006 s | 1.008 s | +0.002 s |
| p95 latency | 1.509 s | 1.475 s | -0.034 s (-2.3%) |
| p99 latency | 4.260 s | 1.881 s | -2.379 s (-55.9%) |
| First batch mean latency | 4.503 s | 1.992 s | -2.511 s |
| QPS | 14.778 | 15.357 | +0.579 (+3.9%) |
| WER | 0.94616% | 0.95453% | +0.008 pp |

Output identity and capture logs:

| Check | A | B |
| --- | ---: | ---: |
| c1 WAVs byte-identical to A | reference | 1088 of 1088 |
| Lazy captures inside serving steps, c1 | 1 | 0 |
| Lazy captures inside serving steps, c16 | 6 | 0 |
| Captures before ready | 0 | 6, in 2.9 s |
| Request under `--enable-deterministic-inference` | CUBLAS error | completes |
