### PR TITLE
[Fun-ASR Perf] Extend prefill graph budget to chunk limit

### DIFF
--- a/sglang_omni/models/fun_asr/engine_builder.py
+++ b/sglang_omni/models/fun_asr/engine_builder.py
@@ -117,9 +117,9 @@ class FunASREngineBuilder(AsrEngineBuilder):
             "mem_fraction_static": self.mem_fraction_static,
             "max_prefill_tokens": 4096,
             "chunked_prefill_size": 4096,
-            # Qualified capture budget; longer prefills run eager.
+            # Capture every admitted prefill shape up to the chunk limit.
             "cuda_graph_backend_prefill": CudaGraphBackend.BREAKABLE,
-            "cuda_graph_bs_prefill": build_default_prefill_cuda_graph_bs(256),
+            "cuda_graph_bs_prefill": build_default_prefill_cuda_graph_bs(4096),
             "sampling_backend": "pytorch",
             "dtype": dtype,
         }

--- a/tests/unit_test/fun_asr/test_pipeline.py
+++ b/tests/unit_test/fun_asr/test_pipeline.py
@@ -266,8 +266,9 @@ def test_fun_asr_threads_generation_batch_and_request_build_policy(monkeypatch) 
         64,
     ]
     assert build_kwargs["cuda_graph_backend_prefill"] == "breakable"
+    assert build_kwargs["chunked_prefill_size"] == 4096
     assert build_kwargs["cuda_graph_bs_prefill"] == build_default_prefill_cuda_graph_bs(
-        256
+        build_kwargs["chunked_prefill_size"]
     )
     assert scheduler.server_args._cuda_graph_config_locked == {("prefill", "bs")}
     assert infra_kwargs[-1]["enable_prefill_input_embeds"] is True


### PR DESCRIPTION
Closed before review so the profiling scope can be clarified and completed independently.