### PR TITLE
[dots.tts] Add opt-in breakable prefill CUDA graphs

### DIFF
--- a/sglang_omni/models/dots_tts/__init__.py
+++ b/sglang_omni/models/dots_tts/__init__.py
@@ -11,7 +11,7 @@ CAPABILITIES = ModelCapabilities(
     supports_streaming_vocoder=True,
     supports_cuda_graph=False,
     supports_torch_compile=True,
-    supports_breakable_prefill_cuda_graph=False,
+    supports_breakable_prefill_cuda_graph=True,
 )
 
 __all__ = ["CAPABILITIES", "config"]

--- a/sglang_omni/models/dots_tts/engine_builder.py
+++ b/sglang_omni/models/dots_tts/engine_builder.py
@@ -6,7 +6,12 @@ from __future__ import annotations
 import logging
 from typing import Any
 
+from sglang_omni.models.dots_tts import CAPABILITIES
 from sglang_omni.scheduling.engine_factory import TtsEngineBuilder
+from sglang_omni.scheduling.generation_batch_policy import (
+    CudaGraphBackend,
+    get_prefill_cuda_graph_backend,
+)
 
 logger = logging.getLogger(__name__)
 
@@ -14,6 +19,9 @@ logger = logging.getLogger(__name__)
 class DotsTTSEngineBuilder(TtsEngineBuilder):
     model_name = "dots.tts"
     context_length = 2048
+    supports_breakable_prefill_cuda_graph = (
+        CAPABILITIES.supports_breakable_prefill_cuda_graph
+    )
 
     def __init__(
         self,
@@ -53,6 +61,7 @@ class DotsTTSEngineBuilder(TtsEngineBuilder):
     def generation_defaults(self, *, dtype: str) -> dict[str, Any]:
         return {
             "disable_cuda_graph": True,
+            "cuda_graph_backend_prefill": CudaGraphBackend.DISABLED,
             "disable_overlap_schedule": True,
             "disable_radix_cache": True,
             "enable_torch_compile": False,
@@ -83,6 +92,18 @@ class DotsTTSEngineBuilder(TtsEngineBuilder):
             # its can_run gate requires an exact hidden-mode match with the
             # acoustic tail's per-step request.
             overrides["enable_return_hidden_states"] = True
+
+    def validate_before_infrastructure(self, server_args: Any) -> None:
+        if get_prefill_cuda_graph_backend(server_args) == CudaGraphBackend.BREAKABLE:
+            # dots requires whole-request prefills, so the disabled chunker
+            # cannot supply a graph cap. Let the shared policy derive its buckets
+            # from the operator's explicit cap instead.
+            prefill = server_args.cuda_graph_config.prefill
+            if not prefill.max_bs or prefill.max_bs <= 0 or not prefill.bs:
+                raise ValueError(
+                    "dots.tts breakable prefill requires an explicit positive "
+                    "cuda_graph_max_bs_prefill (chunked prefill remains disabled)"
+                )
 
     def setup_model(
         self,

--- a/sglang_omni/models/dots_tts/model_runner.py
+++ b/sglang_omni/models/dots_tts/model_runner.py
@@ -10,6 +10,10 @@ import torch
 from sglang.srt.managers.schedule_batch import FINISH_MATCHED_TOKEN
 
 from sglang_omni.model_runner.base import ModelRunner
+from sglang_omni.model_runner.prefill_inputs import (
+    OmniPrefillInputs,
+    attach_omni_prefill_inputs,
+)
 from sglang_omni.models.dots_tts.flow_head import DotsFlowStep
 from sglang_omni.models.dots_tts.request_builders import DotsFlowResume
 
@@ -98,7 +102,10 @@ class DotsTTSModelRunner(ModelRunner):
                         ).to(device=device, dtype=embeddings.dtype)
                     )
                 rows.append(torch.cat(request_rows, dim=0))
-            forward_batch.input_embeds = torch.cat(rows, dim=0)
+            attach_omni_prefill_inputs(
+                forward_batch,
+                OmniPrefillInputs(input_embeds=torch.cat(rows, dim=0)),
+            )
         except BaseException:
             for request_id, data in materialized:
                 self._request_data.pop(request_id, None)

--- a/sglang_omni/models/dots_tts/sglang_model.py
+++ b/sglang_omni/models/dots_tts/sglang_model.py
@@ -50,6 +50,11 @@ class DotsTTSSGLangModel(nn.Module):
         return self.qwen2.get_input_embeddings()
 
     @property
+    def language_model(self) -> Qwen2ForCausalLM:
+        """Expose the backbone boundary used by SGLang's prefill graph runner."""
+        return self.qwen2
+
+    @property
     def graph_feedback_buffer(self) -> torch.Tensor | None:
         return self._graph_feedback_buffer
 

--- a/tests/unit_test/dots_tts/test_engine_builder.py
+++ b/tests/unit_test/dots_tts/test_engine_builder.py
@@ -2,10 +2,16 @@
 
 from __future__ import annotations
 
+from types import SimpleNamespace
+
 import pytest
 
 from sglang_omni.models.dots_tts.engine_builder import DotsTTSEngineBuilder
 from sglang_omni.scheduling.engine_factory import TtsEngineBuilder
+from sglang_omni.scheduling.generation_batch_policy import (
+    CudaGraphBackend,
+    build_generation_batch_overrides,
+)
 
 
 def test_dots_engine_uses_shared_tts_builder() -> None:
@@ -18,6 +24,39 @@ def test_dots_engine_uses_shared_tts_builder() -> None:
 
 def test_dots_engine_accepts_continuous_batching() -> None:
     DotsTTSEngineBuilder().adjust_overrides({"tp_size": 1, "max_running_requests": 16})
+
+
+def test_dots_prefill_graph_is_opt_in_with_shared_buckets() -> None:
+    builder = DotsTTSEngineBuilder()
+    defaults = builder.generation_defaults(dtype="bfloat16")
+    assert defaults["cuda_graph_backend_prefill"] == CudaGraphBackend.DISABLED
+    assert builder.supports_breakable_prefill_cuda_graph
+    overrides = build_generation_batch_overrides(
+        **defaults,
+        server_args_overrides={
+            "disable_cuda_graph": False,
+            "cuda_graph_backend_prefill": CudaGraphBackend.BREAKABLE,
+            "cuda_graph_max_bs_prefill": 512,
+        },
+    )
+    builder.adjust_overrides(overrides)
+
+    assert overrides["chunked_prefill_size"] == 0
+    assert overrides["enable_return_hidden_states"] is True
+    assert overrides["cuda_graph_bs_prefill"][-1] == 512
+
+
+@pytest.mark.parametrize("cap,buckets", [(0, []), (512, [])])
+def test_dots_prefill_graph_rejects_empty_capture(cap, buckets) -> None:
+    args = SimpleNamespace(
+        cuda_graph_config=SimpleNamespace(
+            prefill=SimpleNamespace(
+                backend=CudaGraphBackend.BREAKABLE, max_bs=cap, bs=buckets
+            )
+        )
+    )
+    with pytest.raises(ValueError, match="explicit positive cuda_graph_max_bs_prefill"):
+        DotsTTSEngineBuilder().validate_before_infrastructure(args)
 
 
 @pytest.mark.parametrize(

--- a/tests/unit_test/dots_tts/test_model_runner.py
+++ b/tests/unit_test/dots_tts/test_model_runner.py
@@ -9,6 +9,7 @@ import pytest
 import torch
 from torch import nn
 
+from sglang_omni.model_runner.prefill_inputs import get_omni_prefill_inputs
 from sglang_omni.models.dots_tts.model_runner import DotsTTSModelRunner
 
 
@@ -120,15 +121,23 @@ def test_dots_prefill_batches_request_embeddings_in_scheduler_order() -> None:
     requests = [_request("a", 11.0), _request("b", 22.0)]
     runner._request_data = {"a": requests[0].data}
     forward_batch = SimpleNamespace(
-        input_ids=torch.tensor([1, 2, 3, 1, 2, 3]), input_embeds=None
+        input_ids=torch.tensor([1, 2, 3, 3, 1, 2, 3]),
+        input_embeds=None,
+        replace_embeds=None,
+        mm_inputs=None,
     )
 
     runner.before_prefill(forward_batch, object(), requests)
 
-    assert forward_batch.input_embeds.shape == (7, 4)
-    torch.testing.assert_close(forward_batch.input_embeds[1], torch.full((4,), 11.0))
-    torch.testing.assert_close(forward_batch.input_embeds[3], torch.full((4,), 33.0))
-    torch.testing.assert_close(forward_batch.input_embeds[5], torch.full((4,), 22.0))
+    assert forward_batch.input_embeds is None
+    assert forward_batch.mm_inputs is None
+    prefill_inputs = get_omni_prefill_inputs(forward_batch)
+    assert prefill_inputs is not None
+    embeds = prefill_inputs.input_embeds
+    assert embeds.shape == (7, 4)
+    torch.testing.assert_close(embeds[1], torch.full((4,), 11.0))
+    torch.testing.assert_close(embeds[3], torch.full((4,), 33.0))
+    torch.testing.assert_close(embeds[5], torch.full((4,), 22.0))
     assert suspended == [old_flow_state]
     torch.testing.assert_close(restored_rng[0], torch.tensor([7], dtype=torch.uint8))
     assert restored_rng[1] == 42

--- a/tests/unit_test/dots_tts/test_sglang_model.py
+++ b/tests/unit_test/dots_tts/test_sglang_model.py
@@ -126,6 +126,21 @@ def test_forward_prefill_skips_lm_head_and_keeps_full_hidden_rows() -> None:
     assert model.qwen2.model_kwargs["input_embeds"] is embeds
 
 
+def test_prefill_sidecar_kwargs_reach_exposed_backbone() -> None:
+    model = _forward_model(torch.zeros(3, 2))
+    embeds = torch.ones(3, 2)
+    batch = SimpleNamespace(
+        forward_mode=SimpleNamespace(is_extend=lambda: True),
+        input_embeds=None,
+        extend_seq_lens=torch.tensor([3]),
+    )
+    model.forward(torch.zeros(3, dtype=torch.long), torch.arange(3), batch, embeds)
+
+    assert model.language_model is model.qwen2
+    assert model.qwen2.model_kwargs["input_embeds"] is embeds
+    assert batch.input_embeds is None
+
+
 def test_forward_decode_skips_lm_head_and_returns_per_request_rows() -> None:
     hidden = torch.arange(6.0).reshape(3, 2)
     model = _forward_model(hidden)

--- a/tests/unit_test/models/test_model_capabilities.py
+++ b/tests/unit_test/models/test_model_capabilities.py
@@ -22,7 +22,7 @@ EXPECTED_MODEL_CAPABILITIES = {
         supports_streaming_vocoder=True,
         supports_cuda_graph=False,
         supports_torch_compile=True,
-        supports_breakable_prefill_cuda_graph=False,
+        supports_breakable_prefill_cuda_graph=True,
     ),
     "MiniMaxMusic3ForConditionalGeneration": ModelCapabilities(
         supports_reference_audio=False,


### PR DESCRIPTION
- Opt-in prefill BCG via the shared sidecar; decode/tail unchanged.
- Enable under `latent_engine.engine`: `disable_cuda_graph=false`, `cuda_graph_backend_prefill=breakable`, `cuda_graph_max_bs_prefill=512`.
- Co-authored with @wirybeaver; follows the [prior exploration](https://github.com/wirybeaver/sglang-omni/pull/8).
- Checks: 31 CPU capability tests and static checks. Draft: full model tests, GPU replay, quality and performance validation pending; no speedup claim.