### PR TITLE
[dots.tts Perf] Cover acoustic-tail batch misses (D1/D2, short shape)

### DIFF
--- a/examples/configs/dots_tts.yaml
+++ b/examples/configs/dots_tts.yaml
@@ -24,6 +24,8 @@ stages:
   latent_engine:
     factory:
       optimize: true
+      # Adds reserved state storage; keep opt-in until workload qualification.
+      enable_acoustic_tail_batch_padding: false
     engine:
       mem_fraction_static: 0.20
       max_running_requests: 16

--- a/examples/configs/dots_tts.yaml
+++ b/examples/configs/dots_tts.yaml
@@ -24,7 +24,7 @@ stages:
   latent_engine:
     factory:
       optimize: true
-      # Adds reserved state storage; keep opt-in until workload qualification.
+      # note (0xtoward): Padding reserves an extra row of acoustic state.
       enable_acoustic_tail_batch_padding: false
     engine:
       mem_fraction_static: 0.20

--- a/sglang_omni/models/dots_tts/engine_builder.py
+++ b/sglang_omni/models/dots_tts/engine_builder.py
@@ -22,6 +22,7 @@ class DotsTTSEngineBuilder(TtsEngineBuilder):
         num_steps: int = 4,
         max_audio_patches: int = 500,
         max_running_requests: int = 16,
+        enable_acoustic_tail_batch_padding: bool = False,
     ) -> None:
         from sglang_omni.models.dots_tts.hf_config import DOTS_TTS_MODEL_ARCH_OVERRIDE
 
@@ -30,6 +31,9 @@ class DotsTTSEngineBuilder(TtsEngineBuilder):
         self.num_steps = int(num_steps)
         self.max_audio_patches = int(max_audio_patches)
         self.max_running_requests = int(max_running_requests)
+        if not isinstance(enable_acoustic_tail_batch_padding, bool):
+            raise TypeError("enable_acoustic_tail_batch_padding must be a boolean")
+        self.enable_acoustic_tail_batch_padding = enable_acoustic_tail_batch_padding
         if min(self.num_steps, self.max_audio_patches, self.max_running_requests) <= 0:
             raise ValueError("dots.tts batching limits must be positive")
         self._model_runner: Any | None = None
@@ -121,6 +125,7 @@ class DotsTTSEngineBuilder(TtsEngineBuilder):
                 nfe=self.num_steps,
                 max_audio_patches=self.max_audio_patches,
                 optimize=self.optimize,
+                pad_to_bucket=self.enable_acoustic_tail_batch_padding,
             )
             self._acoustic_tail = model.flow.batched_tail
         if max_running_requests == 1:
@@ -133,11 +138,12 @@ class DotsTTSEngineBuilder(TtsEngineBuilder):
             tail_backend = model.flow.batched_tail.backend
         logger.info(
             "dots.tts latent engine backend: %s (optimize=%s, "
-            "max_running_requests=%d, num_steps=%d)",
+            "max_running_requests=%d, num_steps=%d, batch_padding=%s)",
             tail_backend,
             self.optimize,
             max_running_requests,
             self.num_steps,
+            self.enable_acoustic_tail_batch_padding,
         )
         logger.info(
             "dots.tts backbone decode: %s",

--- a/sglang_omni/models/dots_tts/flow_head.py
+++ b/sglang_omni/models/dots_tts/flow_head.py
@@ -167,6 +167,7 @@ class DotsTTSFlowHead(nn.Module):
         nfe: int,
         max_audio_patches: int,
         optimize: bool = False,
+        pad_to_bucket: bool = False,
     ) -> None:
         if self.mode != "meanflow":
             # note (luojiaxuan): flow-matching checkpoints (SOAR, base) need the
@@ -201,6 +202,7 @@ class DotsTTSFlowHead(nn.Module):
             device=parameter.device,
             dtype=parameter.dtype,
             optimize=optimize,
+            pad_to_bucket=pad_to_bucket,
         )
         self._batched_nfe = int(nfe)
         self._prepare_batched_eos_staging(int(num_slots), parameter.device)

--- a/sglang_omni/models/dots_tts/stages.py
+++ b/sglang_omni/models/dots_tts/stages.py
@@ -420,6 +420,7 @@ def create_sglang_latent_engine_executor(
     optimize: bool = True,
     max_generate_length: int = 500,
     num_steps: int = 4,
+    enable_acoustic_tail_batch_padding: bool = False,
     device: str | None = "cuda",
     gpu_id: int | None = None,
     server_args_overrides: dict[str, Any] | None = None,
@@ -430,6 +431,7 @@ def create_sglang_latent_engine_executor(
         optimize=optimize,
         num_steps=num_steps,
         max_audio_patches=max_generate_length,
+        enable_acoustic_tail_batch_padding=enable_acoustic_tail_batch_padding,
     ).build(
         model_path,
         device=device or "cuda",

--- a/sglang_omni/models/dots_tts/tail.py
+++ b/sglang_omni/models/dots_tts/tail.py
@@ -252,15 +252,20 @@ def estimate_acoustic_pool_bytes(
     mods_width: int,
     dtype: torch.dtype,
     reserved_rows: int = 0,
+    reserved_kv_rows: int | None = None,
 ) -> AcousticPoolMemoryEstimate:
     """Sum pool tensor bytes; excludes weights, backbone KV, and graph workspace.
 
     ``reserved_rows`` adds isolated filler state, not scratch or masks.
+    ``reserved_kv_rows`` overrides its KV portion for masked dummy copies.
     """
     elem = _dtype_nbytes(dtype)
     bool_elem = _dtype_nbytes(torch.bool)
     slots = int(spec.num_slots)
     pool_rows = slots + int(reserved_rows)
+    kv_rows = slots + int(
+        reserved_rows if reserved_kv_rows is None else reserved_kv_rows
+    )
     nfe = int(spec.nfe)
     dit_tokens = int(spec.dit_cache_tokens) + int(spec.unit_len)
     dit_query = 2 * int(spec.unit_len)
@@ -271,7 +276,7 @@ def estimate_acoustic_pool_bytes(
         2
         * nfe
         * int(dit_layers)
-        * pool_rows
+        * kv_rows
         * int(dit_heads)
         * dit_tokens
         * int(dit_head_dim)
@@ -280,7 +285,7 @@ def estimate_acoustic_pool_bytes(
     encoder_kv = (
         2
         * int(encoder_layers)
-        * pool_rows
+        * kv_rows
         * int(encoder_heads)
         * encoder_tokens
         * int(encoder_head_dim)
@@ -470,6 +475,11 @@ class DotsTtsAcousticTail:
             padding_graphs_requested
             and _has_batch_padding_gap(self._graph_batch_buckets)
         )
+        if self._pad_to_bucket:
+            from sglang_omni.models.dots_tts.tail_kv import gather_kv, scatter_kv
+
+            self._gather_kv = gather_kv
+            self._scatter_kv = scatter_kv
         # note (0xtoward): Filler writes must never reach an allocatable slot.
         self._pad_bin_slot = spec.num_slots
         self._mods_width = int(dit.fused_adaln[-1].out_features)
@@ -526,6 +536,7 @@ class DotsTtsAcousticTail:
             mods_width=int(mods_width),
             dtype=self.dtype,
             reserved_rows=1 if self._pad_to_bucket else 0,
+            reserved_kv_rows=0,
         )
 
     def _allocated_pool_bytes(self) -> int:
@@ -564,13 +575,13 @@ class DotsTtsAcousticTail:
         validate_acoustic_pool_memory(estimate, device=self.device)
 
         zeros = partial(torch.zeros, device=self.device, dtype=self.dtype)
-        # note (0xtoward): Only persistent state needs a reserved row;
-        # scratch and masks are indexed by batch position, not slot ID.
+        # note (0xtoward): Dummy history is invisible; only its small auxiliary
+        # state needs a reserved row. Masked copies never access dummy KV.
         pool_rows = spec.num_slots + (1 if self._pad_to_bucket else 0)
         self._dit_k = zeros(
             spec.nfe,
             self._dit_layers,
-            pool_rows,
+            spec.num_slots,
             self._dit_heads,
             spec.dit_cache_tokens + spec.unit_len,
             self._dit_head_dim,
@@ -578,7 +589,7 @@ class DotsTtsAcousticTail:
         self._dit_v = torch.zeros_like(self._dit_k)
         self._encoder_k = zeros(
             self._encoder_layers,
-            pool_rows,
+            spec.num_slots,
             self._encoder_heads,
             spec.patch_capacity * self._encoder_block,
             self._encoder_head_dim,
@@ -989,18 +1000,27 @@ class DotsTtsAcousticTail:
                 else:
                     keys = self._dit_scratch_k[:, :rows, :, : capacity + query_len]
                     values = self._dit_scratch_v[:, :rows, :, : capacity + query_len]
-                    torch.index_select(
-                        self._dit_k[ode_index, :, :, :, :capacity],
-                        1,
-                        slot_index,
-                        out=keys[:, :, :, :capacity],
-                    )
-                    torch.index_select(
-                        self._dit_v[ode_index, :, :, :, :capacity],
-                        1,
-                        slot_index,
-                        out=values[:, :, :, :capacity],
-                    )
+                    if self._pad_to_bucket:
+                        self._gather_kv(
+                            self._dit_k[ode_index],
+                            self._dit_v[ode_index],
+                            slot_index,
+                            keys[:, :, :, :capacity],
+                            values[:, :, :, :capacity],
+                        )
+                    else:
+                        torch.index_select(
+                            self._dit_k[ode_index, :, :, :, :capacity],
+                            1,
+                            slot_index,
+                            out=keys[:, :, :, :capacity],
+                        )
+                        torch.index_select(
+                            self._dit_v[ode_index, :, :, :, :capacity],
+                            1,
+                            slot_index,
+                            out=values[:, :, :, :capacity],
+                        )
 
                 def cached_attention(
                     layer: int, block: nn.Module, value: torch.Tensor
@@ -1031,12 +1051,22 @@ class DotsTtsAcousticTail:
                 )
                 duration = self._times[ode_index + 1] - self._times[ode_index]
                 latent = (latent + duration * velocity).clone()
-                self._dit_k[ode_index][layer_index, batch_index, :, token_index] = keys[
-                    :, :, :, promote
-                ].permute(0, 1, 3, 2, 4)
-                self._dit_v[ode_index][layer_index, batch_index, :, token_index] = (
-                    values[:, :, :, promote].permute(0, 1, 3, 2, 4)
-                )
+                if self._pad_to_bucket and not direct_kv:
+                    self._scatter_kv(
+                        keys[:, :, :, promote],
+                        values[:, :, :, promote],
+                        slot_index,
+                        persistent_index,
+                        self._dit_k[ode_index],
+                        self._dit_v[ode_index],
+                    )
+                else:
+                    self._dit_k[ode_index][layer_index, batch_index, :, token_index] = (
+                        keys[:, :, :, promote].permute(0, 1, 3, 2, 4)
+                    )
+                    self._dit_v[ode_index][layer_index, batch_index, :, token_index] = (
+                        values[:, :, :, promote].permute(0, 1, 3, 2, 4)
+                    )
         return latent
 
     @staticmethod
@@ -1141,18 +1171,27 @@ class DotsTtsAcousticTail:
             cos, sin = _rotary_cos_sin(self._encoder_rotary, start_index, block)
         keys = self._encoder_scratch_k[:, :rows, :, : capacity + block]
         values = self._encoder_scratch_v[:, :rows, :, : capacity + block]
-        torch.index_select(
-            self._encoder_k[:, :, :, :capacity],
-            1,
-            slot_index,
-            out=keys[:, :, :, :capacity],
-        )
-        torch.index_select(
-            self._encoder_v[:, :, :, :capacity],
-            1,
-            slot_index,
-            out=values[:, :, :, :capacity],
-        )
+        if self._pad_to_bucket:
+            self._gather_kv(
+                self._encoder_k,
+                self._encoder_v,
+                slot_index,
+                keys[:, :, :, :capacity],
+                values[:, :, :, :capacity],
+            )
+        else:
+            torch.index_select(
+                self._encoder_k[:, :, :, :capacity],
+                1,
+                slot_index,
+                out=keys[:, :, :, :capacity],
+            )
+            torch.index_select(
+                self._encoder_v[:, :, :, :capacity],
+                1,
+                slot_index,
+                out=values[:, :, :, :capacity],
+            )
         with sdpa_kernel(_TAIL_SDPA_BACKENDS):
             embeddings, conv_tail = self._encoder_step(
                 latent_patches.to(self.dtype),
@@ -1169,12 +1208,22 @@ class DotsTtsAcousticTail:
         layer_index = self._encoder_layer_index.reshape(self._encoder_layers, 1, 1)
         batch_index = slot_index.reshape(1, rows, 1)
         promote = slice(capacity, capacity + block)
-        self._encoder_k[layer_index, batch_index, :, token_index] = keys[
-            :, :, :, promote
-        ].permute(0, 1, 3, 2, 4)
-        self._encoder_v[layer_index, batch_index, :, token_index] = values[
-            :, :, :, promote
-        ].permute(0, 1, 3, 2, 4)
+        if self._pad_to_bucket:
+            self._scatter_kv(
+                keys[:, :, :, promote],
+                values[:, :, :, promote],
+                slot_index,
+                start_index,
+                self._encoder_k,
+                self._encoder_v,
+            )
+        else:
+            self._encoder_k[layer_index, batch_index, :, token_index] = keys[
+                :, :, :, promote
+            ].permute(0, 1, 3, 2, 4)
+            self._encoder_v[layer_index, batch_index, :, token_index] = values[
+                :, :, :, promote
+            ].permute(0, 1, 3, 2, 4)
         self._encoder_conv_tail[slot_index] = conv_tail
         return embeddings.reshape(rows, -1)
 

--- a/sglang_omni/models/dots_tts/tail.py
+++ b/sglang_omni/models/dots_tts/tail.py
@@ -22,12 +22,30 @@ from dots_tts.modules.backbone.dit_inference import FusedAdaLNDiT
 from dots_tts.modules.backbone.inference_utils import fuse_qkv_projection
 from dots_tts.modules.backbone.layers import rotate_half
 
+from sglang_omni.utils.graph_padding import pad_rows, select_padded_graph
+
 logger = logging.getLogger(__name__)
 
 _TAIL_SDPA_BACKENDS = [SDPBackend.EFFICIENT_ATTENTION, SDPBackend.MATH]
-_GRAPH_BATCH_BUCKETS = (8, 16)
+_GRAPH_BATCH_BUCKETS = (1, 8, 16)
 _GRAPH_CONTEXT_PATCH_BUCKETS = (16, 32, 64, 128)
 _TAIL_STEP_LOG_INTERVAL = 50
+
+
+def graph_batch_buckets(
+    num_slots: int, *, include_maximum: bool = False
+) -> tuple[int, ...]:
+    """Return capture buckets, optionally including the deployment maximum."""
+    buckets = {batch for batch in _GRAPH_BATCH_BUCKETS if batch <= num_slots}
+    if include_maximum:
+        buckets.add(num_slots)
+    return tuple(sorted(buckets))
+
+
+def _has_batch_padding_gap(batch_buckets: tuple[int, ...]) -> bool:
+    return any(
+        upper - lower > 1 for lower, upper in zip(batch_buckets, batch_buckets[1:])
+    )
 
 
 def _project_attention(
@@ -233,11 +251,18 @@ def estimate_acoustic_pool_bytes(
     encoder_conv_padding: int,
     mods_width: int,
     dtype: torch.dtype,
+    reserved_rows: int = 0,
 ) -> AcousticPoolMemoryEstimate:
-    """Sum pool tensor bytes; excludes weights, backbone KV, and graph workspace."""
+    """Sum pool tensor bytes; excludes weights, backbone KV, and graph workspace.
+
+    ``reserved_rows`` extends the persistent pools (not scratch/masks) with
+    sacrificial rows for padded graph replays — the sglang "padded slot 0"
+    idiom; see utils/graph_padding.py.
+    """
     elem = _dtype_nbytes(dtype)
     bool_elem = _dtype_nbytes(torch.bool)
     slots = int(spec.num_slots)
+    pool_rows = slots + int(reserved_rows)
     nfe = int(spec.nfe)
     dit_tokens = int(spec.dit_cache_tokens) + int(spec.unit_len)
     dit_query = 2 * int(spec.unit_len)
@@ -248,7 +273,7 @@ def estimate_acoustic_pool_bytes(
         2
         * nfe
         * int(dit_layers)
-        * slots
+        * pool_rows
         * int(dit_heads)
         * dit_tokens
         * int(dit_head_dim)
@@ -257,7 +282,7 @@ def estimate_acoustic_pool_bytes(
     encoder_kv = (
         2
         * int(encoder_layers)
-        * slots
+        * pool_rows
         * int(encoder_heads)
         * encoder_tokens
         * int(encoder_head_dim)
@@ -289,9 +314,11 @@ def estimate_acoustic_pool_bytes(
         * (encoder_tokens + int(encoder_block))
         * bool_elem
     )
-    window = slots * int(spec.window_len) * int(spec.fm_hidden_size) * elem
-    all_mods = nfe * slots * int(mods_width) * elem
-    conv_tail = slots * int(encoder_conv_channels) * int(encoder_conv_padding) * elem
+    window = pool_rows * int(spec.window_len) * int(spec.fm_hidden_size) * elem
+    all_mods = nfe * pool_rows * int(mods_width) * elem
+    conv_tail = (
+        pool_rows * int(encoder_conv_channels) * int(encoder_conv_padding) * elem
+    )
 
     scratch = dit_scratch + encoder_scratch
     aux = dit_mask + encoder_mask + window + all_mods + conv_tail
@@ -400,6 +427,7 @@ class DotsTtsAcousticTail:
         device: torch.device,
         dtype: torch.dtype,
         optimize: bool = False,
+        pad_to_bucket: bool = False,
     ) -> None:
         self.spec = spec
         self.device = device
@@ -426,6 +454,26 @@ class DotsTtsAcousticTail:
         self._encoder_heads = int(encoder_attention.num_heads)
         self._encoder_head_dim = int(encoder_attention.head_dim)
 
+        self._graph_context_patch_buckets = tuple(
+            patches
+            for patches in _GRAPH_CONTEXT_PATCH_BUCKETS
+            if patches < spec.patch_capacity
+        )
+        self._cuda_graph_enabled = bool(optimize and device.type == "cuda")
+        padding_graphs_requested = bool(
+            pad_to_bucket
+            and self._cuda_graph_enabled
+            and self._graph_context_patch_buckets
+        )
+        self._graph_batch_buckets = graph_batch_buckets(
+            spec.num_slots, include_maximum=padding_graphs_requested
+        )
+        self._pad_to_bucket = bool(
+            padding_graphs_requested
+            and _has_batch_padding_gap(self._graph_batch_buckets)
+        )
+        # Reserved sacrificial pool row for padded replays; never allocatable.
+        self._pad_bin_slot = spec.num_slots
         self._mods_width = int(dit.fused_adaln[-1].out_features)
         self._allocate_pools(self._mods_width)
         self._times = torch.linspace(0.0, 1.0, spec.nfe + 1, device=device, dtype=dtype)
@@ -436,14 +484,16 @@ class DotsTtsAcousticTail:
         self._generators: list[torch.Generator | None] = [None] * spec.num_slots
         self._free_slots = list(reversed(range(spec.num_slots)))
         self._meanflow_graphs: dict[tuple[int, int], _CapturedTailGraph] = {}
+        self._meanflow_pad_graphs: dict[tuple[int, int], _CapturedTailGraph] = {}
         self._encoder_graphs: dict[tuple[int, int], _CapturedTailGraph] = {}
         self._graph_pool: Any | None = None
         self._capture_stream: torch.cuda.Stream | None = None
         self._graph_replays: Counter[str] = Counter()
         self._graph_misses: Counter[str] = Counter()
         self._tail_steps = 0
+        self._graph_padded_replays: Counter[str] = Counter()
         self._dit_contiguous_view_steps = 0
-        if optimize and device.type == "cuda":
+        if self._cuda_graph_enabled:
             self._capture_cuda_graphs()
 
     def _pool_tensors(self) -> tuple[torch.Tensor, ...]:
@@ -477,6 +527,7 @@ class DotsTtsAcousticTail:
             encoder_conv_padding=int(self._encoder.ds_proj.left_padding),
             mods_width=int(mods_width),
             dtype=self.dtype,
+            reserved_rows=1 if self._pad_to_bucket else 0,
         )
 
     def _allocated_pool_bytes(self) -> int:
@@ -515,10 +566,14 @@ class DotsTtsAcousticTail:
         validate_acoustic_pool_memory(estimate, device=self.device)
 
         zeros = partial(torch.zeros, device=self.device, dtype=self.dtype)
+        # Persistent pools get one sacrificial row beyond the slot range when
+        # padded replays are enabled (the sglang "padded slot 0" idiom); the
+        # positional scratch/mask buffers never address it and stay slot-sized.
+        pool_rows = spec.num_slots + (1 if self._pad_to_bucket else 0)
         self._dit_k = zeros(
             spec.nfe,
             self._dit_layers,
-            spec.num_slots,
+            pool_rows,
             self._dit_heads,
             spec.dit_cache_tokens + spec.unit_len,
             self._dit_head_dim,
@@ -526,19 +581,19 @@ class DotsTtsAcousticTail:
         self._dit_v = torch.zeros_like(self._dit_k)
         self._encoder_k = zeros(
             self._encoder_layers,
-            spec.num_slots,
+            pool_rows,
             self._encoder_heads,
             spec.patch_capacity * self._encoder_block,
             self._encoder_head_dim,
         )
         self._encoder_v = torch.zeros_like(self._encoder_k)
         self._encoder_conv_tail = zeros(
-            spec.num_slots,
+            pool_rows,
             int(self._encoder.ds_proj.in_channels),
             int(self._encoder.ds_proj.left_padding),
         )
-        self._window = zeros(spec.num_slots, spec.window_len, spec.fm_hidden_size)
-        self._all_mods = zeros(spec.nfe, spec.num_slots, mods_width)
+        self._window = zeros(pool_rows, spec.window_len, spec.fm_hidden_size)
+        self._all_mods = zeros(spec.nfe, pool_rows, mods_width)
 
         dit_query = 2 * spec.unit_len
         self._dit_scratch_k = zeros(
@@ -803,6 +858,15 @@ class DotsTtsAcousticTail:
             work_hidden = fm_hidden_rows
             work_noise = noise
         graph = self._select_graph(self._meanflow_graphs, len(slots), capacity)
+        pad = 0
+        if graph is None:
+            graph, pad = self._select_graph_padded(
+                self._meanflow_graphs,
+                len(slots),
+                capacity,
+                skip_batch=spec.num_slots,
+                extra=self._meanflow_pad_graphs,
+            )
         if graph is None:
             self._graph_misses["meanflow"] += 1
             latent = self._sample_patches_core(
@@ -814,12 +878,27 @@ class DotsTtsAcousticTail:
                 direct_kv=direct_kv,
             )
         else:
+            if pad:
+                bin_slot = self._pad_bin_slot
+                work_slots = pad_rows(work_slots, pad, fill_value=bin_slot)
+                work_persistent = pad_rows(work_persistent, pad)
+                work_hidden = pad_rows(work_hidden, pad)
+                work_noise = pad_rows(work_noise, pad)
+                self._graph_padded_replays["meanflow"] += 1
+                if self._graph_padded_replays["meanflow"] == 1:
+                    logger.info(
+                        "dots.tts padded MeanFlow replay is active "
+                        "(rows=%d pad=%d bin=%d)",
+                        len(slots),
+                        pad,
+                        bin_slot,
+                    )
             graph.inputs["slots"].copy_(work_slots)
             graph.inputs["starts"].copy_(work_persistent)
             graph.inputs["hidden"].copy_(work_hidden)
             graph.inputs["noise"].copy_(work_noise)
             graph.graph.replay()
-            latent = graph.output.clone()
+            latent = graph.output[: len(slots)].clone() if pad else graph.output.clone()
             self._graph_replays["meanflow"] += 1
             if self._graph_replays["meanflow"] == 1:
                 logger.info("dots.tts batched MeanFlow CUDA graph replay is active")
@@ -1006,6 +1085,9 @@ class DotsTtsAcousticTail:
             raise RuntimeError("dots.tts patch-encoder cache overflow")
         start_index = torch.tensor(starts, device=self.device, dtype=torch.long)
         graph = self._select_graph(self._encoder_graphs, rows, capacity)
+        pad = 0
+        if graph is None:
+            graph, pad = self._select_graph_padded(self._encoder_graphs, rows, capacity)
         if graph is None:
             self._graph_misses["semantic_encoder"] += 1
             embeddings = self._encode_feedback_core(
@@ -1015,11 +1097,28 @@ class DotsTtsAcousticTail:
                 latent_patches,
             )
         else:
-            graph.inputs["slots"].copy_(slot_index)
-            graph.inputs["starts"].copy_(start_index)
-            graph.inputs["latent"].copy_(latent_patches)
+            work_index = slot_index
+            work_starts = start_index
+            work_latent = latent_patches
+            if pad:
+                bin_slot = self._pad_bin_slot
+                work_index = pad_rows(slot_index, pad, fill_value=bin_slot)
+                work_starts = pad_rows(start_index, pad)
+                work_latent = pad_rows(latent_patches, pad)
+                self._graph_padded_replays["semantic_encoder"] += 1
+                if self._graph_padded_replays["semantic_encoder"] == 1:
+                    logger.info(
+                        "dots.tts padded semantic-encoder replay is active "
+                        "(rows=%d pad=%d bin=%d)",
+                        rows,
+                        pad,
+                        bin_slot,
+                    )
+            graph.inputs["slots"].copy_(work_index)
+            graph.inputs["starts"].copy_(work_starts)
+            graph.inputs["latent"].copy_(work_latent)
             graph.graph.replay()
-            embeddings = graph.output.clone()
+            embeddings = graph.output[:rows].clone() if pad else graph.output.clone()
             self._graph_replays["semantic_encoder"] += 1
             if self._graph_replays["semantic_encoder"] == 1:
                 logger.info(
@@ -1099,23 +1198,48 @@ class DotsTtsAcousticTail:
         )
         return None if bucket is None else graphs[(rows, bucket)]
 
+    def _select_graph_padded(
+        self,
+        graphs: dict[tuple[int, int], _CapturedTailGraph],
+        rows: int,
+        capacity: int,
+        *,
+        skip_batch: int | None = None,
+        extra: dict[tuple[int, int], _CapturedTailGraph] | None = None,
+    ) -> tuple[_CapturedTailGraph | None, int]:
+        # Pad a bucket-miss batch up to the next captured bucket. Filler rows
+        # all point at the reserved pool row past the slot range: it backs no
+        # request, ever, so their writes are quarantined by construction.
+        # Only slot-index-driven graphs are eligible: the batch == num_slots
+        # meanflow graph is captured over contiguous positional views
+        # (direct_kv) and must be skipped in favor of its gather-mode twin.
+        if not self._pad_to_bucket:
+            return None, 0
+        return select_padded_graph(
+            graphs, rows, capacity, skip_batch=skip_batch, extra=extra
+        )
+
     @torch.no_grad()
     def _capture_cuda_graphs(self) -> None:
-        batch_buckets = tuple(
-            batch for batch in _GRAPH_BATCH_BUCKETS if batch <= self.spec.num_slots
-        )
-        context_buckets = tuple(
-            patches
-            for patches in _GRAPH_CONTEXT_PATCH_BUCKETS
-            if patches < self.spec.patch_capacity
-        )
+        batch_buckets = self._graph_batch_buckets
+        context_buckets = self._graph_context_patch_buckets
         if not batch_buckets or not context_buckets:
             return
 
-        current_stream = torch.cuda.current_stream(self.device)
-        self._capture_stream = torch.cuda.Stream(device=self.device)
-        self._capture_stream.wait_stream(current_stream)
-        self._graph_pool = torch.cuda.graph_pool_handle()
+        try:
+            current_stream = torch.cuda.current_stream(self.device)
+            self._capture_stream = torch.cuda.Stream(device=self.device)
+            self._capture_stream.wait_stream(current_stream)
+            self._graph_pool = torch.cuda.graph_pool_handle()
+        except Exception as exc:
+            self._capture_stream = None
+            self._graph_pool = None
+            logger.warning(
+                "dots.tts acoustic-tail CUDA graph setup failed: %s; "
+                "using eager fallback",
+                exc,
+            )
+            return
         with torch.cuda.stream(self._capture_stream):
             for batch_size in reversed(batch_buckets):
                 for patches in reversed(context_buckets):
@@ -1131,13 +1255,29 @@ class DotsTtsAcousticTail:
                         patches * self._encoder_block,
                         kind="semantic_encoder",
                     )
+            if self._pad_to_bucket and self.spec.num_slots in batch_buckets:
+                # The batch == num_slots meanflow graph above is positional
+                # (direct_kv); padded replays need a gather-mode twin.
+                for patches in reversed(context_buckets):
+                    self._capture_graph(
+                        self._meanflow_pad_graphs,
+                        self.spec.num_slots,
+                        patches * self.spec.unit_len,
+                        kind="meanflow",
+                        force_gather=True,
+                    )
         current_stream.wait_stream(self._capture_stream)
         torch.cuda.synchronize(self.device)
         logger.info(
-            "dots.tts acoustic-tail CUDA graphs: meanflow=%d semantic_encoder=%d "
+            "dots.tts acoustic-tail CUDA graphs: meanflow=%d "
+            "meanflow_gather_twins=%d semantic_encoder=%d total=%d "
             "batch_buckets=%s context_patch_buckets=%s",
             len(self._meanflow_graphs),
+            len(self._meanflow_pad_graphs),
             len(self._encoder_graphs),
+            len(self._meanflow_graphs)
+            + len(self._meanflow_pad_graphs)
+            + len(self._encoder_graphs),
             batch_buckets,
             context_buckets,
         )
@@ -1149,6 +1289,7 @@ class DotsTtsAcousticTail:
         capacity: int,
         *,
         kind: str,
+        force_gather: bool = False,
     ) -> None:
         key = (batch_size, capacity)
         slots = torch.arange(batch_size, device=self.device, dtype=torch.long)
@@ -1179,7 +1320,7 @@ class DotsTtsAcousticTail:
                 capacity,
                 inputs["hidden"],
                 inputs["noise"],
-                direct_kv=batch_size == self.spec.num_slots,
+                direct_kv=batch_size == self.spec.num_slots and not force_gather,
             )
         else:
             inputs = {
@@ -1230,6 +1371,7 @@ class DotsTtsAcousticTail:
             return (
                 "CUDA graph batched tail with eager fallback "
                 f"(meanflow={len(self._meanflow_graphs)}, "
+                f"meanflow_gather_twins={len(self._meanflow_pad_graphs)}, "
                 f"semantic_encoder={len(self._encoder_graphs)})"
             )
         return "fused eager batched tail"
@@ -1241,6 +1383,7 @@ __all__ = [
     "DotsTtsTailSpec",
     "batched_causal_update_mask",
     "estimate_acoustic_pool_bytes",
+    "graph_batch_buckets",
     "fuse_dit_for_inference",
     "validate_acoustic_pool_memory",
 ]

--- a/sglang_omni/models/dots_tts/tail.py
+++ b/sglang_omni/models/dots_tts/tail.py
@@ -22,12 +22,12 @@ from dots_tts.modules.backbone.dit_inference import FusedAdaLNDiT
 from dots_tts.modules.backbone.inference_utils import fuse_qkv_projection
 from dots_tts.modules.backbone.layers import rotate_half
 
-from sglang_omni.utils.graph_padding import pad_rows, select_padded_graph
+from sglang_omni.utils.graph_padding import select_padded_graph
 
 logger = logging.getLogger(__name__)
 
 _TAIL_SDPA_BACKENDS = [SDPBackend.EFFICIENT_ATTENTION, SDPBackend.MATH]
-_GRAPH_BATCH_BUCKETS = (1, 8, 16)
+_GRAPH_BATCH_BUCKETS = (1, 4, 8, 16)
 _GRAPH_CONTEXT_PATCH_BUCKETS = (16, 32, 64, 128)
 _TAIL_STEP_LOG_INTERVAL = 50
 
@@ -255,9 +255,7 @@ def estimate_acoustic_pool_bytes(
 ) -> AcousticPoolMemoryEstimate:
     """Sum pool tensor bytes; excludes weights, backbone KV, and graph workspace.
 
-    ``reserved_rows`` extends the persistent pools (not scratch/masks) with
-    sacrificial rows for padded graph replays — the sglang "padded slot 0"
-    idiom; see utils/graph_padding.py.
+    ``reserved_rows`` adds isolated filler state, not scratch or masks.
     """
     elem = _dtype_nbytes(dtype)
     bool_elem = _dtype_nbytes(torch.bool)
@@ -472,7 +470,7 @@ class DotsTtsAcousticTail:
             padding_graphs_requested
             and _has_batch_padding_gap(self._graph_batch_buckets)
         )
-        # Reserved sacrificial pool row for padded replays; never allocatable.
+        # note (0xtoward): Filler writes must never reach an allocatable slot.
         self._pad_bin_slot = spec.num_slots
         self._mods_width = int(dit.fused_adaln[-1].out_features)
         self._allocate_pools(self._mods_width)
@@ -566,9 +564,8 @@ class DotsTtsAcousticTail:
         validate_acoustic_pool_memory(estimate, device=self.device)
 
         zeros = partial(torch.zeros, device=self.device, dtype=self.dtype)
-        # Persistent pools get one sacrificial row beyond the slot range when
-        # padded replays are enabled (the sglang "padded slot 0" idiom); the
-        # positional scratch/mask buffers never address it and stay slot-sized.
+        # note (0xtoward): Only persistent state needs a reserved row;
+        # scratch and masks are indexed by batch position, not slot ID.
         pool_rows = spec.num_slots + (1 if self._pad_to_bucket else 0)
         self._dit_k = zeros(
             spec.nfe,
@@ -665,7 +662,9 @@ class DotsTtsAcousticTail:
 
     @property
     def has_captured_graphs(self) -> bool:
-        return bool(self._meanflow_graphs or self._encoder_graphs)
+        return bool(
+            self._meanflow_graphs or self._meanflow_pad_graphs or self._encoder_graphs
+        )
 
     def log_graph_counters(self) -> None:
         self._log_graph_counters(logging.INFO)
@@ -680,12 +679,16 @@ class DotsTtsAcousticTail:
             level,
             "dots.tts tail graph counters: steps=%d meanflow_replays=%d "
             "meanflow_misses=%d semantic_encoder_replays=%d "
-            "semantic_encoder_misses=%d",
+            "semantic_encoder_misses=%d meanflow_padded_replays=%d "
+            "semantic_encoder_padded_replays=%d",
             self._tail_steps,
             self._graph_replays["meanflow"],
             self._graph_misses["meanflow"],
             self._graph_replays["semantic_encoder"],
             self._graph_misses["semantic_encoder"],
+            # note (0xtoward): Padded replays are a subset of total replays.
+            self._graph_padded_replays["meanflow"],
+            self._graph_padded_replays["semantic_encoder"],
         )
 
     def note_decode_cycle(self) -> None:
@@ -880,23 +883,23 @@ class DotsTtsAcousticTail:
         else:
             if pad:
                 bin_slot = self._pad_bin_slot
-                work_slots = pad_rows(work_slots, pad, fill_value=bin_slot)
-                work_persistent = pad_rows(work_persistent, pad)
-                work_hidden = pad_rows(work_hidden, pad)
-                work_noise = pad_rows(work_noise, pad)
                 self._graph_padded_replays["meanflow"] += 1
-                if self._graph_padded_replays["meanflow"] == 1:
-                    logger.info(
-                        "dots.tts padded MeanFlow replay is active "
-                        "(rows=%d pad=%d bin=%d)",
-                        len(slots),
-                        pad,
-                        bin_slot,
-                    )
-            graph.inputs["slots"].copy_(work_slots)
-            graph.inputs["starts"].copy_(work_persistent)
-            graph.inputs["hidden"].copy_(work_hidden)
-            graph.inputs["noise"].copy_(work_noise)
+                # note (0xtoward): Refresh filler inputs in place; do not
+                # allocate and concatenate temporary padded tensors.
+                real_rows = len(slots)
+                graph.inputs["slots"][:real_rows].copy_(work_slots)
+                graph.inputs["slots"][real_rows:].fill_(bin_slot)
+                graph.inputs["starts"][:real_rows].copy_(work_persistent)
+                graph.inputs["starts"][real_rows:].fill_(0)
+                graph.inputs["hidden"][:real_rows].copy_(work_hidden)
+                graph.inputs["hidden"][real_rows:].fill_(0)
+                graph.inputs["noise"][:real_rows].copy_(work_noise)
+                graph.inputs["noise"][real_rows:].fill_(0)
+            else:
+                graph.inputs["slots"].copy_(work_slots)
+                graph.inputs["starts"].copy_(work_persistent)
+                graph.inputs["hidden"].copy_(work_hidden)
+                graph.inputs["noise"].copy_(work_noise)
             graph.graph.replay()
             latent = graph.output[: len(slots)].clone() if pad else graph.output.clone()
             self._graph_replays["meanflow"] += 1
@@ -1097,26 +1100,19 @@ class DotsTtsAcousticTail:
                 latent_patches,
             )
         else:
-            work_index = slot_index
-            work_starts = start_index
-            work_latent = latent_patches
             if pad:
                 bin_slot = self._pad_bin_slot
-                work_index = pad_rows(slot_index, pad, fill_value=bin_slot)
-                work_starts = pad_rows(start_index, pad)
-                work_latent = pad_rows(latent_patches, pad)
                 self._graph_padded_replays["semantic_encoder"] += 1
-                if self._graph_padded_replays["semantic_encoder"] == 1:
-                    logger.info(
-                        "dots.tts padded semantic-encoder replay is active "
-                        "(rows=%d pad=%d bin=%d)",
-                        rows,
-                        pad,
-                        bin_slot,
-                    )
-            graph.inputs["slots"].copy_(work_index)
-            graph.inputs["starts"].copy_(work_starts)
-            graph.inputs["latent"].copy_(work_latent)
+                graph.inputs["slots"][:rows].copy_(slot_index)
+                graph.inputs["slots"][rows:].fill_(bin_slot)
+                graph.inputs["starts"][:rows].copy_(start_index)
+                graph.inputs["starts"][rows:].fill_(0)
+                graph.inputs["latent"][:rows].copy_(latent_patches)
+                graph.inputs["latent"][rows:].fill_(0)
+            else:
+                graph.inputs["slots"].copy_(slot_index)
+                graph.inputs["starts"].copy_(start_index)
+                graph.inputs["latent"].copy_(latent_patches)
             graph.graph.replay()
             embeddings = graph.output[:rows].clone() if pad else graph.output.clone()
             self._graph_replays["semantic_encoder"] += 1
@@ -1207,16 +1203,17 @@ class DotsTtsAcousticTail:
         skip_batch: int | None = None,
         extra: dict[tuple[int, int], _CapturedTailGraph] | None = None,
     ) -> tuple[_CapturedTailGraph | None, int]:
-        # Pad a bucket-miss batch up to the next captured bucket. Filler rows
-        # all point at the reserved pool row past the slot range: it backs no
-        # request, ever, so their writes are quarantined by construction.
-        # Only slot-index-driven graphs are eligible: the batch == num_slots
-        # meanflow graph is captured over contiguous positional views
-        # (direct_kv) and must be skipped in favor of its gather-mode twin.
+        # note (0xtoward): Positional captures cannot follow filler slot IDs;
+        # use their gather twins. Cap row expansion, not context capacity.
         if not self._pad_to_bucket:
             return None, 0
         return select_padded_graph(
-            graphs, rows, capacity, skip_batch=skip_batch, extra=extra
+            graphs,
+            rows,
+            capacity,
+            skip_batch=skip_batch,
+            extra=extra,
+            max_batch_ratio=2,
         )
 
     @torch.no_grad()
@@ -1256,8 +1253,8 @@ class DotsTtsAcousticTail:
                         kind="semantic_encoder",
                     )
             if self._pad_to_bucket and self.spec.num_slots in batch_buckets:
-                # The batch == num_slots meanflow graph above is positional
-                # (direct_kv); padded replays need a gather-mode twin.
+                # note (0xtoward): Keep the exact full-batch positional path;
+                # padding to this bucket needs a slot-indexed gather capture.
                 for patches in reversed(context_buckets):
                     self._capture_graph(
                         self._meanflow_pad_graphs,

--- a/sglang_omni/models/dots_tts/tail_kv.py
+++ b/sglang_omni/models/dots_tts/tail_kv.py
@@ -1,0 +1,159 @@
+# SPDX-License-Identifier: Apache-2.0
+"""KV copies for acoustic-tail padding without a persistent dummy KV row."""
+
+import torch
+import triton
+import triton.language as tl
+
+
+@triton.jit
+def _gather_kv(
+    K,
+    V,
+    Slots,
+    OutK,
+    OutV,
+    N: tl.constexpr,
+    B: tl.constexpr,
+    H: tl.constexpr,
+    T: tl.constexpr,
+    D: tl.constexpr,
+    SRC_STRIDES: tl.constexpr,
+    DST_STRIDES: tl.constexpr,
+    BLOCK: tl.constexpr,
+):
+    row = tl.program_id(1).to(tl.int64)
+    head = row % H
+    batch = row // H % B
+    layer = row // (H * B)
+    slot = tl.load(Slots + batch)
+    offset = tl.program_id(0) * BLOCK + tl.arange(0, BLOCK)
+    token, feature = offset // D, offset % D
+    source = layer * SRC_STRIDES[0] + slot * SRC_STRIDES[1] + head * SRC_STRIDES[2]
+    source += token * SRC_STRIDES[3] + feature * SRC_STRIDES[4]
+    target = layer * DST_STRIDES[0] + batch * DST_STRIDES[1] + head * DST_STRIDES[2]
+    target += token * DST_STRIDES[3] + feature * DST_STRIDES[4]
+    # note (0xtoward): Dummy IDs are out of range; mask the access itself.
+    valid = (offset < T * D) & (slot >= 0) & (slot < N)
+    key = tl.load(K + source, mask=valid, other=0)
+    value = tl.load(V + source, mask=valid, other=0)
+    tl.store(OutK + target, key, mask=offset < T * D)
+    tl.store(OutV + target, value, mask=offset < T * D)
+
+
+@triton.jit
+def _scatter_kv(
+    K,
+    V,
+    Slots,
+    Starts,
+    OutK,
+    OutV,
+    N: tl.constexpr,
+    B: tl.constexpr,
+    H: tl.constexpr,
+    T: tl.constexpr,
+    D: tl.constexpr,
+    POOL_T: tl.constexpr,
+    SRC_STRIDES: tl.constexpr,
+    DST_STRIDES: tl.constexpr,
+    BLOCK: tl.constexpr,
+):
+    row = tl.program_id(1).to(tl.int64)
+    head = row % H
+    batch = row // H % B
+    layer = row // (H * B)
+    slot = tl.load(Slots + batch)
+    start = tl.load(Starts + batch)
+    offset = tl.program_id(0) * BLOCK + tl.arange(0, BLOCK)
+    token, feature = offset // D, offset % D
+    source = layer * SRC_STRIDES[0] + batch * SRC_STRIDES[1] + head * SRC_STRIDES[2]
+    source += token * SRC_STRIDES[3] + feature * SRC_STRIDES[4]
+    target = layer * DST_STRIDES[0] + slot * DST_STRIDES[1] + head * DST_STRIDES[2]
+    target += (start + token) * DST_STRIDES[3] + feature * DST_STRIDES[4]
+    valid = (offset < T * D) & (slot >= 0) & (slot < N)
+    valid &= (start + token >= 0) & (start + token < POOL_T)
+    key = tl.load(K + source, mask=valid, other=0)
+    value = tl.load(V + source, mask=valid, other=0)
+    # note (0xtoward): Real slots are unique; repeated dummy slots never store.
+    tl.store(OutK + target, key, mask=valid)
+    tl.store(OutV + target, value, mask=valid)
+
+
+def gather_kv(
+    pool_k: torch.Tensor,
+    pool_v: torch.Tensor,
+    slots: torch.Tensor,
+    out_k: torch.Tensor,
+    out_v: torch.Tensor,
+) -> None:
+    """Gather [L,N,H,T,D] to [L,B,H,T,D], zeroing invalid slot IDs.
+
+    Capacity views may be strided. K and V in each pair share shape/strides.
+    """
+    layers, rows, heads, tokens, dim = out_k.shape
+    assert pool_k.shape == pool_v.shape and pool_k.stride() == pool_v.stride()
+    assert out_k.shape == out_v.shape and out_k.stride() == out_v.stride()
+    assert slots.shape == (rows,) and slots.is_contiguous()
+    assert (layers, heads, dim) == (pool_k.size(0), pool_k.size(2), pool_k.size(4))
+    assert tokens <= pool_k.size(3)
+    if tokens == 0:
+        return
+    block = 1024
+    with torch.cuda.device_of(pool_k):
+        _gather_kv[(triton.cdiv(tokens * dim, block), layers * rows * heads)](
+            pool_k,
+            pool_v,
+            slots,
+            out_k,
+            out_v,
+            pool_k.size(1),
+            rows,
+            heads,
+            tokens,
+            dim,
+            pool_k.stride(),
+            out_k.stride(),
+            block,
+        )
+
+
+def scatter_kv(
+    keys: torch.Tensor,
+    values: torch.Tensor,
+    slots: torch.Tensor,
+    starts: torch.Tensor,
+    pool_k: torch.Tensor,
+    pool_v: torch.Tensor,
+) -> None:
+    """Promote [L,B,H,T,D] at per-row starts; skip invalid slot IDs.
+
+    Live slot IDs must be unique and their promoted tokens must fit the pool.
+    """
+    layers, rows, heads, tokens, dim = keys.shape
+    assert keys.shape == values.shape and keys.stride() == values.stride()
+    assert pool_k.shape == pool_v.shape and pool_k.stride() == pool_v.stride()
+    assert slots.shape == starts.shape == (rows,)
+    assert slots.is_contiguous() and starts.is_contiguous()
+    assert (layers, heads, dim) == (pool_k.size(0), pool_k.size(2), pool_k.size(4))
+    if tokens == 0:
+        return
+    block = min(1024, triton.next_power_of_2(tokens * dim))
+    with torch.cuda.device_of(pool_k):
+        _scatter_kv[(triton.cdiv(tokens * dim, block), layers * rows * heads)](
+            keys,
+            values,
+            slots,
+            starts,
+            pool_k,
+            pool_v,
+            pool_k.size(1),
+            rows,
+            heads,
+            tokens,
+            dim,
+            pool_k.size(3),
+            keys.stride(),
+            pool_k.stride(),
+            block,
+        )

--- a/sglang_omni/utils/graph_padding.py
+++ b/sglang_omni/utils/graph_padding.py
@@ -1,0 +1,73 @@
+# SPDX-License-Identifier: Apache-2.0
+"""Select padded aux graphs and extend their per-row inputs.
+
+Callers must isolate filler writes from live state and slice outputs back to
+the real row count. Positional captures require gather-mode replacements.
+"""
+
+from __future__ import annotations
+
+from typing import TypeVar
+
+import torch
+
+GraphT = TypeVar("GraphT")
+
+
+def select_padded_graph(
+    graphs: dict[tuple[int, int], GraphT],
+    rows: int,
+    capacity: int,
+    *,
+    skip_batch: int | None = None,
+    extra: dict[tuple[int, int], GraphT] | None = None,
+) -> tuple[GraphT | None, int]:
+    """Pick the smallest captured graph a ``rows``-row batch can pad up to.
+
+    Candidates need ``batch_size > rows`` and ``bucket_capacity >= capacity``;
+    ties resolve to the smallest batch then the smallest capacity. Entries in
+    ``graphs`` whose batch equals ``skip_batch`` are ignored (captures that
+    read state positionally instead of via the slot-index input buffer);
+    ``extra`` supplies gather-mode replacements for such batches. Returns
+    ``(graph, filler_row_count)`` or ``(None, 0)``.
+    """
+    pool = [
+        (batch_size, bucket_capacity, graphs)
+        for batch_size, bucket_capacity in graphs
+        if batch_size > rows
+        and bucket_capacity >= capacity
+        and batch_size != skip_batch
+    ]
+    if extra:
+        pool += [
+            (batch_size, bucket_capacity, extra)
+            for batch_size, bucket_capacity in extra
+            if batch_size > rows and bucket_capacity >= capacity
+        ]
+    if not pool:
+        return None, 0
+    batch_size, bucket_capacity, source = min(pool, key=lambda item: (item[0], item[1]))
+    return source[(batch_size, bucket_capacity)], batch_size - rows
+
+
+def pad_rows(
+    tensor: torch.Tensor,
+    pad: int,
+    *,
+    fill_value: int | float | None = None,
+) -> torch.Tensor:
+    """Append ``pad`` filler rows to a per-row input tensor.
+
+    Filler rows are zeros unless ``fill_value`` is given (e.g. the sacrificial
+    slot index for the slot-id tensor). The result matches the captured input
+    buffer's batch dimension, so a plain ``copy_`` stages it for replay.
+    """
+    if pad <= 0:
+        return tensor
+    shape = (pad, *tensor.shape[1:])
+    filler = (
+        tensor.new_zeros(shape)
+        if fill_value is None
+        else tensor.new_full(shape, fill_value)
+    )
+    return torch.cat([tensor, filler])

--- a/sglang_omni/utils/graph_padding.py
+++ b/sglang_omni/utils/graph_padding.py
@@ -1,5 +1,5 @@
 # SPDX-License-Identifier: Apache-2.0
-"""Select padded aux graphs and extend their per-row inputs.
+"""Select padded aux graphs.
 
 Callers must isolate filler writes from live state and slice outputs back to
 the real row count. Positional captures require gather-mode replacements.
@@ -8,8 +8,6 @@ the real row count. Positional captures require gather-mode replacements.
 from __future__ import annotations
 
 from typing import TypeVar
-
-import torch
 
 GraphT = TypeVar("GraphT")
 
@@ -21,6 +19,7 @@ def select_padded_graph(
     *,
     skip_batch: int | None = None,
     extra: dict[tuple[int, int], GraphT] | None = None,
+    max_batch_ratio: float | None = None,
 ) -> tuple[GraphT | None, int]:
     """Pick the smallest captured graph a ``rows``-row batch can pad up to.
 
@@ -28,7 +27,8 @@ def select_padded_graph(
     ties resolve to the smallest batch then the smallest capacity. Entries in
     ``graphs`` whose batch equals ``skip_batch`` are ignored (captures that
     read state positionally instead of via the slot-index input buffer);
-    ``extra`` supplies gather-mode replacements for such batches. Returns
+    ``extra`` supplies gather-mode replacements for such batches.
+    ``max_batch_ratio`` optionally bounds captured rows / real rows. Returns
     ``(graph, filler_row_count)`` or ``(None, 0)``.
     """
     pool = [
@@ -47,27 +47,6 @@ def select_padded_graph(
     if not pool:
         return None, 0
     batch_size, bucket_capacity, source = min(pool, key=lambda item: (item[0], item[1]))
+    if max_batch_ratio is not None and batch_size > rows * max_batch_ratio:
+        return None, 0
     return source[(batch_size, bucket_capacity)], batch_size - rows
-
-
-def pad_rows(
-    tensor: torch.Tensor,
-    pad: int,
-    *,
-    fill_value: int | float | None = None,
-) -> torch.Tensor:
-    """Append ``pad`` filler rows to a per-row input tensor.
-
-    Filler rows are zeros unless ``fill_value`` is given (e.g. the sacrificial
-    slot index for the slot-id tensor). The result matches the captured input
-    buffer's batch dimension, so a plain ``copy_`` stages it for replay.
-    """
-    if pad <= 0:
-        return tensor
-    shape = (pad, *tensor.shape[1:])
-    filler = (
-        tensor.new_zeros(shape)
-        if fill_value is None
-        else tensor.new_full(shape, fill_value)
-    )
-    return torch.cat([tensor, filler])

--- a/tests/unit_test/dots_tts/test_engine_builder.py
+++ b/tests/unit_test/dots_tts/test_engine_builder.py
@@ -11,15 +11,23 @@ from sglang_omni.scheduling.engine_factory import TtsEngineBuilder
 
 
 def test_dots_engine_uses_shared_tts_builder() -> None:
-    builder = DotsTTSEngineBuilder(optimize=True)
+    builder = DotsTTSEngineBuilder(
+        optimize=True, enable_acoustic_tail_batch_padding=True
+    )
 
     assert isinstance(builder, TtsEngineBuilder)
     assert builder.optimize is True
+    assert builder.enable_acoustic_tail_batch_padding is True
     assert builder.generation_defaults(dtype="bfloat16")["max_running_requests"] == 16
 
 
 def test_dots_engine_accepts_continuous_batching() -> None:
     DotsTTSEngineBuilder().adjust_overrides({"tp_size": 1, "max_running_requests": 16})
+
+
+def test_dots_engine_rejects_string_batch_padding_flag() -> None:
+    with pytest.raises(TypeError, match="must be a boolean"):
+        DotsTTSEngineBuilder(enable_acoustic_tail_batch_padding="false")
 
 
 @pytest.mark.parametrize(

--- a/tests/unit_test/dots_tts/test_graph_padding.py
+++ b/tests/unit_test/dots_tts/test_graph_padding.py
@@ -1,0 +1,36 @@
+# SPDX-License-Identifier: Apache-2.0
+
+from __future__ import annotations
+
+import torch
+
+from sglang_omni.utils.graph_padding import pad_rows, select_padded_graph
+
+
+def test_select_padded_graph_uses_smallest_batch_then_capacity() -> None:
+    graphs = {(8, 32): "8x32", (8, 16): "8x16", (16, 16): "16x16"}
+
+    assert select_padded_graph(graphs, 5, 12) == ("8x16", 3)
+    assert select_padded_graph(graphs, 8, 12) == ("16x16", 8)
+    assert select_padded_graph(graphs, 16, 12) == (None, 0)
+
+
+def test_select_padded_graph_can_replace_skipped_positional_capture() -> None:
+    graphs = {(8, 16): "positional"}
+    gather_twins = {(8, 16): "gather"}
+
+    assert select_padded_graph(graphs, 5, 12, skip_batch=8, extra=gather_twins) == (
+        "gather",
+        3,
+    )
+
+
+def test_pad_rows_preserves_tensor_properties_and_fill_value() -> None:
+    source = torch.tensor([[1, 2], [3, 4]], dtype=torch.int32)
+
+    padded = pad_rows(source, 2, fill_value=9)
+
+    assert padded.dtype == source.dtype
+    assert padded.device == source.device
+    assert padded.tolist() == [[1, 2], [3, 4], [9, 9], [9, 9]]
+    assert pad_rows(source, 0) is source

--- a/tests/unit_test/dots_tts/test_graph_padding.py
+++ b/tests/unit_test/dots_tts/test_graph_padding.py
@@ -2,35 +2,65 @@
 
 from __future__ import annotations
 
-import torch
+import pytest
 
-from sglang_omni.utils.graph_padding import pad_rows, select_padded_graph
+from sglang_omni.utils.graph_padding import select_padded_graph
 
 
-def test_select_padded_graph_uses_smallest_batch_then_capacity() -> None:
+@pytest.mark.parametrize(
+    ("rows", "expected"),
+    [(2, ("8x16", 6)), (5, ("8x16", 3)), (8, ("16x16", 8)), (16, (None, 0))],
+)
+def test_select_padded_graph_uses_smallest_batch_then_capacity(
+    rows: int, expected: tuple[str | None, int]
+) -> None:
     graphs = {(8, 32): "8x32", (8, 16): "8x16", (16, 16): "16x16"}
 
-    assert select_padded_graph(graphs, 5, 12) == ("8x16", 3)
-    assert select_padded_graph(graphs, 8, 12) == ("16x16", 8)
-    assert select_padded_graph(graphs, 16, 12) == (None, 0)
+    assert select_padded_graph(graphs, rows, 12) == expected
 
 
-def test_select_padded_graph_can_replace_skipped_positional_capture() -> None:
+@pytest.mark.parametrize(
+    ("rows", "extra", "expected"),
+    [
+        (4, None, (None, 0)),
+        (3, {(8, 16): "gather"}, (None, 0)),
+        (4, {(8, 16): "gather"}, ("gather", 4)),
+        (5, {(8, 16): "gather"}, ("gather", 3)),
+    ],
+)
+def test_select_padded_graph_replaces_positional_capture_with_bounded_gather(
+    rows: int,
+    extra: dict[tuple[int, int], str] | None,
+    expected: tuple[str | None, int],
+) -> None:
     graphs = {(8, 16): "positional"}
-    gather_twins = {(8, 16): "gather"}
 
-    assert select_padded_graph(graphs, 5, 12, skip_batch=8, extra=gather_twins) == (
-        "gather",
-        3,
+    assert (
+        select_padded_graph(
+            graphs, rows, 12, skip_batch=8, extra=extra, max_batch_ratio=2
+        )
+        == expected
     )
 
 
-def test_pad_rows_preserves_tensor_properties_and_fill_value() -> None:
-    source = torch.tensor([[1, 2], [3, 4]], dtype=torch.int32)
+@pytest.mark.parametrize(
+    ("rows", "capacity", "expected"),
+    [
+        (1, 12, (None, 0)),
+        (2, 12, ("4x16", 2)),
+        (3, 12, ("4x16", 1)),
+        (4, 12, ("8x16", 4)),
+        (5, 12, ("8x16", 3)),
+        (4, 24, (None, 0)),
+        (7, 24, (None, 0)),
+        (8, 24, ("16x32", 8)),
+        (8, 33, (None, 0)),
+    ],
+)
+def test_select_padded_graph_bounds_total_batch_expansion(
+    rows: int, capacity: int, expected: tuple[str | None, int]
+) -> None:
+    """The ratio cap covers both exact-boundary and context-driven expansion."""
+    graphs = {(4, 16): "4x16", (8, 16): "8x16", (16, 32): "16x32"}
 
-    padded = pad_rows(source, 2, fill_value=9)
-
-    assert padded.dtype == source.dtype
-    assert padded.device == source.device
-    assert padded.tolist() == [[1, 2], [3, 4], [9, 9], [9, 9]]
-    assert pad_rows(source, 0) is source
+    assert select_padded_graph(graphs, rows, capacity, max_batch_ratio=2) == expected

--- a/tests/unit_test/dots_tts/test_tail.py
+++ b/tests/unit_test/dots_tts/test_tail.py
@@ -101,6 +101,7 @@ def _build_tail(
     dtype: torch.dtype = torch.float32,
     patch_capacity: int = 8,
     optimize: bool = False,
+    pad_to_bucket: bool = False,
 ):
     encoder = _patch_encoder().to(device=device, dtype=dtype)
     with torch.no_grad():
@@ -123,6 +124,112 @@ def _build_tail(
         device=device,
         dtype=dtype,
         optimize=optimize,
+        pad_to_bucket=pad_to_bucket,
+    )
+
+
+def _copy_live_state(source, destination) -> None:
+    slots = source.spec.num_slots
+    slot_dims = {
+        "_dit_k": 2,
+        "_dit_v": 2,
+        "_encoder_k": 1,
+        "_encoder_v": 1,
+        "_encoder_conv_tail": 0,
+        "_window": 0,
+        "_all_mods": 1,
+    }
+    for name, slot_dim in slot_dims.items():
+        source_value = getattr(source, name)
+        source_value.normal_(0, 0.05)
+        destination_value = getattr(destination, name)
+        live = [slice(None)] * source_value.ndim
+        live[slot_dim] = slice(0, slots)
+        destination_value[tuple(live)].copy_(source_value)
+
+
+def _assert_live_state_close(actual, expected) -> None:
+    slots = expected.spec.num_slots
+    slot_dims = {
+        "_dit_k": 2,
+        "_dit_v": 2,
+        "_encoder_k": 1,
+        "_encoder_v": 1,
+        "_encoder_conv_tail": 0,
+        "_window": 0,
+        "_all_mods": 1,
+    }
+    for name, slot_dim in slot_dims.items():
+        actual_value = getattr(actual, name)
+        expected_value = getattr(expected, name)
+        live = [slice(None)] * expected_value.ndim
+        live[slot_dim] = slice(0, slots)
+        torch.testing.assert_close(
+            actual_value[tuple(live)],
+            expected_value,
+            rtol=2e-2,
+            atol=2e-2,
+        )
+    for slot in range(slots):
+        assert torch.equal(
+            actual._generators[slot].get_state(),
+            expected._generators[slot].get_state(),
+        )
+    assert actual._fm_seq_len == expected._fm_seq_len
+    assert actual._encoder_seq_len == expected._encoder_seq_len
+
+
+def _fill_reserved_state(acoustic_tail, value: float) -> None:
+    slot = acoustic_tail.spec.num_slots
+    slot_dims = {
+        "_dit_k": 2,
+        "_dit_v": 2,
+        "_encoder_k": 1,
+        "_encoder_v": 1,
+        "_encoder_conv_tail": 0,
+        "_window": 0,
+        "_all_mods": 1,
+    }
+    for name, slot_dim in slot_dims.items():
+        tensor = getattr(acoustic_tail, name)
+        reserved = [slice(None)] * tensor.ndim
+        reserved[slot_dim] = slot
+        tensor[tuple(reserved)].fill_(value)
+
+
+@pytest.mark.parametrize(
+    ("slots", "enabled", "expected"),
+    [
+        (1, False, (1,)),
+        (8, False, (1, 8)),
+        (12, False, (1, 8)),
+        (12, True, (1, 8, 12)),
+        (24, True, (1, 8, 16, 24)),
+        (32, True, (1, 8, 16, 32)),
+    ],
+)
+def test_graph_batch_buckets_include_deployment_maximum(
+    slots: int, enabled: bool, expected: tuple[int, ...]
+) -> None:
+    assert tail.graph_batch_buckets(slots, include_maximum=enabled) == expected
+
+
+@pytest.mark.parametrize("optimize", [False, True])
+def test_padding_request_does_not_allocate_on_cpu(optimize: bool) -> None:
+    acoustic_tail = _build_tail(
+        _TailModel().eval(),
+        slots=12,
+        patch_capacity=33,
+        optimize=optimize,
+        pad_to_bucket=True,
+    )
+
+    assert acoustic_tail._cuda_graph_enabled is False
+    assert acoustic_tail._pad_to_bucket is False
+    assert acoustic_tail._graph_batch_buckets == (1, 8)
+    assert acoustic_tail._window.shape[0] == 12
+    assert (
+        acoustic_tail._pool_memory_estimate(acoustic_tail._mods_width).num_slots == 12
     )
 
 
@@ -386,7 +493,10 @@ def test_fused_dit_builds_modulations_with_bfloat16_weights() -> None:
 
 
 @pytest.mark.accelerator
-def test_batched_tail_cuda_graph_matches_eager_for_dynamic_slot_order() -> None:
+@pytest.mark.parametrize("slots", [1, 8])
+def test_batched_tail_cuda_graph_matches_eager_for_dynamic_slot_order(
+    slots: int,
+) -> None:
     if not torch.cuda.is_available():
         pytest.skip("CUDA is required")
     torch.manual_seed(1234)
@@ -397,10 +507,55 @@ def test_batched_tail_cuda_graph_matches_eager_for_dynamic_slot_order() -> None:
     torch.manual_seed(9)
     eager = _build_tail(
         eager_model,
-        slots=8,
+        slots=slots,
         device=device,
         dtype=dtype,
         patch_capacity=33,
+    )
+    torch.manual_seed(9)
+    graph = _build_tail(
+        graph_model,
+        slots=slots,
+        device=device,
+        dtype=dtype,
+        patch_capacity=33,
+        optimize=True,
+    )
+
+    _copy_live_state(eager, graph)
+    for slot in range(slots):
+        eager._fm_seq_len[slot] = graph._fm_seq_len[slot] = 15
+        eager._encoder_seq_len[slot] = graph._encoder_seq_len[slot] = 4
+        eager.initialize_slot_rng(slot, 100 + slot)
+        graph.initialize_slot_rng(slot, 100 + slot)
+
+    slot_order = [0] if slots == 1 else [7, 2, 5, 0, 6, 1, 4, 3]
+    hidden = torch.randn(slots, FM_HIDDEN, device=device, dtype=dtype)
+    eager_latent = eager.sample_patches(slot_order, fm_hidden_rows=hidden)
+    graph_latent = graph.sample_patches(slot_order, fm_hidden_rows=hidden)
+    torch.testing.assert_close(graph_latent, eager_latent, rtol=2e-2, atol=2e-2)
+
+    latent = torch.randn(slots, PATCH_SIZE, LATENT_DIM, device=device, dtype=dtype)
+    eager_feedback = eager.encode_feedback(slot_order, latent)
+    graph_feedback = graph.encode_feedback(slot_order, latent)
+    torch.testing.assert_close(graph_feedback, eager_feedback, rtol=2e-2, atol=2e-2)
+    assert graph._graph_replays == {"meanflow": 1, "semantic_encoder": 1}
+    assert not graph._graph_misses
+    assert graph._dit_contiguous_view_steps == NFE
+
+
+@pytest.mark.accelerator
+def test_padded_tail_replay_matches_eager_and_bin_slot_stays_reusable() -> None:
+    if not torch.cuda.is_available():
+        pytest.skip("CUDA is required")
+    torch.manual_seed(1234)
+    device = torch.device("cuda")
+    dtype = torch.bfloat16
+    eager_model = _TailModel().eval().to(device=device, dtype=dtype)
+    graph_model = copy.deepcopy(eager_model)
+    torch.manual_seed(9)
+    eager = _build_tail(
+        eager_model, slots=8, device=device, dtype=dtype, patch_capacity=33
     )
     torch.manual_seed(9)
     graph = _build_tail(
@@ -410,39 +565,76 @@ def test_batched_tail_cuda_graph_matches_eager_for_dynamic_slot_order() -> None:
         dtype=dtype,
         patch_capacity=33,
         optimize=True,
+        pad_to_bucket=True,
     )
 
-    for name in (
-        "_dit_k",
-        "_dit_v",
-        "_encoder_k",
-        "_encoder_v",
-        "_encoder_conv_tail",
-        "_window",
-        "_all_mods",
-    ):
-        eager_value = getattr(eager, name)
-        eager_value.normal_(0, 0.05)
-        getattr(graph, name).copy_(eager_value)
+    _copy_live_state(eager, graph)
+    assert [eager.acquire_slot() for _ in range(8)] == list(range(8))
+    assert [graph.acquire_slot() for _ in range(8)] == list(range(8))
     for slot in range(8):
-        eager._fm_seq_len[slot] = graph._fm_seq_len[slot] = 15
-        eager._encoder_seq_len[slot] = graph._encoder_seq_len[slot] = 4
+        fm_length = 52 if slot in {5, 7} else 15
+        encoder_length = 18 if slot in {5, 7} else 4
+        eager._fm_seq_len[slot] = graph._fm_seq_len[slot] = fm_length
+        eager._encoder_seq_len[slot] = graph._encoder_seq_len[slot] = encoder_length
         eager.initialize_slot_rng(slot, 100 + slot)
         graph.initialize_slot_rng(slot, 100 + slot)
 
-    slots = [7, 2, 5, 0, 6, 1, 4, 3]
-    hidden = torch.randn(8, FM_HIDDEN, device=device, dtype=dtype)
-    eager_latent = eager.sample_patches(slots, fm_hidden_rows=hidden)
-    graph_latent = graph.sample_patches(slots, fm_hidden_rows=hidden)
-    torch.testing.assert_close(graph_latent, eager_latent, rtol=2e-2, atol=2e-2)
+    # A -> B -> A stresses repeated reuse of the shared filler row with
+    # different live members. Repeated updates also cross context capacities.
+    schedules = ([3, 0, 4, 1, 2], [7, 5], [3, 0, 4, 1, 2])
+    for replay_index, slot_order in enumerate(schedules):
+        _fill_reserved_state(graph, 0.25 + replay_index)
+        hidden = torch.randn(len(slot_order), FM_HIDDEN, device=device, dtype=dtype)
+        eager_latent = eager.sample_patches(slot_order, fm_hidden_rows=hidden)
+        graph_latent = graph.sample_patches(slot_order, fm_hidden_rows=hidden)
+        torch.testing.assert_close(graph_latent, eager_latent, rtol=2e-2, atol=2e-2)
 
-    latent = torch.randn(8, PATCH_SIZE, LATENT_DIM, device=device, dtype=dtype)
-    eager_feedback = eager.encode_feedback(slots, latent)
-    graph_feedback = graph.encode_feedback(slots, latent)
-    torch.testing.assert_close(graph_feedback, eager_feedback, rtol=2e-2, atol=2e-2)
-    assert graph._graph_replays == {"meanflow": 1, "semantic_encoder": 1}
+        latent = torch.randn(
+            len(slot_order), PATCH_SIZE, LATENT_DIM, device=device, dtype=dtype
+        )
+        eager_feedback = eager.encode_feedback(slot_order, latent)
+        graph_feedback = graph.encode_feedback(slot_order, latent)
+        torch.testing.assert_close(graph_feedback, eager_feedback, rtol=2e-2, atol=2e-2)
+        _assert_live_state_close(graph, eager)
+
+    assert graph._graph_padded_replays == {"meanflow": 3, "semantic_encoder": 3}
     assert not graph._graph_misses
-    assert graph._dit_contiguous_view_steps == NFE
+
+    # Filler rows write into the reserved pool row past the slot range, so no
+    # allocatable slot ever sees them: a real slot that sat out the padded
+    # batch must still match the eager twin exactly afterwards.
+    assert graph._pad_bin_slot == 8
+    assert graph._dit_k.shape[2] == 9  # 8 slots + 1 reserved row
+    assert eager._window.shape[0] == 8
+    bystander = 7
+    assert bystander not in slot_order
+    hidden_one = torch.randn(1, FM_HIDDEN, device=device, dtype=dtype)
+    eager_one = eager.sample_patches([bystander], fm_hidden_rows=hidden_one)
+    graph_one = graph.sample_patches([bystander], fm_hidden_rows=hidden_one)
+    torch.testing.assert_close(graph_one, eager_one, rtol=2e-2, atol=2e-2)
+
+    # Release/reacquire a real row, reseed it, and prove the reserved row did
+    # not leak state into its next owner.
+    eager.release_slot(bystander)
+    graph.release_slot(bystander)
+    assert eager.acquire_slot() == graph.acquire_slot() == bystander
+    grid = torch.linspace(0.0, 1.0, NFE + 1, device=device, dtype=dtype)
+    g_cond = torch.randn(1, FM_HIDDEN, device=device, dtype=dtype)
+    mods = eager.dit.build_mods(grid[:-1], duration=grid[1:] - grid[:-1], g_cond=g_cond)
+    history = torch.randn(
+        2 * eager.spec.unit_len, FM_HIDDEN, device=device, dtype=dtype
+    )
+    for acoustic_tail in (eager, graph):
+        acoustic_tail.seed_fm_history(bystander, fm_rows=history, all_mods=mods)
+        acoustic_tail.initialize_slot_rng(bystander, 999)
+    hidden_one = torch.randn(1, FM_HIDDEN, device=device, dtype=dtype)
+    torch.testing.assert_close(
+        graph.sample_patches([bystander], fm_hidden_rows=hidden_one),
+        eager.sample_patches([bystander], fm_hidden_rows=hidden_one),
+        rtol=2e-2,
+        atol=2e-2,
+    )
+    _assert_live_state_close(graph, eager)
 
 
 def _seed_single_slot_tail(patch_capacity: int) -> tuple[Any, int]:

--- a/tests/unit_test/dots_tts/test_tail.py
+++ b/tests/unit_test/dots_tts/test_tail.py
@@ -26,6 +26,15 @@ FM_HIDDEN = 32
 LATENT_DIM = 6
 PATCH_SIZE = 2
 NFE = 2
+SLOT_DIMS = {
+    "_dit_k": 2,
+    "_dit_v": 2,
+    "_encoder_k": 1,
+    "_encoder_v": 1,
+    "_encoder_conv_tail": 0,
+    "_window": 0,
+    "_all_mods": 1,
+}
 
 
 def test_batched_tail_mask_hides_padding_and_preserves_causality() -> None:
@@ -130,16 +139,7 @@ def _build_tail(
 
 def _copy_live_state(source, destination) -> None:
     slots = source.spec.num_slots
-    slot_dims = {
-        "_dit_k": 2,
-        "_dit_v": 2,
-        "_encoder_k": 1,
-        "_encoder_v": 1,
-        "_encoder_conv_tail": 0,
-        "_window": 0,
-        "_all_mods": 1,
-    }
-    for name, slot_dim in slot_dims.items():
+    for name, slot_dim in SLOT_DIMS.items():
         source_value = getattr(source, name)
         source_value.normal_(0, 0.05)
         destination_value = getattr(destination, name)
@@ -150,16 +150,7 @@ def _copy_live_state(source, destination) -> None:
 
 def _assert_live_state_close(actual, expected) -> None:
     slots = expected.spec.num_slots
-    slot_dims = {
-        "_dit_k": 2,
-        "_dit_v": 2,
-        "_encoder_k": 1,
-        "_encoder_v": 1,
-        "_encoder_conv_tail": 0,
-        "_window": 0,
-        "_all_mods": 1,
-    }
-    for name, slot_dim in slot_dims.items():
+    for name, slot_dim in SLOT_DIMS.items():
         actual_value = getattr(actual, name)
         expected_value = getattr(expected, name)
         live = [slice(None)] * expected_value.ndim
@@ -181,16 +172,7 @@ def _assert_live_state_close(actual, expected) -> None:
 
 def _fill_reserved_state(acoustic_tail, value: float) -> None:
     slot = acoustic_tail.spec.num_slots
-    slot_dims = {
-        "_dit_k": 2,
-        "_dit_v": 2,
-        "_encoder_k": 1,
-        "_encoder_v": 1,
-        "_encoder_conv_tail": 0,
-        "_window": 0,
-        "_all_mods": 1,
-    }
-    for name, slot_dim in slot_dims.items():
+    for name, slot_dim in SLOT_DIMS.items():
         tensor = getattr(acoustic_tail, name)
         reserved = [slice(None)] * tensor.ndim
         reserved[slot_dim] = slot
@@ -201,11 +183,14 @@ def _fill_reserved_state(acoustic_tail, value: float) -> None:
     ("slots", "enabled", "expected"),
     [
         (1, False, (1,)),
-        (8, False, (1, 8)),
-        (12, False, (1, 8)),
-        (12, True, (1, 8, 12)),
-        (24, True, (1, 8, 16, 24)),
-        (32, True, (1, 8, 16, 32)),
+        (2, True, (1, 2)),
+        (4, False, (1, 4)),
+        (8, False, (1, 4, 8)),
+        (12, False, (1, 4, 8)),
+        (12, True, (1, 4, 8, 12)),
+        (24, False, (1, 4, 8, 16)),
+        (24, True, (1, 4, 8, 16, 24)),
+        (32, True, (1, 4, 8, 16, 32)),
     ],
 )
 def test_graph_batch_buckets_include_deployment_maximum(
@@ -226,11 +211,12 @@ def test_padding_request_does_not_allocate_on_cpu(optimize: bool) -> None:
 
     assert acoustic_tail._cuda_graph_enabled is False
     assert acoustic_tail._pad_to_bucket is False
-    assert acoustic_tail._graph_batch_buckets == (1, 8)
-    assert acoustic_tail._window.shape[0] == 12
-    assert (
-        acoustic_tail._pool_memory_estimate(acoustic_tail._mods_width).num_slots == 12
-    )
+    assert acoustic_tail._graph_batch_buckets == (1, 4, 8)
+    for name, slot_dim in SLOT_DIMS.items():
+        assert getattr(acoustic_tail, name).shape[slot_dim] == 12
+    estimate = acoustic_tail._pool_memory_estimate(acoustic_tail._mods_width)
+    assert estimate.num_slots == 12
+    assert estimate.total_bytes == acoustic_tail._allocated_pool_bytes()
 
 
 def _reference_meanflow(
@@ -545,7 +531,11 @@ def test_batched_tail_cuda_graph_matches_eager_for_dynamic_slot_order(
 
 
 @pytest.mark.accelerator
-def test_padded_tail_replay_matches_eager_and_bin_slot_stays_reusable() -> None:
+@pytest.mark.parametrize(("slots", "first_rows"), [(8, 5), (12, 9), (24, 17)])
+def test_padded_tail_replay_matches_eager_and_bin_slot_stays_reusable(
+    slots: int, first_rows: int
+) -> None:
+    """Padded, exact, and uncaptured-context execution preserve request state."""
     if not torch.cuda.is_available():
         pytest.skip("CUDA is required")
     torch.manual_seed(1234)
@@ -555,34 +545,54 @@ def test_padded_tail_replay_matches_eager_and_bin_slot_stays_reusable() -> None:
     graph_model = copy.deepcopy(eager_model)
     torch.manual_seed(9)
     eager = _build_tail(
-        eager_model, slots=8, device=device, dtype=dtype, patch_capacity=33
+        eager_model, slots=slots, device=device, dtype=dtype, patch_capacity=40
     )
     torch.manual_seed(9)
     graph = _build_tail(
         graph_model,
-        slots=8,
+        slots=slots,
         device=device,
         dtype=dtype,
-        patch_capacity=33,
+        patch_capacity=40,
         optimize=True,
         pad_to_bucket=True,
     )
 
     _copy_live_state(eager, graph)
-    assert [eager.acquire_slot() for _ in range(8)] == list(range(8))
-    assert [graph.acquire_slot() for _ in range(8)] == list(range(8))
-    for slot in range(8):
-        fm_length = 52 if slot in {5, 7} else 15
-        encoder_length = 18 if slot in {5, 7} else 4
+    assert [eager.acquire_slot() for _ in range(slots)] == list(range(slots))
+    assert [graph.acquire_slot() for _ in range(slots)] == list(range(slots))
+    for slot in range(slots):
+        fm_length = 52 if slot in {slots - 3, slots - 1} else 15
+        encoder_length = (
+            18 if slot in {slots - 3, slots - 1} else 4
+        ) * graph._encoder_block
         eager._fm_seq_len[slot] = graph._fm_seq_len[slot] = fm_length
         eager._encoder_seq_len[slot] = graph._encoder_seq_len[slot] = encoder_length
         eager.initialize_slot_rng(slot, 100 + slot)
         graph.initialize_slot_rng(slot, 100 + slot)
 
-    # A -> B -> A stresses repeated reuse of the shared filler row with
-    # different live members. Repeated updates also cross context capacities.
-    schedules = ([3, 0, 4, 1, 2], [7, 5], [3, 0, 4, 1, 2])
+    # note (0xtoward): A uses the maximum-batch gather twin; B changes live
+    # members and uses the largest permitted filler count (2 -> 4).
+    first = list(reversed(range(first_rows)))
+    second = [slots - 1, slots - 2]
+    full = list(reversed(range(slots - 4, slots)))
+    shared_graphs = (
+        graph._meanflow_graphs[(4, 32 * graph.spec.unit_len)],
+        graph._encoder_graphs[(4, 32 * graph._encoder_block)],
+    )
+    schedules = (first, second, first, full, second, [0, 1])
     for replay_index, slot_order in enumerate(schedules):
+        if replay_index == 5:
+            # note (0xtoward): These histories fit the pool but exceed every
+            # captured context, so even a legal 2 -> 4 batch must run eagerly.
+            for acoustic_tail in (eager, graph):
+                for slot in slot_order:
+                    acoustic_tail._fm_seq_len[slot] = (
+                        32 * acoustic_tail.spec.unit_len + acoustic_tail.spec.window_len
+                    )
+                    acoustic_tail._encoder_seq_len[slot] = (
+                        32 * acoustic_tail._encoder_block + 1
+                    )
         _fill_reserved_state(graph, 0.25 + replay_index)
         hidden = torch.randn(len(slot_order), FM_HIDDEN, device=device, dtype=dtype)
         eager_latent = eager.sample_patches(slot_order, fm_hidden_rows=hidden)
@@ -596,25 +606,38 @@ def test_padded_tail_replay_matches_eager_and_bin_slot_stays_reusable() -> None:
         graph_feedback = graph.encode_feedback(slot_order, latent)
         torch.testing.assert_close(graph_feedback, eager_feedback, rtol=2e-2, atol=2e-2)
         _assert_live_state_close(graph, eager)
+        if replay_index == 3:
+            for captured in shared_graphs:
+                assert captured.inputs["slots"].tolist() == full
+        elif replay_index == 4:
+            # note (0xtoward): Reusing the same full -> partial capture must
+            # replace every stale live suffix before replaying filler rows.
+            for captured in shared_graphs:
+                assert captured.inputs["slots"].tolist() == second + [slots, slots]
+                for name, value in captured.inputs.items():
+                    if name != "slots":
+                        assert torch.count_nonzero(value[2:]).item() == 0
 
-    assert graph._graph_padded_replays == {"meanflow": 3, "semantic_encoder": 3}
-    assert not graph._graph_misses
+    assert graph._graph_replays == {"meanflow": 5, "semantic_encoder": 5}
+    assert graph._graph_padded_replays == {"meanflow": 4, "semantic_encoder": 4}
+    assert graph._graph_misses == {"meanflow": 1, "semantic_encoder": 1}
+    assert graph._dit_contiguous_view_steps == 0
 
-    # Filler rows write into the reserved pool row past the slot range, so no
-    # allocatable slot ever sees them: a real slot that sat out the padded
-    # batch must still match the eager twin exactly afterwards.
-    assert graph._pad_bin_slot == 8
-    assert graph._dit_k.shape[2] == 9  # 8 slots + 1 reserved row
-    assert eager._window.shape[0] == 8
-    bystander = 7
+    # note (0xtoward): Filler writes stay outside every allocatable slot.
+    assert graph._pad_bin_slot == slots
+    assert graph._dit_k.shape[2] == slots + 1
+    assert eager._window.shape[0] == slots
+    estimate = graph._pool_memory_estimate(graph._mods_width)
+    assert estimate.num_slots == slots
+    assert estimate.total_bytes == graph._allocated_pool_bytes()
+    bystander = slots - 1
     assert bystander not in slot_order
     hidden_one = torch.randn(1, FM_HIDDEN, device=device, dtype=dtype)
     eager_one = eager.sample_patches([bystander], fm_hidden_rows=hidden_one)
     graph_one = graph.sample_patches([bystander], fm_hidden_rows=hidden_one)
     torch.testing.assert_close(graph_one, eager_one, rtol=2e-2, atol=2e-2)
 
-    # Release/reacquire a real row, reseed it, and prove the reserved row did
-    # not leak state into its next owner.
+    # note (0xtoward): Reacquiring a real row must not inherit filler state.
     eager.release_slot(bystander)
     graph.release_slot(bystander)
     assert eager.acquire_slot() == graph.acquire_slot() == bystander
@@ -635,6 +658,48 @@ def test_padded_tail_replay_matches_eager_and_bin_slot_stays_reusable() -> None:
         atol=2e-2,
     )
     _assert_live_state_close(graph, eager)
+
+
+@pytest.mark.accelerator
+@pytest.mark.parametrize(
+    ("slots", "optimize", "pad_to_bucket", "buckets"),
+    [
+        (12, False, True, (1, 4, 8)),
+        (12, True, False, (1, 4, 8)),
+        (1, True, True, (1,)),
+        (2, True, True, (1, 2)),
+    ],
+)
+def test_inactive_padding_preserves_cuda_pool_storage(
+    slots: int, optimize: bool, pad_to_bucket: bool, buckets: tuple[int, ...]
+) -> None:
+    """Disabled padding or buckets without gaps allocate no reserved row."""
+    if not torch.cuda.is_available():
+        pytest.skip("CUDA is required")
+    device = torch.device("cuda")
+    dtype = torch.bfloat16
+    model = _TailModel().eval().to(device=device, dtype=dtype)
+    graph_model = copy.deepcopy(model)
+    baseline = _build_tail(
+        model, slots=slots, device=device, dtype=dtype, patch_capacity=33
+    )
+    actual = _build_tail(
+        graph_model,
+        slots=slots,
+        device=device,
+        dtype=dtype,
+        patch_capacity=33,
+        optimize=optimize,
+        pad_to_bucket=pad_to_bucket,
+    )
+
+    assert not actual._pad_to_bucket
+    assert actual._graph_batch_buckets == buckets
+    assert not actual._meanflow_pad_graphs
+    assert actual._allocated_pool_bytes() == baseline._allocated_pool_bytes()
+    assert [pool.shape for pool in actual._pool_tensors()] == [
+        pool.shape for pool in baseline._pool_tensors()
+    ]
 
 
 def _seed_single_slot_tail(patch_capacity: int) -> tuple[Any, int]:
@@ -658,12 +723,14 @@ def _counter_records(caplog) -> list[logging.LogRecord]:
     return [r for r in caplog.records if "tail graph counters" in r.getMessage()]
 
 
-def test_tail_logs_graph_counters_every_50_steps(caplog) -> None:
+@pytest.mark.parametrize(
+    "graph_kind", ["_meanflow_graphs", "_meanflow_pad_graphs", "_encoder_graphs"]
+)
+def test_tail_logs_graph_counters_every_50_steps(caplog, graph_kind: str) -> None:
     acoustic_tail, slot = _seed_single_slot_tail(patch_capacity=60)
     # A captured batch-8 bucket that batch-1 decode can never select: every
     # cycle is a real miss, which is exactly what the counters report.
-    acoustic_tail._meanflow_graphs[(8, 16)] = object()
-    acoustic_tail._encoder_graphs[(8, 16)] = object()
+    getattr(acoustic_tail, graph_kind)[(8, 16)] = object()
 
     with caplog.at_level(logging.DEBUG, logger=tail.logger.name):
         for step in range(50):
@@ -688,6 +755,8 @@ def test_tail_logs_graph_counters_every_50_steps(caplog) -> None:
     assert "meanflow_misses=50" in message
     assert "semantic_encoder_replays=0" in message
     assert "semantic_encoder_misses=50" in message
+    assert "meanflow_padded_replays=0" in message
+    assert "semantic_encoder_padded_replays=0" in message
     assert acoustic_tail._graph_misses == Counter(
         {"meanflow": 50, "semantic_encoder": 50}
     )

--- a/tests/unit_test/dots_tts/test_tail.py
+++ b/tests/unit_test/dots_tts/test_tail.py
@@ -174,9 +174,8 @@ def _fill_reserved_state(acoustic_tail, value: float) -> None:
     slot = acoustic_tail.spec.num_slots
     for name, slot_dim in SLOT_DIMS.items():
         tensor = getattr(acoustic_tail, name)
-        reserved = [slice(None)] * tensor.ndim
-        reserved[slot_dim] = slot
-        tensor[tuple(reserved)].fill_(value)
+        if tensor.size(slot_dim) > slot:
+            tensor.select(slot_dim, slot).fill_(value)
 
 
 @pytest.mark.parametrize(
@@ -625,7 +624,13 @@ def test_padded_tail_replay_matches_eager_and_bin_slot_stays_reusable(
 
     # note (0xtoward): Filler writes stay outside every allocatable slot.
     assert graph._pad_bin_slot == slots
-    assert graph._dit_k.shape[2] == slots + 1
+    for name, slot_dim in SLOT_DIMS.items():
+        expected_rows = (
+            slots
+            if name in {"_dit_k", "_dit_v", "_encoder_k", "_encoder_v"}
+            else slots + 1
+        )
+        assert getattr(graph, name).size(slot_dim) == expected_rows
     assert eager._window.shape[0] == slots
     estimate = graph._pool_memory_estimate(graph._mods_width)
     assert estimate.num_slots == slots

--- a/tests/unit_test/dots_tts/test_tail_kv.py
+++ b/tests/unit_test/dots_tts/test_tail_kv.py
@@ -1,0 +1,56 @@
+# SPDX-License-Identifier: Apache-2.0
+
+import pytest
+import torch
+
+
+@pytest.mark.accelerator
+@pytest.mark.parametrize(("num_slots", "tokens"), [(8, 0), (12, 5), (24, 13)])
+def test_kv_copies_preserve_live_rows_and_skip_dummy_storage(
+    num_slots: int, tokens: int
+) -> None:
+    if not torch.cuda.is_available():
+        pytest.skip("CUDA is required for the Triton KV copies")
+
+    from sglang_omni.models.dots_tts.tail_kv import gather_kv, scatter_kv
+
+    torch.manual_seed(0)
+    pool_shape = (2, num_slots, 3, 23, 11)
+    pool_backing = [
+        torch.randn(pool_shape, device="cuda", dtype=torch.bfloat16) for _ in range(2)
+    ]
+    pools = [backing[..., 1:20, 1:8] for backing in pool_backing]
+    out_shape = (2, 6, 3, tokens + 2, 9)
+    out_backing = [
+        torch.full(out_shape, value, device="cuda", dtype=torch.bfloat16)
+        for value in (123, -123)
+    ]
+    outputs = [backing[..., 1 : 1 + tokens, 1:8] for backing in out_backing]
+    expected_outputs = [backing.clone() for backing in out_backing]
+    expected_pools = [backing.clone() for backing in pool_backing]
+    slot_ids = [num_slots - 1, num_slots, 1, num_slots, 0, num_slots // 2]
+    start_ids = [0, 10_000, 3, -10_000, 4, 5]
+    slots = torch.tensor(slot_ids, device="cuda", dtype=torch.long)
+    starts = torch.tensor(start_ids, device="cuda", dtype=torch.long)
+
+    # note (0xtoward): Strided views and repeated dummy IDs exercise masked
+    # accesses; checking the backing tensors also catches writes outside views.
+    gather_kv(*pools, slots, *outputs)
+    for pool, expected in zip(pools, expected_outputs):
+        view = expected[..., 1 : 1 + tokens, 1:8]
+        for row, slot in enumerate(slot_ids):
+            if slot < num_slots:
+                view[:, row].copy_(pool[:, slot, :, :tokens])
+            else:
+                view[:, row].zero_()
+    for actual, expected in zip(out_backing, expected_outputs):
+        assert torch.equal(actual, expected)
+
+    scatter_kv(*outputs, slots, starts, *pools)
+    for output, expected in zip(outputs, expected_pools):
+        view = expected[..., 1:20, 1:8]
+        for row, (slot, start) in enumerate(zip(slot_ids, start_ids)):
+            if slot < num_slots:
+                view[:, slot, :, start : start + tokens].copy_(output[:, row])
+    for actual, expected in zip(pool_backing, expected_pools):
+        assert torch.equal(actual, expected)


### PR DESCRIPTION
## Motivation

Follow-up to #1882 Q2.

- Add B1/B4 acoustic-tail captures alongside B8/B16, including the deployment's `num_slots` bucket.
- Add opt-in padding to the next compatible bucket, retaining the 2× expansion guard:
  `latent_engine.factory.enable_acoustic_tail_batch_padding: true`.
- Fill graph inputs in place, avoiding temporary concatenation. Fused K/V copies skip dummy KV storage: 799.9 MiB saved, leaving 0.87 MiB of extra persistent state at 16 slots / 501 patches / BF16 / NFE4. Padded rows still incur model compute.

## Measurements

A100, short SeedTTS, Omni BenchmarkRunner, 48 requests/cell, hot-reference warmup, profiler off.

| Client concurrency | Comparison | E2E change | Client TTFA change | Notes |
|---|---|---:|---:|---|
| C1 | Current flag off → on | −2.5% | −1.1% | ABBA, 48 requests/cell, two repeats/arm |
| C3 | B4 + pad + staging vs exact-only B1/8/16 | −30.8% | — | Historical, non-factorial comparison |
| C6 | B4 + pad + staging vs exact-only B1/8/16 | −7.7% | — | Historical, non-factorial comparison |
| C8 | Current flag off → on | −11.1% | +24.1% | ABBA; TTFA regressed in both paired repeats |
| C12 | Current flag off → on | −11.3% | +30.8% | ABBA; TTFA regressed in both paired repeats |
| C16 | B4 + pad + staging vs exact-only B1/8/16 | −4.2%* | — | Historical; one run/arm |

Separate comparisons, not cumulative or current-head-vs-main results.
First comparison: two runs/arm for C3/C6; *one for C16.
Second: ABBA with identical buckets/staging; 576/576 requests successful.
Client concurrency is not runtime batch size, including at C16.

Trade-off: earlier padding increased C6 TTFA from 0.663 to 2.288 s;
the KV update increased C3 TTFA by 57 ms. Padding remains default-off.
**Vocoder** queue scheduling becomes a separate follow-up.

## Validation

Numeric checks on A100 (PR tail on the existing serving stack, real weights unless noted).
`pytest -q tests/unit_test/dots_tts/{test_graph_padding,test_tail,test_tail_kv}.py` → 53 passed, 1 failed (see below).

| Check | How | Result |
|---|---|---|
| KV primitives | 8 cases vs a PyTorch copy/zero/indexed-write oracle, strided views, dummy IDs, untouched-buffer guards; + memcheck | 8/8; 0 memcheck errors |
| Tail state / memory | 6 cases vs the previous reserved-KV impl, N8/12/24, slot reuse, padding-off storage | 6/6 exact equality |
| Masked K/V vs old reserved-row K/V | 8 sequential transitions, same shape/seed/history | 8/8 bit-identical (removing the physical dummy K/V row does not change same-shape replay) |
| Filler isolation | flip the auxiliary row 0→100, B9→B16 / B2→B4 | 2/2 bit-exact on latent, feedback, every real state pool, RNG |
| Padded graph vs eager | B9→B16 / B2→B4, real weights | latent rel-L2 1.37/1.39%, cosine 0.9999; 1 element trips the 2e-2 pointwise gate (see below) |
| Full-model audio (C6, fresh corpus) | 64 new texts/ids/refs (no overlap with prior sets), 3 arms off/off/on, repo SeedTTS eval (Qwen3-ASR WER, WavLM SIM), 187 padded B6→B8 replays observed | 64/64 each. WER 0.75 / 0.68 / 0.83%; SIM 80.03 / 80.00 / 80.13 |
| Full current-tree / long shape | clean deploy + tracker long-shape A/A + A/B | Pending |

**The one failing case** — `test_padded_tail_replay_matches_eager_and_bin_slot_stays_reusable[8-5]`, one `_dit_v` element off by 0.0273 under `rtol=atol=2e-2` — is graph-vs-eager **context shape**, not padding or the dummy-KV change. The captured graph attends over a fixed context bucket (96 tokens) while eager uses the compact real context (55), so total KV length is 102 vs 61. A pointwise 2e-2 graph-vs-eager gate cannot hold whenever a padded context crosses a tile boundary the compact context does not.

**On quality:** SIM mean did not regress (paired-difference CI crosses zero — no regression observed this round, not an equivalence claim); `on`'s extra 1–2 char errors are one sentence, not yet listened, so not attributed. Earlier audio smokes (128 and 512 outputs) spanned other code versions and are not counted here. WER/SIM cover content and speaker; the latent/KV/slot numeric gate is the failing case above and is **not** substitutable by WER/SIM — closing it (re-scope the assertion) is the remaining blocker.

