### PR TITLE
[Docs] Fix cookbook commands and API fields

### DIFF
--- a/docs/cookbook/moss_transcribe_diarize.md
+++ b/docs/cookbook/moss_transcribe_diarize.md
@@ -193,8 +193,8 @@ Thanks to the Moss team for providing the benchmark datasets, we prepare movies8
 python -m benchmarks.eval.benchmark_asr_transcribe_diarize \
   --dataset movies800times \
   --concurrency 16 \
-  --asr.engine.max_running_requests 16 \
-  --asr.engine.cuda_graph_max_bs 16 \
+  --max-running-requests 16 \
+  --cuda-graph-max-bs 16 \
   --mem-fraction-static 0.80 \
   --output-dir results/moss_transcribe_diarize_movies800times
 
@@ -211,8 +211,8 @@ python -m benchmarks.eval.benchmark_asr_transcribe_diarize \
 python -m benchmarks.eval.benchmark_asr_transcribe_diarize \
   --dataset aishell4_long \
   --concurrency 16 \
-  --asr.engine.max_running_requests 16 \
-  --asr.engine.cuda_graph_max_bs 16 \
+  --max-running-requests 16 \
+  --cuda-graph-max-bs 16 \
   --mem-fraction-static 0.80 \
   --max-new-tokens 65536 \
   --request-timeout-s 1800 \
@@ -222,8 +222,8 @@ python -m benchmarks.eval.benchmark_asr_transcribe_diarize \
 python -m benchmarks.eval.benchmark_asr_transcribe_diarize \
   --dataset googletime \
   --concurrency 16 \
-  --asr.engine.max_running_requests 16 \
-  --asr.engine.cuda_graph_max_bs 16 \
+  --max-running-requests 16 \
+  --cuda-graph-max-bs 16 \
   --mem-fraction-static 0.80 \
   --max-new-tokens 65536 \
   --request-timeout-s 1800 \

--- a/docs/cookbook/moss_tts.md
+++ b/docs/cookbook/moss_tts.md
@@ -184,7 +184,7 @@ curl -N -X POST http://localhost:8000/v1/audio/speech \
 
 MOSS-TTS conditions on a target **duration token count** (codec frames; a larger count yields
 longer audio). Set it with an inline `${token:N}` prefix on `input` (stripped before synthesis),
-or with a `token_count` (alias `duration_tokens` / `tokens`) parameter. The count must be a
+or with a `token_count` (alias `duration_tokens`) parameter. The count must be a
 positive integer.
 
 ```json
@@ -202,7 +202,7 @@ sample with `--token-count auto`.
 ### Text Markup, Style, and Language
 
 Inline text markup that the model understands (for example `[pause Xs]`, pinyin, and IPA) is
-passed through unchanged. An optional `instructions` (alias `instruct`) field carries a
+passed through unchanged. An optional `instructions` field carries a
 free-text style directive, and an optional `language` hint biases the target language (omit it
 to let the model infer from the text):
 
@@ -212,7 +212,7 @@ to let the model infer from the text):
   "voice": "default",
   "input": "今天天气不错 [pause 0.5s] 就该出去晒晒太阳。",
   "ref_audio": "...", "ref_text": "...",
-  "language": "Chinese",
+  "language": "Chinese"
 }
 ```
 
@@ -227,8 +227,8 @@ to let the model infer from the text):
 | `ref_audio` / `ref_text` | `null` | Shorthand for `references[0].audio_path` / `references[0].text` |
 | `stream` | `false` | Stream raw PCM audio chunks |
 | `language` | `null` | Optional target-language hint. Omit to let the model infer |
-| `instructions` / `instruct` | `null` | Optional free-text style directive |
-| `token_count` / `duration_tokens` / `tokens` | `null` | Target duration in codec frames. It must be `> 0` |
+| `instructions` | `null` | Optional free-text style directive |
+| `token_count` / `duration_tokens` | `null` | Target duration in codec frames. It must be `> 0` |
 | `max_new_tokens` | `4096` | Maximum generated frames. An explicit value must be `> 0` |
 | `temperature` | `1.5` text / `1.7` audio | Sampling temperature. A single `temperature` overrides both channels |
 | `top_p` | `1.0` text / `0.8` audio | Top-p sampling. A single `top_p` overrides both channels |
@@ -236,9 +236,8 @@ to let the model infer from the text):
 | `repetition_penalty` | `1.0` | Audio repetition penalty |
 | `seed` | `null` | Non-negative integer. See [Seed Reproducibility](#seed-reproducibility) |
 
-The per-channel fields (`text_temperature`, `audio_temperature`, `text_top_p`, `audio_top_p`,
-`text_top_k`, `audio_top_k`, `audio_repetition_penalty`) are also accepted and take precedence
-over the single-value aliases.
+The two default values are the model's separate text-channel and audio-channel sampling settings.
+A single `temperature`, `top_p`, or `top_k` applies to both channels.
 
 ## Seed Reproducibility
 

--- a/docs/cookbook/zonos2.md
+++ b/docs/cookbook/zonos2.md
@@ -152,7 +152,6 @@ from the resulting text.
 | `temperature` | (model default) | Sampling temperature |
 | `top_p` | (model default) | Top-p sampling |
 | `top_k` | (model default) | Top-k sampling |
-| `min_p` | (model default) | Min-p sampling |
 | `repetition_penalty` | (model default) | Audio repetition penalty |
 
 ## Benchmarking

--- a/docs/index.rst
+++ b/docs/index.rst
@@ -13,7 +13,7 @@ Core features:
 - **Multi-Stage Pipeline**: Flexible framework for orchestrating preprocessing, AR engine, codec, and vocoder stages across processes and GPUs.
 - **Native SGLang Integration**: Leverages SGLang's RadixAttention, continuous batching, and CUDA Graph optimizations for the AR backbone.
 - **OpenAI-Compatible Server**: Drop-in ``/v1/audio/speech``, ``/v1/audio/transcriptions``, ``/v1/audio/translations``, and ``/v1/chat/completions`` endpoints with real-time streaming support.
-- **Broad Model Support**: TTS (Higgs, Fish S2-Pro, Voxtral, Qwen3-TTS, MOSS-TTS / Local, Ming-Omni-TTS, dots.tts, ZONOS2), Music (MiniMax Music 3), ASR (Qwen3-ASR, Fun-ASR, ARK-ASR, Whisper, MOSS-Transcribe-Diarize), Omni (Qwen3-Omni, Ming-Omni), and LLaDA2.0-Uni.
+- **Broad Model Support**: TTS (Higgs, Fish S2-Pro, Voxtral, Qwen3-TTS, Fun-CosyVoice3, MOSS-TTS / Local, Ming-Omni-TTS, dots.tts, ZONOS2), Music (MiniMax Music 3), ASR (Qwen3-ASR, Fun-ASR, ARK-ASR, Whisper, MOSS-Transcribe-Diarize), Omni (Qwen3-Omni, Ming-Omni), and LLaDA2.0-Uni.
 
 Supported Models
 ----------------
@@ -37,6 +37,9 @@ Supported Models
    * - `Qwen/Qwen3-TTS-12Hz-Base <https://huggingface.co/Qwen/Qwen3-TTS-12Hz-1.7B-Base>`_
      - TTS
      - Voice cloning, streaming, 10 languages, 0.6B / 1.7B
+   * - `FunAudioLLM/Fun-CosyVoice3-0.5B-2512 <https://huggingface.co/FunAudioLLM/Fun-CosyVoice3-0.5B-2512>`_
+     - TTS
+     - Voice cloning, cross-lingual synthesis, instruction control
    * - `OpenMOSS-Team/MOSS-TTS-v1.5 <https://huggingface.co/OpenMOSS-Team/MOSS-TTS-v1.5>`_
      - TTS
      - Delay-pattern MOSS-TTS; voice cloning, streaming, 31 languages
@@ -98,6 +101,7 @@ Supported Models
    cookbook/higgs_tts.md
    cookbook/voxtral_tts.md
    cookbook/fishaudio_s2_pro.md
+   cookbook/fun_cosyvoice3.md
    cookbook/qwen3_tts.md
    cookbook/ming_tts.md
    cookbook/moss_tts.md


### PR DESCRIPTION
## Motivation

Several cookbook examples do not match the command parsers or model request builders on current `main`. The affected examples either fail when copied, advertise ignored request fields, or leave an existing model cookbook out of the documentation navigation.

## Modifications

- Use the benchmark parser flags `--max-running-requests` and `--cuda-graph-max-bs` in the MOSS-Transcribe-Diarize benchmark commands while retaining dotted stage overrides for direct `sgl-omni serve` usage.
- Remove unsupported MOSS-TTS aliases and per-channel sampling fields, clarify how shared sampling values apply, and fix the trailing comma in the JSON example.
- Remove the unsupported ZONOS2 `min_p` request field.
- Add Fun-CosyVoice3 to the supported-model overview and Cookbook toctree.

## Related Issues

None.

## Accuracy Test

Not applicable. This PR changes documentation only and does not affect model behavior.

## Benchmark & Profiling

Not applicable. This PR does not change runtime or performance behavior.

## Checklist

- [x] Format your code according with pre-commit.
- [x] Add unit tests. Not applicable for documentation-only corrections.
- [x] Update documentation / docstrings / example tutorials as needed.
- [x] Provide throughput / latency benchmark results and accuracy evaluation results as needed. Not applicable.
- [x] For reviewers: If you have not made any contributions to this PR and are only assisting with merging the main branch, please remove yourself as a co-author when merging the PR.

## CI

Validated locally:

- `uvx pre-commit run --files docs/cookbook/moss_transcribe_diarize.md docs/cookbook/moss_tts.md docs/cookbook/zonos2.md docs/index.rst`
- `git diff --check origin/main..HEAD`
- Full Sphinx HTML build using `docs/requirements.txt`: succeeded with 22 pre-existing warnings and no new warnings.
- Parsed all three documented MOSS-Transcribe-Diarize benchmark commands with the real `parse_args` implementation: `movies800times`, `aishell4_long`, and `googletime` all succeeded with `max_running_requests=16` and `cuda_graph_max_bs=16`.
- Confirmed the replaced dotted benchmark flags are rejected by the parser with exit code 2 as unrecognized arguments.
