### PR TITLE
ci(xpu): reclaim workspace before checkout on self-hosted runner

### DIFF
--- a/.github/workflows/omni-xpu-ci.yaml
+++ b/.github/workflows/omni-xpu-ci.yaml
@@ -158,6 +158,19 @@ jobs:
       IMAGE_TAG: sglang-omni-xpu-ci:${{ github.event.pull_request.number || github.run_id }}-${{ needs.preflight.outputs.exact_sha }}
       CONTAINER_NAME: ci_omni_xpu_${{ github.event.pull_request.number || github.run_id }}_${{ github.run_attempt }}
     steps:
+      - name: Reclaim workspace from prior runs
+        # Clear root-owned debris from prior rootful containers so
+        # actions/checkout does not EACCES on unlink.
+        shell: bash
+        run: |
+          set -eux
+          if [[ -d "${GITHUB_WORKSPACE}" ]]; then
+            sudo -n chown -R "$(id -u):$(id -g)" "${GITHUB_WORKSPACE}" 2>/dev/null \
+              || docker run --rm -v "${GITHUB_WORKSPACE}:/w" --workdir /w alpine \
+                   sh -c "chown -R $(id -u):$(id -g) ."
+            find "${GITHUB_WORKSPACE}" -mindepth 1 -maxdepth 1 -exec rm -rf -- {} +
+          fi
+
       - name: Checkout PR code
         uses: actions/checkout@v4
         with:


### PR DESCRIPTION
## Summary

`actions/checkout@v4` runs as the runner user and aborts with `EACCES` when a prior rootful docker container left files it cannot unlink in `$GITHUB_WORKSPACE`. Once that state lands on the runner, every subsequent XPU CI run fails at the very first step and no later cleanup gets a chance to run — the runner has to be cleaned by hand.

Observed on [run 33856233673](https://github.com/sgl-project/sglang-omni/actions/runs/33856233673/job/100970591503):

```
##[error]File was unable to be removed Error: EACCES: permission denied,
unlink '/home/devcloud/actions-runner_omni/_work/sglang-omni/sglang-omni/.pytest_cache/.gitignore'
```

The offending `.pytest_cache/.gitignore` is owned by root — almost certainly legacy debris from an earlier rootful pytest run on this runner (the current workflow does not bind-mount the workspace into the container, so newer runs cannot produce it, but they also cannot clear it).

## Change

Adds a `Reclaim workspace from prior runs` step to the `xpu-ci` job that runs before `Checkout PR code`:

- Attempts `sudo -n chown -R \$(id -u):\$(id -g) \"\$GITHUB_WORKSPACE\"` first.
- Falls back to `docker run --rm -v \"\$GITHUB_WORKSPACE:/w\" ... alpine chown -R ...` so runners without passwordless sudo still recover.
- Then clears the tree so `actions/checkout` starts against an empty, writable directory.

Self-contained and idempotent — safe to run on a clean workspace too.

## Test plan

- [ ] Rerun the failed job on this PR and confirm `Checkout PR code` succeeds after the new step.
- [ ] Confirm subsequent runs on the same runner still pass (no regression on a clean workspace).
- [ ] Verify the fallback path by manually seeding a root-owned file in `_work/...` on a runner without passwordless sudo, then rerunning.