### PR TITLE
fix(scheduler): preserve batch row alignment on request removal

### DIFF
--- a/sglang_omni/model_runner/sglang_execution.py
+++ b/sglang_omni/model_runner/sglang_execution.py
@@ -104,6 +104,17 @@ class SGLangExecutionBridge:
         if next_token_ids.device != self.device:
             next_token_ids = next_token_ids.to(self.device, non_blocking=True)
         indices = batch.req_pool_indices
+        counts = {
+            "scheduler_batch_requests": len(batch.reqs),
+            "req_pool_indices": int(indices.shape[0]),
+            "next_token_rows": int(next_token_ids.shape[0]),
+        }
+        if len(set(counts.values())) != 1:
+            request_ids = [str(req.rid) for req in batch.reqs]
+            raise RuntimeError(
+                "SGLang relay state corruption before FutureMap.stash: "
+                f"counts={counts}, request_ids={request_ids}"
+            )
         self.future_map.stash(
             indices,
             self._relay_payload_type(bonus_tokens=next_token_ids),

--- a/sglang_omni/scheduling/omni_scheduler.py
+++ b/sglang_omni/scheduling/omni_scheduler.py
@@ -2719,12 +2719,150 @@ class OmniScheduler:
 def _remove_from_batch(batch: Any, request_id: str) -> None:
     if batch is None:
         return
-    remaining_reqs = []
-    for req in batch.reqs:
-        if req.rid == request_id:
-            _detach_request_data(req)
-        else:
-            remaining_reqs.append(req)
-    batch.reqs = remaining_reqs
-    if not batch.reqs:
+    remove_indices = [
+        index for index, req in enumerate(batch.reqs) if req.rid == request_id
+    ]
+    if not remove_indices:
+        return
+
+    remove_set = set(remove_indices)
+    keep_indices = [
+        index for index in range(len(batch.reqs)) if index not in remove_set
+    ]
+    for index in remove_indices:
+        _detach_request_data(batch.reqs[index])
+
+    # Note (Akazaakane): ScheduleBatch.filter_batch preserves alignment across
+    # per-request state; mutating reqs alone corrupts downstream relay indices.
+    filter_batch = getattr(batch, "filter_batch", None)
+    if not callable(filter_batch):
+        # Note (Akazaakane): Request-only test doubles lack filter_batch;
+        # production batches with row state must not silently use this fallback.
+        aligned_fields = (
+            "req_pool_indices",
+            "req_pool_indices_cpu",
+            "seq_lens",
+            "orig_seq_lens",
+            "seq_lens_cpu",
+            "sampling_info",
+        )
+        populated = [
+            field for field in aligned_fields if getattr(batch, field, None) is not None
+        ]
+        if populated:
+            raise TypeError(
+                "Row-bearing scheduler batch has no filter_batch method: "
+                f"fields={populated}"
+            )
+        batch.reqs = [batch.reqs[index] for index in keep_indices]
+        if not batch.reqs:
+            batch.batch_is_full = False
+        return
+
+    filter_batch(keep_indices=keep_indices)
+    if not keep_indices:
+        # Note (Akazaakane): Upstream leaves empty-batch tensors stale because
+        # callers discard the batch, but Omni retains aliases that require alignment.
+        _clear_empty_schedule_batch_rows(batch)
         batch.batch_is_full = False
+    _validate_schedule_batch_row_alignment(batch)
+
+
+def _clear_empty_schedule_batch_rows(batch: Any) -> None:
+    tensor_fields = (
+        "req_pool_indices",
+        "req_pool_indices_cpu",
+        "seq_lens",
+        "orig_seq_lens",
+        "seq_lens_cpu",
+        "input_ids",
+        "prefill_input_ids_cpu",
+        "input_embeds",
+        "replace_embeds",
+        "replace_positions",
+        "ne_skip_token_table_update",
+        "encoder_lens",
+        "encoder_out_cache_loc",
+        "extend_input_logprob_token_ids",
+    )
+    for field in tensor_fields:
+        value = getattr(batch, field, None)
+        if isinstance(value, torch.Tensor):
+            setattr(batch, field, value[:0])
+
+    list_fields = (
+        "multimodal_inputs",
+        "top_logprobs_nums",
+        "token_ids_logprobs",
+        "encoder_cached",
+        "encoder_lens_cpu",
+        "prefix_lens",
+        "extend_lens",
+        "extend_logprob_start_lens",
+    )
+    for field in list_fields:
+        if isinstance(getattr(batch, field, None), list):
+            setattr(batch, field, [])
+
+    sampling_info = getattr(batch, "sampling_info", None)
+    if sampling_info is not None:
+        device = batch.req_pool_indices.device
+        empty_device_indices = torch.empty(0, dtype=torch.long, device=device)
+        sampling_info.filter_batch([], empty_device_indices)
+
+    spec_info = getattr(batch, "spec_info", None)
+    if spec_info is not None:
+        device = batch.req_pool_indices.device
+        empty_device_indices = torch.empty(0, dtype=torch.long, device=device)
+        spec_info.filter_batch(
+            new_indices=empty_device_indices,
+            has_been_filtered=False,
+            new_indices_cpu=[],
+        )
+
+    batch.out_cache_loc = None
+    batch.mamba_track_indices = None
+    batch.mamba_track_mask = None
+    batch.mamba_track_seqlens = None
+    batch.mamba_cow_src_indices = None
+    batch.mamba_cow_dst_indices = None
+    batch.mamba_clear_indices = None
+    batch.seq_lens_sum = 0
+    if batch.extend_num_tokens is not None:
+        batch.extend_num_tokens = 0
+
+
+def _validate_schedule_batch_row_alignment(batch: Any) -> None:
+    expected = len(batch.reqs)
+    row_fields = (
+        "req_pool_indices",
+        "req_pool_indices_cpu",
+        "seq_lens",
+        "orig_seq_lens",
+        "seq_lens_cpu",
+        "multimodal_inputs",
+        "top_logprobs_nums",
+        "token_ids_logprobs",
+        "encoder_cached",
+        "encoder_lens",
+        "encoder_lens_cpu",
+    )
+    mismatches = {}
+    for field in row_fields:
+        value = getattr(batch, field, None)
+        if value is not None and len(value) != expected:
+            mismatches[field] = len(value)
+
+    forward_mode = getattr(batch, "forward_mode", None)
+    is_decode = forward_mode is not None and forward_mode.is_decode()
+    if is_decode:
+        for field in ("input_ids", "input_embeds"):
+            value = getattr(batch, field, None)
+            if value is not None and len(value) != expected:
+                mismatches[field] = len(value)
+
+    if mismatches:
+        raise RuntimeError(
+            "ScheduleBatch row alignment violated after request removal: "
+            f"requests={expected}, fields={mismatches}"
+        )

--- a/sglang_omni/scheduling/omni_scheduler.py
+++ b/sglang_omni/scheduling/omni_scheduler.py
@@ -372,6 +372,7 @@ class OmniScheduler:
         # decode batch, or None. Tracked here (not just a loop local) so abort
         # can reach the in-flight step. See _event_loop_async_decode.
         self._async_pending = None
+        self._immediately_cleaned_pending_rids: set[str] = set()
         self.forward_ct = 0
         self.return_health_check_ct = 0
         self.num_retracted_reqs = 0
@@ -1868,6 +1869,11 @@ class OmniScheduler:
         self._prefill_end_done.discard(request_id)
         if not running_abort:
             self._release_immediate_request_resources(request_id)
+            pending_batch = self._async_pending_batch()
+            if pending_batch is not None and any(
+                req.rid == request_id for req in pending_batch.reqs
+            ):
+                self._immediately_cleaned_pending_rids.add(request_id)
             _remove_from_batch(self.running_batch, request_id)
             _remove_from_batch(self.cur_batch, request_id)
             _remove_from_batch(self.last_batch, request_id)
@@ -2408,12 +2414,17 @@ class OmniScheduler:
         _mark_sampler_finished sets) must be KEPT so process_batch_result emits
         it — only reqs finished in a *prior* step are the overrun to drop.
         """
-        # Note (Akazaakane): Keep in-flight snapshot rows intact until resolve
-        # so aborted requests and their token rows are dropped together.
+        # Note (Akazaakane): Deferred aborts must reach result processing to
+        # release KV; only immediately cleaned pending rows skip that cleanup.
         pre_finished = [
-            r.finished() or r.is_retracted or r.rid in self._aborted_request_ids
+            r.finished()
+            or r.is_retracted
+            or r.rid in self._immediately_cleaned_pending_rids
             for r in batch.reqs
         ]
+        self._immediately_cleaned_pending_rids.difference_update(
+            r.rid for r in batch.reqs
+        )
         skip_rids = {batch.reqs[i].rid for i, was in enumerate(pre_finished) if was}
         result = self._run_batch_resolve(
             batch, sched_output, pending_step, skip_rids=skip_rids
@@ -2466,77 +2477,7 @@ class OmniScheduler:
         if not any(drop):
             return batch
         keep = [i for i, d in enumerate(drop) if not d]
-        out_cache_loc = batch.out_cache_loc
-        forward_mode = batch.forward_mode
-        if forward_mode is not None and forward_mode.is_extend():
-            if batch.mix_running_indices is not None:
-                raise RuntimeError(
-                    "Omni does not support stale-row filtering for SGLang mixed "
-                    "chunked-prefill batches"
-                )
-            # Note:(Wenyao Gao) extend/mixed batches carry per-token fields
-            # (req i owns extend_lens[i] slots) that filter_batch leaves
-            # stale; reslice them here. The asserted fields are never
-            # populated on omni extend batches; trip instead of misslicing.
-            assert (
-                batch.input_embeds is None and batch.replace_embeds is None
-            ), "unhandled per-token field on drop-stale extend batch"
-            lens = batch.extend_lens
-            starts = [0] * len(lens)
-            for i in range(1, len(lens)):
-                starts[i] = starts[i - 1] + lens[i - 1]
-            keep_tokens = [
-                t for i in keep for t in range(starts[i], starts[i] + lens[i])
-            ]
-            input_ids = batch.input_ids
-            prefill_input_ids_cpu = batch.prefill_input_ids_cpu
-            if input_ids is None and prefill_input_ids_cpu is None:
-                raise RuntimeError(
-                    "extend batch carries neither input_ids nor "
-                    "prefill_input_ids_cpu"
-                )
-            prefix_lens = batch.prefix_lens
-            extend_logprob_start_lens = batch.extend_logprob_start_lens
-            lp_token_ids = batch.extend_input_logprob_token_ids
-            batch.filter_batch(keep_indices=keep)
-            if input_ids is not None:
-                batch.input_ids = input_ids[keep_tokens]
-            else:
-                batch.prefill_input_ids_cpu = prefill_input_ids_cpu[keep_tokens]
-            if out_cache_loc is not None:
-                batch.out_cache_loc = out_cache_loc[keep_tokens]
-            batch.extend_lens = [lens[i] for i in keep]
-            batch.extend_num_tokens = sum(batch.extend_lens)
-            batch.prefix_lens = [prefix_lens[i] for i in keep]
-            batch.extend_logprob_start_lens = [
-                extend_logprob_start_lens[i] for i in keep
-            ]
-            if lp_token_ids is not None:
-                # Note:(Wenyao Gao) every req contributes a segment of
-                # lens[i] - start_lens[i] ids; not aligned with the token
-                # slices above.
-                if not batch.return_logprob:
-                    batch.extend_input_logprob_token_ids = None
-                else:
-                    lp_lens = [
-                        lens[i] - extend_logprob_start_lens[i] for i in range(len(lens))
-                    ]
-                    lp_starts = [0] * len(lp_lens)
-                    for i in range(1, len(lp_lens)):
-                        lp_starts[i] = lp_starts[i - 1] + lp_lens[i - 1]
-                    keep_lp_tokens = [
-                        t
-                        for i in keep
-                        for t in range(lp_starts[i], lp_starts[i] + lp_lens[i])
-                    ]
-                    batch.extend_input_logprob_token_ids = lp_token_ids[keep_lp_tokens]
-        else:
-            batch.filter_batch(keep_indices=keep)
-            if out_cache_loc is not None:
-                batch.out_cache_loc = out_cache_loc[keep]
-        if batch.decoding_reqs:
-            kept_ids = {id(r) for r in batch.reqs}
-            batch.decoding_reqs = [r for r in batch.decoding_reqs if id(r) in kept_ids]
+        _filter_schedule_batch_rows(batch, keep)
         return batch if batch.reqs else None
 
     def _event_loop_async_decode(self) -> None:
@@ -2717,6 +2658,79 @@ class OmniScheduler:
         self._stream_done_handler(req_data)
 
 
+def _filter_schedule_batch_rows(batch: ScheduleBatch, keep_indices: list[int]) -> None:
+    out_cache_loc = batch.out_cache_loc
+    forward_mode = batch.forward_mode
+    if forward_mode is not None and forward_mode.is_extend():
+        if batch.mix_running_indices is not None:
+            raise RuntimeError(
+                "Omni does not support stale-row filtering for SGLang mixed "
+                "chunked-prefill batches"
+            )
+        # Note:(Wenyao Gao) extend/mixed batches carry per-token fields
+        # (req i owns extend_lens[i] slots) that filter_batch leaves
+        # stale; reslice them here. The asserted fields are never
+        # populated on omni extend batches; trip instead of misslicing.
+        assert (
+            batch.input_embeds is None and batch.replace_embeds is None
+        ), "unhandled per-token field on drop-stale extend batch"
+        lens = batch.extend_lens
+        starts = [0] * len(lens)
+        for i in range(1, len(lens)):
+            starts[i] = starts[i - 1] + lens[i - 1]
+        keep_tokens = [
+            t for i in keep_indices for t in range(starts[i], starts[i] + lens[i])
+        ]
+        input_ids = batch.input_ids
+        prefill_input_ids_cpu = batch.prefill_input_ids_cpu
+        if input_ids is None and prefill_input_ids_cpu is None:
+            raise RuntimeError(
+                "extend batch carries neither input_ids nor prefill_input_ids_cpu"
+            )
+        prefix_lens = batch.prefix_lens
+        extend_logprob_start_lens = batch.extend_logprob_start_lens
+        lp_token_ids = batch.extend_input_logprob_token_ids
+        batch.filter_batch(keep_indices=keep_indices)
+        if input_ids is not None:
+            batch.input_ids = input_ids[keep_tokens]
+        if prefill_input_ids_cpu is not None:
+            batch.prefill_input_ids_cpu = prefill_input_ids_cpu[keep_tokens]
+        if out_cache_loc is not None:
+            batch.out_cache_loc = out_cache_loc[keep_tokens]
+        batch.extend_lens = [lens[i] for i in keep_indices]
+        batch.extend_num_tokens = sum(batch.extend_lens)
+        batch.prefix_lens = [prefix_lens[i] for i in keep_indices]
+        batch.extend_logprob_start_lens = [
+            extend_logprob_start_lens[i] for i in keep_indices
+        ]
+        if lp_token_ids is not None:
+            # Note:(Wenyao Gao) every req contributes a segment of
+            # lens[i] - start_lens[i] ids; not aligned with the token
+            # slices above.
+            if not batch.return_logprob:
+                batch.extend_input_logprob_token_ids = None
+            else:
+                lp_lens = [
+                    lens[i] - extend_logprob_start_lens[i] for i in range(len(lens))
+                ]
+                lp_starts = [0] * len(lp_lens)
+                for i in range(1, len(lp_lens)):
+                    lp_starts[i] = lp_starts[i - 1] + lp_lens[i - 1]
+                keep_lp_tokens = [
+                    t
+                    for i in keep_indices
+                    for t in range(lp_starts[i], lp_starts[i] + lp_lens[i])
+                ]
+                batch.extend_input_logprob_token_ids = lp_token_ids[keep_lp_tokens]
+    else:
+        batch.filter_batch(keep_indices=keep_indices)
+        if out_cache_loc is not None:
+            batch.out_cache_loc = out_cache_loc[keep_indices]
+    if batch.decoding_reqs:
+        kept_ids = {id(r) for r in batch.reqs}
+        batch.decoding_reqs = [r for r in batch.decoding_reqs if id(r) in kept_ids]
+
+
 def _remove_from_batch(batch: ScheduleBatch | None, request_id: str) -> None:
     if batch is None:
         return
@@ -2733,12 +2747,13 @@ def _remove_from_batch(batch: ScheduleBatch | None, request_id: str) -> None:
     for index in remove_indices:
         _detach_request_data(batch.reqs[index])
 
-    # Note (Akazaakane): ScheduleBatch.filter_batch preserves alignment across
-    # per-request state; mutating reqs alone corrupts downstream relay indices.
-    batch.filter_batch(keep_indices=keep_indices)
-    if not batch.reqs:
+    # Note (Akazaakane): Extend batches need token-range slicing as well as
+    # request-row filtering to preserve downstream relay and KV ownership.
+    if not keep_indices:
+        batch.filter_batch(keep_indices=keep_indices)
         batch.batch_is_full = False
         return
+    _filter_schedule_batch_rows(batch, keep_indices)
     _validate_schedule_batch_row_alignment(batch)
 
 

--- a/sglang_omni/scheduling/omni_scheduler.py
+++ b/sglang_omni/scheduling/omni_scheduler.py
@@ -1871,7 +1871,6 @@ class OmniScheduler:
             _remove_from_batch(self.running_batch, request_id)
             _remove_from_batch(self.cur_batch, request_id)
             _remove_from_batch(self.last_batch, request_id)
-            _remove_from_batch(self._async_pending_batch(), request_id)
         self._drain_inbox_for_request(request_id)
 
     def admin(
@@ -2409,10 +2408,12 @@ class OmniScheduler:
         _mark_sampler_finished sets) must be KEPT so process_batch_result emits
         it — only reqs finished in a *prior* step are the overrun to drop.
         """
-        # A request retracted at step S is still in step S+1's lagged batch;
-        # drop it like a prior-step finish so its KV is not re-freed.
-        pre_finished = [r.finished() or r.is_retracted for r in batch.reqs]
-        # rids finished/retracted in a prior step (overrun): suppress their emit
+        # Note (Akazaakane): Keep in-flight snapshot rows intact until resolve
+        # so aborted requests and their token rows are dropped together.
+        pre_finished = [
+            r.finished() or r.is_retracted or r.rid in self._aborted_request_ids
+            for r in batch.reqs
+        ]
         skip_rids = {batch.reqs[i].rid for i, was in enumerate(pre_finished) if was}
         result = self._run_batch_resolve(
             batch, sched_output, pending_step, skip_rids=skip_rids
@@ -2716,7 +2717,7 @@ class OmniScheduler:
         self._stream_done_handler(req_data)
 
 
-def _remove_from_batch(batch: Any, request_id: str) -> None:
+def _remove_from_batch(batch: ScheduleBatch | None, request_id: str) -> None:
     if batch is None:
         return
     remove_indices = [
@@ -2734,105 +2735,14 @@ def _remove_from_batch(batch: Any, request_id: str) -> None:
 
     # Note (Akazaakane): ScheduleBatch.filter_batch preserves alignment across
     # per-request state; mutating reqs alone corrupts downstream relay indices.
-    filter_batch = getattr(batch, "filter_batch", None)
-    if not callable(filter_batch):
-        # Note (Akazaakane): Request-only test doubles lack filter_batch;
-        # production batches with row state must not silently use this fallback.
-        aligned_fields = (
-            "req_pool_indices",
-            "req_pool_indices_cpu",
-            "seq_lens",
-            "orig_seq_lens",
-            "seq_lens_cpu",
-            "sampling_info",
-        )
-        populated = [
-            field for field in aligned_fields if getattr(batch, field, None) is not None
-        ]
-        if populated:
-            raise TypeError(
-                "Row-bearing scheduler batch has no filter_batch method: "
-                f"fields={populated}"
-            )
-        batch.reqs = [batch.reqs[index] for index in keep_indices]
-        if not batch.reqs:
-            batch.batch_is_full = False
-        return
-
-    filter_batch(keep_indices=keep_indices)
-    if not keep_indices:
-        # Note (Akazaakane): Upstream leaves empty-batch tensors stale because
-        # callers discard the batch, but Omni retains aliases that require alignment.
-        _clear_empty_schedule_batch_rows(batch)
+    batch.filter_batch(keep_indices=keep_indices)
+    if not batch.reqs:
         batch.batch_is_full = False
+        return
     _validate_schedule_batch_row_alignment(batch)
 
 
-def _clear_empty_schedule_batch_rows(batch: Any) -> None:
-    tensor_fields = (
-        "req_pool_indices",
-        "req_pool_indices_cpu",
-        "seq_lens",
-        "orig_seq_lens",
-        "seq_lens_cpu",
-        "input_ids",
-        "prefill_input_ids_cpu",
-        "input_embeds",
-        "replace_embeds",
-        "replace_positions",
-        "ne_skip_token_table_update",
-        "encoder_lens",
-        "encoder_out_cache_loc",
-        "extend_input_logprob_token_ids",
-    )
-    for field in tensor_fields:
-        value = getattr(batch, field, None)
-        if isinstance(value, torch.Tensor):
-            setattr(batch, field, value[:0])
-
-    list_fields = (
-        "multimodal_inputs",
-        "top_logprobs_nums",
-        "token_ids_logprobs",
-        "encoder_cached",
-        "encoder_lens_cpu",
-        "prefix_lens",
-        "extend_lens",
-        "extend_logprob_start_lens",
-    )
-    for field in list_fields:
-        if isinstance(getattr(batch, field, None), list):
-            setattr(batch, field, [])
-
-    sampling_info = getattr(batch, "sampling_info", None)
-    if sampling_info is not None:
-        device = batch.req_pool_indices.device
-        empty_device_indices = torch.empty(0, dtype=torch.long, device=device)
-        sampling_info.filter_batch([], empty_device_indices)
-
-    spec_info = getattr(batch, "spec_info", None)
-    if spec_info is not None:
-        device = batch.req_pool_indices.device
-        empty_device_indices = torch.empty(0, dtype=torch.long, device=device)
-        spec_info.filter_batch(
-            new_indices=empty_device_indices,
-            has_been_filtered=False,
-            new_indices_cpu=[],
-        )
-
-    batch.out_cache_loc = None
-    batch.mamba_track_indices = None
-    batch.mamba_track_mask = None
-    batch.mamba_track_seqlens = None
-    batch.mamba_cow_src_indices = None
-    batch.mamba_cow_dst_indices = None
-    batch.mamba_clear_indices = None
-    batch.seq_lens_sum = 0
-    if batch.extend_num_tokens is not None:
-        batch.extend_num_tokens = 0
-
-
-def _validate_schedule_batch_row_alignment(batch: Any) -> None:
+def _validate_schedule_batch_row_alignment(batch: ScheduleBatch) -> None:
     expected = len(batch.reqs)
     row_fields = (
         "req_pool_indices",
@@ -2849,15 +2759,15 @@ def _validate_schedule_batch_row_alignment(batch: Any) -> None:
     )
     mismatches = {}
     for field in row_fields:
-        value = getattr(batch, field, None)
+        value = getattr(batch, field)
         if value is not None and len(value) != expected:
             mismatches[field] = len(value)
 
-    forward_mode = getattr(batch, "forward_mode", None)
+    forward_mode = batch.forward_mode
     is_decode = forward_mode is not None and forward_mode.is_decode()
     if is_decode:
         for field in ("input_ids", "input_embeds"):
-            value = getattr(batch, field, None)
+            value = getattr(batch, field)
             if value is not None and len(value) != expected:
                 mismatches[field] = len(value)
 

--- a/tests/unit_test/model_runner/test_sglang_execution.py
+++ b/tests/unit_test/model_runner/test_sglang_execution.py
@@ -43,6 +43,7 @@ def _make_bridge() -> tuple[SGLangExecutionBridge, _FutureMap]:
 def test_publish_next_tokens_uses_future_map_and_retires_input_ids() -> None:
     bridge, future_map = _make_bridge()
     batch = SimpleNamespace(
+        reqs=[SimpleNamespace(rid="req-a"), SimpleNamespace(rid="req-b")],
         req_pool_indices=torch.tensor([4, 7]),
         seq_lens=torch.tensor([12, 19]),
         input_ids=torch.tensor([1, 2]),
@@ -57,6 +58,18 @@ def test_publish_next_tokens_uses_future_map_and_retires_input_ids() -> None:
     # new_seq_lens_buf has no non-spec reader; the bridge must not publish.
     assert future_map.published is None
     assert batch.input_ids is None
+
+
+def test_publish_next_tokens_detects_scheduler_row_mismatch() -> None:
+    bridge, _ = _make_bridge()
+    batch = SimpleNamespace(
+        reqs=[SimpleNamespace(rid="req-a")],
+        req_pool_indices=torch.tensor([4, 7]),
+        input_ids=torch.tensor([1]),
+    )
+
+    with pytest.raises(RuntimeError, match="relay state corruption"):
+        bridge.publish_next_tokens(batch, torch.tensor([31]))
 
 
 def test_forward_context_resolves_inputs_without_copying_sampling_info(

--- a/tests/unit_test/pipeline/test_scheduler.py
+++ b/tests/unit_test/pipeline/test_scheduler.py
@@ -172,12 +172,20 @@ def test_remove_from_batch_compacts_sequential_removals() -> None:
     _assert_row_aligned_batch(batch, [10, 12])
 
 
-def test_remove_from_batch_clears_every_row_for_only_request() -> None:
+def test_remove_from_batch_discards_empty_batch(monkeypatch) -> None:
     batch = _make_row_aligned_schedule_batch(size=1)
+    batch.batch_is_full = True
+    removed_req = batch.reqs[0]
+    monkeypatch.setattr(
+        omni_scheduler_module,
+        "_validate_schedule_batch_row_alignment",
+        lambda _batch: pytest.fail("empty batches must not be validated"),
+    )
 
     omni_scheduler_module._remove_from_batch(batch, "req-0")
 
-    _assert_row_aligned_batch(batch, [])
+    assert batch.reqs == []
+    assert removed_req._omni_data is None
     assert batch.batch_is_full is False
 
 
@@ -223,6 +231,60 @@ def test_terminal_failure_abort_compacts_finished_schedule_batch_row() -> None:
     scheduler.abort("req-0")
 
     _assert_row_aligned_batch(batch, [11])
+
+
+@pytest.mark.parametrize(("size", "aborted_indices"), [(3, [1]), (2, [0, 1])])
+@pytest.mark.parametrize("defer_running_cleanup", [False, True])
+def test_async_abort_preserves_snapshot_until_resolve(
+    monkeypatch, size, aborted_indices, defer_running_cleanup
+) -> None:
+    batch = _make_row_aligned_schedule_batch(size=size)
+    scheduler = _make_row_removal_abort_scheduler(batch)
+    reqs = list(batch.reqs)
+    snapshot = batch.copy()
+    snapshot_reqs = snapshot.reqs
+    sched_output, pending_step = object(), object()
+    scheduler._async_pending = (snapshot, sched_output, pending_step)
+    captured = {}
+
+    def fail_snapshot_filter(*args, **kwargs):
+        pytest.fail("async snapshots must not use ScheduleBatch.filter_batch")
+
+    monkeypatch.setattr(snapshot, "filter_batch", fail_snapshot_filter)
+
+    def resolve(resolved_batch, output, step, *, skip_rids):
+        assert resolved_batch is snapshot
+        assert output is sched_output
+        assert step is pending_step
+        assert all(actual is expected for actual, expected in zip(snapshot.reqs, reqs))
+        captured["skip_rids"] = skip_rids
+        return SimpleNamespace(next_token_ids=torch.arange(10, 10 + size))
+
+    def process(resolved_batch, result):
+        captured["reqs"] = list(resolved_batch.reqs)
+        captured["tokens"] = result.next_token_ids.tolist()
+
+    scheduler._run_batch_resolve = resolve
+    scheduler.process_batch_result = process
+    scheduler._handle_batch_failure = lambda _batch, exc: pytest.fail(str(exc))
+
+    for index in aborted_indices:
+        scheduler.abort(reqs[index].rid, defer_running_cleanup=defer_running_cleanup)
+        assert snapshot.reqs is snapshot_reqs
+        assert len(snapshot.reqs) == size
+        assert all(actual is expected for actual, expected in zip(snapshot.reqs, reqs))
+
+    scheduler._resolve_pending_async()
+
+    assert scheduler._async_pending is None
+    assert captured["skip_rids"] == {reqs[i].rid for i in aborted_indices}
+    keep = [i for i in range(size) if i not in aborted_indices]
+    assert snapshot.reqs == [reqs[i] for i in keep]
+    if keep:
+        assert captured["reqs"] == [reqs[i] for i in keep]
+        assert captured["tokens"] == [10 + i for i in keep]
+    else:
+        assert "reqs" not in captured
 
 
 @pytest.mark.parametrize("tp_size,is_entry_rank", [(1, True), (2, True), (2, False)])
@@ -489,25 +551,28 @@ def test_omni_scheduler_run_batch_failure_emits_error_and_aborts(monkeypatch) ->
     scheduler._prefill_start_done = set()
     scheduler._prefill_end_done = set()
 
-    batch = SimpleNamespace(
-        reqs=[
-            SimpleNamespace(
-                rid="req-1",
-                _omni_data=SimpleNamespace(),
-                kv=ReqKvInfo(req_pool_idx=1),
-                inflight_middle_chunks=0,
-            ),
-            SimpleNamespace(
-                rid="req-2",
-                _omni_data=SimpleNamespace(),
-                kv=ReqKvInfo(req_pool_idx=2),
-                inflight_middle_chunks=0,
-            ),
-        ],
-        batch_is_full=True,
-        is_prefill_only=True,
-        is_extend_in_batch=False,
-    )
+    batch = _make_row_aligned_schedule_batch(size=2)
+    batch.reqs = [
+        SimpleNamespace(
+            rid="req-1",
+            _omni_data=SimpleNamespace(),
+            kv=ReqKvInfo(req_pool_idx=1),
+            inflight_middle_chunks=0,
+        ),
+        SimpleNamespace(
+            rid="req-2",
+            _omni_data=SimpleNamespace(),
+            kv=ReqKvInfo(req_pool_idx=2),
+            inflight_middle_chunks=0,
+        ),
+    ]
+    batch.batch_is_full = True
+    batch.is_prefill_only = True
+    batch.is_extend_in_batch = False
+    for req in batch.reqs:
+        req.return_logprob = False
+        req.return_hidden_states_mode = batch.return_hidden_states_mode
+        req.grammar = None
     failed_reqs = list(batch.reqs)
     for req in failed_reqs:
         req._omni_data.req = req
@@ -1044,6 +1109,7 @@ def test_omni_scheduler_resolve_drops_retracted_req() -> None:
         captured["ntids"] = result.next_token_ids.tolist()
 
     scheduler = object.__new__(OmniScheduler)
+    scheduler._aborted_request_ids = set()
     scheduler._run_batch_resolve = fake_resolve
     scheduler.process_batch_result = fake_process
 
@@ -1272,7 +1338,8 @@ def test_omni_scheduler_abort_treats_retracted_alias_as_waiting_owned() -> None:
     )
     request_data = SimpleNamespace(req=req)
     req._omni_data = request_data
-    stale_batch = SimpleNamespace(reqs=[req], batch_is_full=True)
+    stale_batch = _make_row_aligned_schedule_batch(size=1)
+    stale_batch.reqs = [req]
     scheduler.waiting_queue = [req]
     scheduler.running_batch = SimpleNamespace(reqs=[], batch_is_full=False)
     scheduler.cur_batch = None
@@ -1667,7 +1734,8 @@ def test_stream_output_atomically_claims_request_data_against_abort() -> None:
     )
     req = Request(data)
     data.req = req
-    batch = SimpleNamespace(reqs=[req], batch_is_full=True)
+    batch = _make_row_aligned_schedule_batch(size=1)
+    batch.reqs = [req]
     scheduler.running_batch = batch
     scheduler.cur_batch = batch
     scheduler.last_batch = None
@@ -1718,7 +1786,8 @@ def test_abort_after_terminal_close_runs_its_own_cleanup() -> None:
         kv=ReqKvInfo(),
     )
     data.req = req
-    batch = SimpleNamespace(reqs=[req], batch_is_full=True)
+    batch = _make_row_aligned_schedule_batch(size=1)
+    batch.reqs = [req]
     scheduler.running_batch = batch
     scheduler.cur_batch = batch
     scheduler.last_batch = None

--- a/tests/unit_test/pipeline/test_scheduler.py
+++ b/tests/unit_test/pipeline/test_scheduler.py
@@ -60,6 +60,7 @@ def _init_sync_request_build_state(scheduler: OmniScheduler) -> None:
     scheduler._backlogged_request_build_payloads = deque()
     scheduler._request_build_max_pending_observed = 0
     scheduler._async_pending = None
+    scheduler._immediately_cleaned_pending_rids = set()
     scheduler.enable_priority_scheduling = False
     scheduler.abort_on_priority_when_disabled = False
     if not hasattr(scheduler, "max_queued_requests"):
@@ -163,6 +164,61 @@ def test_remove_from_batch_compacts_every_scheduler_row(
     _assert_row_aligned_batch(batch, expected_pool_indices)
 
 
+@pytest.mark.parametrize(
+    "token_storage", ["input_ids", "prefill_input_ids_cpu", "both"]
+)
+def test_remove_from_extend_batch_compacts_request_and_token_rows(
+    token_storage,
+) -> None:
+    from sglang.srt.model_executor.forward_batch_info import ForwardMode
+
+    batch = _make_row_aligned_schedule_batch(size=3)
+    batch.forward_mode = ForwardMode.EXTEND
+    batch.extend_lens = [2, 3, 1]
+    batch.extend_num_tokens = 6
+    batch.prefix_lens = [10, 20, 30]
+    batch.extend_logprob_start_lens = [1, 1, 0]
+    batch.input_ids = (
+        torch.arange(6) if token_storage in ("input_ids", "both") else None
+    )
+    batch.prefill_input_ids_cpu = (
+        torch.arange(6) if token_storage in ("prefill_input_ids_cpu", "both") else None
+    )
+    batch.out_cache_loc = torch.arange(100, 106)
+    batch.return_logprob = True
+    batch.top_logprobs_nums = [1, 2, 3]
+    batch.token_ids_logprobs = [[10], [20], [30]]
+    batch.extend_input_logprob_token_ids = torch.arange(200, 204)
+    for req in batch.reqs:
+        req.return_logprob = True
+    batch.decoding_reqs = [batch.reqs[1], batch.reqs[2]]
+    removed_req = batch.reqs[1]
+
+    omni_scheduler_module._remove_from_batch(batch, "req-1")
+
+    assert [req.rid for req in batch.reqs] == ["req-0", "req-2"]
+    assert removed_req._omni_data is None
+    assert batch.req_pool_indices.tolist() == [10, 12]
+    assert batch.req_pool_indices_cpu.tolist() == [10, 12]
+    assert batch.seq_lens.tolist() == [110, 112]
+    assert batch.sampling_info.values.tolist() == [10, 12]
+    for field in ("input_ids", "prefill_input_ids_cpu"):
+        value = getattr(batch, field)
+        if token_storage in (field, "both"):
+            assert value.tolist() == [0, 1, 5]
+        else:
+            assert value is None
+    assert batch.out_cache_loc.tolist() == [100, 101, 105]
+    assert batch.extend_lens == [2, 1]
+    assert batch.extend_num_tokens == 3
+    assert batch.prefix_lens == [10, 30]
+    assert batch.extend_logprob_start_lens == [1, 0]
+    assert batch.extend_input_logprob_token_ids.tolist() == [200, 203]
+    assert batch.top_logprobs_nums == [1, 3]
+    assert batch.token_ids_logprobs == [[10], [30]]
+    assert batch.decoding_reqs == [batch.reqs[1]]
+
+
 def test_remove_from_batch_compacts_sequential_removals() -> None:
     batch = _make_row_aligned_schedule_batch()
 
@@ -206,6 +262,7 @@ def _make_row_removal_abort_scheduler(batch):
     scheduler._prefill_start_done = set()
     scheduler._prefill_end_done = set()
     scheduler._async_pending = None
+    scheduler._immediately_cleaned_pending_rids = set()
     scheduler.inbox = Queue()
     scheduler.running_batch = batch
     scheduler.cur_batch = batch
@@ -246,6 +303,21 @@ def test_async_abort_preserves_snapshot_until_resolve(
     sched_output, pending_step = object(), object()
     scheduler._async_pending = (snapshot, sched_output, pending_step)
     captured = {}
+    release_calls = []
+    scheduler.tree_cache = object()
+    scheduler._release_immediate_request_resources = (
+        OmniScheduler._release_immediate_request_resources.__get__(scheduler)
+    )
+    for index, req in enumerate(reqs):
+        req.kv = ReqKvInfo(req_pool_idx=index)
+
+    def release(req, cache):
+        assert cache is scheduler.tree_cache
+        assert req.kv.holds_kv
+        release_calls.append(req.rid)
+        req.kv.req_pool_idx = None
+
+    monkeypatch.setattr(omni_scheduler_module, "release_kv_cache", release)
 
     def fail_snapshot_filter(*args, **kwargs):
         pytest.fail("async snapshots must not use ScheduleBatch.filter_batch")
@@ -263,6 +335,10 @@ def test_async_abort_preserves_snapshot_until_resolve(
     def process(resolved_batch, result):
         captured["reqs"] = list(resolved_batch.reqs)
         captured["tokens"] = result.next_token_ids.tolist()
+        for req in resolved_batch.reqs:
+            if req.to_finish is not None:
+                assert req.to_finish.to_json()["type"] == "abort"
+                scheduler._release_request_kv_cache(req)
 
     scheduler._run_batch_resolve = resolve
     scheduler.process_batch_result = process
@@ -274,11 +350,21 @@ def test_async_abort_preserves_snapshot_until_resolve(
         assert len(snapshot.reqs) == size
         assert all(actual is expected for actual, expected in zip(snapshot.reqs, reqs))
 
+    aborted_rids = [reqs[i].rid for i in aborted_indices]
+    dropped = set() if defer_running_cleanup else set(aborted_rids)
+    assert release_calls == ([] if defer_running_cleanup else aborted_rids)
+    assert scheduler._immediately_cleaned_pending_rids == dropped
+    for index in aborted_indices:
+        assert reqs[index].kv.holds_kv == defer_running_cleanup
+
     scheduler._resolve_pending_async()
 
     assert scheduler._async_pending is None
-    assert captured["skip_rids"] == {reqs[i].rid for i in aborted_indices}
-    keep = [i for i in range(size) if i not in aborted_indices]
+    assert scheduler._immediately_cleaned_pending_rids == set()
+    assert captured["skip_rids"] == dropped
+    assert release_calls == aborted_rids
+    assert all(not reqs[i].kv.holds_kv for i in aborted_indices)
+    keep = [i for i in range(size) if reqs[i].rid not in dropped]
     assert snapshot.reqs == [reqs[i] for i in keep]
     if keep:
         assert captured["reqs"] == [reqs[i] for i in keep]
@@ -1109,7 +1195,7 @@ def test_omni_scheduler_resolve_drops_retracted_req() -> None:
         captured["ntids"] = result.next_token_ids.tolist()
 
     scheduler = object.__new__(OmniScheduler)
-    scheduler._aborted_request_ids = set()
+    scheduler._immediately_cleaned_pending_rids = set()
     scheduler._run_batch_resolve = fake_resolve
     scheduler.process_batch_result = fake_process
 

--- a/tests/unit_test/pipeline/test_scheduler.py
+++ b/tests/unit_test/pipeline/test_scheduler.py
@@ -86,6 +86,145 @@ def _new_stage_payload(request_id: str) -> StagePayload:
     )
 
 
+class _RowSamplingInfo:
+    def __init__(self, values: list[int]) -> None:
+        self.values = torch.tensor(values)
+
+    def filter_batch(self, keep_indices, keep_indices_device) -> None:
+        del keep_indices
+        self.values = self.values[keep_indices_device]
+
+
+def _make_row_aligned_schedule_batch(size: int = 4):
+    from sglang.srt.managers.schedule_batch import ScheduleBatch
+    from sglang.srt.model_executor.forward_batch_info import CaptureHiddenMode
+
+    reqs = [
+        SimpleNamespace(
+            rid=f"req-{index}",
+            _omni_data=object(),
+            return_logprob=False,
+            return_hidden_states_mode=CaptureHiddenMode.NULL,
+            grammar=None,
+            finished=lambda: False,
+            is_retracted=False,
+            _omni_terminal_claimed=False,
+            to_finish=None,
+        )
+        for index in range(size)
+    ]
+    row_values = list(range(10, 10 + size))
+    batch = ScheduleBatch(
+        reqs=reqs,
+        model_config=SimpleNamespace(is_encoder_decoder=False),
+        device="cpu",
+    )
+    batch.req_pool_indices = torch.tensor(row_values)
+    batch.req_pool_indices_cpu = torch.tensor(row_values)
+    batch.seq_lens = torch.tensor([100 + value for value in row_values])
+    batch.orig_seq_lens = torch.tensor([200 + value for value in row_values])
+    batch.seq_lens_cpu = torch.tensor([300 + value for value in row_values])
+    batch.input_ids = torch.tensor([400 + value for value in row_values])
+    batch.multimodal_inputs = [f"mm-{value}" for value in row_values]
+    batch.sampling_info = _RowSamplingInfo(row_values)
+    return batch
+
+
+def _assert_row_aligned_batch(batch, expected_pool_indices: list[int]) -> None:
+    expected = len(expected_pool_indices)
+    assert [req.rid for req in batch.reqs] == [
+        f"req-{value - 10}" for value in expected_pool_indices
+    ]
+    assert batch.req_pool_indices.tolist() == expected_pool_indices
+    assert batch.req_pool_indices_cpu.tolist() == expected_pool_indices
+    assert len(batch.seq_lens) == expected
+    assert len(batch.orig_seq_lens) == expected
+    assert len(batch.seq_lens_cpu) == expected
+    assert len(batch.input_ids) == expected
+    assert len(batch.multimodal_inputs) == expected
+    assert batch.sampling_info.values.tolist() == expected_pool_indices
+
+
+@pytest.mark.parametrize(
+    ("request_id", "expected_pool_indices"),
+    [
+        ("req-0", [11, 12, 13]),
+        ("req-1", [10, 12, 13]),
+        ("req-3", [10, 11, 12]),
+    ],
+)
+def test_remove_from_batch_compacts_every_scheduler_row(
+    request_id: str, expected_pool_indices: list[int]
+) -> None:
+    batch = _make_row_aligned_schedule_batch()
+
+    omni_scheduler_module._remove_from_batch(batch, request_id)
+
+    _assert_row_aligned_batch(batch, expected_pool_indices)
+
+
+def test_remove_from_batch_compacts_sequential_removals() -> None:
+    batch = _make_row_aligned_schedule_batch()
+
+    omni_scheduler_module._remove_from_batch(batch, "req-1")
+    omni_scheduler_module._remove_from_batch(batch, "req-3")
+
+    _assert_row_aligned_batch(batch, [10, 12])
+
+
+def test_remove_from_batch_clears_every_row_for_only_request() -> None:
+    batch = _make_row_aligned_schedule_batch(size=1)
+
+    omni_scheduler_module._remove_from_batch(batch, "req-0")
+
+    _assert_row_aligned_batch(batch, [])
+    assert batch.batch_is_full is False
+
+
+def _make_row_removal_abort_scheduler(batch):
+    scheduler = object.__new__(OmniScheduler)
+    scheduler._request_admission_lock = threading.RLock()
+    scheduler._aborted_request_ids = set()
+    scheduler._aborted_request_id_order = deque()
+    scheduler._pending_request_builds = {}
+    scheduler._pending_request_admissions = {}
+    scheduler._backlogged_request_build_payloads = deque()
+    scheduler.waiting_queue = []
+    scheduler._abort_callback = None
+    scheduler._pending_stream_ingress = {}
+    scheduler._deferred_request_payloads = {}
+    scheduler._dirty_deferred_request_ids = set()
+    scheduler._first_emit_done = set()
+    scheduler._prefill_start_done = set()
+    scheduler._prefill_end_done = set()
+    scheduler._async_pending = None
+    scheduler.inbox = Queue()
+    scheduler.running_batch = batch
+    scheduler.cur_batch = batch
+    scheduler.last_batch = None
+    scheduler._release_immediate_request_resources = lambda _request_id: None
+    return scheduler
+
+
+def test_immediate_abort_compacts_live_schedule_batch_rows() -> None:
+    batch = _make_row_aligned_schedule_batch(size=2)
+    scheduler = _make_row_removal_abort_scheduler(batch)
+
+    scheduler.abort("req-0", defer_running_cleanup=False)
+
+    _assert_row_aligned_batch(batch, [11])
+
+
+def test_terminal_failure_abort_compacts_finished_schedule_batch_row() -> None:
+    batch = _make_row_aligned_schedule_batch(size=2)
+    batch.reqs[0].finished = lambda: True
+    scheduler = _make_row_removal_abort_scheduler(batch)
+
+    scheduler.abort("req-0")
+
+    _assert_row_aligned_batch(batch, [11])
+
+
 @pytest.mark.parametrize("tp_size,is_entry_rank", [(1, True), (2, True), (2, False)])
 @pytest.mark.parametrize(
     "pending_queue", ["_pending_request_builds", "_pending_request_admissions"]

--- a/tests/unit_test/qwen3_omni/test_talker_row_ownership.py
+++ b/tests/unit_test/qwen3_omni/test_talker_row_ownership.py
@@ -266,6 +266,7 @@ class _FakeReq:
 def _resolve_scheduler(result: SimpleNamespace) -> tuple[OmniScheduler, list]:
     scheduler = object.__new__(OmniScheduler)
     captured: list = []
+    scheduler._aborted_request_ids = set()
     scheduler._run_batch_resolve = (
         lambda batch, sched_output, pending_step, skip_rids=(): result
     )

--- a/tests/unit_test/qwen3_omni/test_talker_row_ownership.py
+++ b/tests/unit_test/qwen3_omni/test_talker_row_ownership.py
@@ -266,7 +266,7 @@ class _FakeReq:
 def _resolve_scheduler(result: SimpleNamespace) -> tuple[OmniScheduler, list]:
     scheduler = object.__new__(OmniScheduler)
     captured: list = []
-    scheduler._aborted_request_ids = set()
+    scheduler._immediately_cleaned_pending_rids = set()
     scheduler._run_batch_resolve = (
         lambda batch, sched_output, pending_step, skip_rids=(): result
     )


### PR DESCRIPTION
Request removal now preserves request-aligned state and slices extend-batch token fields using each request's `extend_lens` range. The execution bridge also validates request/token row alignment before forwarding.

Async pending snapshots remain intact until resolution. Immediately cleaned abort rows are dropped with their token rows, while deferred aborts still reach result processing to release KV resources. Regression coverage checks cleanup timing, partial extend removal, and relay row ownership.

Rebased onto `main` after #1955 merged.

Validation: venv pre-commit across the PR diff and `git diff --check origin/main..HEAD`. Unit tests and benchmarks were not run, per repository instructions.
