### PR TITLE
[Qwen3-TTS] Serve Qwen3-TTS on Apple Silicon (MLX + Torch MPS)

### DIFF
--- a/examples/qwen3_tts_mlx_clone.py
+++ b/examples/qwen3_tts_mlx_clone.py
@@ -1,0 +1,94 @@
+#!/usr/bin/env python3
+# SPDX-License-Identifier: Apache-2.0
+"""Qwen3-TTS Base voice cloning on Apple Silicon via MLX.
+
+Needs a Base checkpoint (CustomVoice and VoiceDesign ship no speech-tokenizer
+encoder, so they cannot encode reference audio):
+
+    huggingface-cli download Qwen/Qwen3-TTS-12Hz-0.6B-Base --local-dir q3tts-base
+
+    python examples/qwen3_tts_mlx_clone.py \\
+        --model q3tts-base \\
+        --ref-audio reference.wav \\
+        --ref-text "exact transcript of reference.wav" \\
+        --text "Text to speak in that voice." \\
+        --out cloned.wav
+
+``--ref-text`` must transcribe the *whole* reference clip. A mismatched or
+partial transcript is a conditioning error, not a tolerance: it degrades output
+badly in the official implementation too.
+"""
+
+from __future__ import annotations
+
+import argparse
+import time
+
+from sglang_omni.models.qwen3_tts.mlx.generate import (
+    CloneRequest,
+    Qwen3TTSMlxGenerator,
+    frames_to_seconds,
+    write_wav,
+)
+from sglang_omni.models.qwen3_tts.mlx.sampling import SamplingParams
+
+
+def main() -> int:
+    parser = argparse.ArgumentParser(description=__doc__)
+    parser.add_argument("--model", required=True, help="Path to a Base checkpoint")
+    parser.add_argument("--ref-audio", required=True, help="Reference audio file")
+    parser.add_argument("--ref-text", required=True, help="Transcript of --ref-audio")
+    parser.add_argument("--text", required=True, help="Text to synthesise")
+    parser.add_argument("--out", default="cloned.wav")
+    parser.add_argument("--language", default="auto")
+    parser.add_argument("--temperature", type=float, default=0.9)
+    parser.add_argument("--top-k", type=int, default=50)
+    parser.add_argument("--top-p", type=float, default=1.0)
+    parser.add_argument("--repetition-penalty", type=float, default=1.05)
+    parser.add_argument("--max-frames", type=int, default=4096)
+    parser.add_argument("--seed", type=int, default=None)
+    args = parser.parse_args()
+
+    started = time.perf_counter()
+    generator = Qwen3TTSMlxGenerator.from_pretrained(args.model)
+    print(f"loaded {args.model} in {time.perf_counter() - started:.1f}s")
+    if not generator.speech_tokenizer.has_encoder:
+        parser.error(
+            f"{args.model} has no speech-tokenizer encoder, so it cannot clone a "
+            "voice; use a *-Base checkpoint"
+        )
+
+    request = CloneRequest(
+        text=args.text,
+        ref_audio=args.ref_audio,
+        ref_text=args.ref_text,
+        language=args.language,
+        max_frames=args.max_frames,
+        semantic=SamplingParams(
+            temperature=args.temperature,
+            top_k=args.top_k,
+            top_p=args.top_p,
+            repetition_penalty=args.repetition_penalty,
+        ),
+        subtalker=SamplingParams(
+            temperature=args.temperature,
+            top_k=args.top_k,
+            top_p=args.top_p,
+        ),
+        seed=args.seed,
+    )
+
+    started = time.perf_counter()
+    audio = generator.clone(request)
+    elapsed = time.perf_counter() - started
+    seconds = write_wav(args.out, audio)
+    print(
+        f"wrote {args.out}: {seconds:.2f}s of audio in {elapsed:.1f}s "
+        f"(RTF {elapsed / max(seconds, 1e-6):.2f}, "
+        f"{frames_to_seconds(1) * 1000:.0f}ms per codec frame)"
+    )
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/playground/README.md
+++ b/playground/README.md
@@ -1,17 +1,22 @@
 # Playground
 
-Browser playgrounds for the three models served by SGLang-Omni.
+Browser playgrounds for models served by SGLang-Omni.
 
 | Subdirectory | Model | UI |
 |---|---|---|
 | `qwen-omni/` | Qwen3-Omni — multimodal chat (text / audio / image / video). | HTML / CSS / JS |
 | `s2pro/` | S2 Pro — text-to-speech with voice cloning, streaming and non-streaming. | Gradio |
 | `higgs/` | Higgs Audio v3 — multilingual TTS with inline control tokens (emotion / style / sfx / prosody) and streaming. | HTML / CSS / JS |
+| `qwen3_tts_mlx/` | Qwen3-TTS Base — voice cloning on Apple Silicon via MLX. Runs in-process, no backend. | Gradio |
 
 Each `start.sh` launches the backend, waits for `/health`, then launches the
 playground UI in the foreground. `Ctrl-C` stops both. The raw `sgl-omni serve`
 command is shown alongside in case you want to run the backend yourself (for
 example, on a separate host) and point the UI at it.
+
+`qwen3_tts_mlx/` is the exception: MLX is not wired into Omni's scheduler yet, so
+that playground loads the checkpoint into the UI process instead of talking to a
+backend over HTTP.
 
 ## Qwen3-Omni
 
@@ -95,3 +100,36 @@ From your local machine:
 ```bash
 ssh -L 8000:localhost:8000 -L 7860:localhost:7860 user@host
 ```
+
+## Qwen3-TTS voice cloning on MLX (Apple Silicon)
+
+Clone a voice from a reference clip, entirely on-device via MLX. There is no
+backend process — the UI loads the model itself.
+
+```bash
+# Voice cloning needs a *-Base checkpoint: CustomVoice and VoiceDesign ship no
+# speech-tokenizer encoder, so they cannot encode reference audio.
+huggingface-cli download Qwen/Qwen3-TTS-12Hz-0.6B-Base --local-dir q3tts-base
+
+./playground/qwen3_tts_mlx/start.sh --model-path ./q3tts-base
+```
+
+```bash
+# Or launch the UI directly
+python -m playground.qwen3_tts_mlx.app --model-path ./q3tts-base --port 7860
+```
+
+Open <http://localhost:7860>. Upload or record reference audio (any sample rate —
+it is resampled to 24 kHz), enter its transcript and the text to speak, then
+`Clone voice`. The run detail panel breaks down prefill / talker / vocoder time
+and the realtime factor.
+
+**The reference transcript must cover the whole clip.** A partial or mismatched
+transcript degrades output badly in the official implementation too — it is a
+conditioning requirement, not a tolerance. Trim audio and transcript together.
+
+Repeated runs against the same reference reuse its cached codes and skip
+re-encoding, so only the first request pays that cost.
+
+Requires `pip install mlx mlx-lm` on Apple Silicon. For scripted use without a
+UI, see `examples/qwen3_tts_mlx_clone.py`.

--- a/playground/qwen3_tts_mlx/__init__.py
+++ b/playground/qwen3_tts_mlx/__init__.py
@@ -1,0 +1,3 @@
+# SPDX-License-Identifier: Apache-2.0
+
+"""Gradio playground for MLX Qwen3-TTS voice cloning on Apple Silicon."""

--- a/playground/qwen3_tts_mlx/app.py
+++ b/playground/qwen3_tts_mlx/app.py
@@ -1,0 +1,34 @@
+# SPDX-License-Identifier: Apache-2.0
+"""Entrypoint for the MLX Qwen3-TTS voice-cloning Gradio playground."""
+
+from __future__ import annotations
+
+import argparse
+
+from playground.qwen3_tts_mlx.ui import create_demo
+
+DEFAULT_MODEL = "Qwen/Qwen3-TTS-12Hz-0.6B-Base"
+
+
+def main() -> None:
+    parser = argparse.ArgumentParser(
+        description="MLX Qwen3-TTS voice-cloning playground (Apple Silicon)"
+    )
+    parser.add_argument(
+        "--model-path",
+        type=str,
+        default=DEFAULT_MODEL,
+        help="Local path to a Qwen3-TTS *-Base checkpoint",
+    )
+    parser.add_argument("--host", type=str, default="127.0.0.1")
+    parser.add_argument("--port", type=int, default=7860)
+    parser.add_argument("--share", action="store_true")
+    args = parser.parse_args()
+
+    demo = create_demo(args.model_path)
+    demo.queue()
+    demo.launch(server_name=args.host, server_port=args.port, share=args.share)
+
+
+if __name__ == "__main__":
+    main()

--- a/playground/qwen3_tts_mlx/generator.py
+++ b/playground/qwen3_tts_mlx/generator.py
@@ -1,0 +1,166 @@
+# SPDX-License-Identifier: Apache-2.0
+"""Lazily loaded MLX Qwen3-TTS generator shared by the playground UI.
+
+Unlike the other playgrounds, this one has no HTTP backend: MLX serving is not
+wired into Omni's scheduler yet, so the UI drives the model in process.
+"""
+
+from __future__ import annotations
+
+import threading
+import time
+from dataclasses import dataclass
+from typing import Callable
+
+import numpy as np
+
+FRAME_RATE_HZ = 12.5
+SAMPLE_RATE = 24000
+
+
+class ModelUnsupportedError(RuntimeError):
+    """Raised when the checkpoint cannot clone a voice."""
+
+
+@dataclass
+class CloneResult:
+    """One completed synthesis, with the numbers the UI reports."""
+
+    audio: np.ndarray
+    frames: int
+    prompt_tokens: int
+    reference_frames: int
+    reference_cached: bool
+    prefill_seconds: float
+    decode_seconds: float
+    vocoder_seconds: float
+
+    @property
+    def audio_seconds(self) -> float:
+        return len(self.audio) / SAMPLE_RATE
+
+    @property
+    def total_seconds(self) -> float:
+        return self.prefill_seconds + self.decode_seconds + self.vocoder_seconds
+
+    @property
+    def realtime_factor(self) -> float:
+        return self.total_seconds / max(self.audio_seconds, 1e-6)
+
+
+class LazyGenerator:
+    """Loads the checkpoint on first use and keeps it warm.
+
+    Generation is serialised: MLX arrays and the reference cache are shared
+    mutable state, and the playground is single-user anyway.
+    """
+
+    def __init__(self, model_path: str) -> None:
+        self.model_path = model_path
+        self._generator = None
+        self._lock = threading.Lock()
+
+    @property
+    def loaded(self) -> bool:
+        return self._generator is not None
+
+    def load(self):
+        """Return the generator, loading it the first time. Raises on non-Base."""
+        with self._lock:
+            if self._generator is not None:
+                return self._generator
+
+            from sglang_omni.models.qwen3_tts.mlx.generate import Qwen3TTSMlxGenerator
+
+            generator = Qwen3TTSMlxGenerator.from_pretrained(self.model_path)
+            if not generator.speech_tokenizer.has_encoder:
+                raise ModelUnsupportedError(
+                    f"{self.model_path} has no speech-tokenizer encoder, so it "
+                    "cannot encode reference audio. Voice cloning needs a "
+                    "*-Base checkpoint, for example "
+                    "Qwen/Qwen3-TTS-12Hz-0.6B-Base."
+                )
+            self._generator = generator
+            return generator
+
+    def clone(
+        self,
+        *,
+        text: str,
+        ref_audio: str,
+        ref_text: str,
+        language: str,
+        max_frames: int,
+        temperature: float,
+        top_k: int,
+        top_p: float,
+        repetition_penalty: float,
+        seed: int | None,
+        on_frame: Callable[[int], None] | None = None,
+    ) -> CloneResult:
+        """Synthesise one request, reporting progress per generated frame."""
+        import mlx.core as mx
+
+        from sglang_omni.models.qwen3_tts.mlx.generate import (
+            CloneRequest,
+            _load_audio_24k,
+        )
+        from sglang_omni.models.qwen3_tts.mlx.sampling import SamplingParams
+
+        generator = self.load()
+        params = SamplingParams(
+            temperature=temperature,
+            top_k=int(top_k),
+            top_p=top_p,
+            repetition_penalty=repetition_penalty,
+        )
+        request = CloneRequest(
+            text=text,
+            ref_audio=ref_audio,
+            ref_text=ref_text,
+            language=language,
+            max_frames=int(max_frames),
+            semantic=params,
+            subtalker=SamplingParams(
+                temperature=temperature, top_k=int(top_k), top_p=top_p
+            ),
+            seed=seed,
+        )
+
+        with self._lock:
+            if seed is not None:
+                mx.random.seed(seed)
+
+            audio = _load_audio_24k(ref_audio)
+            references_before = generator.cached_reference_count
+
+            started = time.perf_counter()
+            prompt = generator.build_icl_prompt(text, audio, ref_text, language)
+            mx.eval(prompt.input_embeds, prompt.ref_codes)
+            prefill_seconds = time.perf_counter() - started
+            reference_cached = (
+                generator.cached_reference_count == references_before
+            )
+
+            started = time.perf_counter()
+            frames = []
+            for frame in generator.generate_frames(prompt, request):
+                frames.append(frame)
+                if on_frame is not None:
+                    on_frame(len(frames))
+            decode_seconds = time.perf_counter() - started
+
+            started = time.perf_counter()
+            waveform = generator.decode_frames(frames, prompt.ref_codes)
+            vocoder_seconds = time.perf_counter() - started
+
+        return CloneResult(
+            audio=waveform,
+            frames=len(frames),
+            prompt_tokens=int(prompt.input_embeds.shape[1]),
+            reference_frames=int(prompt.ref_codes.shape[-1]),
+            reference_cached=reference_cached,
+            prefill_seconds=prefill_seconds,
+            decode_seconds=decode_seconds,
+            vocoder_seconds=vocoder_seconds,
+        )

--- a/playground/qwen3_tts_mlx/generator.py
+++ b/playground/qwen3_tts_mlx/generator.py
@@ -138,9 +138,7 @@ class LazyGenerator:
             prompt = generator.build_icl_prompt(text, audio, ref_text, language)
             mx.eval(prompt.input_embeds, prompt.ref_codes)
             prefill_seconds = time.perf_counter() - started
-            reference_cached = (
-                generator.cached_reference_count == references_before
-            )
+            reference_cached = generator.cached_reference_count == references_before
 
             started = time.perf_counter()
             frames = []

--- a/playground/qwen3_tts_mlx/start.sh
+++ b/playground/qwen3_tts_mlx/start.sh
@@ -1,0 +1,48 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+# ---------------------------------------------------------------------------
+# Start the MLX Qwen3-TTS voice-cloning playground.
+#
+# There is no separate backend: MLX serving is not wired into Omni's scheduler
+# yet, so the UI loads the checkpoint in its own process.
+#
+# Usage:
+#   ./playground/qwen3_tts_mlx/start.sh
+#   ./playground/qwen3_tts_mlx/start.sh --model-path ~/models/qwen3-tts-base
+#   ./playground/qwen3_tts_mlx/start.sh --port 7861 --share
+# ---------------------------------------------------------------------------
+
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+REPO_DIR="$(cd "${SCRIPT_DIR}/../.." && pwd)"
+PYTHON_BIN="${PYTHON_BIN:-python}"
+
+MODEL_PATH="${QWEN3_TTS_CKPT:-${MODEL_PATH:-Qwen/Qwen3-TTS-12Hz-0.6B-Base}}"
+GRADIO_PORT="7860"
+GRADIO_HOST="127.0.0.1"
+GRADIO_SHARE=""
+
+while [[ $# -gt 0 ]]; do
+  case "$1" in
+    --model-path) MODEL_PATH="$2"; shift 2 ;;
+    --port)       GRADIO_PORT="$2"; shift 2 ;;
+    --host)       GRADIO_HOST="$2"; shift 2 ;;
+    --share)      GRADIO_SHARE="--share"; shift ;;
+    -h|--help)    sed -n '4,14p' "${BASH_SOURCE[0]}"; exit 0 ;;
+    *) echo "Unknown argument: $1" >&2; exit 2 ;;
+  esac
+done
+
+if ! "${PYTHON_BIN}" -c "import mlx.core" >/dev/null 2>&1; then
+  echo "MLX is not importable. On Apple Silicon: pip install mlx mlx-lm" >&2
+  exit 1
+fi
+
+cd "${REPO_DIR}"
+echo "Model:  ${MODEL_PATH}"
+echo "UI:     http://${GRADIO_HOST}:${GRADIO_PORT}"
+exec "${PYTHON_BIN}" -m playground.qwen3_tts_mlx.app \
+  --model-path "${MODEL_PATH}" \
+  --host "${GRADIO_HOST}" \
+  --port "${GRADIO_PORT}" \
+  ${GRADIO_SHARE}

--- a/playground/qwen3_tts_mlx/ui.py
+++ b/playground/qwen3_tts_mlx/ui.py
@@ -1,0 +1,221 @@
+# SPDX-License-Identifier: Apache-2.0
+"""Gradio UI for MLX Qwen3-TTS voice cloning."""
+
+from __future__ import annotations
+
+import gradio as gr
+
+from playground.qwen3_tts_mlx.generator import (
+    FRAME_RATE_HZ,
+    SAMPLE_RATE,
+    LazyGenerator,
+    ModelUnsupportedError,
+)
+
+_REFERENCE_NOTE = """
+**The transcript must cover the whole reference clip.** A partial or mismatched
+transcript is a conditioning error, not a tolerance — the official
+implementation degrades the same way. Trim the audio and the transcript
+together.
+"""
+
+
+def _format_summary(result) -> str:
+    cached = (
+        "reused cached reference" if result.reference_cached else "encoded reference"
+    )
+    return "\n".join(
+        [
+            f"audio          {result.audio_seconds:.2f}s "
+            f"({result.frames} frames @ {FRAME_RATE_HZ:g} Hz)",
+            f"prompt         {result.prompt_tokens} positions, "
+            f"{result.reference_frames} reference frames ({cached})",
+            f"prefill        {result.prefill_seconds:.2f}s",
+            f"talker         {result.decode_seconds:.2f}s "
+            f"({result.decode_seconds / max(result.frames, 1) * 1000:.0f} ms/frame)",
+            f"vocoder        {result.vocoder_seconds:.2f}s",
+            f"total          {result.total_seconds:.2f}s "
+            f"(RTF {result.realtime_factor:.2f})",
+        ]
+    )
+
+
+def make_handler(generator: LazyGenerator):
+    """Build the Gradio click handler for one synthesis."""
+
+    def synthesize(
+        text: str,
+        ref_audio: str | None,
+        ref_text: str,
+        language: str,
+        max_seconds: float,
+        temperature: float,
+        top_k: int,
+        top_p: float,
+        repetition_penalty: float,
+        seed: int,
+        progress=gr.Progress(),
+    ):
+        if not (text or "").strip():
+            raise gr.Error("Enter some text to synthesise.")
+        if not ref_audio:
+            raise gr.Error("Upload or record reference audio to clone.")
+        if not (ref_text or "").strip():
+            raise gr.Error(
+                "Enter the transcript of the reference audio — cloning is "
+                "conditioned on it."
+            )
+
+        max_frames = max(1, int(max_seconds * FRAME_RATE_HZ))
+
+        progress(0.0, desc="Loading model" if not generator.loaded else "Preparing")
+
+        def on_frame(count: int) -> None:
+            # The talker stops at EOS, so this is an upper bound, not a total.
+            progress(
+                min(count / max_frames, 1.0),
+                desc=f"Generating {count / FRAME_RATE_HZ:.1f}s of audio",
+            )
+
+        try:
+            result = generator.clone(
+                text=text,
+                ref_audio=ref_audio,
+                ref_text=ref_text,
+                language=language,
+                max_frames=max_frames,
+                temperature=temperature,
+                top_k=top_k,
+                top_p=top_p,
+                repetition_penalty=repetition_penalty,
+                seed=None if int(seed) < 0 else int(seed),
+                on_frame=on_frame,
+            )
+        except ModelUnsupportedError as exc:
+            raise gr.Error(str(exc)) from exc
+
+        if result.frames == 0:
+            raise gr.Error(
+                "The talker emitted end-of-speech immediately and produced no "
+                "audio. Check that the reference transcript matches the "
+                "reference audio."
+            )
+
+        progress(1.0, desc="Vocoding complete")
+        return (SAMPLE_RATE, result.audio), _format_summary(result)
+
+    return synthesize
+
+
+def create_demo(model_path: str) -> gr.Blocks:
+    """Build the playground layout for one checkpoint."""
+    generator = LazyGenerator(model_path)
+    handler = make_handler(generator)
+
+    with gr.Blocks(title="Qwen3-TTS MLX voice cloning") as demo:
+        gr.Markdown(
+            "# Qwen3-TTS voice cloning (MLX)\n"
+            f"Running `{model_path}` in this process on MLX — no server needed. "
+            "Requires a **Base** checkpoint; CustomVoice and VoiceDesign ship no "
+            "speech-tokenizer encoder and cannot encode reference audio."
+        )
+
+        with gr.Row():
+            with gr.Column(scale=3):
+                text_input = gr.Textbox(
+                    label="Text to speak",
+                    placeholder="What the cloned voice should say.",
+                    lines=4,
+                )
+                ref_audio = gr.Audio(
+                    label="Reference audio (any sample rate; resampled to 24 kHz)",
+                    type="filepath",
+                    sources=["upload", "microphone"],
+                )
+                ref_text = gr.Textbox(
+                    label="Reference transcript",
+                    placeholder="Exactly what is said in the reference audio.",
+                    lines=3,
+                )
+                gr.Markdown(_REFERENCE_NOTE)
+
+            with gr.Column(scale=2):
+                language = gr.Dropdown(
+                    label="Language",
+                    choices=[
+                        "auto",
+                        "en",
+                        "zh",
+                        "ja",
+                        "ko",
+                        "de",
+                        "fr",
+                        "es",
+                        "it",
+                        "pt",
+                        "ru",
+                    ],
+                    value="auto",
+                    info="'auto' skips the language control token.",
+                )
+                max_seconds = gr.Slider(
+                    label="Max output seconds",
+                    minimum=1,
+                    maximum=120,
+                    step=1,
+                    value=20,
+                    info="Upper bound; generation stops early at end-of-speech.",
+                )
+                with gr.Accordion("Sampling", open=False):
+                    temperature = gr.Slider(
+                        label="Temperature",
+                        minimum=0.0,
+                        maximum=1.5,
+                        step=0.05,
+                        value=0.9,
+                        info="0 is greedy.",
+                    )
+                    top_k = gr.Slider(
+                        label="Top-k", minimum=0, maximum=200, step=1, value=50
+                    )
+                    top_p = gr.Slider(
+                        label="Top-p", minimum=0.05, maximum=1.0, step=0.05, value=1.0
+                    )
+                    repetition_penalty = gr.Slider(
+                        label="Repetition penalty",
+                        minimum=1.0,
+                        maximum=1.5,
+                        step=0.01,
+                        value=1.05,
+                        info="Applied to the talker's recent codec tokens only.",
+                    )
+                    seed = gr.Number(
+                        label="Seed",
+                        value=-1,
+                        precision=0,
+                        info="-1 for a fresh random draw each run.",
+                    )
+                synthesize_btn = gr.Button("Clone voice", variant="primary")
+
+        audio_output = gr.Audio(label="Generated speech", type="numpy")
+        status = gr.Code(label="Run detail", interactive=False)
+
+        synthesize_btn.click(
+            fn=handler,
+            inputs=[
+                text_input,
+                ref_audio,
+                ref_text,
+                language,
+                max_seconds,
+                temperature,
+                top_k,
+                top_p,
+                repetition_penalty,
+                seed,
+            ],
+            outputs=[audio_output, status],
+            api_name="synthesize",
+        )
+
+    return demo

--- a/sglang_omni/model_runner/mlx_model_worker.py
+++ b/sglang_omni/model_runner/mlx_model_worker.py
@@ -4,9 +4,40 @@
 from __future__ import annotations
 
 from dataclasses import dataclass, replace
-from typing import Any
+from importlib import import_module
+from typing import Any, Callable
 
 from sglang_omni.model_runner.base import ModelRunner
+
+# note: Runner factories are registered as ``module:attribute`` strings and
+# imported on demand. Their modules import ``mlx`` at module scope, so eager
+# imports here would pull MLX into every platform's worker startup.
+_MLX_RUNNER_FACTORIES: dict[str, str] = {
+    "Qwen3ASRForConditionalGeneration": (
+        "sglang_omni.models.qwen3_asr.mlx.runner:make_qwen3_asr_mlx_runner_class"
+    ),
+    "Qwen3TTSTalker": (
+        "sglang_omni.models.qwen3_tts.mlx.runner:make_qwen3_tts_mlx_runner_class"
+    ),
+}
+
+
+def register_mlx_runner_factory(model_arch: str, factory_path: str) -> None:
+    """Register an ``module:attribute`` runner factory for one architecture."""
+    _MLX_RUNNER_FACTORIES[model_arch] = factory_path
+
+
+def resolve_mlx_runner_factory(model_arch: str | None) -> Callable[[], type]:
+    """Import the registered runner-class factory for ``model_arch``."""
+    factory_path = _MLX_RUNNER_FACTORIES.get(model_arch)
+    if factory_path is None:
+        supported = ", ".join(sorted(_MLX_RUNNER_FACTORIES))
+        raise NotImplementedError(
+            f"Omni's MLX worker has no runner for architecture {model_arch!r}; "
+            f"supported architectures: {supported}"
+        )
+    module_name, _, attribute = factory_path.partition(":")
+    return getattr(import_module(module_name), attribute)
 
 
 @dataclass(slots=True)
@@ -169,11 +200,7 @@ def create_mlx_model_worker(
     tp_rank: int = 0,
 ):
     """Construct an MLX worker with the same scheduler-facing contract as Omni."""
-    if config.model_arch_override != "Qwen3ASRForConditionalGeneration":
-        raise NotImplementedError(
-            "Omni's MLX worker currently supports only "
-            "Qwen3ASRForConditionalGeneration"
-        )
+    make_runner_class = resolve_mlx_runner_factory(config.model_arch_override)
 
     from sglang.srt.distributed.parallel_state_wrapper import ParallelState
     from sglang.srt.hardware_backend.mlx.model_runner_stub import MlxModelRunnerStub
@@ -190,16 +217,14 @@ def create_mlx_model_worker(
     )
     from sglang.srt.server_args import PortArgs
 
-    from sglang_omni.models.qwen3_asr.mlx.runner import make_qwen3_asr_mlx_runner_class
-
-    class OmniQwen3ASRMlxWorker(MlxTpModelWorker):
+    class OmniMlxWorker(MlxTpModelWorker):
         @property
         def tp_rank(self) -> int:
             return self.ps.tp_rank
 
         def _init_model_runner(self):
             MlxModelRunnerStub.validate_startup_weight_load_mode(self.server_args)
-            runner_class = make_qwen3_asr_mlx_runner_class()
+            runner_class = make_runner_class()
             init_kwargs = {
                 "model_path": get_model().model_path,
                 "trust_remote_code": get_model().trust_remote_code,
@@ -275,7 +300,7 @@ def create_mlx_model_worker(
     nccl_port = config.nccl_port
     if nccl_port is None:
         nccl_port = PortArgs.init_new(server_args).nccl_port
-    return OmniQwen3ASRMlxWorker(
+    return OmniMlxWorker(
         server_args=server_args,
         gpu_id=gpu_id,
         ps=ps,

--- a/sglang_omni/models/qwen3_tts/backend.py
+++ b/sglang_omni/models/qwen3_tts/backend.py
@@ -1,0 +1,23 @@
+# SPDX-License-Identifier: Apache-2.0
+"""Execution backend selection for Qwen3-TTS."""
+
+from __future__ import annotations
+
+from enum import Enum
+
+
+class Qwen3TTSBackend(str, Enum):
+    """Model implementation selected for the Qwen3-TTS pipeline."""
+
+    TORCH = "torch"
+    MLX = "mlx"
+
+
+def get_qwen3_tts_backend() -> Qwen3TTSBackend:
+    """Return the model backend; device selection remains a Torch concern."""
+    from sglang.srt.utils.tensor_bridge import use_mlx
+
+    return Qwen3TTSBackend.MLX if use_mlx() else Qwen3TTSBackend.TORCH
+
+
+__all__ = ["Qwen3TTSBackend", "get_qwen3_tts_backend"]

--- a/sglang_omni/models/qwen3_tts/engine_builder.py
+++ b/sglang_omni/models/qwen3_tts/engine_builder.py
@@ -12,6 +12,7 @@ from sglang.srt.runtime_context import get_model, get_schedule
 
 from sglang_omni.models.qwen3_tts import CAPABILITIES, request_builders
 from sglang_omni.models.qwen3_tts import stages as qwen3_stages
+from sglang_omni.models.qwen3_tts.backend import Qwen3TTSBackend, get_qwen3_tts_backend
 from sglang_omni.models.qwen3_tts.config import qwen3_tts_checkpoint_model_type
 from sglang_omni.scheduling.engine_factory import TtsEngineBuilder
 from sglang_omni.scheduling.generation_batch_policy import (
@@ -85,6 +86,23 @@ class Qwen3TtsEngineBuilder(TtsEngineBuilder):
         *,
         dtype: str,
     ) -> dict[str, Any]:
+        if get_qwen3_tts_backend() is Qwen3TTSBackend.MLX:
+            # MLX owns evaluation and request-local caches. Torch graph capture,
+            # radix reuse, and split prefill do not apply to this runner.
+            return {
+                "max_running_requests": 16,
+                "max_queued_requests": 16,
+                "dtype": dtype,
+                "disable_cuda_graph": True,
+                "disable_overlap_schedule": True,
+                "disable_radix_cache": True,
+                "enable_torch_compile": False,
+                "mem_fraction_static": 0.85,
+                "max_prefill_tokens": self.context_length,
+                "chunked_prefill_size": -1,
+                "trust_remote_code": True,
+            }
+
         defaults: dict[str, Any] = {
             "max_running_requests": 16,
             "max_queued_requests": 16,
@@ -122,9 +140,7 @@ class Qwen3TtsEngineBuilder(TtsEngineBuilder):
         server_args: Any,
     ) -> None:
         del gpu_id
-        from sglang.srt.utils.tensor_bridge import use_mlx
-
-        if use_mlx():
+        if get_qwen3_tts_backend() is Qwen3TTSBackend.MLX:
             return
 
         from qwen_tts import Qwen3TTSModel
@@ -206,9 +222,7 @@ class Qwen3TtsEngineBuilder(TtsEngineBuilder):
         server_args: Any,
     ) -> None:
         del device, gpu_id, server_args
-        from sglang.srt.utils.tensor_bridge import use_mlx
-
-        if use_mlx():
+        if get_qwen3_tts_backend() is Qwen3TTSBackend.MLX:
             self._setup_mlx_model(
                 model_worker=model_worker, checkpoint_dir=checkpoint_dir
             )
@@ -219,6 +233,8 @@ class Qwen3TtsEngineBuilder(TtsEngineBuilder):
 
     def post_scheduler_setup(self, scheduler: Any, model_runner: Any) -> None:
         del model_runner
+        if get_qwen3_tts_backend() is Qwen3TTSBackend.MLX:
+            return
         schedule = get_schedule()
         running = int(schedule.max_running_requests)
         context = int(get_model().context_length)
@@ -236,9 +252,7 @@ class Qwen3TtsEngineBuilder(TtsEngineBuilder):
         )
 
     def make_model_runner(self, model_worker: Any, output_proc: Any) -> Any:
-        from sglang.srt.utils.tensor_bridge import use_mlx
-
-        if use_mlx():
+        if get_qwen3_tts_backend() is Qwen3TTSBackend.MLX:
             # The MLX talker keeps its own frame state, so it needs a different
             # bridge than the Torch AR stage.
             scheduler_runner_mod = importlib.import_module(

--- a/sglang_omni/models/qwen3_tts/engine_builder.py
+++ b/sglang_omni/models/qwen3_tts/engine_builder.py
@@ -62,11 +62,20 @@ class Qwen3TtsEngineBuilder(TtsEngineBuilder):
         self.prefill_coalesce_requests = prefill_coalesce_requests
         self.prefill_coalesce_wait_ms = prefill_coalesce_wait_ms
         self.wrapper: Any | None = None
+        self._torch_mps_model_runner: Any | None = None
         self._stream_output_builder: Any | None = None
         # note (luojiaxuan): the factory assigns this before generation_defaults
         # runs, but Qwen3TTSPipelineConfig.generation_admission_defaults builds a
         # bare builder just to read the admission keys, so it needs a value.
         self.checkpoint_dir: str = ""
+        self.device: str | None = None
+
+    def _uses_torch_mps(self) -> bool:
+        return (
+            get_qwen3_tts_backend() is Qwen3TTSBackend.TORCH
+            and self.device is not None
+            and torch.device(self.device).type == "mps"
+        )
 
     def resolve_checkpoint(self, model_path: str) -> str:
         qwen3_stages.apply_qwen_tts_transformers_compatibility_patches()
@@ -100,6 +109,23 @@ class Qwen3TtsEngineBuilder(TtsEngineBuilder):
                 "mem_fraction_static": 0.85,
                 "max_prefill_tokens": self.context_length,
                 "chunked_prefill_size": -1,
+                "trust_remote_code": True,
+            }
+        if self._uses_torch_mps():
+            return {
+                "max_running_requests": 1,
+                "max_queued_requests": 1,
+                "dtype": dtype,
+                "disable_cuda_graph": True,
+                "disable_overlap_schedule": True,
+                "disable_radix_cache": True,
+                "enable_torch_compile": False,
+                "context_length": 2048,
+                "max_total_tokens": 2048,
+                "max_prefill_tokens": 2048,
+                "chunked_prefill_size": -1,
+                "attention_backend": "torch_native",
+                "sampling_backend": "pytorch",
                 "trust_remote_code": True,
             }
 
@@ -149,6 +175,12 @@ class Qwen3TtsEngineBuilder(TtsEngineBuilder):
         # note(ratish): the tokenizer and the predictor graphs live for the whole
         # process, so they are attached before sglang reads free memory for the pool.
         model = model_worker.model_runner.model
+        if self._uses_torch_mps():
+            from sglang_omni.models.qwen3_tts.torch_mps_runner import (
+                install_torch_mps_talker,
+            )
+
+            install_torch_mps_talker(model, checkpoint_dir)
         speech_tokenizer = qwen3_stages._load_qwen3_tts_tokenizer(
             checkpoint_dir,
             device=device,
@@ -172,7 +204,7 @@ class Qwen3TtsEngineBuilder(TtsEngineBuilder):
             wrapper=self.wrapper,
             device=torch.device(device),
         )
-        if bool(server_args.disable_cuda_graph):
+        if self._uses_torch_mps() or bool(server_args.disable_cuda_graph):
             return
         # note(ratish): the bucket warmups also build cuDNN's attention plans,
         # which otherwise land inside the first serving step of each batch size.
@@ -228,8 +260,20 @@ class Qwen3TtsEngineBuilder(TtsEngineBuilder):
             )
 
     def adjust_overrides(self, overrides: dict[str, Any]) -> None:
+        if self._uses_torch_mps():
+            self.context_length = int(
+                overrides.pop("context_length", self.context_length)
+            )
+            overrides["enable_torch_compile"] = False
         if _is_truthy(overrides.get("enable_torch_compile", False)):
             raise ValueError("Qwen3-TTS torch.compile is not supported")
+
+    def validate_before_infrastructure(self, server_args: Any) -> None:
+        if self._uses_torch_mps() and server_args.max_running_requests != 1:
+            raise ValueError(
+                "Qwen3-TTS Torch MPS currently requires max_running_requests=1"
+            )
+        super().validate_before_infrastructure(server_args)
 
     def post_scheduler_setup(self, scheduler: Any, model_runner: Any) -> None:
         del model_runner
@@ -261,6 +305,15 @@ class Qwen3TtsEngineBuilder(TtsEngineBuilder):
             return scheduler_runner_mod.Qwen3TTSMlxSchedulerModelRunner(
                 model_worker, output_proc
             )
+        if self._uses_torch_mps():
+            from sglang_omni.models.qwen3_tts.torch_mps_runner import (
+                Qwen3TTSTorchMpsModelRunner,
+            )
+
+            self._torch_mps_model_runner = Qwen3TTSTorchMpsModelRunner(
+                model_worker, output_proc
+            )
+            return self._torch_mps_model_runner
 
         model_runner_mod = importlib.import_module(
             "sglang_omni.models.qwen3_tts.model_runner"
@@ -280,11 +333,18 @@ class Qwen3TtsEngineBuilder(TtsEngineBuilder):
     def extra_scheduler_kwargs(self) -> dict[str, Any]:
         return {
             "stream_output_builder": self._stream_output_builder,
-            "request_build_max_workers": 4,
+            "request_build_max_workers": 1 if self._uses_torch_mps() else 4,
             "request_build_max_pending": 16,
-            "prefill_coalesce_requests": self.prefill_coalesce_requests,
+            "prefill_coalesce_requests": (
+                0 if self._uses_torch_mps() else self.prefill_coalesce_requests
+            ),
             "prefill_coalesce_wait_ms": self.prefill_coalesce_wait_ms,
         }
 
     def make_abort_callback(self) -> Any | None:
-        return request_builders.cleanup_prepared_qwen3_tts_request
+        def cleanup(request_id: str) -> None:
+            request_builders.cleanup_prepared_qwen3_tts_request(request_id)
+            if self._torch_mps_model_runner is not None:
+                self._torch_mps_model_runner.abort_request(request_id)
+
+        return cleanup

--- a/sglang_omni/models/qwen3_tts/engine_builder.py
+++ b/sglang_omni/models/qwen3_tts/engine_builder.py
@@ -122,6 +122,11 @@ class Qwen3TtsEngineBuilder(TtsEngineBuilder):
         server_args: Any,
     ) -> None:
         del gpu_id
+        from sglang.srt.utils.tensor_bridge import use_mlx
+
+        if use_mlx():
+            return
+
         from qwen_tts import Qwen3TTSModel
         from transformers import AutoProcessor
 
@@ -164,6 +169,33 @@ class Qwen3TtsEngineBuilder(TtsEngineBuilder):
             top_p=subtalker.top_p,
         )
 
+    def _setup_mlx_model(self, *, model_worker: Any, checkpoint_dir: str) -> None:
+        """Register MLX-native preprocessing.
+
+        The engine's model here is the MLX talker, which has none of the Torch
+        prompt builders and cannot hold a Torch speech tokenizer, so prompts are
+        assembled from the MLX talker instead.
+        """
+        from transformers import AutoTokenizer
+
+        from sglang_omni.models.qwen3_tts.mlx.preprocessing import (
+            Qwen3TTSMlxPreprocessor,
+        )
+
+        talker = model_worker._mlx_runner.model
+        self.wrapper = None
+        preprocessor = Qwen3TTSMlxPreprocessor(
+            talker,
+            talker.model_config,
+            AutoTokenizer.from_pretrained(checkpoint_dir),
+            checkpoint_dir=checkpoint_dir,
+        )
+        request_builders.set_qwen3_tts_preprocessing_context(
+            model=talker,
+            wrapper=None,
+            mlx_preprocessor=preprocessor,
+        )
+
     def setup_model(
         self,
         *,
@@ -173,9 +205,13 @@ class Qwen3TtsEngineBuilder(TtsEngineBuilder):
         gpu_id: int,
         server_args: Any,
     ) -> None:
-        # note(ratish): everything Qwen3-TTS attaches stays resident, so it all
-        # runs in before_memory_pool and nothing is left for after the pool.
-        del model_worker, checkpoint_dir, device, gpu_id, server_args
+        del device, gpu_id, server_args
+        from sglang.srt.utils.tensor_bridge import use_mlx
+
+        if use_mlx():
+            self._setup_mlx_model(
+                model_worker=model_worker, checkpoint_dir=checkpoint_dir
+            )
 
     def adjust_overrides(self, overrides: dict[str, Any]) -> None:
         if _is_truthy(overrides.get("enable_torch_compile", False)):
@@ -200,6 +236,18 @@ class Qwen3TtsEngineBuilder(TtsEngineBuilder):
         )
 
     def make_model_runner(self, model_worker: Any, output_proc: Any) -> Any:
+        from sglang.srt.utils.tensor_bridge import use_mlx
+
+        if use_mlx():
+            # The MLX talker keeps its own frame state, so it needs a different
+            # bridge than the Torch AR stage.
+            scheduler_runner_mod = importlib.import_module(
+                "sglang_omni.models.qwen3_tts.mlx.scheduler_runner"
+            )
+            return scheduler_runner_mod.Qwen3TTSMlxSchedulerModelRunner(
+                model_worker, output_proc
+            )
+
         model_runner_mod = importlib.import_module(
             "sglang_omni.models.qwen3_tts.model_runner"
         )

--- a/sglang_omni/models/qwen3_tts/mlx/__init__.py
+++ b/sglang_omni/models/qwen3_tts/mlx/__init__.py
@@ -1,0 +1,3 @@
+# SPDX-License-Identifier: Apache-2.0
+
+"""Native MLX backend for Qwen3-TTS."""

--- a/sglang_omni/models/qwen3_tts/mlx/config.py
+++ b/sglang_omni/models/qwen3_tts/mlx/config.py
@@ -1,0 +1,274 @@
+# SPDX-License-Identifier: MIT
+# Derived from mlx-audio Qwen3-TTS (Copyright 2025 Prince Canuma and contributors).
+
+from __future__ import annotations
+
+import inspect
+from dataclasses import dataclass, field
+from typing import Any
+
+
+def _filtered(cls: type, params: dict[str, Any]) -> dict[str, Any]:
+    allowed = inspect.signature(cls).parameters
+    return {k: v for k, v in params.items() if k in allowed}
+
+
+@dataclass
+class SpeakerEncoderConfig:
+    """Configuration for the ECAPA-TDNN speaker encoder (Base voice cloning)."""
+
+    mel_dim: int = 128
+    enc_dim: int = 1024
+    enc_channels: list[int] = field(default_factory=lambda: [512, 512, 512, 512, 1536])
+    enc_kernel_sizes: list[int] = field(default_factory=lambda: [5, 3, 3, 3, 1])
+    enc_dilations: list[int] = field(default_factory=lambda: [1, 2, 3, 4, 1])
+    enc_attention_channels: int = 128
+    enc_res2net_scale: int = 8
+    enc_se_channels: int = 128
+    sample_rate: int = 24000
+
+    @classmethod
+    def from_dict(cls, params: dict[str, Any]) -> SpeakerEncoderConfig:
+        return cls(**_filtered(cls, params))
+
+
+@dataclass
+class CodePredictorConfig:
+    """Configuration for the Qwen3-TTS talker code predictor (MTP) sub-model."""
+
+    vocab_size: int = 2048
+    hidden_size: int = 1024
+    intermediate_size: int = 3072
+    num_hidden_layers: int = 5
+    num_attention_heads: int = 16
+    num_key_value_heads: int = 8
+    head_dim: int = 128
+    hidden_act: str = "silu"
+    max_position_embeddings: int = 65536
+    rms_norm_eps: float = 1e-6
+    rope_theta: float = 1000000.0
+    attention_bias: bool = False
+    attention_dropout: float = 0.0
+    num_code_groups: int = 16
+
+    @classmethod
+    def from_dict(cls, params: dict[str, Any]) -> CodePredictorConfig:
+        return cls(**_filtered(cls, params))
+
+
+@dataclass
+class TalkerConfig:
+    """Configuration for the Qwen3-TTS talker transformer."""
+
+    code_predictor_config: CodePredictorConfig | dict[str, Any] | None = None
+    vocab_size: int = 3072
+    hidden_size: int = 1024
+    intermediate_size: int = 3072
+    num_hidden_layers: int = 28
+    num_attention_heads: int = 16
+    num_key_value_heads: int = 8
+    head_dim: int = 128
+    hidden_act: str = "silu"
+    max_position_embeddings: int = 32768
+    rms_norm_eps: float = 1e-6
+    rope_theta: float = 1000000.0
+    rope_scaling: dict[str, Any] | None = field(
+        default_factory=lambda: {
+            "interleaved": True,
+            "mrope_section": [24, 20, 20],
+            "rope_type": "default",
+        }
+    )
+    attention_bias: bool = False
+    attention_dropout: float = 0.0
+    num_code_groups: int = 16
+    text_hidden_size: int = 2048
+    text_vocab_size: int = 151936
+    codec_eos_token_id: int = 2150
+    codec_think_id: int = 2154
+    codec_nothink_id: int = 2155
+    codec_think_bos_id: int = 2156
+    codec_think_eos_id: int = 2157
+    codec_pad_id: int = 2148
+    codec_bos_id: int = 2149
+    codec_language_id: dict[str, int] | None = None
+    spk_id: dict[str, list[int]] | None = None
+    spk_is_dialect: dict[str, str] | None = None
+
+    def __post_init__(self) -> None:
+        if self.code_predictor_config is None:
+            self.code_predictor_config = CodePredictorConfig()
+        elif isinstance(self.code_predictor_config, dict):
+            self.code_predictor_config = CodePredictorConfig.from_dict(
+                self.code_predictor_config
+            )
+
+    @property
+    def mrope_section(self) -> list[int] | None:
+        if not self.rope_scaling:
+            return None
+        return self.rope_scaling.get("mrope_section")
+
+    @classmethod
+    def from_dict(cls, params: dict[str, Any]) -> TalkerConfig:
+        return cls(**_filtered(cls, params))
+
+
+@dataclass
+class TokenizerDecoderConfig:
+    """Configuration for the speech-tokenizer decoder (codes -> waveform)."""
+
+    latent_dim: int = 1024
+    codebook_dim: int = 512
+    codebook_size: int = 2048
+    decoder_dim: int = 1536
+    hidden_act: str = "silu"
+    hidden_size: int = 512
+    intermediate_size: int = 1024
+    layer_scale_initial_scale: float = 0.01
+    max_position_embeddings: int = 8000
+    head_dim: int = 64
+    num_attention_heads: int = 16
+    num_hidden_layers: int = 8
+    num_key_value_heads: int = 16
+    num_quantizers: int = 16
+    num_semantic_quantizers: int = 1
+    rms_norm_eps: float = 1e-5
+    rope_theta: float = 10000.0
+    semantic_codebook_size: int = 4096
+    attention_bias: bool = False
+    attention_dropout: float = 0.0
+    # Every code2wav transformer layer is sliding-window attention; the
+    # official config exposes this as a computed property rather than data,
+    # so it is not present in config.json and must not be read from there.
+    sliding_window: int = 72
+    upsample_rates: list[int] = field(default_factory=lambda: [8, 5, 4, 3])
+    upsampling_ratios: list[int] = field(default_factory=lambda: [2, 2])
+    vector_quantization_hidden_dimension: int = 512
+
+    @classmethod
+    def from_dict(cls, params: dict[str, Any]) -> TokenizerDecoderConfig:
+        return cls(**_filtered(cls, params))
+
+
+@dataclass
+class TokenizerEncoderConfig:
+    """Configuration for the speech-tokenizer encoder (waveform -> codes)."""
+
+    frame_rate: float = 12.5
+    audio_channels: int = 1
+    codebook_dim: int = 256
+    codebook_size: int = 2048
+    compress: int = 2
+    dilation_growth_rate: int = 2
+    head_dim: int = 64
+    hidden_act: str = "gelu"
+    hidden_size: int = 512
+    intermediate_size: int = 2048
+    kernel_size: int = 7
+    last_kernel_size: int = 3
+    layer_scale_initial_scale: float = 0.01
+    max_position_embeddings: int = 8000
+    norm_eps: float = 1e-5
+    num_attention_heads: int = 8
+    num_filters: int = 64
+    num_hidden_layers: int = 8
+    num_key_value_heads: int = 8
+    num_quantizers: int = 32
+    num_residual_layers: int = 1
+    num_semantic_quantizers: int = 1
+    pad_mode: str = "constant"
+    residual_kernel_size: int = 3
+    rope_theta: float = 10000.0
+    sampling_rate: int = 24000
+    sliding_window: int = 250
+    upsampling_ratios: list[int] = field(default_factory=lambda: [8, 6, 5, 4])
+    use_causal_conv: bool = True
+    use_conv_shortcut: bool = False
+    vector_quantization_hidden_dimension: int = 256
+    attention_bias: bool = False
+    attention_dropout: float = 0.0
+
+    @classmethod
+    def from_dict(cls, params: dict[str, Any]) -> TokenizerEncoderConfig:
+        params = dict(params)
+        # The checkpoint spells the frame rate as a private field.
+        if "frame_rate" not in params and "_frame_rate" in params:
+            params["frame_rate"] = params["_frame_rate"]
+        return cls(**_filtered(cls, params))
+
+
+@dataclass
+class TokenizerConfig:
+    """Configuration for the Qwen3-TTS speech tokenizer.
+
+    Loaded from the ``speech_tokenizer/config.json`` subdirectory of a
+    checkpoint, not from the top-level model config.
+    """
+
+    encoder_config: TokenizerEncoderConfig | dict[str, Any] | None = None
+    decoder_config: TokenizerDecoderConfig | dict[str, Any] | None = None
+    encoder_valid_num_quantizers: int = 16
+    input_sample_rate: int = 24000
+    output_sample_rate: int = 24000
+    decode_upsample_rate: int = 1920
+    encode_downsample_rate: int = 1920
+
+    def __post_init__(self) -> None:
+        if isinstance(self.encoder_config, dict):
+            self.encoder_config = TokenizerEncoderConfig.from_dict(self.encoder_config)
+        if self.decoder_config is None:
+            self.decoder_config = TokenizerDecoderConfig()
+        elif isinstance(self.decoder_config, dict):
+            self.decoder_config = TokenizerDecoderConfig.from_dict(self.decoder_config)
+
+    @property
+    def has_encoder(self) -> bool:
+        return self.encoder_config is not None
+
+    @classmethod
+    def from_dict(cls, params: dict[str, Any]) -> TokenizerConfig:
+        return cls(**_filtered(cls, params))
+
+
+@dataclass
+class ModelConfig:
+    """Configuration for the MLX Qwen3-TTS stack.
+
+    ``tokenizer_config`` stays a raw mapping: the speech tokenizer ships its
+    own ``config.json`` in a subdirectory and is configured from there.
+    """
+
+    talker_config: TalkerConfig | dict[str, Any] | None = None
+    speaker_encoder_config: SpeakerEncoderConfig | dict[str, Any] | None = None
+    tokenizer_config: dict[str, Any] | None = None
+    model_type: str = "qwen3_tts"
+    tokenizer_type: str = "qwen3_tts_tokenizer_12hz"
+    tts_model_size: str = "0b6"
+    tts_model_type: str = "base"
+    im_start_token_id: int = 151644
+    im_end_token_id: int = 151645
+    tts_pad_token_id: int = 151671
+    tts_bos_token_id: int = 151672
+    tts_eos_token_id: int = 151673
+    sample_rate: int = 24000
+
+    def __post_init__(self) -> None:
+        if self.talker_config is None:
+            self.talker_config = TalkerConfig()
+        elif isinstance(self.talker_config, dict):
+            self.talker_config = TalkerConfig.from_dict(self.talker_config)
+        # Only Base checkpoints carry a speaker encoder; CustomVoice and
+        # VoiceDesign select a preset voice instead and omit the section.
+        if isinstance(self.speaker_encoder_config, dict):
+            self.speaker_encoder_config = SpeakerEncoderConfig.from_dict(
+                self.speaker_encoder_config
+            )
+
+    @property
+    def has_speaker_encoder(self) -> bool:
+        return self.speaker_encoder_config is not None
+
+    @classmethod
+    def from_dict(cls, params: dict[str, Any]) -> ModelConfig:
+        return cls(**_filtered(cls, params))

--- a/sglang_omni/models/qwen3_tts/mlx/dsp.py
+++ b/sglang_omni/models/qwen3_tts/mlx/dsp.py
@@ -1,0 +1,176 @@
+# SPDX-License-Identifier: MIT
+# Derived from mlx-audio (Copyright 2025 Prince Canuma and contributors).
+"""MLX signal-processing primitives for the Qwen3-TTS speaker encoder.
+
+Only what Qwen3-TTS needs: a Hann-window STFT, a Slaney-normalised mel
+filterbank, and the log-mel front end that feeds the ECAPA-TDNN speaker
+encoder. Kept separate from the models so it can be tested against a
+torchaudio/librosa reference on its own.
+"""
+
+from __future__ import annotations
+
+import math
+from functools import lru_cache
+
+import mlx.core as mx
+
+
+@lru_cache(maxsize=None)
+def hann_window(size: int, periodic: bool = False) -> mx.array:
+    """Hann window; ``periodic=False`` matches torch's default ``hann_window``."""
+    denom = size if periodic else size - 1
+    return mx.array(
+        [0.5 * (1 - math.cos(2 * math.pi * n / denom)) for n in range(size)]
+    )
+
+
+def reflect_pad_1d(x: mx.array, padding: int) -> mx.array:
+    """Reflect-pad a 1-D signal without repeating the boundary sample."""
+    if padding <= 0:
+        return x
+    prefix = x[1 : padding + 1][::-1]
+    suffix = x[-(padding + 1) : -1][::-1]
+    return mx.concatenate([prefix, x, suffix])
+
+
+def stft(
+    x: mx.array,
+    n_fft: int = 1024,
+    hop_length: int | None = None,
+    win_length: int | None = None,
+    center: bool = True,
+) -> mx.array:
+    """Short-time Fourier transform of a 1-D signal.
+
+    Returns ``[frames, n_fft // 2 + 1]`` complex coefficients.
+    """
+    if hop_length is None:
+        hop_length = n_fft // 4
+    if win_length is None:
+        win_length = n_fft
+
+    window = hann_window(win_length)
+    if window.shape[0] < n_fft:
+        window = mx.concatenate([window, mx.zeros((n_fft - window.shape[0],))], axis=0)
+
+    if center:
+        x = reflect_pad_1d(x, n_fft // 2)
+
+    num_frames = 1 + (x.shape[0] - n_fft) // hop_length
+    if num_frames <= 0:
+        raise ValueError(
+            f"Signal of length {x.shape[0]} is too short for n_fft={n_fft} "
+            f"with hop_length={hop_length} and center={center}"
+        )
+
+    frames = mx.as_strided(x, shape=(num_frames, n_fft), strides=(hop_length, 1))
+    return mx.fft.rfft(frames * window)
+
+
+def _hz_to_mel_slaney(freq: float) -> float:
+    f_sp = 200.0 / 3
+    min_log_hz = 1000.0
+    if freq >= min_log_hz:
+        min_log_mel = min_log_hz / f_sp
+        return min_log_mel + math.log(freq / min_log_hz) / (math.log(6.4) / 27.0)
+    return freq / f_sp
+
+
+def _mel_to_hz_slaney(mels: mx.array) -> mx.array:
+    f_sp = 200.0 / 3
+    min_log_hz = 1000.0
+    min_log_mel = min_log_hz / f_sp
+    logstep = math.log(6.4) / 27.0
+    return mx.where(
+        mels >= min_log_mel,
+        min_log_hz * mx.exp(logstep * (mels - min_log_mel)),
+        f_sp * mels,
+    )
+
+
+@lru_cache(maxsize=None)
+def mel_filters(
+    sample_rate: int,
+    n_fft: int,
+    n_mels: int,
+    f_min: float = 0.0,
+    f_max: float | None = None,
+) -> mx.array:
+    """Slaney-scale, Slaney-normalised triangular mel filterbank.
+
+    Returns ``[n_mels, n_fft // 2 + 1]``. Built in float64 on the CPU stream
+    and cast down, because the float32 path drifts enough from a torchaudio
+    reference to shift log-mel values in the last couple of digits.
+    """
+    if f_max is None:
+        f_max = sample_rate / 2
+
+    def build(dtype) -> mx.array:
+        n_freqs = n_fft // 2 + 1
+        all_freqs = mx.linspace(0, sample_rate // 2, n_freqs, dtype=dtype)
+        m_pts = mx.linspace(
+            _hz_to_mel_slaney(f_min),
+            _hz_to_mel_slaney(f_max),
+            n_mels + 2,
+            dtype=dtype,
+        )
+        f_pts = _mel_to_hz_slaney(m_pts)
+
+        f_diff = f_pts[1:] - f_pts[:-1]
+        slopes = mx.expand_dims(f_pts, 0) - mx.expand_dims(all_freqs, 1)
+        down = (-slopes[:, :-2]) / f_diff[:-1]
+        up = slopes[:, 2:] / f_diff[1:]
+        filterbank = mx.maximum(mx.zeros_like(down), mx.minimum(down, up))
+
+        enorm = 2.0 / (f_pts[2 : n_mels + 2] - f_pts[:n_mels])
+        filterbank = filterbank * mx.expand_dims(enorm, 0)
+        return filterbank.moveaxis(0, 1)
+
+    with mx.stream(mx.cpu):
+        return build(mx.float64).astype(mx.float32)
+
+
+def mel_spectrogram(
+    audio: mx.array,
+    *,
+    n_fft: int = 1024,
+    num_mels: int = 128,
+    sample_rate: int = 24000,
+    hop_size: int = 256,
+    win_size: int = 1024,
+    fmin: float = 0.0,
+    fmax: float = 12000.0,
+) -> mx.array:
+    """Log-mel spectrogram, ``[batch, frames, num_mels]``.
+
+    The reference pads by ``(n_fft - hop_size) // 2`` on each side and then
+    runs an uncentred STFT, which is not the same as ``center=True``; keep both
+    steps or the frame grid shifts.
+    """
+    if audio.ndim == 1:
+        audio = audio[None, :]
+
+    basis = mel_filters(
+        sample_rate=sample_rate,
+        n_fft=n_fft,
+        n_mels=num_mels,
+        f_min=fmin,
+        f_max=fmax,
+    )
+    padding = (n_fft - hop_size) // 2
+
+    mels = []
+    for index in range(audio.shape[0]):
+        spec = stft(
+            reflect_pad_1d(audio[index], padding),
+            n_fft=n_fft,
+            hop_length=hop_size,
+            win_length=win_size,
+            center=False,
+        )
+        magnitude = mx.sqrt(mx.abs(spec) ** 2 + 1e-9)
+        mel = mx.matmul(magnitude, basis.T)
+        mels.append(mx.log(mx.clip(mel, 1e-5, None)))
+
+    return mx.stack(mels, axis=0)

--- a/sglang_omni/models/qwen3_tts/mlx/generate.py
+++ b/sglang_omni/models/qwen3_tts/mlx/generate.py
@@ -1,0 +1,437 @@
+# SPDX-License-Identifier: MIT
+# Derived from mlx-audio Qwen3-TTS (Copyright 2025 Prince Canuma and contributors).
+"""Single-request Qwen3-TTS generation on MLX, including Base voice cloning.
+
+This is the model-level driver: it owns prompt construction, the autoregressive
+frame loop, and vocoding for one request. Omni's scheduler-driven runner reuses
+these pieces rather than replacing them, so the frame loop here is the same one
+batched serving will call.
+"""
+
+from __future__ import annotations
+
+import json
+import math
+from dataclasses import dataclass, field
+from pathlib import Path
+from typing import Any, Iterator
+
+import mlx.core as mx
+import numpy as np
+
+from .config import ModelConfig, TokenizerConfig
+from .sampling import SamplingParams, sample_codec_token, special_codec_token_ids
+from .speaker_encoder import Qwen3TTSSpeakerEncoder
+from .speech_tokenizer import Qwen3TTSSpeechTokenizer
+from .talker import Qwen3TTSTalkerForConditionalGeneration
+from .weights import align_conv_weights
+
+SAMPLE_RATE = 24000
+
+
+@dataclass
+class CloneRequest:
+    """One voice-cloning request."""
+
+    text: str
+    ref_audio: Any
+    ref_text: str
+    language: str = "auto"
+    max_frames: int = 4096
+    semantic: SamplingParams = field(
+        default_factory=lambda: SamplingParams(
+            temperature=0.9, top_k=50, top_p=1.0, repetition_penalty=1.05
+        )
+    )
+    subtalker: SamplingParams = field(
+        default_factory=lambda: SamplingParams(
+            temperature=0.9, top_k=50, top_p=1.0, repetition_penalty=1.0
+        )
+    )
+    seed: int | None = None
+
+
+@dataclass
+class IclPrompt:
+    """Everything the frame loop needs after prompt construction."""
+
+    input_embeds: mx.array
+    trailing_text_embeds: mx.array
+    pad_embed: mx.array
+    ref_codes: mx.array
+
+
+def _load_audio_24k(source: Any) -> np.ndarray:
+    """Mono 24 kHz float32 samples from a path, URL, bytes, or array."""
+    if isinstance(source, mx.array):
+        return np.array(source, dtype=np.float32).reshape(-1)
+    if isinstance(source, np.ndarray):
+        return source.astype(np.float32).reshape(-1)
+
+    from sglang_omni.utils.audio import load_audio
+
+    return load_audio(source, target_sample_rate=SAMPLE_RATE, mono=True).astype(
+        np.float32
+    )
+
+
+class Qwen3TTSMlxGenerator:
+    """Talker + speech tokenizer + speaker encoder, loaded from a checkpoint."""
+
+    def __init__(
+        self,
+        talker: Qwen3TTSTalkerForConditionalGeneration,
+        speech_tokenizer: Qwen3TTSSpeechTokenizer,
+        tokenizer: Any,
+        config: ModelConfig,
+        speaker_encoder: Qwen3TTSSpeakerEncoder | None = None,
+    ) -> None:
+        self.talker = talker
+        self.speech_tokenizer = speech_tokenizer
+        self.tokenizer = tokenizer
+        self.config = config
+        self.speaker_encoder = speaker_encoder
+        self._reference_cache: dict[tuple, tuple[mx.array, mx.array]] = {}
+
+    # -- loading ---------------------------------------------------------
+
+    @classmethod
+    def from_pretrained(cls, model_path: str | Path) -> Qwen3TTSMlxGenerator:
+        from transformers import AutoTokenizer
+
+        model_path = Path(model_path)
+        config = ModelConfig.from_dict(
+            json.loads((model_path / "config.json").read_text())
+        )
+
+        weights = mx.load(str(model_path / "model.safetensors"))
+
+        talker = Qwen3TTSTalkerForConditionalGeneration(config.talker_config)
+        talker.load_weights(list(talker.sanitize(weights).items()), strict=True)
+        talker.eval()
+
+        speaker_encoder = None
+        if config.speaker_encoder_config is not None:
+            speaker_encoder = Qwen3TTSSpeakerEncoder(config.speaker_encoder_config)
+            speaker_weights = align_conv_weights(
+                speaker_encoder.sanitize(weights), speaker_encoder
+            )
+            speaker_encoder.load_weights(list(speaker_weights.items()), strict=True)
+            speaker_encoder.eval()
+        del weights
+
+        tokenizer_dir = model_path / "speech_tokenizer"
+        tokenizer_config = TokenizerConfig.from_dict(
+            json.loads((tokenizer_dir / "config.json").read_text())
+        )
+        speech_tokenizer = Qwen3TTSSpeechTokenizer(tokenizer_config)
+        tokenizer_weights = mx.load(str(tokenizer_dir / "model.safetensors"))
+        speech_tokenizer.load_weights(
+            list(
+                align_conv_weights(
+                    speech_tokenizer.sanitize(tokenizer_weights), speech_tokenizer
+                ).items()
+            ),
+            strict=True,
+        )
+        speech_tokenizer.eval()
+        del tokenizer_weights
+
+        mx.eval(talker.parameters(), speech_tokenizer.parameters())
+        if speaker_encoder is not None:
+            mx.eval(speaker_encoder.parameters())
+
+        return cls(
+            talker=talker,
+            speech_tokenizer=speech_tokenizer,
+            tokenizer=AutoTokenizer.from_pretrained(str(model_path)),
+            config=config,
+            speaker_encoder=speaker_encoder,
+        )
+
+    # -- prompt pieces ---------------------------------------------------
+
+    @property
+    def _talker_config(self):
+        return self.config.talker_config
+
+    def _project_text(self, token_ids: mx.array) -> mx.array:
+        return self.talker.text_projection(self.talker.get_text_embeddings()(token_ids))
+
+    def _codec(self, token_ids: list[list[int]]) -> mx.array:
+        return self.talker.get_input_embeddings()(mx.array(token_ids, dtype=mx.int32))
+
+    def speaker_embedding(self, audio: np.ndarray) -> mx.array:
+        """ECAPA-TDNN x-vector for the reference waveform."""
+        if self.speaker_encoder is None:
+            raise ValueError("This checkpoint has no speaker encoder")
+        from .dsp import mel_spectrogram
+
+        mels = mel_spectrogram(
+            mx.array(audio),
+            n_fft=1024,
+            num_mels=self.config.speaker_encoder_config.mel_dim,
+            sample_rate=SAMPLE_RATE,
+            hop_size=256,
+            win_size=1024,
+            fmin=0.0,
+            fmax=12000.0,
+        )
+        return self.speaker_encoder(mels)
+
+    @property
+    def cached_reference_count(self) -> int:
+        """How many distinct references are memoised. See ``encode_reference``."""
+        return len(self._reference_cache)
+
+    def encode_reference(
+        self, audio: np.ndarray, ref_text: str
+    ) -> tuple[mx.array, mx.array]:
+        """Reference codes and reference text ids, memoised per reference.
+
+        Re-encoding a reference costs a full pass over its audio, which
+        dominates time-to-first-audio when the same voice is reused.
+        """
+        key = (ref_text, audio.shape[0], float(audio.sum()))
+        cached = self._reference_cache.get(key)
+        if cached is not None:
+            return cached
+
+        codes = self.speech_tokenizer.encode(mx.array(audio)[None, None, :])
+        chat = f"<|im_start|>assistant\n{ref_text}<|im_end|>\n"
+        # Drop the 3 role tokens at the front and "<|im_end|>\n" at the back.
+        ids = mx.array(self.tokenizer.encode(chat), dtype=mx.int32)[None, 3:-2]
+        mx.eval(codes, ids)
+        self._reference_cache[key] = (codes, ids)
+        return codes, ids
+
+    def build_icl_prompt(
+        self,
+        text: str,
+        audio: np.ndarray,
+        ref_text: str,
+        language: str = "auto",
+    ) -> IclPrompt:
+        """Assemble the in-context voice-cloning prefill.
+
+        Layout: role tokens, then a codec control prefix carrying the speaker
+        embedding, then the text and reference-codec streams laid end to end.
+        Both streams are summed with the other's padding embedding so every
+        position carries one text and one codec contribution.
+        """
+        config = self._talker_config
+        ref_codes, ref_text_ids = self.encode_reference(audio, ref_text)
+
+        target_chat = (
+            f"<|im_start|>assistant\n{text}<|im_end|>\n<|im_start|>assistant\n"
+        )
+        target_ids = mx.array(self.tokenizer.encode(target_chat), dtype=mx.int32)[None]
+        # Drop the 3 role tokens and the 5-token trailing template.
+        text_ids = target_ids[:, 3:-5]
+
+        specials = self._project_text(
+            mx.array(
+                [
+                    [
+                        self.config.tts_bos_token_id,
+                        self.config.tts_eos_token_id,
+                        self.config.tts_pad_token_id,
+                    ]
+                ],
+                dtype=mx.int32,
+            )
+        )
+        bos_embed, eos_embed, pad_embed = (
+            specials[:, 0:1, :],
+            specials[:, 1:2, :],
+            specials[:, 2:3, :],
+        )
+
+        text_embed = self._project_text(
+            mx.concatenate([ref_text_ids, text_ids], axis=1)
+        )
+        text_embed = mx.concatenate([text_embed, eos_embed], axis=1)
+
+        # Reference codec stream: every codebook summed, group 0 through the
+        # talker's table and the rest through the predictor's.
+        codec_embed = self.talker.get_input_embeddings()(ref_codes[:, 0, :])
+        for group in range(config.num_code_groups - 1):
+            codec_embed = codec_embed + self.talker.code_predictor.codec_embedding[
+                group
+            ](ref_codes[:, group + 1, :])
+        codec_embed = mx.concatenate(
+            [self._codec([[config.codec_bos_id]]), codec_embed], axis=1
+        )
+
+        codec_pad_embed = self._codec([[config.codec_pad_id]])
+        icl_embed = mx.concatenate(
+            [
+                text_embed + codec_pad_embed,
+                codec_embed + pad_embed,
+            ],
+            axis=1,
+        )
+
+        language_id = None
+        if language.lower() != "auto" and config.codec_language_id:
+            language_id = config.codec_language_id.get(language.lower())
+
+        if language_id is None:
+            control = [
+                config.codec_nothink_id,
+                config.codec_think_bos_id,
+                config.codec_think_eos_id,
+            ]
+        else:
+            control = [
+                config.codec_think_id,
+                config.codec_think_bos_id,
+                language_id,
+                config.codec_think_eos_id,
+            ]
+        prefix_embed = self._codec([control])
+
+        if self.speaker_encoder is not None:
+            speaker = self.speaker_embedding(audio)
+            # The encoder runs in float32; without this cast the whole prompt
+            # and the talker's KV cache get promoted along with it.
+            speaker = speaker.astype(prefix_embed.dtype).reshape(1, 1, -1)
+            prefix_embed = mx.concatenate([prefix_embed, speaker], axis=1)
+        prefix_embed = mx.concatenate(
+            [prefix_embed, self._codec([[config.codec_pad_id, config.codec_bos_id]])],
+            axis=1,
+        )
+
+        # Text side of the control prefix: padding, then the TTS BOS, summed
+        # with every control embedding except the final codec BOS.
+        pad_run = mx.broadcast_to(
+            pad_embed, (1, prefix_embed.shape[1] - 2, pad_embed.shape[-1])
+        )
+        control_embed = (
+            mx.concatenate([pad_run, bos_embed], axis=1) + prefix_embed[:, :-1, :]
+        )
+
+        role_embed = self._project_text(target_ids[:, :3])
+        return IclPrompt(
+            input_embeds=mx.concatenate([role_embed, control_embed, icl_embed], axis=1),
+            trailing_text_embeds=pad_embed,
+            pad_embed=pad_embed,
+            ref_codes=ref_codes,
+        )
+
+    # -- autoregressive loop ---------------------------------------------
+
+    def generate_frames(
+        self,
+        prompt: IclPrompt,
+        request: CloneRequest,
+    ) -> Iterator[mx.array]:
+        """Yield one ``[1, num_code_groups]`` codec frame at a time."""
+        config = self._talker_config
+        eos_id = config.codec_eos_token_id
+        suppress_tokens = special_codec_token_ids(config.vocab_size, keep=eos_id)
+
+        cache = self.talker.make_cache()
+        code_cache = self.talker.code_predictor.make_cache()
+        input_embeds = prompt.input_embeds
+        emitted: list[int] = []
+        trailing_index = 0
+
+        for _ in range(request.max_frames):
+            logits, hidden = self.talker(input_embeds, cache=cache)
+            semantic = sample_codec_token(
+                logits[:, -1, :],
+                request.semantic,
+                recent_tokens=emitted,
+                suppress_tokens=suppress_tokens,
+            )
+
+            frame, codec_embed = self.talker.predict_codes(
+                semantic,
+                hidden,
+                cache=code_cache,
+                sampler=lambda group_logits, _index: sample_codec_token(
+                    group_logits, request.subtalker
+                ),
+            )
+
+            if trailing_index < prompt.trailing_text_embeds.shape[1]:
+                text_embed = prompt.trailing_text_embeds[
+                    :, trailing_index : trailing_index + 1, :
+                ]
+                trailing_index += 1
+            else:
+                text_embed = prompt.pad_embed
+            next_embeds = text_embed + codec_embed
+
+            # One sync per frame: the whole graph above resolves together.
+            mx.eval(semantic, frame, next_embeds)
+            token = int(semantic[0, 0])
+            if token == eos_id:
+                break
+
+            emitted.append(token)
+            input_embeds = next_embeds
+            yield frame
+
+    def decode_frames(self, frames: list[mx.array], ref_codes: mx.array) -> np.ndarray:
+        """Vocode generated frames, using the reference codes as left context.
+
+        The reference and generated codes are decoded as one sequence so the
+        decoder starts from the reference's acoustic state, then the reference
+        span is cut off the front of the waveform.
+        """
+        if not frames:
+            return np.zeros((0,), dtype=np.float32)
+
+        generated = mx.stack(frames, axis=1)
+        reference = mx.transpose(ref_codes, (0, 2, 1))
+        full = mx.concatenate([reference, generated], axis=1)
+
+        waveform, lengths = self.speech_tokenizer.decode(full)
+        audio = waveform[0]
+        mx.eval(audio, lengths)
+
+        valid = int(lengths[0])
+        if 0 < valid < audio.shape[0]:
+            audio = audio[:valid]
+        cut = int(reference.shape[1] / max(full.shape[1], 1) * audio.shape[0])
+        if 0 < cut < audio.shape[0]:
+            audio = audio[cut:]
+        return np.array(audio, dtype=np.float32)
+
+    def clone(self, request: CloneRequest) -> np.ndarray:
+        """Synthesise ``request.text`` in the reference voice, at 24 kHz."""
+        if not self.speech_tokenizer.has_encoder:
+            raise ValueError(
+                "Voice cloning needs a Base checkpoint: this speech tokenizer "
+                "has no encoder, so reference audio cannot be encoded"
+            )
+        if request.seed is not None:
+            mx.random.seed(request.seed)
+
+        audio = _load_audio_24k(request.ref_audio)
+        prompt = self.build_icl_prompt(
+            request.text, audio, request.ref_text, request.language
+        )
+        frames = list(self.generate_frames(prompt, request))
+        return self.decode_frames(frames, prompt.ref_codes)
+
+
+def frames_to_seconds(num_frames: int) -> float:
+    """Codec frames at 12.5 Hz to seconds of audio."""
+    return num_frames / 12.5
+
+
+def write_wav(path: str | Path, audio: np.ndarray, sample_rate: int = SAMPLE_RATE):
+    """Write mono float32 samples as a 16-bit WAV."""
+    import wave
+
+    clipped = np.clip(audio, -1.0, 1.0)
+    pcm = (clipped * 32767.0).astype("<i2")
+    with wave.open(str(path), "wb") as handle:
+        handle.setnchannels(1)
+        handle.setsampwidth(2)
+        handle.setframerate(sample_rate)
+        handle.writeframes(pcm.tobytes())
+    return math.ceil(len(audio) / sample_rate * 1000) / 1000

--- a/sglang_omni/models/qwen3_tts/mlx/model.py
+++ b/sglang_omni/models/qwen3_tts/mlx/model.py
@@ -1,0 +1,31 @@
+# SPDX-License-Identifier: MIT
+# Derived from mlx-audio Qwen3-TTS (Copyright 2025 Prince Canuma and contributors).
+"""Loader-facing MLX Qwen3-TTS talker model."""
+
+from __future__ import annotations
+
+from .config import ModelConfig
+from .talker import Qwen3TTSTalkerForConditionalGeneration
+
+
+class Qwen3TTSTalkerModel(Qwen3TTSTalkerForConditionalGeneration):
+    """The talker, built from a whole-checkpoint Qwen3-TTS config.
+
+    ``mlx_lm.utils.load_model`` calls ``ModelClass(ModelArgs.from_dict(config))``
+    with the checkpoint's full ``config.json``, while the talker itself only
+    needs ``talker_config``. Subclassing rather than wrapping keeps the module
+    tree at ``model.layers``, which is where SGLang's MLX backend discovers
+    attention layers and installs its per-request KV caches.
+    """
+
+    def __init__(self, config: ModelConfig) -> None:
+        super().__init__(config.talker_config)
+        self.model_config = config
+
+    @property
+    def tts_model_type(self) -> str:
+        return self.model_config.tts_model_type
+
+
+Model = Qwen3TTSTalkerModel
+ModelArgs = ModelConfig

--- a/sglang_omni/models/qwen3_tts/mlx/pending.py
+++ b/sglang_omni/models/qwen3_tts/mlx/pending.py
@@ -1,0 +1,31 @@
+# SPDX-License-Identifier: Apache-2.0
+"""Lazy decode state for the MLX Qwen3-TTS runner."""
+
+from __future__ import annotations
+
+from dataclasses import dataclass
+from typing import Any
+
+import mlx.core as mx
+from sglang.srt.hardware_backend.mlx.model_runner import MlxPendingDecode
+
+
+@dataclass
+class Qwen3TTSMlxPendingDecode(MlxPendingDecode):
+    """One lazily launched codec frame.
+
+    ``lazy_tokens`` stays the base contract's group-0 token per request, so
+    SGLang's bookkeeping is unchanged. Two fields are added:
+
+    ``lazy_codes``    the full ``[B, num_code_groups]`` frame for the vocoder.
+    ``lazy_feedback`` the ``[B, 1, hidden]`` input for the next step, which is
+                      what makes a chained step possible without evaluating
+                      this one first.
+    """
+
+    lazy_codes: Any = None
+    lazy_feedback: Any = None
+
+    def feedback_row(self, index: int) -> mx.array:
+        """The still-lazy next input for one request in the batch."""
+        return self.lazy_feedback[index : index + 1]

--- a/sglang_omni/models/qwen3_tts/mlx/preprocessing.py
+++ b/sglang_omni/models/qwen3_tts/mlx/preprocessing.py
@@ -1,0 +1,241 @@
+# SPDX-License-Identifier: Apache-2.0
+"""MLX-native Qwen3-TTS request preprocessing.
+
+The Torch preprocessing path reuses the engine's own model and wraps it in
+``qwen_tts.Qwen3TTSModel`` to build prompts. Neither works on the MLX path: the
+engine's model is the MLX talker, which has none of those builder methods, and
+the wrapper additionally drags in a Torch speech tokenizer.
+
+This assembles the same prompt tensors from the MLX talker instead, adding the
+MLX speech-tokenizer encoder and speaker encoder only for Base voice cloning,
+which is the only task that needs reference audio.
+"""
+
+from __future__ import annotations
+
+import logging
+from pathlib import Path
+from typing import Any
+
+import mlx.core as mx
+import numpy as np
+
+from .prompt import PromptInputs, Qwen3TTSMlxPromptBuilder
+
+logger = logging.getLogger(__name__)
+
+TASK_BASE = "Base"
+TASK_CUSTOM_VOICE = "CustomVoice"
+TASK_VOICE_DESIGN = "VoiceDesign"
+SAMPLE_RATE = 24000
+
+
+class Qwen3TTSMlxPreprocessor:
+    """Builds prompts for the MLX talker, with lazily loaded audio encoders."""
+
+    def __init__(
+        self,
+        talker: Any,
+        model_config: Any,
+        tokenizer: Any,
+        *,
+        checkpoint_dir: str | Path,
+    ) -> None:
+        self.talker = talker
+        self.model_config = model_config
+        self.checkpoint_dir = Path(checkpoint_dir)
+        self.prompts = Qwen3TTSMlxPromptBuilder(talker, model_config, tokenizer)
+        self._speech_tokenizer: Any | None = None
+        self._speaker_encoder: Any | None = None
+        self._generate_defaults: dict[str, Any] | None = None
+        # Reference codes and text ids keyed by reference identity; re-encoding
+        # a repeated voice dominates time-to-first-audio otherwise.
+        self._reference_cache: dict[tuple, mx.array] = {}
+
+    # -- lazily loaded audio front ends ----------------------------------
+
+    @property
+    def speech_tokenizer(self) -> Any:
+        """The encoder half, loaded on first voice-clone request."""
+        if self._speech_tokenizer is None:
+            from .vocoder_loader import load_mlx_speech_tokenizer
+
+            self._speech_tokenizer = load_mlx_speech_tokenizer(self.checkpoint_dir)
+            if not self._speech_tokenizer.has_encoder:
+                raise ValueError(
+                    "Qwen3-TTS voice cloning needs a Base checkpoint: this "
+                    "speech tokenizer has no encoder"
+                )
+        return self._speech_tokenizer
+
+    @property
+    def speaker_encoder(self) -> Any | None:
+        """The x-vector encoder, or None when the checkpoint has none."""
+        if self._speaker_encoder is None:
+            config = self.model_config.speaker_encoder_config
+            if config is None:
+                return None
+            from .speaker_encoder import Qwen3TTSSpeakerEncoder
+            from .weights import align_conv_weights
+
+            encoder = Qwen3TTSSpeakerEncoder(config)
+            weights = mx.load(str(self.checkpoint_dir / "model.safetensors"))
+            encoder.load_weights(
+                list(align_conv_weights(encoder.sanitize(weights), encoder).items()),
+                strict=True,
+            )
+            encoder.eval()
+            mx.eval(encoder.parameters())
+            self._speaker_encoder = encoder
+        return self._speaker_encoder
+
+    # -- reference audio --------------------------------------------------
+
+    def _load_reference_audio(self, ref_audio: Any) -> np.ndarray:
+        from sglang_omni.utils.audio import load_audio
+
+        if isinstance(ref_audio, mx.array):
+            return np.array(ref_audio, dtype=np.float32).reshape(-1)
+        if isinstance(ref_audio, np.ndarray):
+            return ref_audio.astype(np.float32).reshape(-1)
+        return load_audio(ref_audio, target_sample_rate=SAMPLE_RATE, mono=True).astype(
+            np.float32
+        )
+
+    def _encode_reference(self, audio: np.ndarray) -> mx.array:
+        key = (audio.shape[0], float(audio.sum()))
+        cached = self._reference_cache.get(key)
+        if cached is not None:
+            return cached
+        codes = self.speech_tokenizer.encode(mx.array(audio)[None, None, :])
+        mx.eval(codes)
+        self._reference_cache[key] = codes
+        return codes
+
+    def _speaker_embedding(self, audio: np.ndarray) -> mx.array | None:
+        encoder = self.speaker_encoder
+        if encoder is None:
+            return None
+        from .dsp import mel_spectrogram
+
+        mels = mel_spectrogram(
+            mx.array(audio),
+            num_mels=self.model_config.speaker_encoder_config.mel_dim,
+            sample_rate=SAMPLE_RATE,
+        )
+        return encoder(mels)
+
+    # -- entry point ------------------------------------------------------
+
+    def prepare(self, state: Any) -> PromptInputs:
+        """Build the prompt for one request from its pipeline state."""
+        task = str(state.task_type or TASK_BASE)
+        language = state.language or "auto"
+
+        if task == TASK_CUSTOM_VOICE:
+            from sglang_omni.models.qwen3_tts.request_builders import (
+                QWEN3_TTS_DEFAULT_CUSTOM_VOICE,
+            )
+
+            return self.prompts.build_custom_voice(
+                text=state.text,
+                voice=state.voice or QWEN3_TTS_DEFAULT_CUSTOM_VOICE,
+                language=language,
+                non_streaming_mode=bool(state.non_streaming_mode),
+                instructions=state.instructions,
+            )
+
+        if task == TASK_VOICE_DESIGN:
+            return self.prompts.build_voice_design(
+                text=state.text,
+                instructions=state.instructions or "",
+                language=language,
+                non_streaming_mode=bool(state.non_streaming_mode),
+            )
+
+        if task != TASK_BASE:
+            raise ValueError(f"Unhandled Qwen3-TTS task type: {task!r}")
+
+        if state.ref_audio is None or not state.ref_text:
+            raise ValueError(
+                "Qwen3-TTS Base needs both ref_audio and ref_text to clone a voice"
+            )
+        audio = self._load_reference_audio(state.ref_audio)
+        return self.prompts.build_voice_clone(
+            text=state.text,
+            ref_codes=self._encode_reference(audio),
+            ref_text=state.ref_text,
+            speaker_embed=self._speaker_embedding(audio),
+            language=language,
+            instructions=state.instructions,
+        )
+
+    # -- generation defaults ---------------------------------------------
+
+    def merge_generate_kwargs(self, **overrides: Any) -> dict[str, Any]:
+        """Request overrides on top of the checkpoint's generation_config."""
+        merged = dict(self._generation_defaults())
+        merged.update({k: v for k, v in overrides.items() if v is not None})
+        return merged
+
+    def _generation_defaults(self) -> dict[str, Any]:
+        if self._generate_defaults is None:
+            import json
+
+            path = self.checkpoint_dir / "generation_config.json"
+            try:
+                self._generate_defaults = json.loads(path.read_text())
+            except (OSError, ValueError):
+                logger.warning("No usable %s; using built-in defaults", path)
+                self._generate_defaults = {}
+        return self._generate_defaults
+
+
+def build_mlx_prepared_request(
+    preprocessor: Qwen3TTSMlxPreprocessor,
+    state: Any,
+    *,
+    gen_kwargs: dict[str, Any],
+) -> Any:
+    """Assemble the scheduler's prepared-request record from an MLX prompt.
+
+    Prompt tensors stay as MLX arrays: the MLX runner consumes them directly, so
+    converting to Torch here and back at prefill would be pure overhead. Only the
+    radix cache key is derived through Torch, because that keying is shared with
+    every other backend.
+    """
+    import torch
+
+    from sglang_omni.models.qwen3_tts.request_builders import (
+        Qwen3TTSPreparedRequest,
+        build_embedding_cache_key_ids,
+    )
+
+    prompt = preprocessor.prepare(state)
+    mx.eval(prompt.input_embeds, prompt.trailing_text_embeds, prompt.pad_embed)
+
+    # [1, T, hidden] -> [T, hidden], matching the Torch path's squeeze.
+    prompt_embeds = prompt.input_embeds[0]
+    trailing = prompt.trailing_text_embeds[0]
+
+    key_source = torch.from_numpy(
+        np.array(prompt_embeds.astype(mx.float32), dtype=np.float32)
+    )
+    input_ids_list = build_embedding_cache_key_ids(key_source)
+
+    ref_codes = prompt.ref_codes
+    if ref_codes is not None:
+        mx.eval(ref_codes)
+        state.ref_code_len = int(ref_codes.shape[-1])
+
+    return Qwen3TTSPreparedRequest(
+        state=state,
+        input_ids_list=input_ids_list,
+        input_ids=torch.tensor(input_ids_list, dtype=torch.long),
+        attention_mask=torch.ones((1, int(prompt_embeds.shape[0])), dtype=torch.long),
+        trailing_text_hidden=trailing,
+        ref_code=ref_codes,
+        prompt_input_embeds=prompt_embeds,
+        tts_pad_embed=prompt.pad_embed,
+        gen_kwargs=gen_kwargs,
+    )

--- a/sglang_omni/models/qwen3_tts/mlx/prompt.py
+++ b/sglang_omni/models/qwen3_tts/mlx/prompt.py
@@ -1,0 +1,403 @@
+# SPDX-License-Identifier: Apache-2.0
+"""MLX-native Qwen3-TTS prompt construction.
+
+Ports the prompt assembly from ``qwen3_tts/sglang_model.py`` so a request can be
+prepared without a Torch copy of the model. On Apple Silicon that is the
+difference between one resident model and two.
+
+All three task types share one skeleton:
+
+    [instructions] role(3 text tokens) | codec control prefix | text + codec
+
+The codec control prefix carries think/no-think, an optional language id, the
+speaker conditioning, and codec BOS. Each position sums one text-side and one
+codec-side embedding, so the two streams stay aligned; whichever stream has
+nothing to say at a position contributes its pad embedding.
+"""
+
+from __future__ import annotations
+
+from dataclasses import dataclass
+from typing import Any
+
+import mlx.core as mx
+
+# The chat template is fixed, and the slice offsets below follow from it:
+# 3 leading role tokens, and 5 trailing tokens on the target template.
+ASSISTANT_TEMPLATE = "<|im_start|>assistant\n{text}<|im_end|>\n<|im_start|>assistant\n"
+REF_TEMPLATE = "<|im_start|>assistant\n{text}<|im_end|>\n"
+INSTRUCT_TEMPLATE = "<|im_start|>user\n{text}<|im_end|>\n"
+ROLE_TOKENS = 3
+TARGET_TAIL_TOKENS = 5
+REF_TAIL_TOKENS = 2
+
+
+@dataclass
+class PromptInputs:
+    """What the talker needs to start generating."""
+
+    input_embeds: mx.array
+    trailing_text_embeds: mx.array
+    pad_embed: mx.array
+    ref_codes: mx.array | None = None
+
+
+class Qwen3TTSMlxPromptBuilder:
+    """Builds Qwen3-TTS prompts from text, entirely in MLX."""
+
+    def __init__(self, talker: Any, model_config: Any, tokenizer: Any) -> None:
+        self.talker = talker
+        self.model_config = model_config
+        self.config = model_config.talker_config
+        self.tokenizer = tokenizer
+        self._check_token_ids()
+
+    def _check_token_ids(self) -> None:
+        """Fail loudly on ids that fall outside their embedding table.
+
+        An out-of-range MLX embedding lookup segfaults rather than raising, so a
+        mismatched config would otherwise take down the worker with no message.
+        """
+        config = self.config
+        codec_ids = {
+            "codec_eos_token_id": config.codec_eos_token_id,
+            "codec_think_id": config.codec_think_id,
+            "codec_nothink_id": config.codec_nothink_id,
+            "codec_think_bos_id": config.codec_think_bos_id,
+            "codec_think_eos_id": config.codec_think_eos_id,
+            "codec_pad_id": config.codec_pad_id,
+            "codec_bos_id": config.codec_bos_id,
+        }
+        for name, value in (config.codec_language_id or {}).items():
+            codec_ids[f"codec_language_id[{name!r}]"] = value
+        for name, value in (config.spk_id or {}).items():
+            codec_ids[f"spk_id[{name!r}]"] = (
+                value[0] if isinstance(value, (list, tuple)) else value
+            )
+        self._check_range(codec_ids, config.vocab_size, "codec vocab_size")
+
+        self._check_range(
+            {
+                "tts_bos_token_id": self.model_config.tts_bos_token_id,
+                "tts_eos_token_id": self.model_config.tts_eos_token_id,
+                "tts_pad_token_id": self.model_config.tts_pad_token_id,
+            },
+            config.text_vocab_size,
+            "text_vocab_size",
+        )
+
+    @staticmethod
+    def _check_range(ids: dict[str, Any], limit: int, label: str) -> None:
+        bad = {
+            name: int(value)
+            for name, value in ids.items()
+            if value is not None and not 0 <= int(value) < int(limit)
+        }
+        if bad:
+            listed = ", ".join(f"{name}={value}" for name, value in sorted(bad.items()))
+            raise ValueError(
+                f"Qwen3-TTS config has token ids outside {label}={limit}: {listed}"
+            )
+
+    # -- token / embedding primitives ------------------------------------
+
+    def _tokenize(self, text: str) -> mx.array:
+        return mx.array(self.tokenizer.encode(text), dtype=mx.int32)[None]
+
+    def _text(self, token_ids: mx.array) -> mx.array:
+        return self.talker.text_projection(self.talker.get_text_embeddings()(token_ids))
+
+    def _codec(self, token_ids: list[int]) -> mx.array:
+        return self.talker.get_input_embeddings()(mx.array([token_ids], dtype=mx.int32))
+
+    def _special_embeds(self) -> tuple[mx.array, mx.array, mx.array]:
+        """The TTS bos / eos / pad embeddings, in that order."""
+        embeds = self._text(
+            mx.array(
+                [
+                    [
+                        self.model_config.tts_bos_token_id,
+                        self.model_config.tts_eos_token_id,
+                        self.model_config.tts_pad_token_id,
+                    ]
+                ],
+                dtype=mx.int32,
+            )
+        )
+        return embeds[:, 0:1], embeds[:, 1:2], embeds[:, 2:3]
+
+    # -- control prefix ---------------------------------------------------
+
+    def _language_id(self, language: str, voice: str | None = None) -> int | None:
+        language_map = self.config.codec_language_id or {}
+        if language.lower() != "auto":
+            if language.lower() not in language_map:
+                supported = ", ".join(sorted(language_map))
+                raise ValueError(
+                    f"Unsupported Qwen3-TTS language {language!r}. "
+                    f"Supported: {supported}"
+                )
+            return language_map[language.lower()]
+        if voice is None:
+            return None
+        # A dialect voice implies its language even when the caller said auto.
+        dialects = self.config.spk_is_dialect or {}
+        dialect = dialects.get(voice.lower())
+        if isinstance(dialect, str) and dialect:
+            return language_map.get(dialect)
+        return None
+
+    def _codec_prefill(self, language: str, voice: str | None = None) -> mx.array:
+        language_id = self._language_id(language, voice)
+        config = self.config
+        if language_id is None:
+            ids = [
+                config.codec_nothink_id,
+                config.codec_think_bos_id,
+                config.codec_think_eos_id,
+            ]
+        else:
+            ids = [
+                config.codec_think_id,
+                config.codec_think_bos_id,
+                language_id,
+                config.codec_think_eos_id,
+            ]
+        return self._codec(ids)
+
+    def _speaker_suffix(self) -> mx.array:
+        return self._codec([self.config.codec_pad_id, self.config.codec_bos_id])
+
+    # -- skeleton ---------------------------------------------------------
+
+    def _conditioned_prefix(
+        self,
+        input_ids: mx.array,
+        codec_input: mx.array,
+        bos_embed: mx.array,
+        pad_embed: mx.array,
+    ) -> mx.array:
+        """Role tokens, then the control prefix summed with text padding."""
+        role_embed = self._text(input_ids[:, :ROLE_TOKENS])
+        pad_run = mx.broadcast_to(
+            pad_embed,
+            (1, codec_input.shape[1] - 2, pad_embed.shape[-1]),
+        )
+        text_side = mx.concatenate([pad_run, bos_embed], axis=1)
+        return mx.concatenate([role_embed, text_side + codec_input[:, :-1]], axis=1)
+
+    def _finish_text(
+        self,
+        prefix: mx.array,
+        input_ids: mx.array,
+        codec_last_embed: mx.array,
+        pad_embed: mx.array,
+        eos_embed: mx.array,
+        non_streaming_mode: bool,
+    ) -> tuple[mx.array, mx.array]:
+        """Attach the text stream; returns (prefill, trailing text).
+
+        Non-streaming puts the whole text in the prefill, which keeps full text
+        context when the codec side is long. Streaming leaves all but the first
+        text position for the decode loop to consume one per frame.
+        """
+        body = input_ids[:, ROLE_TOKENS:-TARGET_TAIL_TOKENS]
+        if non_streaming_mode:
+            text_all = mx.concatenate([self._text(body), eos_embed], axis=1)
+            codec_pad = self._codec([self.config.codec_pad_id])
+            return (
+                mx.concatenate(
+                    [
+                        prefix,
+                        text_all + codec_pad,
+                        pad_embed + self._codec([self.config.codec_bos_id]),
+                    ],
+                    axis=1,
+                ),
+                pad_embed,
+            )
+
+        first_text = self._text(input_ids[:, ROLE_TOKENS : ROLE_TOKENS + 1])
+        prefill = mx.concatenate([prefix, first_text + codec_last_embed], axis=1)
+        trailing = mx.concatenate(
+            [
+                self._text(input_ids[:, ROLE_TOKENS + 1 : -TARGET_TAIL_TOKENS]),
+                eos_embed,
+            ],
+            axis=1,
+        )
+        return prefill, trailing
+
+    def _apply_instructions(
+        self, prefill: mx.array, instructions: str | None
+    ) -> mx.array:
+        if not instructions:
+            return prefill
+        instruct_embed = self._text(
+            self._tokenize(INSTRUCT_TEMPLATE.format(text=instructions))
+        )
+        return mx.concatenate([instruct_embed, prefill], axis=1)
+
+    def _assemble(
+        self,
+        *,
+        text: str,
+        codec_input: mx.array,
+        language: str,
+        non_streaming_mode: bool,
+        instructions: str | None,
+        ref_codes: mx.array | None = None,
+    ) -> PromptInputs:
+        del language
+        input_ids = self._tokenize(ASSISTANT_TEMPLATE.format(text=text))
+        bos_embed, eos_embed, pad_embed = self._special_embeds()
+        prefix = self._conditioned_prefix(input_ids, codec_input, bos_embed, pad_embed)
+        prefill, trailing = self._finish_text(
+            prefix,
+            input_ids,
+            codec_input[:, -1:],
+            pad_embed,
+            eos_embed,
+            non_streaming_mode,
+        )
+        return PromptInputs(
+            input_embeds=self._apply_instructions(prefill, instructions),
+            trailing_text_embeds=trailing,
+            pad_embed=pad_embed,
+            ref_codes=ref_codes,
+        )
+
+    # -- task types -------------------------------------------------------
+
+    def build_custom_voice(
+        self,
+        *,
+        text: str,
+        voice: str,
+        language: str = "auto",
+        non_streaming_mode: bool = False,
+        instructions: str | None = None,
+    ) -> PromptInputs:
+        """Prompt for a preset speaker."""
+        speaker_ids = self.config.spk_id or {}
+        if not speaker_ids:
+            raise ValueError(
+                "Qwen3-TTS CustomVoice requires a checkpoint with configured spk_id"
+            )
+        by_lowered = {str(key).lower(): value for key, value in speaker_ids.items()}
+        key = voice.lower()
+        if key not in by_lowered:
+            supported = ", ".join(sorted(str(k) for k in speaker_ids))
+            raise ValueError(
+                f"Unsupported Qwen3-TTS CustomVoice speaker {voice!r}. "
+                f"Supported speakers: {supported}"
+            )
+
+        speaker_token = by_lowered[key]
+        if isinstance(speaker_token, (list, tuple)):
+            speaker_token = speaker_token[0]
+        codec_input = mx.concatenate(
+            [
+                self._codec_prefill(language, voice=key),
+                self._codec([int(speaker_token)]),
+                self._speaker_suffix(),
+            ],
+            axis=1,
+        )
+        return self._assemble(
+            text=text,
+            codec_input=codec_input,
+            language=language,
+            non_streaming_mode=non_streaming_mode,
+            instructions=instructions,
+        )
+
+    def build_voice_design(
+        self,
+        *,
+        text: str,
+        instructions: str,
+        language: str = "auto",
+        non_streaming_mode: bool = False,
+    ) -> PromptInputs:
+        """Prompt for a voice described in words; instructions are required."""
+        if not instructions:
+            raise ValueError("Qwen3-TTS VoiceDesign requires instructions")
+        codec_input = mx.concatenate(
+            [self._codec_prefill(language), self._speaker_suffix()], axis=1
+        )
+        return self._assemble(
+            text=text,
+            codec_input=codec_input,
+            language=language,
+            non_streaming_mode=non_streaming_mode,
+            instructions=instructions,
+        )
+
+    def build_voice_clone(
+        self,
+        *,
+        text: str,
+        ref_codes: mx.array,
+        ref_text: str,
+        speaker_embed: mx.array | None,
+        language: str = "auto",
+        instructions: str | None = None,
+    ) -> PromptInputs:
+        """Prompt for in-context voice cloning.
+
+        Always non-streaming: the reference codec stream is usually longer than
+        the text, and interleaving would drop text context.
+        """
+        config = self.config
+        codec_prefix = self._codec_prefill(language)
+        if speaker_embed is not None:
+            # The speaker encoder runs in float32; without this cast the whole
+            # prompt and the talker's KV are promoted with it.
+            speaker = speaker_embed.astype(codec_prefix.dtype).reshape(1, 1, -1)
+            codec_prefix = mx.concatenate([codec_prefix, speaker], axis=1)
+        codec_input = mx.concatenate([codec_prefix, self._speaker_suffix()], axis=1)
+
+        input_ids = self._tokenize(ASSISTANT_TEMPLATE.format(text=text))
+        ref_ids = self._tokenize(REF_TEMPLATE.format(text=ref_text))[
+            :, ROLE_TOKENS:-REF_TAIL_TOKENS
+        ]
+        bos_embed, eos_embed, pad_embed = self._special_embeds()
+
+        text_embed = mx.concatenate(
+            [
+                self._text(
+                    mx.concatenate(
+                        [ref_ids, input_ids[:, ROLE_TOKENS:-TARGET_TAIL_TOKENS]],
+                        axis=1,
+                    )
+                ),
+                eos_embed,
+            ],
+            axis=1,
+        )
+
+        codec_embed = self.talker.get_input_embeddings()(ref_codes[:, 0, :])
+        for group in range(config.num_code_groups - 1):
+            codec_embed = codec_embed + self.talker.code_predictor.codec_embedding[
+                group
+            ](ref_codes[:, group + 1, :])
+        codec_embed = mx.concatenate(
+            [self._codec([config.codec_bos_id]), codec_embed], axis=1
+        )
+
+        icl_embed = mx.concatenate(
+            [
+                text_embed + self._codec([config.codec_pad_id]),
+                codec_embed + pad_embed,
+            ],
+            axis=1,
+        )
+        prefix = self._conditioned_prefix(input_ids, codec_input, bos_embed, pad_embed)
+        prefill = mx.concatenate([prefix, icl_embed], axis=1)
+        return PromptInputs(
+            input_embeds=self._apply_instructions(prefill, instructions),
+            trailing_text_embeds=pad_embed,
+            pad_embed=pad_embed,
+            ref_codes=ref_codes,
+        )

--- a/sglang_omni/models/qwen3_tts/mlx/request_spec.py
+++ b/sglang_omni/models/qwen3_tts/mlx/request_spec.py
@@ -1,0 +1,120 @@
+# SPDX-License-Identifier: Apache-2.0
+"""Translate Omni's Qwen3-TTS request data into the MLX runner's spec.
+
+The preprocessing stage currently assembles prompt embeddings with the Torch
+model, so this converts them once at admission. Replacing that with MLX-native
+prompt construction removes the conversion *and* the second copy of the model on
+an Apple Silicon host; until then this keeps the scheduler path working.
+"""
+
+from __future__ import annotations
+
+import logging
+from typing import Any
+
+import mlx.core as mx
+import numpy as np
+
+from .runner import Qwen3TTSRequestSpec
+from .sampling import SamplingParams
+
+logger = logging.getLogger(__name__)
+
+
+def _to_mlx(value: Any) -> mx.array | None:
+    """Convert a Torch tensor / NumPy array to an ``mx.array``."""
+    if value is None:
+        return None
+    if isinstance(value, mx.array):
+        return value
+    if isinstance(value, np.ndarray):
+        return mx.array(value)
+    detach = getattr(value, "detach", None)
+    if detach is None:
+        return None
+    tensor = detach().cpu()
+    # MLX has no bfloat16 NumPy bridge, so promote then cast back.
+    if str(tensor.dtype) == "torch.bfloat16":
+        return mx.array(tensor.float().numpy()).astype(mx.bfloat16)
+    return mx.array(tensor.numpy())
+
+
+def _with_batch_dim(value: mx.array | None) -> mx.array | None:
+    """Ensure ``[1, rows, hidden]``; preprocessing squeezes the batch away."""
+    if value is None:
+        return None
+    if value.ndim == 2:
+        return value[None, :, :]
+    return value
+
+
+def _trailing_rows(data: Any) -> Any:
+    """The unconsumed trailing-text rows, as one tensor.
+
+    Omni stores them in a chunked device queue; the MLX runner keeps its own
+    cursor, so the whole remainder is taken at once.
+    """
+    queue = getattr(data, "pending_text_queue", None)
+    if queue is None:
+        return None
+    rows = getattr(queue, "rows", None)
+    if rows is None:
+        return None
+    cursor = int(getattr(queue, "cursor", 0) or 0)
+    remaining = rows[cursor:] if cursor else rows
+    chunks = getattr(queue, "_chunks", None)
+    if chunks:
+        import torch
+
+        remaining = torch.cat([remaining, *chunks], dim=0)
+    return remaining
+
+
+def _semantic_params(data: Any) -> SamplingParams:
+    return SamplingParams(
+        temperature=float(getattr(data, "temperature", 0.9) or 0.0),
+        top_k=int(getattr(data, "top_k", 50) or 0),
+        top_p=float(getattr(data, "top_p", 1.0) or 1.0),
+        repetition_penalty=float(getattr(data, "repetition_penalty", 1.0) or 1.0),
+    )
+
+
+def _subtalker_params(data: Any) -> SamplingParams:
+    if not bool(getattr(data, "subtalker_dosample", True)):
+        return SamplingParams(temperature=0.0)
+    return SamplingParams(
+        temperature=float(getattr(data, "subtalker_temperature", 0.9) or 0.0),
+        top_k=int(getattr(data, "subtalker_top_k", 50) or 0),
+        top_p=float(getattr(data, "subtalker_top_p", 1.0) or 1.0),
+        repetition_penalty=1.0,
+    )
+
+
+def build_request_spec(data: Any) -> Qwen3TTSRequestSpec | None:
+    """Build the runner's spec, or ``None`` if this request has no prompt yet."""
+    # Not `a or b`: these are tensors, and truth-testing a multi-element
+    # tensor raises.
+    raw_prompt = getattr(data, "prefill_input_embeds", None)
+    if raw_prompt is None:
+        raw_prompt = getattr(data, "prompt_input_embeds", None)
+    prompt = _with_batch_dim(_to_mlx(raw_prompt))
+    if prompt is None:
+        return None
+
+    pad_embed = _with_batch_dim(_to_mlx(getattr(data, "tts_pad_embed", None)))
+    if pad_embed is None:
+        raise ValueError(
+            "Qwen3-TTS MLX needs tts_pad_embed to continue the text stream "
+            "after the prompt"
+        )
+    trailing = _with_batch_dim(_to_mlx(_trailing_rows(data)))
+
+    seed = getattr(data, "semantic_sampling_seed", None)
+    return Qwen3TTSRequestSpec(
+        prompt_embeds=prompt,
+        trailing_text_embeds=trailing,
+        pad_embed=pad_embed,
+        semantic=_semantic_params(data),
+        subtalker=_subtalker_params(data),
+        seed=int(seed) if seed is not None else None,
+    )

--- a/sglang_omni/models/qwen3_tts/mlx/runner.py
+++ b/sglang_omni/models/qwen3_tts/mlx/runner.py
@@ -115,7 +115,7 @@ class Qwen3TTSMlxModelRunner:
         ensure_remote_code_allowed(model_path, self.trust_remote_code)
         logger.info("Loading native MLX Qwen3-TTS talker: %s", model_path)
         started = time.perf_counter()
-        self.model, _config = load_model(
+        self.model, _ = load_model(
             model_path,
             get_model_classes=lambda config: (Qwen3TTSTalkerModel, ModelConfig),
         )

--- a/sglang_omni/models/qwen3_tts/mlx/runner.py
+++ b/sglang_omni/models/qwen3_tts/mlx/runner.py
@@ -1,0 +1,419 @@
+# SPDX-License-Identifier: Apache-2.0
+"""SGLang MLX runner for the Qwen3-TTS talker.
+
+Qwen3-TTS does not decode like a text model, so three things differ from the
+Qwen3-ASR MLX runner:
+
+*Steps are frames, not tokens.*  Every step samples codec group 0 from the
+talker and then expands it to a full ``num_code_groups`` frame through the code
+predictor.  Group 0 is what SGLang tracks as the request's "next token" (the
+CUDA path does the same), and the rest of the frame is handed to the vocoder.
+
+*Input is an embedding, not a token id.*  The next step's input is the summed
+codec embedding of the frame just produced plus the next trailing-text
+embedding, so ``decode_batch_start`` cannot read ``_req_token_ids`` the way the
+base class does.
+
+*The frame stays lazy.*  A step builds talker -> sample -> predictor -> feedback
+embedding as one graph and evaluates once, and a chained step is built on the
+previous step's still-lazy feedback embedding, so consecutive frames run
+back-to-back with no host round trip in between.
+"""
+
+from __future__ import annotations
+
+import logging
+import time
+from dataclasses import dataclass, field
+from typing import Any
+
+import mlx.core as mx
+import numpy as np
+
+from .sampling import SamplingParams, sample_codec_token, special_codec_token_ids
+
+logger = logging.getLogger(__name__)
+
+
+@dataclass
+class Qwen3TTSRequestSpec:
+    """Per-request generation state the scheduler hands to the runner.
+
+    ``prompt_embeds`` is the assembled prefill sequence ``[1, T, hidden]`` and
+    ``trailing_text_embeds`` is the text stream consumed one position per frame
+    after it (``[1, N, hidden]``); once exhausted, ``pad_embed`` repeats.
+    """
+
+    prompt_embeds: mx.array
+    trailing_text_embeds: mx.array
+    pad_embed: mx.array
+    semantic: SamplingParams = field(default_factory=SamplingParams)
+    subtalker: SamplingParams = field(default_factory=SamplingParams)
+    seed: int | None = None
+    trailing_index: int = 0
+    # The next step's input embedding, kept lazy between steps.
+    pending_input: Any = None
+
+    def next_text_embed(self) -> mx.array:
+        """The text half of the next frame's input, advancing the stream."""
+        trailing = self.trailing_text_embeds
+        if trailing is not None and self.trailing_index < trailing.shape[1]:
+            embed = trailing[:, self.trailing_index : self.trailing_index + 1, :]
+            self.trailing_index += 1
+            return embed
+        return self.pad_embed
+
+
+def _as_mlx(value: Any) -> mx.array:
+    """Accept an MLX array, a NumPy array, or a Torch tensor."""
+    if isinstance(value, mx.array):
+        return value
+    if isinstance(value, np.ndarray):
+        return mx.array(value)
+    detach = getattr(value, "detach", None)
+    if detach is not None:  # torch.Tensor
+        tensor = detach().cpu()
+        if str(tensor.dtype) == "torch.bfloat16":
+            return mx.array(tensor.float().numpy()).astype(mx.bfloat16)
+        return mx.array(tensor.numpy())
+    raise TypeError(f"Cannot convert {type(value).__name__} to an mx.array")
+
+
+class Qwen3TTSMlxModelRunner:
+    """Qwen3-TTS support layered on SGLang's native MLX model runner.
+
+    The base runner keeps owning cache layout, pool sizing and batched decode;
+    this mixin supplies the model class, the embedding-driven step, and the
+    per-request codec frames the vocoder stage consumes.
+    """
+
+    def __init__(self, *args: Any, **kwargs: Any) -> None:
+        super().__init__(*args, **kwargs)
+        self._tts_specs: dict[str, Qwen3TTSRequestSpec] = {}
+        self._tts_frames: dict[str, list[np.ndarray]] = {}
+        self._tts_predictor_cache: list[Any] | None = None
+        self._tts_staged_prefill: dict[str, tuple[mx.array, mx.array]] = {}
+        self._tts_suppress: list[int] | None = None
+        # Emitted group-0 codes per request. The base class's _req_token_ids
+        # starts from the prompt's *text* ids, so it cannot feed a codec-domain
+        # repetition penalty.
+        self._tts_emitted: dict[str, list[int]] = {}
+
+    # -- model ----------------------------------------------------------
+
+    def _load_model(self) -> None:
+        from mlx_lm.utils import load_model
+        from sglang.srt.hardware_backend.mlx.remote_code_gate import (
+            ensure_remote_code_allowed,
+            resolve_model_directory,
+        )
+
+        from .config import ModelConfig
+        from .model import Qwen3TTSTalkerModel
+
+        model_path = resolve_model_directory(self.model_path, revision=self.revision)
+        ensure_remote_code_allowed(model_path, self.trust_remote_code)
+        logger.info("Loading native MLX Qwen3-TTS talker: %s", model_path)
+        started = time.perf_counter()
+        self.model, _config = load_model(
+            model_path,
+            get_model_classes=lambda config: (Qwen3TTSTalkerModel, ModelConfig),
+        )
+        logger.info(
+            "Loaded native MLX Qwen3-TTS talker in %.2fs",
+            time.perf_counter() - started,
+        )
+
+    @property
+    def _talker_config(self):
+        return self.model.config
+
+    @property
+    def _num_code_groups(self) -> int:
+        return int(self._talker_config.code_predictor_config.num_code_groups)
+
+    # -- request registration ------------------------------------------
+
+    def register_request(self, req_id: str, spec: Qwen3TTSRequestSpec) -> None:
+        """Attach generation state before the request's prefill is launched.
+
+        SGLang's ``prefill_start`` only receives its own ``Req``, so Omni's
+        scheduler-side runner registers the assembled prompt here first.
+        """
+        self._tts_specs[req_id] = spec
+        self._tts_frames.setdefault(req_id, [])
+        self._tts_emitted.setdefault(req_id, [])
+
+    def drain_frames(self, req_id: str) -> list[np.ndarray]:
+        """Take and clear the frames finalised for one request."""
+        frames = self._tts_frames.get(req_id)
+        if not frames:
+            return []
+        self._tts_frames[req_id] = []
+        return frames
+
+    def remove_request(self, req_id: str) -> None:
+        self._tts_specs.pop(req_id, None)
+        self._tts_frames.pop(req_id, None)
+        self._tts_emitted.pop(req_id, None)
+        self._tts_staged_prefill.pop(req_id, None)
+        super().remove_request(req_id)
+
+    def clear(self) -> None:
+        self._tts_specs.clear()
+        self._tts_frames.clear()
+        self._tts_emitted.clear()
+        self._tts_staged_prefill.clear()
+        self._tts_predictor_cache = None
+        super().clear()
+
+    # -- one autoregressive frame ---------------------------------------
+
+    def _predictor_cache(self) -> list[Any]:
+        """A reusable code-predictor cache.
+
+        The predictor restarts at position 0 for every frame, so one cache is
+        reset and reused rather than reallocated per frame; ``predict_codes``
+        does the reset. Batch size changes are safe because a reset cache
+        re-allocates from the first write.
+        """
+        if self._tts_predictor_cache is None:
+            self._tts_predictor_cache = self.model.code_predictor.make_cache()
+        return self._tts_predictor_cache
+
+    def _suppress_tokens(self) -> list[int]:
+        if self._tts_suppress is None:
+            config = self._talker_config
+            self._tts_suppress = special_codec_token_ids(
+                int(config.vocab_size), keep=int(config.codec_eos_token_id)
+            )
+        return self._tts_suppress
+
+    def _frame_from_hidden(
+        self,
+        logits: mx.array,
+        hidden: mx.array,
+        specs: list[Qwen3TTSRequestSpec],
+        recent_tokens: list[list[int]] | None = None,
+    ) -> tuple[mx.array, mx.array, mx.array]:
+        """Sample one frame per row and build the next input embedding.
+
+        Returns ``(group-0 tokens [B, 1], frame [B, groups], next input
+        [B, 1, hidden])``, all still lazy.
+        """
+        # Sampling parameters are per request, so rows are sampled separately
+        # and restacked; a homogeneous batch collapses to a single call.
+        semantic_rows = []
+        for index, spec in enumerate(specs):
+            history = recent_tokens[index] if recent_tokens else None
+            semantic_rows.append(
+                sample_codec_token(
+                    logits[index : index + 1],
+                    spec.semantic,
+                    recent_tokens=history,
+                    suppress_tokens=self._suppress_tokens(),
+                )
+            )
+        semantic = (
+            semantic_rows[0]
+            if len(semantic_rows) == 1
+            else mx.concatenate(semantic_rows, axis=0)
+        )
+
+        def sample_group(group_logits: mx.array, _group_index: int) -> mx.array:
+            # The predictor runs batched, so honour each row's own subtalker
+            # settings rather than letting row 0 speak for the batch.
+            if len(specs) == 1:
+                return sample_codec_token(group_logits, specs[0].subtalker)
+            return mx.concatenate(
+                [
+                    sample_codec_token(group_logits[index : index + 1], spec.subtalker)
+                    for index, spec in enumerate(specs)
+                ],
+                axis=0,
+            )
+
+        frame, codec_embed = self.model.predict_codes(
+            semantic,
+            hidden,
+            cache=self._predictor_cache(),
+            sampler=sample_group,
+        )
+
+        text_embed = mx.concatenate([spec.next_text_embed() for spec in specs], axis=0)
+        return semantic, frame, text_embed + codec_embed
+
+    # -- prefill --------------------------------------------------------
+
+    def prefill_start(
+        self,
+        req_id: str,
+        new_token_ids: list[int],
+        full_token_ids: list[int],
+        prefix_slot_ids: list[int],
+        new_slot_ids: list[int],
+        req_pool_idx: int,
+        req: Any | None = None,
+        needs_logits: bool = True,
+        logit_edit_row: mx.array | None = None,
+        logprob_spec: Any = None,
+    ):
+        """Prefill the assembled prompt and produce the request's first frame."""
+        from sglang.srt.hardware_backend.mlx.model_runner import MlxPendingPrefill
+
+        del new_token_ids, new_slot_ids, req, needs_logits
+        spec = self._tts_specs.get(req_id)
+        if spec is None:
+            raise RuntimeError(
+                f"Qwen3-TTS MLX prefill has no registered prompt for {req_id!r}; "
+                "the scheduler runner must call register_request first"
+            )
+        if prefix_slot_ids:
+            raise NotImplementedError(
+                "Qwen3-TTS MLX prefill does not support a radix prefix; the "
+                "prompt is an embedding sequence, not a token prefix"
+            )
+        if not self.disable_radix_cache:
+            raise RuntimeError("Qwen3-TTS MLX requires disable_radix_cache=True")
+        if logit_edit_row is not None or logprob_spec is not None:
+            raise NotImplementedError(
+                "Qwen3-TTS MLX prefill supports neither logit edits nor logprobs"
+            )
+        if spec.seed is not None:
+            mx.random.seed(spec.seed)
+
+        cache = self._acquire_cache()
+        logits, hidden = self.model(spec.prompt_embeds, cache=cache)
+        semantic, frame, next_embeds = self._frame_from_hidden(
+            logits[:, -1, :], hidden, [spec]
+        )
+
+        pending = MlxPendingPrefill(
+            lazy_token=semantic.reshape(-1),
+            cache=cache,
+            req_id=req_id,
+            full_token_ids=list(full_token_ids),
+            req_pool_idx=req_pool_idx,
+            synced_offset=0,
+            lazy_logprobs=None,
+        )
+        # The frame and the next input ride alongside the pending; the base
+        # class never looks at them, and prefill_finalize collects them.
+        self._tts_staged_prefill[req_id] = (frame, next_embeds)
+        return pending
+
+    def prefill_finalize(self, pending: Any) -> int:
+        token = super().prefill_finalize(pending)
+        staged = self._tts_staged_prefill.pop(pending.req_id, None)
+        if staged is not None:
+            frame, next_embeds = staged
+            self._commit_frames([pending.req_id], frame)
+            self._tts_specs[pending.req_id].pending_input = next_embeds
+            self._tts_emitted[pending.req_id].append(token)
+        return token
+
+    # -- decode ---------------------------------------------------------
+
+    def _commit_frames(self, req_ids: list[str], frame: mx.array) -> None:
+        """Materialise a lazy frame and stash one row per request."""
+        codes = np.array(frame, copy=True)
+        if codes.ndim == 1:
+            codes = codes[None, :]
+        for index, req_id in enumerate(req_ids):
+            self._tts_frames.setdefault(req_id, []).append(codes[index])
+
+    def decode_batch_start(
+        self,
+        req_ids: list[str],
+        edit_rows: mx.array | None = None,
+        logprob_spec: Any = None,
+        logits_hook: Any = None,
+    ):
+        """Run one frame for every request from its stored feedback embedding."""
+        if edit_rows is not None or logprob_spec is not None or logits_hook is not None:
+            raise NotImplementedError(
+                "Qwen3-TTS MLX decode supports neither logit edits, logprobs, "
+                "nor logits hooks"
+            )
+        specs = [self._tts_specs[rid] for rid in req_ids]
+        caches = [self._req_caches[rid] for rid in req_ids]
+        batched_input = mx.concatenate([spec.pending_input for spec in specs], axis=0)
+        return self._decode_step(req_ids, specs, caches, batched_input)
+
+    def decode_batch_start_chained(self, prev: Any):
+        """Continue from the previous step's still-lazy feedback embedding."""
+        specs = [self._tts_specs[rid] for rid in prev.req_ids]
+        return self._decode_step(prev.req_ids, specs, prev.caches, prev.lazy_feedback)
+
+    def _decode_step(
+        self,
+        req_ids: list[str],
+        specs: list[Qwen3TTSRequestSpec],
+        caches: list[list[Any]],
+        batched_input: mx.array,
+    ):
+        from .pending import Qwen3TTSMlxPendingDecode
+
+        logits, hidden = self._talker_forward(caches, req_ids, batched_input)
+        recent = [self._tts_emitted[rid] for rid in req_ids]
+        semantic, frame, next_embeds = self._frame_from_hidden(
+            logits, hidden, specs, recent_tokens=recent
+        )
+        return Qwen3TTSMlxPendingDecode(
+            lazy_tokens=semantic.reshape(-1),
+            req_ids=list(req_ids),
+            caches=caches,
+            lazy_logprobs=None,
+            logprob_spec=None,
+            edit_rows=None,
+            lazy_codes=frame,
+            lazy_feedback=next_embeds,
+        )
+
+    def _talker_forward(
+        self,
+        caches: list[list[Any]],
+        req_ids: list[str],
+        batched_input: mx.array,
+    ) -> tuple[mx.array, mx.array]:
+        """One batched talker step over embeddings, via SGLang's KV plumbing."""
+        from sglang.srt.hardware_backend.mlx.kv_cache import (
+            AttentionOffsetCache,
+            clear_context,
+            set_context,
+        )
+
+        if len(req_ids) == 1:
+            logits, hidden = self.model(batched_input, cache=caches[0])
+            return logits[:, -1, :], hidden
+
+        context = self._build_batched_decode_context(caches, list(req_ids))
+        set_context(context)
+        try:
+            shim = [
+                AttentionOffsetCache(offset=max(context.seq_lens))
+                for _ in range(self._cache_layout.num_layers)
+            ]
+            logits, hidden = self.model(batched_input, cache=shim)
+        finally:
+            clear_context()
+        return logits[:, -1, :], hidden
+
+    def decode_batch_finalize(self, pending: Any) -> list[int]:
+        """Materialise the step, stash its frames, carry the feedback forward."""
+        next_tokens = super().decode_batch_finalize(pending)
+        self._commit_frames(pending.req_ids, pending.lazy_codes)
+        for index, req_id in enumerate(pending.req_ids):
+            self._tts_specs[req_id].pending_input = pending.feedback_row(index)
+            self._tts_emitted[req_id].append(next_tokens[index])
+        return next_tokens
+
+
+def make_qwen3_tts_mlx_runner_class():
+    """Build the extension class after the MLX backend has been selected."""
+    from sglang.srt.hardware_backend.mlx.model_runner import MlxModelRunner
+
+    class Qwen3TTSMlxRunner(Qwen3TTSMlxModelRunner, MlxModelRunner):
+        pass
+
+    return Qwen3TTSMlxRunner

--- a/sglang_omni/models/qwen3_tts/mlx/sampling.py
+++ b/sglang_omni/models/qwen3_tts/mlx/sampling.py
@@ -1,0 +1,130 @@
+# SPDX-License-Identifier: Apache-2.0
+"""Codec-token sampling for the MLX Qwen3-TTS talker.
+
+Qwen3-TTS samples twice per frame with independent settings: the talker picks
+codec group 0 (the "semantic" token, with a repetition penalty over recent
+history), and the code predictor picks groups 1..N-1 (the "subtalker" tokens,
+with no history). Both live here so the model code stays sampling-agnostic.
+"""
+
+from __future__ import annotations
+
+from dataclasses import dataclass
+from typing import Sequence
+
+import mlx.core as mx
+
+
+@dataclass
+class SamplingParams:
+    """Sampling settings for one of the two stages."""
+
+    temperature: float = 0.9
+    top_k: int = 50
+    top_p: float = 1.0
+    repetition_penalty: float = 1.0
+    repetition_context_size: int = 64
+
+    @property
+    def greedy(self) -> bool:
+        return self.temperature <= 0.0
+
+
+def apply_top_k(logits: mx.array, top_k: int) -> mx.array:
+    """Mask everything outside the ``top_k`` highest logits."""
+    if top_k <= 0 or top_k >= logits.shape[-1]:
+        return logits
+    kth = mx.sort(logits, axis=-1)[..., -top_k, None]
+    return mx.where(logits < kth, mx.array(-mx.inf, logits.dtype), logits)
+
+
+def apply_top_p(logits: mx.array, top_p: float) -> mx.array:
+    """Keep the smallest prefix of probability mass reaching ``top_p``."""
+    if top_p <= 0.0 or top_p >= 1.0:
+        return logits
+    probs = mx.softmax(logits.astype(mx.float32), axis=-1)
+    order = mx.argsort(probs, axis=-1)
+    sorted_probs = mx.take_along_axis(probs, order, axis=-1)
+    cumulative = mx.cumsum(sorted_probs, axis=-1)
+    # Drop tokens whose entire remaining tail is outside the nucleus. The
+    # comparison is on the cumulative sum *including* the token, so the token
+    # that crosses the threshold is kept.
+    keep_sorted = cumulative > (1.0 - top_p)
+    keep = mx.put_along_axis(mx.zeros_like(keep_sorted), order, keep_sorted, axis=-1)
+    return mx.where(keep, logits, mx.array(-mx.inf, logits.dtype))
+
+
+def suppress(logits: mx.array, token_ids: Sequence[int]) -> mx.array:
+    """Force the given vocabulary entries to zero probability."""
+    if not token_ids:
+        return logits
+    index = mx.array(list(token_ids), dtype=mx.int32)
+    index = mx.broadcast_to(index[None, :], (logits.shape[0], index.shape[0]))
+    return mx.put_along_axis(logits, index, mx.array(-mx.inf, logits.dtype), axis=-1)
+
+
+def apply_repetition_penalty(
+    logits: mx.array,
+    recent_tokens: Sequence[int],
+    penalty: float,
+    context_size: int,
+) -> mx.array:
+    """Divide positive / multiply negative logits of recently emitted tokens."""
+    if penalty == 1.0 or not recent_tokens:
+        return logits
+    window = {
+        int(token)
+        for token in recent_tokens[-context_size:]
+        if 0 <= int(token) < logits.shape[-1]
+    }
+    if not window:
+        return logits
+    index = mx.array(sorted(window), dtype=mx.int32)
+    index = mx.broadcast_to(index[None, :], (logits.shape[0], index.shape[0]))
+    selected = mx.take_along_axis(logits, index, axis=-1)
+    penalized = mx.where(selected < 0, selected * penalty, selected / penalty)
+    return mx.put_along_axis(logits, index, penalized, axis=-1)
+
+
+def sample_codec_token(
+    logits: mx.array,
+    params: SamplingParams,
+    *,
+    recent_tokens: Sequence[int] | None = None,
+    suppress_tokens: Sequence[int] | None = None,
+) -> mx.array:
+    """Sample one token per row from ``[batch, vocab]`` logits.
+
+    Returns ``[batch, 1]``. Stays lazy: no ``mx.eval`` and no host sync, so a
+    caller can chain a whole frame before evaluating.
+    """
+    if suppress_tokens:
+        logits = suppress(logits, suppress_tokens)
+    if recent_tokens:
+        logits = apply_repetition_penalty(
+            logits,
+            recent_tokens,
+            params.repetition_penalty,
+            params.repetition_context_size,
+        )
+    if params.greedy:
+        return mx.argmax(logits, axis=-1, keepdims=True)
+
+    if params.temperature != 1.0:
+        logits = logits / params.temperature
+    logits = apply_top_k(logits, params.top_k)
+    logits = apply_top_p(logits, params.top_p)
+    return mx.random.categorical(logits.astype(mx.float32), axis=-1)[:, None]
+
+
+def special_codec_token_ids(vocab_size: int, keep: int) -> list[int]:
+    """The trailing special-token block of the codec vocabulary, minus ``keep``.
+
+    Qwen3-TTS reserves the last 1024 ids for control tokens; all but the EOS
+    must be suppressed so the talker cannot emit one as audio.
+    """
+    return [
+        token_id
+        for token_id in range(max(0, vocab_size - 1024), vocab_size)
+        if token_id != keep
+    ]

--- a/sglang_omni/models/qwen3_tts/mlx/scheduler_runner.py
+++ b/sglang_omni/models/qwen3_tts/mlx/scheduler_runner.py
@@ -1,0 +1,96 @@
+# SPDX-License-Identifier: Apache-2.0
+"""Omni scheduler bridge for the MLX Qwen3-TTS talker.
+
+Two jobs the generic MLX bridge cannot do:
+
+*Register prompts.*  SGLang's ``prefill_start`` only sees its own ``Req``, so
+the assembled prompt embeddings and per-request sampling settings are pushed
+into the MLX runner here, before the launch.
+
+*Collect frames.*  ``finalize_mlx_result`` returns only group-0 token ids, so
+the rest of each codec frame is drained out of the MLX runner and appended to
+the request state the vocoder stage reads.
+"""
+
+from __future__ import annotations
+
+import logging
+from typing import Any
+
+from sglang_omni.model_runner.mlx_model_worker import MlxSchedulerModelRunner
+from sglang_omni.scheduling.types import RequestOutput
+
+logger = logging.getLogger(__name__)
+
+
+class Qwen3TTSMlxSchedulerModelRunner(MlxSchedulerModelRunner):
+    """Drives Qwen3-TTS frames through Omni's MLX scheduler path."""
+
+    @property
+    def _mlx_runner(self):
+        return self.tp_worker._mlx_runner
+
+    # -- prompt registration --------------------------------------------
+
+    def execute_launch(self, scheduler_output: Any):
+        self._register_new_requests(scheduler_output)
+        return super().execute_launch(scheduler_output)
+
+    def custom_prefill_forward(
+        self,
+        forward_batch: Any,
+        schedule_batch: Any,
+        requests: list[Any],
+    ) -> Any:
+        self._register_requests(requests)
+        return super().custom_prefill_forward(forward_batch, schedule_batch, requests)
+
+    def _register_new_requests(self, scheduler_output: Any) -> None:
+        requests = getattr(scheduler_output, "requests", None)
+        if requests:
+            self._register_requests(requests)
+
+    def _register_requests(self, requests: list[Any]) -> None:
+        """Hand the runner any prompt it has not seen yet."""
+        from sglang_omni.models.qwen3_tts.mlx.request_spec import build_request_spec
+
+        runner = self._mlx_runner
+        for sched_req in requests:
+            req_id = getattr(sched_req, "request_id", None)
+            data = getattr(sched_req, "data", None)
+            if req_id is None or data is None:
+                continue
+            if req_id in runner._tts_specs or runner.has_request(req_id):
+                continue
+            spec = build_request_spec(data)
+            if spec is not None:
+                runner.register_request(req_id, spec)
+
+    # -- frame collection ------------------------------------------------
+
+    def post_process_outputs(
+        self,
+        result: Any,
+        scheduler_output: Any,
+        outputs: dict[str, RequestOutput],
+    ) -> None:
+        """Append this step's codec frames to each request's output.
+
+        A request whose reported token is the codec EOS produced no audio for
+        this step, matching the CUDA path, so its frame is dropped.
+        """
+        runner = self._mlx_runner
+        eos_id = int(runner._talker_config.codec_eos_token_id)
+
+        for sched_req in scheduler_output.requests:
+            frames = runner.drain_frames(sched_req.request_id)
+            if not frames:
+                continue
+            req_output = outputs.get(sched_req.request_id)
+            if req_output is None:
+                continue
+            if req_output.data is not None and int(req_output.data) == eos_id:
+                continue
+            for frame in frames:
+                sched_req.data.output_codes.append(frame)
+            sched_req.data.latest_stream_code_chunk = frames[-1]

--- a/sglang_omni/models/qwen3_tts/mlx/speaker_encoder.py
+++ b/sglang_omni/models/qwen3_tts/mlx/speaker_encoder.py
@@ -1,0 +1,263 @@
+# SPDX-License-Identifier: MIT
+# Derived from mlx-audio Qwen3-TTS (Copyright 2025 Prince Canuma and contributors).
+"""ECAPA-TDNN speaker encoder: reference mel spectrogram -> x-vector.
+
+Used by Qwen3-TTS Base voice cloning to condition the talker on a speaker
+embedding alongside the in-context reference codes.
+
+Tensors move in ``[batch, channels, time]`` (NCL) throughout, because that is
+how ECAPA-TDNN is described and how the checkpoint is laid out; MLX ``Conv1d``
+wants NLC, so each convolution transposes in and out.
+"""
+
+from __future__ import annotations
+
+from typing import Dict
+
+import mlx.core as mx
+import mlx.nn as nn
+
+from .config import SpeakerEncoderConfig
+
+
+def reflect_pad_time(x: mx.array, padding: int) -> mx.array:
+    """Reflect-pad the time axis of an NLC tensor without repeating the edge."""
+    if padding <= 0:
+        return x
+    left = x[:, 1 : padding + 1, :][:, ::-1, :]
+    right = x[:, -(padding + 1) : -1, :][:, ::-1, :]
+    return mx.concatenate([left, x, right], axis=1)
+
+
+class TimeDelayNetBlock(nn.Module):
+    """Dilated 1-D convolution with reflect "same" padding and ReLU."""
+
+    def __init__(
+        self,
+        in_channels: int,
+        out_channels: int,
+        kernel_size: int,
+        dilation: int,
+    ) -> None:
+        super().__init__()
+        self.pad = (kernel_size - 1) * dilation // 2
+        self.conv = nn.Conv1d(
+            in_channels,
+            out_channels,
+            kernel_size=kernel_size,
+            stride=1,
+            padding=0,
+            dilation=dilation,
+        )
+
+    def __call__(self, x: mx.array) -> mx.array:
+        x = mx.transpose(x, (0, 2, 1))
+        x = reflect_pad_time(x, self.pad)
+        out = self.conv(x)
+        return nn.relu(mx.transpose(out, (0, 2, 1)))
+
+
+class Res2NetBlock(nn.Module):
+    """Res2Net multi-scale block: channel groups chained through TDNN blocks."""
+
+    def __init__(
+        self,
+        in_channels: int,
+        out_channels: int,
+        scale: int = 8,
+        kernel_size: int = 3,
+        dilation: int = 1,
+    ) -> None:
+        super().__init__()
+        self.scale = scale
+        self.blocks = [
+            TimeDelayNetBlock(
+                in_channels // scale,
+                out_channels // scale,
+                kernel_size=kernel_size,
+                dilation=dilation,
+            )
+            for _ in range(scale - 1)
+        ]
+
+    def __call__(self, x: mx.array) -> mx.array:
+        chunks = mx.split(x, self.scale, axis=1)
+        outputs = []
+        carried = None
+        for index, chunk in enumerate(chunks):
+            if index == 0:
+                carried = chunk
+            elif index == 1:
+                carried = self.blocks[index - 1](chunk)
+            else:
+                carried = self.blocks[index - 1](chunk + carried)
+            outputs.append(carried)
+        return mx.concatenate(outputs, axis=1)
+
+
+class SqueezeExcitationBlock(nn.Module):
+    """Channel attention from the time-averaged signal."""
+
+    def __init__(self, in_channels: int, se_channels: int, out_channels: int) -> None:
+        super().__init__()
+        self.conv1 = nn.Conv1d(in_channels, se_channels, kernel_size=1)
+        self.conv2 = nn.Conv1d(se_channels, out_channels, kernel_size=1)
+
+    def __call__(self, x: mx.array) -> mx.array:
+        pooled = mx.mean(x, axis=2, keepdims=True)
+        gate = mx.transpose(pooled, (0, 2, 1))
+        gate = nn.relu(self.conv1(gate))
+        gate = mx.sigmoid(self.conv2(gate))
+        return x * mx.transpose(gate, (0, 2, 1))
+
+
+class SqueezeExcitationRes2NetBlock(nn.Module):
+    """TDNN -> Res2Net -> TDNN -> SE with a residual connection."""
+
+    def __init__(
+        self,
+        in_channels: int,
+        out_channels: int,
+        res2net_scale: int = 8,
+        se_channels: int = 128,
+        kernel_size: int = 3,
+        dilation: int = 1,
+    ) -> None:
+        super().__init__()
+        self.out_channels = out_channels
+        self.tdnn1 = TimeDelayNetBlock(in_channels, out_channels, 1, 1)
+        self.res2net_block = Res2NetBlock(
+            out_channels, out_channels, res2net_scale, kernel_size, dilation
+        )
+        self.tdnn2 = TimeDelayNetBlock(out_channels, out_channels, 1, 1)
+        self.se_block = SqueezeExcitationBlock(out_channels, se_channels, out_channels)
+
+    def __call__(self, x: mx.array) -> mx.array:
+        residual = x
+        x = self.tdnn1(x)
+        x = self.res2net_block(x)
+        x = self.tdnn2(x)
+        x = self.se_block(x)
+        return x + residual
+
+
+class AttentiveStatisticsPooling(nn.Module):
+    """Pool over time into attention-weighted mean and standard deviation."""
+
+    def __init__(self, channels: int, attention_channels: int = 128) -> None:
+        super().__init__()
+        self.eps = 1e-12
+        self.tdnn = TimeDelayNetBlock(channels * 3, attention_channels, 1, 1)
+        self.conv = nn.Conv1d(attention_channels, channels, kernel_size=1)
+
+    def __call__(self, x: mx.array) -> mx.array:
+        batch, channels, length = x.shape
+
+        mean = mx.mean(x, axis=2, keepdims=True)
+        std = mx.sqrt(mx.var(x, axis=2, keepdims=True) + self.eps)
+        attention = mx.concatenate(
+            [
+                x,
+                mx.broadcast_to(mean, (batch, channels, length)),
+                mx.broadcast_to(std, (batch, channels, length)),
+            ],
+            axis=1,
+        )
+
+        attention = mx.tanh(self.tdnn(attention))
+        attention = mx.transpose(attention, (0, 2, 1))
+        attention = self.conv(attention)
+        attention = mx.transpose(attention, (0, 2, 1))
+        attention = mx.softmax(attention, axis=2)
+
+        mean = mx.sum(attention * x, axis=2, keepdims=True)
+        var = mx.sum(attention * (x - mean) ** 2, axis=2, keepdims=True)
+        std = mx.sqrt(mx.clip(var, self.eps, None))
+        return mx.concatenate([mean, std], axis=1)
+
+
+class Qwen3TTSSpeakerEncoder(nn.Module):
+    """ECAPA-TDNN x-vector encoder."""
+
+    def __init__(self, config: SpeakerEncoderConfig) -> None:
+        super().__init__()
+        self.config = config
+        channels = config.enc_channels
+
+        self.blocks = [
+            TimeDelayNetBlock(
+                config.mel_dim,
+                channels[0],
+                config.enc_kernel_sizes[0],
+                config.enc_dilations[0],
+            )
+        ]
+        for index in range(1, len(channels) - 1):
+            self.blocks.append(
+                SqueezeExcitationRes2NetBlock(
+                    channels[index - 1],
+                    channels[index],
+                    res2net_scale=config.enc_res2net_scale,
+                    se_channels=config.enc_se_channels,
+                    kernel_size=config.enc_kernel_sizes[index],
+                    dilation=config.enc_dilations[index],
+                )
+            )
+
+        # Multi-layer feature aggregation consumes the concatenated SE-Res2Net
+        # outputs, so the declared final width must equal their sum (the
+        # released config is [512, 512, 512, 512, 1536]).
+        aggregated = sum(channels[1:-1])
+        if aggregated != channels[-1]:
+            raise ValueError(
+                "Speaker encoder enc_channels[-1] must equal the sum of the "
+                f"SE-Res2Net widths: got {channels[-1]} for {channels[1:-1]} "
+                f"(sum {aggregated})"
+            )
+        self.mfa = TimeDelayNetBlock(
+            channels[-1],
+            channels[-1],
+            config.enc_kernel_sizes[-1],
+            config.enc_dilations[-1],
+        )
+        self.asp = AttentiveStatisticsPooling(
+            channels[-1],
+            attention_channels=config.enc_attention_channels,
+        )
+        self.fc = nn.Conv1d(channels[-1] * 2, config.enc_dim, kernel_size=1)
+
+    def __call__(self, mels: mx.array) -> mx.array:
+        """``mels`` is ``[batch, frames, mel_dim]``; returns ``[batch, enc_dim]``."""
+        x = mx.transpose(mels, (0, 2, 1))
+
+        hidden_states = []
+        for block in self.blocks:
+            x = block(x)
+            hidden_states.append(x)
+
+        # Multi-layer feature aggregation over the SE-Res2Net outputs only.
+        x = self.mfa(mx.concatenate(hidden_states[1:], axis=1))
+        x = self.asp(x)
+
+        x = mx.transpose(x, (0, 2, 1))
+        x = self.fc(x)
+        x = mx.transpose(x, (0, 2, 1))
+        return mx.squeeze(x, axis=-1)
+
+    @staticmethod
+    def sanitize(weights: Dict[str, mx.array]) -> Dict[str, mx.array]:
+        """Keep the ``speaker_encoder.`` subtree, unprefixed.
+
+        Conv layout is fixed separately by
+        :func:`~sglang_omni.models.qwen3_tts.mlx.weights.align_conv_weights`,
+        which derives the permutation from each module's type instead of
+        guessing from dimension sizes.
+        """
+        prefix = "speaker_encoder."
+        if not any(key.startswith(prefix) for key in weights):
+            return dict(weights)
+        return {
+            key[len(prefix) :]: value
+            for key, value in weights.items()
+            if key.startswith(prefix)
+        }

--- a/sglang_omni/models/qwen3_tts/mlx/speech_tokenizer.py
+++ b/sglang_omni/models/qwen3_tts/mlx/speech_tokenizer.py
@@ -1,0 +1,1272 @@
+# SPDX-License-Identifier: MIT
+# Derived from mlx-audio Qwen3-TTS (Copyright 2025 Prince Canuma and contributors).
+"""MLX Qwen3-TTS speech tokenizer: codec frames <-> 24 kHz waveform.
+
+The decoder ("code2wav") is a split residual vector quantiser, a small
+sliding-window transformer, two ConvNeXt upsampling stages and a stack of
+Snake/ConvTranspose blocks. Everything downstream of the quantiser runs in NLC
+(``[batch, time, channels]``) because that is MLX's convolution layout; only
+the quantiser and the final waveform are NCL.
+
+One deliberate divergence from mlx-audio: the decoder transformer applies
+sliding-window attention. The official configuration declares
+``layer_types == ["sliding_attention"] * num_hidden_layers`` with
+``sliding_window == 72`` as a computed property, so it never appears in
+``config.json``; mlx-audio stores the window on the attention module but never
+masks with it. That is invisible while decoding in short chunks and diverges
+once a pass exceeds 72 frames (5.76 s at 12.5 Hz) -- which is the norm on the
+voice-cloning path, where reference and generated codes are decoded together in
+a single pass.
+"""
+
+from __future__ import annotations
+
+import math
+from contextlib import contextmanager
+from typing import Any, Dict, Iterator, List, Optional, Tuple
+
+import mlx.core as mx
+import mlx.nn as nn
+
+from .config import TokenizerConfig, TokenizerDecoderConfig, TokenizerEncoderConfig
+
+
+def sliding_causal_mask(
+    query_len: int,
+    key_len: int,
+    window: int | None,
+    dtype: mx.Dtype,
+) -> Optional[mx.array]:
+    """Additive mask for causal attention restricted to a trailing window.
+
+    Queries occupy the last ``query_len`` absolute positions of ``key_len``.
+    A key at ``j`` is visible to a query at ``i`` when ``j <= i`` and
+    ``j > i - window``, matching the reference
+    ``kv_idx > q_idx - sliding_window`` overlay on a causal mask.
+    """
+    if query_len == 1 and (window is None or key_len <= window):
+        return None
+
+    offset = key_len - query_len
+    queries = mx.arange(offset, offset + query_len)[:, None]
+    keys = mx.arange(key_len)[None, :]
+    allowed = keys <= queries
+    if window is not None:
+        allowed = allowed & (keys > queries - window)
+    return mx.where(allowed, mx.array(0.0, dtype), mx.array(-mx.inf, dtype))
+
+
+class SnakeBeta(nn.Module):
+    """``x + sin^2(alpha * x) / beta``, with log-parameterised alpha/beta."""
+
+    def __init__(self, channels: int) -> None:
+        super().__init__()
+        self.alpha = mx.zeros((channels,))
+        self.beta = mx.zeros((channels,))
+        self.eps = 1e-9
+
+    def __call__(self, x: mx.array) -> mx.array:
+        alpha = mx.exp(self.alpha)
+        beta = mx.exp(self.beta)
+        return x + (1.0 / (beta + self.eps)) * mx.square(mx.sin(x * alpha))
+
+
+class CausalConv1d(nn.Module):
+    """Left-padded convolution with an optional streaming tail buffer."""
+
+    def __init__(
+        self,
+        in_channels: int,
+        out_channels: int,
+        kernel_size: int,
+        stride: int = 1,
+        dilation: int = 1,
+        groups: int = 1,
+    ) -> None:
+        super().__init__()
+        self.stride = stride
+        self.padding = (kernel_size - 1) * dilation + 1 - stride
+        self._buffer: mx.array | None = None
+        self.conv = nn.Conv1d(
+            in_channels,
+            out_channels,
+            kernel_size,
+            stride=stride,
+            padding=0,
+            dilation=dilation,
+            groups=groups,
+        )
+
+    def __call__(self, x: mx.array) -> mx.array:
+        if self.padding > 0:
+            x = mx.pad(x, [(0, 0), (self.padding, 0), (0, 0)])
+        return self.conv(x)
+
+    def step(self, x: mx.array) -> mx.array:
+        if self.padding > 0:
+            if self._buffer is None:
+                x = mx.pad(x, [(0, 0), (self.padding, 0), (0, 0)])
+            else:
+                x = mx.concatenate([self._buffer, x], axis=1)
+            self._buffer = x[:, -self.padding :, :]
+        return self.conv(x)
+
+    def reset_state(self) -> None:
+        self._buffer = None
+
+
+class CausalTransposeConv1d(nn.Module):
+    """Transposed convolution trimmed on the right to stay causal."""
+
+    def __init__(
+        self,
+        in_channels: int,
+        out_channels: int,
+        kernel_size: int,
+        stride: int = 1,
+    ) -> None:
+        super().__init__()
+        self.conv = nn.ConvTranspose1d(
+            in_channels, out_channels, kernel_size, stride=stride, padding=0
+        )
+        self.trim_right = kernel_size - stride
+
+    def __call__(self, x: mx.array) -> mx.array:
+        x = self.conv(x)
+        if self.trim_right > 0:
+            x = x[:, : -self.trim_right, :]
+        return x
+
+
+class ConvNeXtBlock(nn.Module):
+    """Depthwise causal conv, LayerNorm, pointwise MLP, scaled residual."""
+
+    def __init__(self, dim: int) -> None:
+        super().__init__()
+        self.dwconv = CausalConv1d(dim, dim, kernel_size=7, groups=dim)
+        self.norm = nn.LayerNorm(dim, eps=1e-6)
+        self.pwconv1 = nn.Linear(dim, 4 * dim)
+        self.pwconv2 = nn.Linear(4 * dim, dim)
+        self.gamma = mx.ones((dim,)) * 1e-6
+
+    def _body(self, x: mx.array) -> mx.array:
+        x = self.norm(x)
+        x = self.pwconv1(x)
+        x = nn.gelu(x)
+        x = self.pwconv2(x)
+        return self.gamma * x
+
+    def __call__(self, x: mx.array) -> mx.array:
+        return x + self._body(self.dwconv(x))
+
+    def step(self, x: mx.array) -> mx.array:
+        return x + self._body(self.dwconv.step(x))
+
+
+class DecoderRMSNorm(nn.Module):
+    """RMS norm accumulated in float32."""
+
+    def __init__(self, hidden_size: int, eps: float = 1e-6) -> None:
+        super().__init__()
+        self.weight = mx.ones((hidden_size,))
+        self.eps = eps
+
+    def __call__(self, x: mx.array) -> mx.array:
+        promoted = x.astype(mx.float32)
+        variance = mx.mean(promoted**2, axis=-1, keepdims=True)
+        normed = promoted * mx.rsqrt(variance + self.eps)
+        return (self.weight * normed).astype(x.dtype)
+
+
+class LayerScale(nn.Module):
+    """Per-channel residual scale."""
+
+    def __init__(self, channels: int, initial_scale: float = 0.01) -> None:
+        super().__init__()
+        self.scale = mx.ones((channels,)) * initial_scale
+
+    def __call__(self, x: mx.array) -> mx.array:
+        return self.scale * x
+
+
+class DecoderAttention(nn.Module):
+    """Sliding-window causal self-attention."""
+
+    def __init__(self, config: TokenizerDecoderConfig, layer_idx: int) -> None:
+        super().__init__()
+        self.layer_idx = layer_idx
+        self.head_dim = config.head_dim
+        self.num_heads = config.num_attention_heads
+        self.num_kv_heads = config.num_key_value_heads
+        self.scale = self.head_dim**-0.5
+
+        self.q_proj = nn.Linear(
+            config.hidden_size,
+            self.num_heads * self.head_dim,
+            bias=config.attention_bias,
+        )
+        self.k_proj = nn.Linear(
+            config.hidden_size,
+            self.num_kv_heads * self.head_dim,
+            bias=config.attention_bias,
+        )
+        self.v_proj = nn.Linear(
+            config.hidden_size,
+            self.num_kv_heads * self.head_dim,
+            bias=config.attention_bias,
+        )
+        self.o_proj = nn.Linear(
+            self.num_heads * self.head_dim,
+            config.hidden_size,
+            bias=config.attention_bias,
+        )
+        self.rope = nn.RoPE(self.head_dim, traditional=False, base=config.rope_theta)
+
+    def __call__(
+        self,
+        x: mx.array,
+        mask: Optional[mx.array] = None,
+        cache: Optional[Any] = None,
+    ) -> mx.array:
+        batch, length, _ = x.shape
+
+        queries = (
+            self.q_proj(x)
+            .reshape(batch, length, self.num_heads, self.head_dim)
+            .transpose(0, 2, 1, 3)
+        )
+        keys = (
+            self.k_proj(x)
+            .reshape(batch, length, self.num_kv_heads, self.head_dim)
+            .transpose(0, 2, 1, 3)
+        )
+        values = (
+            self.v_proj(x)
+            .reshape(batch, length, self.num_kv_heads, self.head_dim)
+            .transpose(0, 2, 1, 3)
+        )
+
+        offset = 0 if cache is None else cache.offset
+        queries = self.rope(queries, offset=offset)
+        keys = self.rope(keys, offset=offset)
+        if cache is not None:
+            keys, values = cache.update_and_fetch(keys, values)
+
+        output = mx.fast.scaled_dot_product_attention(
+            queries, keys, values, scale=self.scale, mask=mask
+        )
+        output = output.transpose(0, 2, 1, 3).reshape(batch, length, -1)
+        return self.o_proj(output)
+
+
+class DecoderMLP(nn.Module):
+    """SwiGLU feed-forward block."""
+
+    def __init__(self, config: TokenizerDecoderConfig) -> None:
+        super().__init__()
+        self.gate_proj = nn.Linear(
+            config.hidden_size, config.intermediate_size, bias=False
+        )
+        self.up_proj = nn.Linear(
+            config.hidden_size, config.intermediate_size, bias=False
+        )
+        self.down_proj = nn.Linear(
+            config.intermediate_size, config.hidden_size, bias=False
+        )
+
+    def __call__(self, x: mx.array) -> mx.array:
+        return self.down_proj(nn.silu(self.gate_proj(x)) * self.up_proj(x))
+
+
+class DecoderTransformerLayer(nn.Module):
+    """Pre-norm layer with per-branch learned residual scales."""
+
+    def __init__(self, config: TokenizerDecoderConfig, layer_idx: int) -> None:
+        super().__init__()
+        self.self_attn = DecoderAttention(config, layer_idx)
+        self.mlp = DecoderMLP(config)
+        self.input_layernorm = DecoderRMSNorm(config.hidden_size, config.rms_norm_eps)
+        self.post_attention_layernorm = DecoderRMSNorm(
+            config.hidden_size, config.rms_norm_eps
+        )
+        self.self_attn_layer_scale = LayerScale(
+            config.hidden_size, config.layer_scale_initial_scale
+        )
+        self.mlp_layer_scale = LayerScale(
+            config.hidden_size, config.layer_scale_initial_scale
+        )
+
+    def __call__(
+        self,
+        x: mx.array,
+        mask: Optional[mx.array] = None,
+        cache: Optional[Any] = None,
+    ) -> mx.array:
+        residual = x
+        x = self.input_layernorm(x)
+        x = self.self_attn(x, mask=mask, cache=cache)
+        x = residual + self.self_attn_layer_scale(x)
+
+        residual = x
+        x = self.post_attention_layernorm(x)
+        x = self.mlp(x)
+        return residual + self.mlp_layer_scale(x)
+
+
+class DecoderTransformer(nn.Module):
+    """Latent-space transformer between the quantiser and the upsampler."""
+
+    def __init__(self, config: TokenizerDecoderConfig) -> None:
+        super().__init__()
+        self.config = config
+        self.layers = [
+            DecoderTransformerLayer(config, i) for i in range(config.num_hidden_layers)
+        ]
+        self.norm = DecoderRMSNorm(config.hidden_size, config.rms_norm_eps)
+        self.input_proj = nn.Linear(config.latent_dim, config.hidden_size)
+        self.output_proj = nn.Linear(config.hidden_size, config.latent_dim)
+
+    def make_cache(self) -> List[Any]:
+        from mlx_lm.models.cache import KVCache
+
+        return [KVCache() for _ in self.layers]
+
+    def __call__(
+        self,
+        inputs_embeds: mx.array,
+        cache: Optional[List[Any]] = None,
+    ) -> mx.array:
+        x = self.input_proj(inputs_embeds)
+        offset = 0 if cache is None else cache[0].offset
+        mask = sliding_causal_mask(
+            x.shape[1],
+            offset + x.shape[1],
+            self.config.sliding_window,
+            x.dtype,
+        )
+
+        if cache is None:
+            cache = [None] * len(self.layers)
+        for layer, layer_cache in zip(self.layers, cache):
+            x = layer(x, mask=mask, cache=layer_cache)
+
+        return self.output_proj(self.norm(x))
+
+
+class EuclideanCodebook(nn.Module):
+    """Codebook lookup. The checkpoint's ``cluster_usage``/``embedding_sum``
+    pair is folded into a single embedding table during sanitisation."""
+
+    def __init__(self, dim: int, codebook_size: int) -> None:
+        super().__init__()
+        self.dim = dim
+        self.codebook_size = codebook_size
+        self.embed = nn.Embedding(codebook_size, dim)
+
+    def decode(self, codes: mx.array) -> mx.array:
+        return self.embed(codes)
+
+
+class VectorQuantization(nn.Module):
+    """One codebook plus its optional output projection."""
+
+    def __init__(
+        self,
+        dim: int,
+        codebook_size: int,
+        codebook_dim: Optional[int] = None,
+    ) -> None:
+        super().__init__()
+        codebook_dim = codebook_dim or dim
+        self.project_out = nn.Linear(codebook_dim, dim) if codebook_dim != dim else None
+        self.codebook = EuclideanCodebook(codebook_dim, codebook_size)
+        self.codebook_size = codebook_size
+
+    def decode(self, codes: mx.array) -> mx.array:
+        quantized = self.codebook.decode(codes)
+        if self.project_out is not None:
+            quantized = self.project_out(quantized)
+        return mx.transpose(quantized, (0, 2, 1))
+
+
+class ResidualVectorQuantization(nn.Module):
+    """Sum of a stack of codebook lookups."""
+
+    def __init__(
+        self,
+        num_quantizers: int,
+        dim: int,
+        codebook_size: int,
+        codebook_dim: Optional[int] = None,
+    ) -> None:
+        super().__init__()
+        self.layers = [
+            VectorQuantization(dim, codebook_size, codebook_dim)
+            for _ in range(num_quantizers)
+        ]
+
+    def decode(self, codes: mx.array) -> mx.array:
+        quantized = None
+        for index, layer_codes in enumerate(codes):
+            decoded = self.layers[index].decode(layer_codes)
+            quantized = decoded if quantized is None else quantized + decoded
+        return quantized
+
+
+class ResidualVectorQuantizer(nn.Module):
+    """Residual VQ with 1x1 input/output projections."""
+
+    def __init__(
+        self,
+        dimension: int = 128,
+        input_dimension: Optional[int] = None,
+        output_dimension: Optional[int] = None,
+        n_q: int = 8,
+        bins: int = 1024,
+        force_projection: bool = False,
+    ) -> None:
+        super().__init__()
+        self.n_q = n_q
+        self.dimension = dimension
+        self.input_dimension = input_dimension or dimension
+        self.output_dimension = output_dimension or dimension
+        self.bins = bins
+
+        needs_input = self.input_dimension != dimension or force_projection
+        needs_output = self.output_dimension != dimension or force_projection
+        self.input_proj = (
+            nn.Conv1d(self.input_dimension, dimension, 1, bias=False)
+            if needs_input
+            else None
+        )
+        self.output_proj = (
+            nn.Conv1d(dimension, self.output_dimension, 1, bias=False)
+            if needs_output
+            else None
+        )
+        self.vq = ResidualVectorQuantization(
+            num_quantizers=n_q, dim=dimension, codebook_size=bins
+        )
+
+    def decode(self, codes: mx.array) -> mx.array:
+        quantized = self.vq.decode(mx.transpose(codes, (1, 0, 2)))
+        if self.output_proj is not None:
+            quantized = mx.transpose(quantized, (0, 2, 1))
+            quantized = self.output_proj(quantized)
+            quantized = mx.transpose(quantized, (0, 2, 1))
+        return quantized
+
+
+class SplitResidualVectorQuantizer(nn.Module):
+    """Semantic codebook(s) plus the acoustic remainder."""
+
+    def __init__(
+        self,
+        n_q: int = 8,
+        n_q_semantic: int = 1,
+        dimension: int = 128,
+        input_dimension: Optional[int] = None,
+        output_dimension: Optional[int] = None,
+        bins: int = 1024,
+    ) -> None:
+        super().__init__()
+        self.n_q_semantic = n_q_semantic
+        self.n_q_acoustic = n_q - n_q_semantic
+        self.rvq_first = ResidualVectorQuantizer(
+            dimension=dimension,
+            input_dimension=input_dimension,
+            output_dimension=output_dimension,
+            n_q=n_q_semantic,
+            bins=bins,
+            force_projection=True,
+        )
+        self.rvq_rest = ResidualVectorQuantizer(
+            dimension=dimension,
+            input_dimension=input_dimension,
+            output_dimension=output_dimension,
+            n_q=n_q - n_q_semantic,
+            bins=bins,
+            force_projection=True,
+        )
+
+    def decode(self, codes: mx.array) -> mx.array:
+        quantized = self.rvq_first.decode(codes[:, : self.n_q_semantic])
+        if codes.shape[1] > self.n_q_semantic:
+            quantized = quantized + self.rvq_rest.decode(codes[:, self.n_q_semantic :])
+        return quantized
+
+
+class DecoderResidualUnit(nn.Module):
+    """Snake -> dilated conv -> Snake -> 1x1 conv, with a residual."""
+
+    def __init__(self, dim: int, dilation: int = 1) -> None:
+        super().__init__()
+        self.act1 = SnakeBeta(dim)
+        self.conv1 = CausalConv1d(dim, dim, kernel_size=7, dilation=dilation)
+        self.act2 = SnakeBeta(dim)
+        self.conv2 = CausalConv1d(dim, dim, kernel_size=1)
+
+    def __call__(self, x: mx.array) -> mx.array:
+        return x + self.conv2(self.act2(self.conv1(self.act1(x))))
+
+    def step(self, x: mx.array) -> mx.array:
+        return x + self.conv2.step(self.act2(self.conv1.step(self.act1(x))))
+
+
+class DecoderBlockUpsample(nn.Module):
+    """Causal transposed convolution with a streaming overlap-add tail."""
+
+    def __init__(self, in_dim: int, out_dim: int, upsample_rate: int) -> None:
+        super().__init__()
+        kernel_size = 2 * upsample_rate
+        self.conv = nn.ConvTranspose1d(
+            in_dim, out_dim, kernel_size, stride=upsample_rate, padding=0
+        )
+        self.trim_right = kernel_size - upsample_rate
+        self._overflow: mx.array | None = None
+
+    def __call__(self, x: mx.array) -> mx.array:
+        x = self.conv(x)
+        if self.trim_right > 0:
+            x = x[:, : -self.trim_right, :]
+        return x
+
+    def step(self, x: mx.array) -> mx.array:
+        y = self.conv(x)
+        if self._overflow is not None:
+            width = self._overflow.shape[1]
+            y = mx.concatenate(
+                [y[:, :width, :] + self._overflow, y[:, width:, :]], axis=1
+            )
+        if self.trim_right > 0:
+            self._overflow = y[:, -self.trim_right :, :]
+            y = y[:, : -self.trim_right, :]
+        return y
+
+    def reset_state(self) -> None:
+        self._overflow = None
+
+
+class DecoderBlock(nn.Module):
+    """One waveform upsampling stage.
+
+    ``block`` is a list to match the checkpoint's ``ModuleList`` keys:
+    ``0`` Snake, ``1`` upsample, ``2..4`` residual units.
+    """
+
+    def __init__(self, config: TokenizerDecoderConfig, layer_idx: int) -> None:
+        super().__init__()
+        in_dim = config.decoder_dim // (2**layer_idx)
+        out_dim = config.decoder_dim // (2 ** (layer_idx + 1))
+        self.block = [
+            SnakeBeta(in_dim),
+            DecoderBlockUpsample(in_dim, out_dim, config.upsample_rates[layer_idx]),
+            DecoderResidualUnit(out_dim, dilation=1),
+            DecoderResidualUnit(out_dim, dilation=3),
+            DecoderResidualUnit(out_dim, dilation=9),
+        ]
+
+    def __call__(self, x: mx.array) -> mx.array:
+        for layer in self.block:
+            x = layer(x)
+        return x
+
+    def step(self, x: mx.array) -> mx.array:
+        x = self.block[0](x)
+        x = self.block[1].step(x)
+        for unit in self.block[2:]:
+            x = unit.step(x)
+        return x
+
+
+class _PaddedConv(nn.Module):
+    """Left-padded convolution wrapper matching a ``.conv.*`` weight prefix."""
+
+    def __init__(self, in_channels: int, out_channels: int, kernel_size: int) -> None:
+        super().__init__()
+        self.conv = nn.Conv1d(in_channels, out_channels, kernel_size, padding=0)
+        self.kernel_size = kernel_size
+        self._buffer: mx.array | None = None
+
+    def __call__(self, x: mx.array) -> mx.array:
+        return self.conv(mx.pad(x, [(0, 0), (self.kernel_size - 1, 0), (0, 0)]))
+
+    def step(self, x: mx.array) -> mx.array:
+        padding = self.kernel_size - 1
+        if padding > 0:
+            if self._buffer is None:
+                x = mx.pad(x, [(0, 0), (padding, 0), (0, 0)])
+            else:
+                x = mx.concatenate([self._buffer, x], axis=1)
+            self._buffer = x[:, -padding:, :]
+        return self.conv(x)
+
+    def reset_state(self) -> None:
+        self._buffer = None
+
+
+class Qwen3TTSSpeechTokenizerDecoder(nn.Module):
+    """Codec frames -> 24 kHz waveform."""
+
+    def __init__(self, config: TokenizerDecoderConfig) -> None:
+        super().__init__()
+        self.config = config
+        self.total_upsample = math.prod(
+            list(config.upsample_rates) + list(config.upsampling_ratios)
+        )
+        self._transformer_cache: List[Any] | None = None
+
+        self.pre_transformer = DecoderTransformer(config)
+        self.quantizer = SplitResidualVectorQuantizer(
+            dimension=config.codebook_dim // 2,
+            n_q=config.num_quantizers,
+            n_q_semantic=config.num_semantic_quantizers,
+            bins=config.codebook_size,
+            input_dimension=config.codebook_dim,
+            output_dimension=config.codebook_dim,
+        )
+        self.pre_conv = CausalConv1d(
+            config.codebook_dim, config.latent_dim, kernel_size=3
+        )
+        self.upsample = [
+            [
+                CausalTransposeConv1d(
+                    config.latent_dim, config.latent_dim, factor, factor
+                ),
+                ConvNeXtBlock(config.latent_dim),
+            ]
+            for factor in config.upsampling_ratios
+        ]
+        output_dim = config.decoder_dim // (2 ** len(config.upsample_rates))
+        self.decoder = [
+            _PaddedConv(config.latent_dim, config.decoder_dim, 7),
+            *[DecoderBlock(config, i) for i in range(len(config.upsample_rates))],
+            SnakeBeta(output_dim),
+            _PaddedConv(output_dim, 1, 7),
+        ]
+
+    def _check_codes(self, codes: mx.array) -> None:
+        if codes.shape[1] != self.config.num_quantizers:
+            raise ValueError(
+                f"Expected {self.config.num_quantizers} codebooks, "
+                f"got {codes.shape[1]}"
+            )
+
+    def __call__(self, codes: mx.array) -> mx.array:
+        """``codes`` is ``[batch, num_quantizers, time]``; returns ``[batch, 1, samples]``."""
+        self._check_codes(codes)
+
+        hidden = mx.transpose(self.quantizer.decode(codes), (0, 2, 1))
+        hidden = self.pre_conv(hidden)
+        hidden = self.pre_transformer(hidden)
+
+        for transpose_conv, convnext in self.upsample:
+            hidden = convnext(transpose_conv(hidden))
+
+        for layer in self.decoder:
+            hidden = layer(hidden)
+
+        return mx.clip(mx.transpose(hidden, (0, 2, 1)), -1.0, 1.0)
+
+    def reset_streaming_state(self) -> None:
+        """Drop every convolution buffer, overlap tail, and the KV cache."""
+        self._transformer_cache = None
+        for _, module in self.named_modules():
+            reset = getattr(module, "reset_state", None)
+            if callable(reset):
+                reset()
+
+    def streaming_step(self, codes: mx.array) -> mx.array:
+        """Decode only the new ``codes``, carrying convolution and KV state."""
+        self._check_codes(codes)
+        if self._transformer_cache is None:
+            self._transformer_cache = self.pre_transformer.make_cache()
+
+        hidden = mx.transpose(self.quantizer.decode(codes), (0, 2, 1))
+        hidden = self.pre_conv.step(hidden)
+        hidden = self.pre_transformer(hidden, cache=self._transformer_cache)
+
+        for transpose_conv, convnext in self.upsample:
+            hidden = convnext.step(transpose_conv(hidden))
+
+        hidden = self.decoder[0].step(hidden)
+        for block in self.decoder[1:-2]:
+            hidden = block.step(hidden)
+        hidden = self.decoder[-2](hidden)
+        hidden = self.decoder[-1].step(hidden)
+
+        return mx.clip(mx.transpose(hidden, (0, 2, 1)), -1.0, 1.0)
+
+    # Names of the mutable streaming buffers scattered through the decoder:
+    # convolution tails and the transposed-convolution overlap-add remainder.
+    _STREAM_BUFFER_ATTRS = ("_buffer", "_overflow")
+
+    def new_streaming_session(self) -> dict:
+        """An empty per-request streaming state.
+
+        The decoder's convolution tails, overlap-add remainders and transformer
+        KV live on the module, so concurrent requests would otherwise overwrite
+        each other. A session holds one request's values; install it with
+        :meth:`streaming_session` around that request's steps.
+        """
+        return {"buffers": {}, "cache": None}
+
+    @contextmanager
+    def streaming_session(self, session: dict) -> Iterator[None]:
+        """Install ``session``'s streaming state for the duration of the block.
+
+        Only references are swapped, never tensor data, so entering and leaving
+        a session costs nothing measurable.
+        """
+        saved_buffers: dict[tuple[str, str], Any] = {}
+        saved_cache = self._transformer_cache
+
+        for path, module in self.named_modules():
+            for attr in self._STREAM_BUFFER_ATTRS:
+                if hasattr(module, attr):
+                    saved_buffers[(path, attr)] = getattr(module, attr)
+                    setattr(module, attr, session["buffers"].get((path, attr)))
+        self._transformer_cache = session["cache"]
+
+        try:
+            yield
+        finally:
+            for (path, attr), previous in saved_buffers.items():
+                module = self._module_at(path)
+                session["buffers"][(path, attr)] = getattr(module, attr)
+                setattr(module, attr, previous)
+            session["cache"] = self._transformer_cache
+            self._transformer_cache = saved_cache
+
+    def _module_at(self, path: str):
+        """Resolve a dotted ``named_modules`` path, list indices included."""
+        target = self
+        for part in path.split("."):
+            if part.isdigit():
+                target = target[int(part)]
+            else:
+                target = getattr(target, part)
+        return target
+
+    def chunked_decode(
+        self,
+        codes: mx.array,
+        chunk_size: int = 300,
+        left_context_size: int | None = None,
+    ) -> mx.array:
+        """Decode long sequences in bounded-memory chunks.
+
+        Each chunk is re-decoded with ``left_context_size`` frames of discarded
+        history. Because attention is limited to ``sliding_window`` frames, a
+        context of ``sliding_window - 1`` makes this *exact* rather than an
+        approximation -- every query in the chunk sees its full window, and the
+        convolution stack's receptive field is far shorter than that. Passing a
+        smaller context trades accuracy for memory.
+        """
+        if left_context_size is None:
+            window = self.config.sliding_window
+            left_context_size = 0 if window is None else window - 1
+
+        waveforms = []
+        start = 0
+        while start < codes.shape[-1]:
+            end = min(start + chunk_size, codes.shape[-1])
+            context = min(left_context_size, start)
+            chunk = self(codes[..., start - context : end])
+            waveforms.append(chunk[..., context * self.total_upsample :])
+            start = end
+        return mx.concatenate(waveforms, axis=-1)
+
+
+# --------------------------------------------------------------------------
+# Encoder: waveform -> codec frames (Base voice cloning only)
+#
+# Mirrors the checkpoint's own module layout -- which is that of
+# ``transformers.MimiModel``, since the official encoder subclasses it -- so
+# weight keys need no remapping beyond convolution layout and codebook folding.
+# --------------------------------------------------------------------------
+
+
+def _causal_pad_width(
+    length: int, kernel_size: int, stride: int, dilation: int
+) -> tuple[int, int]:
+    """Left/right padding for a causal strided convolution.
+
+    Left padding is the whole ``effective_kernel - stride`` budget; the right
+    side gets only the extra needed to round the output up to a whole frame.
+    """
+    effective = (kernel_size - 1) * dilation + 1
+    total = effective - stride
+    frames = max(length + total - effective, 0) / stride + 1.0
+    ideal = (math.ceil(frames) - 1) * stride + effective - total
+    return total, max(0, ideal - length)
+
+
+class StreamableConv1d(nn.Module):
+    """Causal convolution with reference-compatible length rounding."""
+
+    def __init__(
+        self,
+        in_channels: int,
+        out_channels: int,
+        kernel_size: int,
+        stride: int = 1,
+        dilation: int = 1,
+        bias: bool = True,
+        pad_mode: str = "constant",
+    ) -> None:
+        super().__init__()
+        self.kernel_size = kernel_size
+        self.stride = stride
+        self.dilation = dilation
+        self.pad_mode = pad_mode
+        self.conv = nn.Conv1d(
+            in_channels,
+            out_channels,
+            kernel_size,
+            stride=stride,
+            padding=0,
+            dilation=dilation,
+            bias=bias,
+        )
+
+    def __call__(self, x: mx.array) -> mx.array:
+        left, right = _causal_pad_width(
+            x.shape[1], self.kernel_size, self.stride, self.dilation
+        )
+        if left or right:
+            x = mx.pad(x, [(0, 0), (left, right), (0, 0)], mode=self.pad_mode)
+        return self.conv(x)
+
+
+class _Elu(nn.Module):
+    """Parameter-free ELU, kept as a module so SEANet layer indices line up
+    with the checkpoint's flat ``ModuleList``."""
+
+    def __call__(self, x: mx.array) -> mx.array:
+        return nn.elu(x, alpha=1.0)
+
+
+class SeanetResnetBlock(nn.Module):
+    """Pre-activation residual block; ``block`` indices 1 and 3 hold the convs."""
+
+    def __init__(
+        self,
+        dim: int,
+        kernel_size: int,
+        dilation: int,
+        compress: int,
+        pad_mode: str,
+    ) -> None:
+        super().__init__()
+        hidden = dim // compress
+        self.block = [
+            _Elu(),
+            StreamableConv1d(
+                dim, hidden, kernel_size, dilation=dilation, pad_mode=pad_mode
+            ),
+            _Elu(),
+            StreamableConv1d(hidden, dim, 1, pad_mode=pad_mode),
+        ]
+
+    def __call__(self, x: mx.array) -> mx.array:
+        residual = x
+        for layer in self.block:
+            x = layer(x)
+        return x + residual
+
+
+class SeanetEncoder(nn.Module):
+    """Strided convolutional encoder, one flat layer list.
+
+    Downsampling ratios are applied in reverse of ``upsampling_ratios``, each
+    with kernel ``2 * ratio``, doubling the channel count.
+    """
+
+    def __init__(self, config: TokenizerEncoderConfig) -> None:
+        super().__init__()
+        pad_mode = config.pad_mode
+        layers: List[Any] = [
+            StreamableConv1d(
+                config.audio_channels,
+                config.num_filters,
+                config.kernel_size,
+                pad_mode=pad_mode,
+            )
+        ]
+        channels = config.num_filters
+        for ratio in reversed(config.upsampling_ratios):
+            dilation = 1
+            for _ in range(config.num_residual_layers):
+                layers.append(
+                    SeanetResnetBlock(
+                        channels,
+                        config.residual_kernel_size,
+                        dilation,
+                        config.compress,
+                        pad_mode,
+                    )
+                )
+                dilation *= config.dilation_growth_rate
+            layers.append(_Elu())
+            layers.append(
+                StreamableConv1d(
+                    channels,
+                    channels * 2,
+                    ratio * 2,
+                    stride=ratio,
+                    pad_mode=pad_mode,
+                )
+            )
+            channels *= 2
+        layers.append(_Elu())
+        layers.append(
+            StreamableConv1d(
+                channels, config.hidden_size, config.last_kernel_size, pad_mode=pad_mode
+            )
+        )
+        self.layers = layers
+
+    def __call__(self, x: mx.array) -> mx.array:
+        for layer in self.layers:
+            x = layer(x)
+        return x
+
+
+class EncoderAttention(nn.Module):
+    """Sliding-window causal attention with separate q/k/v projections."""
+
+    def __init__(self, config: TokenizerEncoderConfig) -> None:
+        super().__init__()
+        self.num_heads = config.num_attention_heads
+        self.num_kv_heads = config.num_key_value_heads
+        self.head_dim = config.head_dim
+        self.scale = self.head_dim**-0.5
+        bias = config.attention_bias
+        inner = self.num_heads * self.head_dim
+        kv_inner = self.num_kv_heads * self.head_dim
+        self.q_proj = nn.Linear(config.hidden_size, inner, bias=bias)
+        self.k_proj = nn.Linear(config.hidden_size, kv_inner, bias=bias)
+        self.v_proj = nn.Linear(config.hidden_size, kv_inner, bias=bias)
+        self.o_proj = nn.Linear(inner, config.hidden_size, bias=bias)
+        self.rope = nn.RoPE(self.head_dim, traditional=False, base=config.rope_theta)
+
+    def __call__(self, x: mx.array, mask: Optional[mx.array] = None) -> mx.array:
+        batch, length, _ = x.shape
+        queries = (
+            self.q_proj(x)
+            .reshape(batch, length, self.num_heads, self.head_dim)
+            .transpose(0, 2, 1, 3)
+        )
+        keys = (
+            self.k_proj(x)
+            .reshape(batch, length, self.num_kv_heads, self.head_dim)
+            .transpose(0, 2, 1, 3)
+        )
+        values = (
+            self.v_proj(x)
+            .reshape(batch, length, self.num_kv_heads, self.head_dim)
+            .transpose(0, 2, 1, 3)
+        )
+        queries = self.rope(queries)
+        keys = self.rope(keys)
+        output = mx.fast.scaled_dot_product_attention(
+            queries, keys, values, scale=self.scale, mask=mask
+        )
+        return self.o_proj(output.transpose(0, 2, 1, 3).reshape(batch, length, -1))
+
+
+class EncoderMLP(nn.Module):
+    """Two-layer feed-forward with exact (erf) GELU, per ``hidden_act``."""
+
+    def __init__(self, config: TokenizerEncoderConfig) -> None:
+        super().__init__()
+        self.fc1 = nn.Linear(config.hidden_size, config.intermediate_size, bias=False)
+        self.fc2 = nn.Linear(config.intermediate_size, config.hidden_size, bias=False)
+
+    def __call__(self, x: mx.array) -> mx.array:
+        return self.fc2(nn.gelu(self.fc1(x)))
+
+
+class EncoderTransformerLayer(nn.Module):
+    """Pre-norm layer with LayerNorm and learned residual scales."""
+
+    def __init__(self, config: TokenizerEncoderConfig) -> None:
+        super().__init__()
+        self.self_attn = EncoderAttention(config)
+        self.mlp = EncoderMLP(config)
+        self.input_layernorm = nn.LayerNorm(config.hidden_size, eps=config.norm_eps)
+        self.post_attention_layernorm = nn.LayerNorm(
+            config.hidden_size, eps=config.norm_eps
+        )
+        self.self_attn_layer_scale = LayerScale(
+            config.hidden_size, config.layer_scale_initial_scale
+        )
+        self.mlp_layer_scale = LayerScale(
+            config.hidden_size, config.layer_scale_initial_scale
+        )
+
+    def __call__(self, x: mx.array, mask: Optional[mx.array] = None) -> mx.array:
+        x = x + self.self_attn_layer_scale(
+            self.self_attn(self.input_layernorm(x), mask=mask)
+        )
+        return x + self.mlp_layer_scale(self.mlp(self.post_attention_layernorm(x)))
+
+
+class EncoderTransformer(nn.Module):
+    """Transformer over encoder frames, in NCL like the surrounding convs."""
+
+    def __init__(self, config: TokenizerEncoderConfig) -> None:
+        super().__init__()
+        self.config = config
+        self.layers = [
+            EncoderTransformerLayer(config) for _ in range(config.num_hidden_layers)
+        ]
+
+    def __call__(self, x: mx.array) -> mx.array:
+        mask = sliding_causal_mask(
+            x.shape[1], x.shape[1], self.config.sliding_window, x.dtype
+        )
+        for layer in self.layers:
+            x = layer(x, mask=mask)
+        return x
+
+
+class EncoderEuclideanCodebook(nn.Module):
+    """Nearest-codeword lookup over a folded codebook table."""
+
+    def __init__(self, dim: int, codebook_size: int) -> None:
+        super().__init__()
+        self.dim = dim
+        self.codebook_size = codebook_size
+        self.embed = nn.Embedding(codebook_size, dim)
+
+    def encode(self, x: mx.array) -> mx.array:
+        table = self.embed.weight.astype(mx.float32)
+        half_sq = (table**2).sum(axis=-1) / 2
+        flat = x.reshape(-1, x.shape[-1]).astype(mx.float32)
+        return mx.argmin(half_sq - flat @ table.T, axis=-1).reshape(x.shape[:-1])
+
+    def decode(self, codes: mx.array) -> mx.array:
+        return self.embed(codes)
+
+
+class EncoderVectorQuantization(nn.Module):
+    """One residual stage. ``codebook_dim == dim`` here, so no projections."""
+
+    def __init__(self, dim: int, codebook_size: int) -> None:
+        super().__init__()
+        self.codebook = EncoderEuclideanCodebook(dim, codebook_size)
+
+    def encode(self, x: mx.array) -> mx.array:
+        return self.codebook.encode(mx.swapaxes(x, -1, -2))
+
+    def decode(self, codes: mx.array) -> mx.array:
+        return mx.swapaxes(self.codebook.decode(codes), -1, -2)
+
+
+class EncoderResidualVectorQuantizer(nn.Module):
+    """Residual VQ stack with 1x1 input/output projections."""
+
+    def __init__(
+        self,
+        dim: int,
+        input_dim: int,
+        output_dim: int,
+        num_quantizers: int,
+        codebook_size: int,
+    ) -> None:
+        super().__init__()
+        self.input_proj = nn.Conv1d(input_dim, dim, 1, bias=False)
+        self.output_proj = nn.Conv1d(dim, output_dim, 1, bias=False)
+        self.layers = [
+            EncoderVectorQuantization(dim, codebook_size) for _ in range(num_quantizers)
+        ]
+
+    def encode(self, x: mx.array) -> mx.array:
+        projected = mx.swapaxes(self.input_proj(mx.swapaxes(x, -1, -2)), -1, -2)
+        codes = []
+        residual = projected
+        for layer in self.layers:
+            indices = layer.encode(residual)
+            residual = (
+                residual.astype(mx.float32) - layer.decode(indices).astype(mx.float32)
+            ).astype(projected.dtype)
+            codes.append(indices)
+        # [num_quantizers, batch, time] -> [batch, num_quantizers, time]
+        return mx.swapaxes(mx.stack(codes, axis=0), 0, 1)
+
+
+class EncoderSplitResidualVectorQuantizer(nn.Module):
+    """Semantic stage plus the acoustic remainder, both fed the same input."""
+
+    def __init__(self, config: TokenizerEncoderConfig) -> None:
+        super().__init__()
+        dim = config.vector_quantization_hidden_dimension
+        self.num_quantizers = config.num_quantizers
+        self.semantic_residual_vector_quantizer = EncoderResidualVectorQuantizer(
+            dim,
+            config.hidden_size,
+            config.hidden_size,
+            config.num_semantic_quantizers,
+            config.codebook_size,
+        )
+        self.acoustic_residual_vector_quantizer = EncoderResidualVectorQuantizer(
+            dim,
+            config.hidden_size,
+            config.hidden_size,
+            config.num_quantizers - config.num_semantic_quantizers,
+            config.codebook_size,
+        )
+
+    def encode(self, x: mx.array) -> mx.array:
+        codes = self.semantic_residual_vector_quantizer.encode(x)
+        if self.acoustic_residual_vector_quantizer.layers:
+            codes = mx.concatenate(
+                [codes, self.acoustic_residual_vector_quantizer.encode(x)], axis=1
+            )
+        return codes
+
+
+class Qwen3TTSSpeechTokenizerEncoder(nn.Module):
+    """Waveform -> codec frames.
+
+    Attribute names match the checkpoint (and ``MimiModel``): the inner
+    ``encoder`` is the convolutional trunk, followed by a transformer, a strided
+    downsample to the 12.5 Hz frame rate, and the split residual quantiser.
+    """
+
+    def __init__(
+        self,
+        config: TokenizerEncoderConfig,
+        valid_num_quantizers: int = 16,
+    ) -> None:
+        super().__init__()
+        self.config = config
+        self.valid_num_quantizers = valid_num_quantizers
+        self.encoder = SeanetEncoder(config)
+        self.encoder_transformer = EncoderTransformer(config)
+        encoder_frame_rate = config.sampling_rate / math.prod(config.upsampling_ratios)
+        stride = int(encoder_frame_rate / config.frame_rate)
+        # ``edge`` padding, unlike the SEANet trunk's zeros.
+        self.downsample = StreamableConv1d(
+            config.hidden_size,
+            config.hidden_size,
+            2 * stride,
+            stride=stride,
+            bias=False,
+            pad_mode="edge",
+        )
+        self.quantizer = EncoderSplitResidualVectorQuantizer(config)
+
+    def encode(self, audio: mx.array) -> mx.array:
+        """``[batch, 1, samples]`` -> ``[batch, valid_num_quantizers, frames]``."""
+        x = mx.swapaxes(audio, -1, -2)
+        x = self.encoder(x)
+        x = self.encoder_transformer(x)
+        x = self.downsample(x)
+        codes = self.quantizer.encode(mx.swapaxes(x, -1, -2))
+        return codes[:, : self.valid_num_quantizers, :]
+
+
+class Qwen3TTSSpeechTokenizer(nn.Module):
+    """Speech tokenizer wrapper. The encoder is optional: only Base voice
+    cloning needs waveform -> codes."""
+
+    def __init__(self, config: TokenizerConfig) -> None:
+        super().__init__()
+        self.config = config
+        self.decoder = Qwen3TTSSpeechTokenizerDecoder(config.decoder_config)
+        self.encoder = (
+            Qwen3TTSSpeechTokenizerEncoder(
+                config.encoder_config,
+                valid_num_quantizers=config.encoder_valid_num_quantizers,
+            )
+            if config.encoder_config is not None
+            else None
+        )
+        self.decode_upsample_rate = config.decode_upsample_rate
+        self.encode_downsample_rate = config.encode_downsample_rate
+
+    @property
+    def sample_rate(self) -> int:
+        return self.config.output_sample_rate
+
+    @property
+    def has_encoder(self) -> bool:
+        return self.encoder is not None
+
+    def encode(self, audio: mx.array) -> mx.array:
+        """``[batch, 1, samples]`` waveform -> ``[batch, groups, frames]`` codes."""
+        if self.encoder is None:
+            raise ValueError(
+                "This speech tokenizer has no encoder; only Base checkpoints "
+                "ship one, and only voice cloning needs it"
+            )
+        return self.encoder.encode(audio)
+
+    def decode(self, audio_codes: mx.array) -> Tuple[mx.array, mx.array]:
+        """``[batch, time, groups]`` codes -> ``([batch, samples], [batch])``.
+
+        Lengths come from the count of non-padding group-0 codes, matching the
+        reference's trimming rule.
+        """
+        codes = mx.transpose(audio_codes, (0, 2, 1))
+        waveform = self.decoder(codes).squeeze(1)
+        lengths = (audio_codes[..., 0] > 0).sum(axis=-1) * self.decode_upsample_rate
+        return waveform, lengths
+
+    def streaming_decode(self, audio_codes: mx.array, chunk_tokens: int = 100):
+        """Yield waveform chunks for ``[batch, time, groups]`` codes."""
+        codes = mx.transpose(audio_codes, (0, 2, 1))
+        total = codes.shape[-1]
+        self.decoder.reset_streaming_state()
+        start = 0
+        while start < total:
+            end = min(start + chunk_tokens, total)
+            yield self.decoder.streaming_step(codes[..., start:end])
+            start = end
+
+    def sanitize(self, weights: Dict[str, mx.array]) -> Dict[str, mx.array]:
+        """Fold codebook statistics into lookup tables; keep names otherwise.
+
+        Both halves store each codebook as a running sum plus a usage count,
+        and the usable table is their ratio with the denominator floored. The
+        decoder spells this ``._codebook.embedding_sum`` and the encoder
+        ``.codebook.embed_sum``, so both spellings are folded to
+        ``.codebook.embed.weight``. ``initialized`` is training state and is
+        dropped.
+
+        Every other key passes through unchanged, because this port mirrors the
+        checkpoint's own module layout. Convolution layout is fixed separately
+        by :func:`~sglang_omni.models.qwen3_tts.mlx.weights.align_conv_weights`.
+
+        When this tokenizer was built without an encoder, the checkpoint's
+        encoder subtree is dropped so a strict load still succeeds.
+        """
+        sanitized: Dict[str, mx.array] = {}
+        codebooks: Dict[str, Dict[str, mx.array]] = {}
+        skip_encoder = self.encoder is None
+
+        for key, value in weights.items():
+            if skip_encoder and key.startswith("encoder."):
+                continue
+            base = None
+            for marker in ("._codebook.", ".codebook."):
+                if marker in key:
+                    base, _, stat = key.rpartition(marker)
+                    if stat == "cluster_usage":
+                        codebooks.setdefault(base, {})["usage"] = value
+                    elif stat in ("embedding_sum", "embed_sum"):
+                        codebooks.setdefault(base, {})["sum"] = value
+                    break
+            if base is None:
+                sanitized[key] = value
+
+        for base, entry in codebooks.items():
+            if "sum" not in entry or "usage" not in entry:
+                continue
+            usage = mx.clip(entry["usage"][:, None], 1e-5, None)
+            sanitized[f"{base}.codebook.embed.weight"] = entry["sum"] / usage
+
+        return sanitized

--- a/sglang_omni/models/qwen3_tts/mlx/streaming_vocoder.py
+++ b/sglang_omni/models/qwen3_tts/mlx/streaming_vocoder.py
@@ -1,0 +1,318 @@
+# SPDX-License-Identifier: Apache-2.0
+"""MLX streaming vocoder stage for Qwen3-TTS.
+
+Plugs the MLX speech-tokenizer decoder into Omni's
+:class:`StreamingVocoderBase`, so the stage lifecycle, chunk ingestion and
+payload emission are the shared ones and only the codec call is model specific.
+
+Two differences from the CUDA vocoder. It has no CUDA graphs or pinned staging,
+because neither exists on Metal. And it decodes *statefully*: the MLX decoder
+keeps convolution tails, overlap-add remainders and transformer KV per request,
+so each step decodes only the newly arrived frames instead of re-running a
+left-context window. Those buffers live on the shared decoder module, so every
+request owns a session that is swapped in around its own steps.
+"""
+
+from __future__ import annotations
+
+import logging
+from dataclasses import dataclass, field
+from typing import Any, Mapping
+
+import mlx.core as mx
+import numpy as np
+import torch
+
+from sglang_omni.models.qwen3_tts.payload_types import Qwen3TTSState
+from sglang_omni.proto import StagePayload
+from sglang_omni.scheduling.pipeline_state import build_usage
+from sglang_omni.scheduling.streaming_vocoder import StreamingVocoderBase
+from sglang_omni.utils.audio_payload import audio_waveform_payload
+
+logger = logging.getLogger(__name__)
+
+DEFAULT_MLX_STREAM_STRIDE = 8
+CODEBOOK_SIZE = 2048
+
+
+@dataclass
+class Qwen3TTSMlxStreamState:
+    """Per-request vocoder state.
+
+    ``session`` holds this request's decoder streaming buffers; ``ref_frames``
+    is how many leading frames are reference audio whose waveform must not be
+    emitted.
+    """
+
+    session: dict = field(default_factory=dict)
+    pending: list[np.ndarray] = field(default_factory=list)
+    num_quantizers: int | None = None
+    ref_frames: int = 0
+    pending_ref_frames: int = 0
+    ref_frames_consumed: int = 0
+    emitted_frames: int = 0
+    total_frames: int = 0
+
+
+class Qwen3TTSMlxStreamingVocoder(StreamingVocoderBase[Qwen3TTSMlxStreamState, None]):
+    """Decodes Qwen3-TTS codec frames to 24 kHz PCM with MLX."""
+
+    def __init__(
+        self,
+        speech_tokenizer: Any,
+        *,
+        sample_rate: int = 24000,
+        stream_stride: int = DEFAULT_MLX_STREAM_STRIDE,
+        initial_chunk_frames: int | None = None,
+        max_batch_size: int = 1,
+        max_batch_wait_ms: int = 0,
+        abort_callback: Any = None,
+    ) -> None:
+        self._tokenizer = speech_tokenizer
+        self._decoder = speech_tokenizer.decoder
+        self._stream_stride = max(1, int(stream_stride))
+        self._initial_chunk_frames = (
+            self._stream_stride
+            if initial_chunk_frames is None
+            else max(1, int(initial_chunk_frames))
+        )
+        super().__init__(
+            self._vocode_payload,
+            sample_rate=sample_rate,
+            stream_source_hint="qwen3-tts-mlx",
+            batch_compute_fn=None,
+            max_batch_size=max_batch_size,
+            max_batch_wait_ms=max_batch_wait_ms,
+            abort_callback=abort_callback,
+        )
+
+    # -- lifecycle ------------------------------------------------------
+
+    def create_stream_state(self, request_id: str) -> Qwen3TTSMlxStreamState:
+        del request_id
+        return Qwen3TTSMlxStreamState(session=self._decoder.new_streaming_session())
+
+    def latch_stream_contract(
+        self,
+        request_id: str,
+        state: Qwen3TTSMlxStreamState,
+        source: StagePayload | Mapping[str, Any],
+        *,
+        origin: str,
+    ) -> None:
+        """Latch how many leading frames are reference audio.
+
+        Voice cloning streams the reference codes ahead of the generated ones so
+        the decoder starts from the reference's acoustic state; their waveform is
+        dropped. The count is immutable once latched.
+        """
+        metadata = source.data if origin == "payload" else source
+        if not isinstance(metadata, Mapping) or "ref_code_len" not in metadata:
+            return
+        ref_frames = int(metadata["ref_code_len"] or 0)
+        if ref_frames < 0:
+            raise ValueError(
+                f"Qwen3-TTS ref_code_len for {request_id!r} must not be negative"
+            )
+        if state.total_frames or state.ref_frames:
+            if ref_frames != state.ref_frames:
+                raise ValueError(
+                    f"Qwen3-TTS ref_code_len for {request_id!r} changed after "
+                    "frames were already ingested"
+                )
+            return
+        state.pending_ref_frames = ref_frames
+
+    def release_stream_resources(
+        self, request_id: str, state: Qwen3TTSMlxStreamState
+    ) -> None:
+        del request_id
+        # Dropping the session frees this request's conv tails and KV.
+        state.session = {}
+        state.pending = []
+
+    def on_serving_stop(self) -> None:
+        # Reclaim MLX buffers once, at teardown, never inside the decode loop.
+        mx.clear_cache()
+
+    # -- ingestion ------------------------------------------------------
+
+    def validate_chunk(
+        self,
+        request_id: str,
+        state: Qwen3TTSMlxStreamState,
+        codes: torch.Tensor,
+    ) -> torch.Tensor:
+        if codes.ndim != 2:
+            raise ValueError(
+                f"Qwen3-TTS stream chunk for {request_id!r} must be "
+                f"[frames, quantizers], got shape {tuple(codes.shape)}"
+            )
+        if state.num_quantizers is None:
+            state.num_quantizers = int(codes.shape[1])
+        elif int(codes.shape[1]) != state.num_quantizers:
+            raise ValueError(
+                f"Qwen3-TTS stream chunk has {int(codes.shape[1])} quantizers, "
+                f"expected {state.num_quantizers}"
+            )
+        if bool((codes < 0).any()) or bool((codes >= CODEBOOK_SIZE).any()):
+            raise ValueError(
+                f"Qwen3-TTS stream chunk for {request_id!r} contains codec ids "
+                f"outside [0, {CODEBOOK_SIZE})"
+            )
+        return codes
+
+    def ingest(
+        self,
+        request_id: str,
+        state: Qwen3TTSMlxStreamState,
+        codes: torch.Tensor,
+    ) -> None:
+        del request_id
+        if state.pending_ref_frames:
+            state.ref_frames = state.pending_ref_frames
+            state.pending_ref_frames = 0
+        frames = np.asarray(codes.detach().cpu().numpy(), dtype=np.int32)
+        state.pending.append(frames)
+        state.total_frames += int(frames.shape[0])
+
+    def should_decode(self, state: Qwen3TTSMlxStreamState, *, is_final: bool) -> bool:
+        if is_final:
+            return True
+        buffered = sum(int(chunk.shape[0]) for chunk in state.pending)
+        # Reference frames only prime the decoder, so they never count toward
+        # the emit threshold.
+        priming = max(0, state.ref_frames - state.ref_frames_consumed)
+        threshold = (
+            self._initial_chunk_frames
+            if state.emitted_frames == 0
+            else self._stream_stride
+        )
+        return buffered - priming >= threshold
+
+    # -- decode ---------------------------------------------------------
+
+    def decode_delta(
+        self,
+        request_id: str,
+        state: Qwen3TTSMlxStreamState,
+        *,
+        is_final: bool,
+    ) -> torch.Tensor | None:
+        del request_id, is_final
+        if not state.pending:
+            return None
+
+        frames = np.concatenate(state.pending, axis=0)
+        state.pending = []
+
+        # [frames, groups] -> [1, groups, frames]
+        codes = mx.array(frames)[None].transpose(0, 2, 1)
+        with self._decoder.streaming_session(state.session):
+            waveform = self._decoder.streaming_step(codes)
+        audio = waveform.squeeze(1)[0]
+        mx.eval(audio)
+
+        upsample = self._decoder.total_upsample
+        emitted = int(frames.shape[0])
+
+        # Drop the waveform belonging to reference frames still being consumed.
+        priming = min(max(0, state.ref_frames - state.ref_frames_consumed), emitted)
+        if priming:
+            state.ref_frames_consumed += priming
+            audio = audio[priming * upsample :]
+        state.emitted_frames += emitted - priming
+
+        if audio.shape[0] == 0:
+            return None
+        return torch.from_numpy(np.array(audio, dtype=np.float32))
+
+    # -- terminal payloads ----------------------------------------------
+
+    def final_result_data(
+        self,
+        request_id: str,
+        payload: StagePayload,
+        state: Qwen3TTSMlxStreamState,
+    ) -> dict[str, Any]:
+        del request_id, state
+        final_state = Qwen3TTSState.from_dict(payload.data)
+        data: dict[str, Any] = {
+            "modality": "audio",
+            "sample_rate": self._sample_rate,
+        }
+        usage = build_usage(final_state)
+        if usage is not None:
+            data["usage"] = usage
+        return data
+
+    def fallback_full_decode(
+        self,
+        request_id: str,
+        payload: StagePayload,
+        state: Qwen3TTSMlxStreamState,
+    ) -> torch.Tensor | None:
+        """Decode the whole utterance when streaming emitted nothing."""
+        del request_id
+        codes = self._payload_codes(payload)
+        if codes is None:
+            return None
+        return self._decode_whole(codes, ref_frames=state.ref_frames)
+
+    # -- non-streaming requests -----------------------------------------
+
+    async def _vocode_payload(self, payload: StagePayload) -> StagePayload:
+        """Whole-utterance path for a request that never streamed."""
+        state = Qwen3TTSState.from_dict(payload.data)
+        codes = self._payload_codes(payload)
+        if codes is None:
+            raise RuntimeError(
+                "Qwen3-TTS MLX vocoder requires audio_codes from tts_engine"
+            )
+        waveform = self._decode_whole(codes, ref_frames=int(state.ref_code_len or 0))
+
+        data = audio_waveform_payload(
+            waveform,
+            sample_rate=self._sample_rate,
+            modality="audio",
+            source_hint=self._stream_source_hint,
+        )
+        usage = build_usage(state)
+        if usage is not None:
+            data["usage"] = usage
+        payload.data = data
+        return payload
+
+    @staticmethod
+    def _payload_codes(payload: StagePayload) -> np.ndarray | None:
+        state = Qwen3TTSState.from_dict(payload.data)
+        codes = state.audio_codes
+        if codes is None:
+            return None
+        if isinstance(codes, list):
+            if not codes:
+                return None
+            stacked = [
+                (
+                    entry.detach().cpu().numpy()
+                    if hasattr(entry, "detach")
+                    else np.asarray(entry)
+                )
+                for entry in codes
+            ]
+            return np.stack(stacked, axis=0).astype(np.int32)
+        if hasattr(codes, "detach"):
+            return codes.detach().cpu().numpy().astype(np.int32)
+        return np.asarray(codes, dtype=np.int32)
+
+    def _decode_whole(self, frames: np.ndarray, *, ref_frames: int) -> torch.Tensor:
+        """Decode ``[frames, groups]`` in one pass and trim the reference span."""
+        codes = mx.array(frames)[None]
+        waveform, _ = self._tokenizer.decode(codes)
+        audio = waveform[0]
+        mx.eval(audio)
+        if ref_frames:
+            cut = ref_frames * self._decoder.total_upsample
+            if 0 < cut < audio.shape[0]:
+                audio = audio[cut:]
+        return torch.from_numpy(np.array(audio, dtype=np.float32))

--- a/sglang_omni/models/qwen3_tts/mlx/talker.py
+++ b/sglang_omni/models/qwen3_tts/mlx/talker.py
@@ -1,0 +1,494 @@
+# SPDX-License-Identifier: MIT
+# Derived from mlx-audio Qwen3-TTS (Copyright 2025 Prince Canuma and contributors).
+"""MLX Qwen3-TTS talker, adapted to SGLang's MLX attention contract.
+
+Two deliberate departures from the mlx-audio reference:
+
+*Plain RoPE instead of external MRoPE.*  mlx-audio computes interleaved MRoPE
+in ``TalkerRotaryEmbedding`` and threads ``(cos, sin)`` through every layer, so
+its attention takes ``position_embeddings`` and owns no ``rope``.  SGLang's
+``MLXAttentionWrapper`` instead requires ``rope`` on the attention module and
+calls it with per-request offsets, which is what makes generic batched decode
+work.  The two are numerically identical here: Qwen3-TTS drives the talker with
+``position_ids = stack([pos, pos, pos])`` (and SGLang's CUDA path likewise
+builds three identical M-RoPE rows), and interleaved MRoPE over three equal
+rows collapses to its temporal row -- i.e. ordinary 1-D RoPE.  That collapse is
+pinned by ``tests/unit_test/qwen3_tts/test_mlx_talker.py``.  Positions therefore
+come only from cache offsets; this port accepts no ``position_ids``.
+
+*No padded-batch attention mask.*  mlx-audio left-pads a batch into one shared
+cache and passes an ``attention_mask``.  SGLang keeps one cache per request and
+batches through the wrapper, so there is nothing to pad.
+"""
+
+from __future__ import annotations
+
+from typing import Any, Callable, Dict, List, Optional, Tuple, Union
+
+import mlx.core as mx
+import mlx.nn as nn
+from mlx_lm.models.base import create_attention_mask, scaled_dot_product_attention
+
+from .config import CodePredictorConfig, TalkerConfig
+
+
+def _rope_safe(rope: nn.RoPE, x: mx.array, offset: int) -> mx.array:
+    """Apply RoPE, working around an mx.fast.rope bug.
+
+    For a 4D tensor (B, heads, L, dim) with L == 1 and B > 1, mx.fast.rope
+    (used by nn.RoPE) corrupts every batch row except the first on Metal. This
+    only bites a shared-cache batched decode; SGLang's per-request decode goes
+    through MLXAttentionWrapper with array offsets instead. Padding the
+    sequence to length 2 and slicing keeps the fast kernel while producing the
+    exact correct result. Mirrors the same helper in the Qwen3-ASR MLX port.
+    """
+    if x.ndim == 4 and x.shape[0] > 1 and x.shape[2] == 1:
+        x = mx.concatenate([x, mx.zeros_like(x)], axis=2)
+        return rope(x, offset=offset)[:, :, :1, :]
+    return rope(x, offset=offset)
+
+
+class _QKNormAttention(nn.Module):
+    """Grouped-query attention with Q/K norms and SGLang-compatible RoPE.
+
+    Satisfies SGLang's MLX attention contract: ``q_proj``/``k_proj``/``v_proj``/
+    ``o_proj``/``rope`` plus ``scale`` and head counts, called as
+    ``(x, mask=..., cache=...)``.
+    """
+
+    def __init__(
+        self,
+        config: Union[TalkerConfig, CodePredictorConfig],
+        layer_idx: int,
+    ) -> None:
+        super().__init__()
+        self.config = config
+        self.layer_idx = layer_idx
+        self.hidden_size = config.hidden_size
+        self.num_heads = config.num_attention_heads
+        self.num_kv_heads = config.num_key_value_heads
+        self.head_dim = config.head_dim
+        self.scale = self.head_dim**-0.5
+
+        self.q_proj = nn.Linear(
+            self.hidden_size,
+            self.num_heads * self.head_dim,
+            bias=config.attention_bias,
+        )
+        self.k_proj = nn.Linear(
+            self.hidden_size,
+            self.num_kv_heads * self.head_dim,
+            bias=config.attention_bias,
+        )
+        self.v_proj = nn.Linear(
+            self.hidden_size,
+            self.num_kv_heads * self.head_dim,
+            bias=config.attention_bias,
+        )
+        self.o_proj = nn.Linear(
+            self.num_heads * self.head_dim,
+            self.hidden_size,
+            bias=config.attention_bias,
+        )
+
+        self.q_norm = nn.RMSNorm(self.head_dim, eps=config.rms_norm_eps)
+        self.k_norm = nn.RMSNorm(self.head_dim, eps=config.rms_norm_eps)
+        self.rope = nn.RoPE(self.head_dim, traditional=False, base=config.rope_theta)
+
+    def __call__(
+        self,
+        hidden_states: mx.array,
+        mask: Optional[Union[str, mx.array]] = None,
+        cache: Optional[Any] = None,
+    ) -> mx.array:
+        B, L, _ = hidden_states.shape
+
+        queries = self.q_proj(hidden_states).reshape(
+            B, L, self.num_heads, self.head_dim
+        )
+        keys = self.k_proj(hidden_states).reshape(
+            B, L, self.num_kv_heads, self.head_dim
+        )
+        values = self.v_proj(hidden_states).reshape(
+            B, L, self.num_kv_heads, self.head_dim
+        )
+
+        queries = self.q_norm(queries)
+        keys = self.k_norm(keys)
+
+        queries = queries.transpose(0, 2, 1, 3)
+        keys = keys.transpose(0, 2, 1, 3)
+        values = values.transpose(0, 2, 1, 3)
+
+        if cache is not None:
+            offset = cache.offset
+            queries = _rope_safe(self.rope, queries, offset)
+            keys = _rope_safe(self.rope, keys, offset)
+            keys, values = cache.update_and_fetch(keys, values)
+        else:
+            queries = self.rope(queries)
+            keys = self.rope(keys)
+
+        output = scaled_dot_product_attention(
+            queries,
+            keys,
+            values,
+            cache=cache,
+            scale=self.scale,
+            mask=mask,
+        )
+        output = output.transpose(0, 2, 1, 3).reshape(B, L, -1)
+        return self.o_proj(output)
+
+
+class TalkerAttention(_QKNormAttention):
+    """Talker self-attention (1-D RoPE; see the module docstring)."""
+
+
+class CodePredictorAttention(_QKNormAttention):
+    """Code-predictor self-attention."""
+
+
+class MLP(nn.Module):
+    """SwiGLU feed-forward block."""
+
+    def __init__(self, hidden_size: int, intermediate_size: int) -> None:
+        super().__init__()
+        self.gate_proj = nn.Linear(hidden_size, intermediate_size, bias=False)
+        self.up_proj = nn.Linear(hidden_size, intermediate_size, bias=False)
+        self.down_proj = nn.Linear(intermediate_size, hidden_size, bias=False)
+
+    def __call__(self, x: mx.array) -> mx.array:
+        return self.down_proj(nn.silu(self.gate_proj(x)) * self.up_proj(x))
+
+
+class ResizeMLP(nn.Module):
+    """Two-layer projection between the text and talker hidden sizes."""
+
+    def __init__(
+        self,
+        input_size: int,
+        intermediate_size: int,
+        output_size: int,
+        hidden_act: str = "silu",
+        bias: bool = True,
+    ) -> None:
+        super().__init__()
+        self.linear_fc1 = nn.Linear(input_size, intermediate_size, bias=bias)
+        self.linear_fc2 = nn.Linear(intermediate_size, output_size, bias=bias)
+        self.act_fn = {
+            "silu": nn.silu,
+            "gelu": nn.gelu,
+            "relu": nn.relu,
+        }.get(hidden_act, nn.silu)
+
+    def __call__(self, x: mx.array) -> mx.array:
+        return self.linear_fc2(self.act_fn(self.linear_fc1(x)))
+
+
+class _DecoderLayer(nn.Module):
+    """Pre-norm transformer decoder layer."""
+
+    def __init__(
+        self,
+        config: Union[TalkerConfig, CodePredictorConfig],
+        layer_idx: int,
+        attention_cls: type,
+    ) -> None:
+        super().__init__()
+        self.hidden_size = config.hidden_size
+        self.self_attn = attention_cls(config, layer_idx)
+        self.mlp = MLP(config.hidden_size, config.intermediate_size)
+        self.input_layernorm = nn.RMSNorm(config.hidden_size, eps=config.rms_norm_eps)
+        self.post_attention_layernorm = nn.RMSNorm(
+            config.hidden_size, eps=config.rms_norm_eps
+        )
+
+    def __call__(
+        self,
+        hidden_states: mx.array,
+        mask: Optional[Union[str, mx.array]] = None,
+        cache: Optional[Any] = None,
+    ) -> mx.array:
+        residual = hidden_states
+        hidden_states = self.input_layernorm(hidden_states)
+        hidden_states = self.self_attn(hidden_states, mask=mask, cache=cache)
+        hidden_states = residual + hidden_states
+
+        residual = hidden_states
+        hidden_states = self.post_attention_layernorm(hidden_states)
+        hidden_states = self.mlp(hidden_states)
+        return residual + hidden_states
+
+
+class TalkerDecoderLayer(_DecoderLayer):
+    def __init__(self, config: TalkerConfig, layer_idx: int) -> None:
+        super().__init__(config, layer_idx, TalkerAttention)
+
+
+class CodePredictorDecoderLayer(_DecoderLayer):
+    def __init__(self, config: CodePredictorConfig, layer_idx: int) -> None:
+        super().__init__(config, layer_idx, CodePredictorAttention)
+
+
+class Qwen3TTSTalkerModel(nn.Module):
+    """Talker transformer trunk.
+
+    This is the container SGLang discovers (``model.layers``), so its KV is the
+    persistent, pool-backed cache. Attribute names are deliberately free of
+    ``sliding_window``/``window_size``/``layer_types``: the talker uses full
+    attention, and those names would make SGLang treat it as sliding-window.
+    """
+
+    def __init__(self, config: TalkerConfig) -> None:
+        super().__init__()
+        self.config = config
+        self.hidden_size = config.hidden_size
+        self.codec_embedding = nn.Embedding(config.vocab_size, config.hidden_size)
+        self.text_embedding = nn.Embedding(
+            config.text_vocab_size, config.text_hidden_size
+        )
+        self.layers = [
+            TalkerDecoderLayer(config, i) for i in range(config.num_hidden_layers)
+        ]
+        self.norm = nn.RMSNorm(config.hidden_size, eps=config.rms_norm_eps)
+
+    def __call__(
+        self,
+        inputs_embeds: mx.array,
+        cache: Optional[List[Any]] = None,
+        mask: Optional[Union[str, mx.array]] = None,
+    ) -> mx.array:
+        if cache is None:
+            cache = [None] * len(self.layers)
+        if mask is None:
+            mask = create_attention_mask(inputs_embeds, cache[0])
+
+        hidden_states = inputs_embeds
+        for layer, layer_cache in zip(self.layers, cache):
+            hidden_states = layer(hidden_states, mask=mask, cache=layer_cache)
+        return self.norm(hidden_states)
+
+    def make_cache(self) -> List[Any]:
+        from mlx_lm.models.cache import KVCache
+
+        return [KVCache() for _ in self.layers]
+
+
+class CodePredictorModel(nn.Module):
+    """Code-predictor trunk, matching the ``code_predictor.model.*`` weights."""
+
+    def __init__(self, config: CodePredictorConfig, talker_hidden_size: int) -> None:
+        super().__init__()
+        self.config = config
+        # Groups 1..N-1 embed in talker hidden size; group 0 reuses the
+        # talker's own codec_embedding.
+        self.codec_embedding = [
+            nn.Embedding(config.vocab_size, talker_hidden_size)
+            for _ in range(config.num_code_groups - 1)
+        ]
+        self.layers = [
+            CodePredictorDecoderLayer(config, i)
+            for i in range(config.num_hidden_layers)
+        ]
+        self.norm = nn.RMSNorm(config.hidden_size, eps=config.rms_norm_eps)
+
+    def __call__(
+        self,
+        inputs_embeds: mx.array,
+        cache: Optional[List[Any]] = None,
+        mask: Optional[Union[str, mx.array]] = None,
+    ) -> mx.array:
+        if cache is None:
+            cache = [None] * len(self.layers)
+        if mask is None:
+            mask = create_attention_mask(inputs_embeds, cache[0])
+
+        hidden_states = inputs_embeds
+        for layer, layer_cache in zip(self.layers, cache):
+            hidden_states = layer(hidden_states, mask=mask, cache=layer_cache)
+        return self.norm(hidden_states)
+
+    def make_cache(self) -> List[Any]:
+        from mlx_lm.models.cache import KVCache
+
+        return [KVCache() for _ in self.layers]
+
+
+def reset_code_cache(cache: List[Any]) -> None:
+    """Clear a code-predictor cache in place for the next codec frame.
+
+    The predictor restarts from position 0 on every frame, so its KV is
+    frame-local. Resetting in place keeps the per-frame allocation out of the
+    decode hot loop.
+    """
+    for entry in cache:
+        entry.keys = None
+        entry.values = None
+        entry.offset = 0
+
+
+class Qwen3TTSCodePredictor(nn.Module):
+    """Predicts codec groups 1..N-1 from group 0 and the talker hidden state."""
+
+    def __init__(self, config: CodePredictorConfig, talker_hidden_size: int) -> None:
+        super().__init__()
+        self.config = config
+        self.num_code_groups = config.num_code_groups
+        self.talker_hidden_size = talker_hidden_size
+
+        if config.hidden_size != talker_hidden_size:
+            self.small_to_mtp_projection = nn.Linear(
+                talker_hidden_size, config.hidden_size, bias=True
+            )
+        else:
+            self.small_to_mtp_projection = None
+
+        self.model = CodePredictorModel(config, talker_hidden_size)
+        self.lm_head = [
+            nn.Linear(config.hidden_size, config.vocab_size, bias=False)
+            for _ in range(config.num_code_groups - 1)
+        ]
+
+    @property
+    def codec_embedding(self) -> List[nn.Embedding]:
+        return self.model.codec_embedding
+
+    def project_input(self, hidden_states: mx.array) -> mx.array:
+        if self.small_to_mtp_projection is None:
+            return hidden_states
+        return self.small_to_mtp_projection(hidden_states)
+
+    def __call__(
+        self,
+        inputs_embeds: mx.array,
+        cache: Optional[List[Any]] = None,
+        generation_step: int = 0,
+    ) -> mx.array:
+        hidden_states = self.model(self.project_input(inputs_embeds), cache=cache)
+        return self.lm_head[generation_step](hidden_states)
+
+    def make_cache(self) -> List[Any]:
+        return self.model.make_cache()
+
+
+def greedy_code_sampler(logits: mx.array, group_index: int) -> mx.array:
+    """Default code sampler: argmax over ``[B, vocab]``, returning ``[B, 1]``."""
+    del group_index
+    return mx.argmax(logits, axis=-1, keepdims=True)
+
+
+class Qwen3TTSTalkerForConditionalGeneration(nn.Module):
+    """Full Qwen3-TTS talker: trunk + codec head + code predictor."""
+
+    def __init__(self, config: TalkerConfig) -> None:
+        super().__init__()
+        self.config = config
+        self.model = Qwen3TTSTalkerModel(config)
+        self.text_projection = ResizeMLP(
+            config.text_hidden_size,
+            config.text_hidden_size,
+            config.hidden_size,
+            config.hidden_act,
+            bias=True,
+        )
+        self.codec_head = nn.Linear(config.hidden_size, config.vocab_size, bias=False)
+        self.code_predictor = Qwen3TTSCodePredictor(
+            config.code_predictor_config,
+            config.hidden_size,
+        )
+
+    def get_input_embeddings(self) -> nn.Embedding:
+        return self.model.codec_embedding
+
+    def get_text_embeddings(self) -> nn.Embedding:
+        return self.model.text_embedding
+
+    def __call__(
+        self,
+        inputs_embeds: mx.array,
+        cache: Optional[List[Any]] = None,
+        mask: Optional[Union[str, mx.array]] = None,
+    ) -> Tuple[mx.array, mx.array]:
+        """Return ``(codec logits, hidden states)`` for ``inputs_embeds``."""
+        hidden_states = self.model(inputs_embeds, cache=cache, mask=mask)
+        return self.codec_head(hidden_states), hidden_states
+
+    def codec_embeds_for_codes(self, codes: List[mx.array]) -> mx.array:
+        """Sum the per-group codec embeddings of one frame's codes.
+
+        ``codes[0]`` uses the talker's own codec embedding; groups 1..N-1 use
+        the predictor's. The result is the codec half of the next talker input.
+        """
+        summed = self.get_input_embeddings()(codes[0])
+        for index, code in enumerate(codes[1:]):
+            summed = summed + self.code_predictor.codec_embedding[index](code)
+        return summed
+
+    def predict_codes(
+        self,
+        first_code: mx.array,
+        talker_hidden: mx.array,
+        *,
+        cache: Optional[List[Any]] = None,
+        sampler: Callable[[mx.array, int], mx.array] = greedy_code_sampler,
+    ) -> Tuple[mx.array, mx.array]:
+        """Expand codec group 0 into a full frame of ``num_code_groups`` codes.
+
+        ``first_code`` is ``[B, 1]`` and ``talker_hidden`` is ``[B, L, H]``
+        (only its last position is read). ``sampler`` receives ``[B, vocab]``
+        logits plus the 0-based group offset, so callers own group-specific
+        sampling parameters; it defaults to greedy.
+
+        Returns ``(codes [B, num_code_groups], summed codec embedding
+        [B, 1, H])``. Everything stays lazy: no ``mx.eval`` here.
+        """
+        if cache is None:
+            cache = self.code_predictor.make_cache()
+        else:
+            reset_code_cache(cache)
+
+        codes = [first_code]
+        code_hidden = talker_hidden[:, -1:, :]
+        num_groups = self.config.code_predictor_config.num_code_groups
+
+        for group_index in range(num_groups - 1):
+            if group_index == 0:
+                # Prime the frame with the talker hidden state followed by the
+                # group-0 embedding, matching the reference two-token prefill.
+                predictor_input = mx.concatenate(
+                    [code_hidden, self.get_input_embeddings()(first_code)],
+                    axis=1,
+                )
+            else:
+                predictor_input = self.code_predictor.codec_embedding[group_index - 1](
+                    codes[-1]
+                )
+
+            logits = self.code_predictor(
+                predictor_input,
+                cache=cache,
+                generation_step=group_index,
+            )
+            codes.append(sampler(logits[:, -1, :], group_index))
+
+        return mx.concatenate(codes, axis=1), self.codec_embeds_for_codes(codes)
+
+    def make_cache(self) -> List[Any]:
+        return self.model.make_cache()
+
+    @staticmethod
+    def sanitize(weights: Dict[str, mx.array]) -> Dict[str, mx.array]:
+        """Keep the talker subtree of a Qwen3-TTS checkpoint, unprefixed.
+
+        MLX ``nn.Linear`` uses the same ``[out, in]`` layout as PyTorch, so no
+        transposition is needed. Checkpoints that are already talker-scoped
+        pass through unchanged.
+        """
+        if not any(key.startswith("talker.") for key in weights):
+            return dict(weights)
+        return {
+            key[len("talker.") :]: value
+            for key, value in weights.items()
+            if key.startswith("talker.")
+        }

--- a/sglang_omni/models/qwen3_tts/mlx/vocoder_loader.py
+++ b/sglang_omni/models/qwen3_tts/mlx/vocoder_loader.py
@@ -1,0 +1,67 @@
+# SPDX-License-Identifier: Apache-2.0
+"""Build the MLX Qwen3-TTS vocoder stage from a checkpoint."""
+
+from __future__ import annotations
+
+import json
+import logging
+from pathlib import Path
+from typing import Any
+
+import mlx.core as mx
+
+logger = logging.getLogger(__name__)
+
+
+def load_mlx_speech_tokenizer(model_path: str | Path) -> Any:
+    """Load the speech tokenizer from a checkpoint's ``speech_tokenizer/``."""
+    from .config import TokenizerConfig
+    from .speech_tokenizer import Qwen3TTSSpeechTokenizer
+    from .weights import align_conv_weights
+
+    tokenizer_dir = Path(model_path) / "speech_tokenizer"
+    config_path = tokenizer_dir / "config.json"
+    if not config_path.exists():
+        raise FileNotFoundError(
+            f"Qwen3-TTS MLX vocoder needs {config_path}; the checkpoint has no "
+            "speech tokenizer"
+        )
+
+    config = TokenizerConfig.from_dict(json.loads(config_path.read_text()))
+    tokenizer = Qwen3TTSSpeechTokenizer(config)
+    weights = mx.load(str(tokenizer_dir / "model.safetensors"))
+    tokenizer.load_weights(
+        list(align_conv_weights(tokenizer.sanitize(weights), tokenizer).items()),
+        strict=True,
+    )
+    tokenizer.eval()
+    mx.eval(tokenizer.parameters())
+    return tokenizer
+
+
+def create_mlx_vocoder_scheduler(
+    model_path: str,
+    *,
+    stream_stride: int | None = None,
+    initial_chunk_frames: int | None = None,
+    max_batch_size: int = 1,
+    max_batch_wait_ms: int = 0,
+) -> Any:
+    """Construct the MLX vocoder stage scheduler."""
+    from .streaming_vocoder import (
+        DEFAULT_MLX_STREAM_STRIDE,
+        Qwen3TTSMlxStreamingVocoder,
+    )
+
+    tokenizer = load_mlx_speech_tokenizer(model_path)
+    logger.info("Loaded MLX Qwen3-TTS speech tokenizer from %s", model_path)
+    return Qwen3TTSMlxStreamingVocoder(
+        tokenizer,
+        sample_rate=int(tokenizer.sample_rate),
+        stream_stride=(
+            DEFAULT_MLX_STREAM_STRIDE if stream_stride is None else stream_stride
+        ),
+        initial_chunk_frames=initial_chunk_frames,
+        max_batch_size=max_batch_size,
+        max_batch_wait_ms=max_batch_wait_ms,
+    )

--- a/sglang_omni/models/qwen3_tts/mlx/weights.py
+++ b/sglang_omni/models/qwen3_tts/mlx/weights.py
@@ -1,0 +1,61 @@
+# SPDX-License-Identifier: Apache-2.0
+"""Weight-layout helpers for the MLX Qwen3-TTS ports."""
+
+from __future__ import annotations
+
+from typing import Any
+
+import mlx.core as mx
+import mlx.nn as nn
+from mlx.utils import tree_flatten
+
+# PyTorch and MLX disagree on convolution weight layout, and the two
+# convolution kinds disagree with each other:
+#   Conv1d           torch [out, in, kernel]  -> mlx [out, kernel, in]
+#   ConvTranspose1d  torch [in, out, kernel]  -> mlx [out, kernel, in]
+_CONV_PERMUTATIONS: tuple[tuple[type, tuple[int, int, int]], ...] = (
+    # ConvTranspose1d first: it subclasses nothing shared, but keep the more
+    # specific check ahead of Conv1d in case that changes upstream.
+    (nn.ConvTranspose1d, (1, 2, 0)),
+    (nn.Conv1d, (0, 2, 1)),
+)
+
+
+def align_conv_weights(
+    weights: dict[str, mx.array],
+    model: Any,
+) -> dict[str, mx.array]:
+    """Permute checkpoint convolution weights into MLX layout.
+
+    The permutation is chosen from each module's *type*, not from the shape,
+    because a transposed convolution with equal input and output channels has
+    the same shape under either permutation and cannot be told apart
+    numerically. A tensor already in MLX layout is left alone, so re-loading a
+    converted checkpoint is a no-op.
+    """
+    expected = {
+        key: value.shape
+        for key, value in tree_flatten(model.parameters())
+        if value.ndim == 3
+    }
+
+    permutation_by_key: dict[str, tuple[int, int, int]] = {}
+    for path, module in model.named_modules():
+        for module_type, permutation in _CONV_PERMUTATIONS:
+            if isinstance(module, module_type):
+                key = f"{path}.weight" if path else "weight"
+                permutation_by_key[key] = permutation
+                break
+
+    aligned = dict(weights)
+    for key, permutation in permutation_by_key.items():
+        value = aligned.get(key)
+        target = expected.get(key)
+        if value is None or target is None or value.ndim != 3:
+            continue
+        if value.shape == target:
+            continue
+        permuted = mx.transpose(value, permutation)
+        if permuted.shape == target:
+            aligned[key] = permuted
+    return aligned

--- a/sglang_omni/models/qwen3_tts/request_builders.py
+++ b/sglang_omni/models/qwen3_tts/request_builders.py
@@ -1338,7 +1338,7 @@ def preprocess_qwen3_tts_payload(
                 model=context.model,
                 wrapper=context.wrapper,
                 default_stream_codec_output=default_stream_codec_output,
-            mlx_preprocessor=context.mlx_preprocessor,
+                mlx_preprocessor=context.mlx_preprocessor,
             )
             prepared.ready_event = torch.cuda.Event()
             prepared.ready_event.record(context.stream)

--- a/sglang_omni/models/qwen3_tts/request_builders.py
+++ b/sglang_omni/models/qwen3_tts/request_builders.py
@@ -170,6 +170,9 @@ class Qwen3TTSPreprocessingContext:
     # stream so it never queues behind the talker's step on the default
     # stream; the scheduler waits on the per-request event before reading.
     stream: Any = None
+    # Set only on the MLX path, where the engine's model is the MLX talker and
+    # has none of the Torch prompt builders.
+    mlx_preprocessor: Any = None
 
 
 _PREPROCESSING_CONTEXT: Qwen3TTSPreprocessingContext | None = None
@@ -186,12 +189,16 @@ def set_qwen3_tts_preprocessing_context(
     wrapper: Any,
     standalone: bool = False,
     device: torch.device | None = None,
+    mlx_preprocessor: Any = None,
 ) -> None:
     """Register model objects used by the preprocessing stage."""
 
     global _PREPROCESSING_CONTEXT
     with _PREPARED_REQUESTS_LOCK:
-        _get_qwen3_tts_adhoc_reference_service_locked(model, wrapper)
+        if mlx_preprocessor is None:
+            # The ad-hoc reference service encodes reference audio with the Torch
+            # speech tokenizer; the MLX preprocessor owns that itself.
+            _get_qwen3_tts_adhoc_reference_service_locked(model, wrapper)
         _PREPROCESSING_CONTEXT = Qwen3TTSPreprocessingContext(
             model=model,
             wrapper=wrapper,
@@ -201,6 +208,7 @@ def set_qwen3_tts_preprocessing_context(
                 if device is not None and device.type == "cuda" and not standalone
                 else None
             ),
+            mlx_preprocessor=mlx_preprocessor,
         )
         _PREPARED_REQUESTS.clear()
 
@@ -1210,10 +1218,24 @@ def _prepare_qwen3_tts_request(
     model: Any,
     wrapper: Any,
     default_stream_codec_output: bool = True,
+    mlx_preprocessor: Any = None,
 ) -> Qwen3TTSPreparedRequest:
     state = build_qwen3_tts_state(
         payload, default_stream_codec_output=default_stream_codec_output
     )
+
+    if mlx_preprocessor is not None:
+        from sglang_omni.models.qwen3_tts.mlx.preprocessing import (
+            build_mlx_prepared_request,
+        )
+
+        return build_mlx_prepared_request(
+            mlx_preprocessor,
+            state,
+            gen_kwargs=mlx_preprocessor.merge_generate_kwargs(
+                **state.generation_kwargs
+            ),
+        )
 
     _validate_qwen3_tts_model_task(model, state)
     gen_kwargs = wrapper._merge_generate_kwargs(**state.generation_kwargs)
@@ -1307,6 +1329,7 @@ def preprocess_qwen3_tts_payload(
             model=context.model,
             wrapper=context.wrapper,
             default_stream_codec_output=default_stream_codec_output,
+            mlx_preprocessor=context.mlx_preprocessor,
         )
     else:
         with torch.cuda.stream(context.stream):
@@ -1315,6 +1338,7 @@ def preprocess_qwen3_tts_payload(
                 model=context.model,
                 wrapper=context.wrapper,
                 default_stream_codec_output=default_stream_codec_output,
+            mlx_preprocessor=context.mlx_preprocessor,
             )
             prepared.ready_event = torch.cuda.Event()
             prepared.ready_event.record(context.stream)

--- a/sglang_omni/models/qwen3_tts/stages.py
+++ b/sglang_omni/models/qwen3_tts/stages.py
@@ -12,6 +12,7 @@ from typing import Any
 
 import torch
 
+from sglang_omni.models.qwen3_tts.backend import Qwen3TTSBackend, get_qwen3_tts_backend
 from sglang_omni.models.qwen3_tts.compat import (
     apply_qwen_tts_transformers_compatibility_patches,
 )
@@ -266,9 +267,7 @@ def create_vocoder_executor(
     suppress_bootstrap_silence: bool = True,
     suppress_bootstrap_max_streams: int = 24,
 ) -> SimpleScheduler:
-    from sglang.srt.utils.tensor_bridge import use_mlx
-
-    if use_mlx():
+    if get_qwen3_tts_backend() is Qwen3TTSBackend.MLX:
         # Metal has neither CUDA graphs nor pinned staging; the MLX vocoder
         # decodes statefully per request instead of re-running a left-context
         # window, so the CUDA tuning knobs do not apply.

--- a/sglang_omni/models/qwen3_tts/stages.py
+++ b/sglang_omni/models/qwen3_tts/stages.py
@@ -297,6 +297,12 @@ def create_vocoder_executor(
         dtype=dtype,
         attn_implementation=attn_implementation,
     )
+    if torch.device(device).type == "mps":
+        from sglang_omni.models.qwen3_tts.torch_mps_vocoder import (
+            create_torch_mps_vocoder_scheduler,
+        )
+
+        return create_torch_mps_vocoder_scheduler(tokenizer)
 
     scheduler = Qwen3TTSStreamingVocoderScheduler(
         tokenizer,

--- a/sglang_omni/models/qwen3_tts/stages.py
+++ b/sglang_omni/models/qwen3_tts/stages.py
@@ -266,6 +266,24 @@ def create_vocoder_executor(
     suppress_bootstrap_silence: bool = True,
     suppress_bootstrap_max_streams: int = 24,
 ) -> SimpleScheduler:
+    from sglang.srt.utils.tensor_bridge import use_mlx
+
+    if use_mlx():
+        # Metal has neither CUDA graphs nor pinned staging; the MLX vocoder
+        # decodes statefully per request instead of re-running a left-context
+        # window, so the CUDA tuning knobs do not apply.
+        from sglang_omni.models.qwen3_tts.mlx.vocoder_loader import (
+            create_mlx_vocoder_scheduler,
+        )
+
+        return create_mlx_vocoder_scheduler(
+            model_path,
+            stream_stride=stream_stride,
+            initial_chunk_frames=initial_chunk_frames,
+            max_batch_size=max_batch_size,
+            max_batch_wait_ms=max_batch_wait_ms,
+        )
+
     device = resolve_device_spec(device, gpu_id)
     # note (luojiaxuan): the graph and compile switches follow the decoder
     # they belong to unless set explicitly, so turning the stateful decoder

--- a/sglang_omni/models/qwen3_tts/torch_mps_runner.py
+++ b/sglang_omni/models/qwen3_tts/torch_mps_runner.py
@@ -1,0 +1,368 @@
+# SPDX-License-Identifier: Apache-2.0
+"""Canonical Torch compatibility runner for Qwen3-TTS on MPS."""
+
+from __future__ import annotations
+
+import gc
+import logging
+from dataclasses import dataclass
+from pathlib import Path
+from typing import Any
+
+import torch
+from safetensors import safe_open
+
+from sglang_omni.model_runner.base import ModelRunner
+from sglang_omni.models.qwen3_tts.compat import (
+    apply_qwen_tts_transformers_compatibility_patches,
+)
+
+logger = logging.getLogger(__name__)
+
+
+def _resolve_model_path(model_path: str) -> Path:
+    path = Path(model_path).expanduser()
+    if path.is_dir():
+        return path.resolve()
+
+    from huggingface_hub import snapshot_download
+
+    return Path(snapshot_download(model_path))
+
+
+def _materialize_rotary_buffers(talker: torch.nn.Module) -> None:
+    """Recreate non-persistent RoPE buffers omitted from checkpoint weights."""
+    for module in talker.modules():
+        inv_freq = getattr(module, "inv_freq", None)
+        if not isinstance(inv_freq, torch.Tensor) or not inv_freq.is_meta:
+            continue
+        rope_init_fn = getattr(module, "rope_init_fn", None)
+        config = getattr(module, "config", None)
+        if rope_init_fn is None or config is None:
+            raise RuntimeError(
+                "Qwen3-TTS Torch MPS cannot initialize a meta rotary buffer"
+            )
+        initialized, attention_scaling = rope_init_fn(config, torch.device("cpu"))
+        module.inv_freq = initialized
+        module.original_inv_freq = initialized.clone()
+        module.attention_scaling = attention_scaling
+
+    meta_buffers = [name for name, value in talker.named_buffers() if value.is_meta]
+    if meta_buffers:
+        raise RuntimeError(
+            "Qwen3-TTS Torch MPS talker has uninitialized buffers: "
+            f"{meta_buffers[:10]}"
+        )
+
+
+def _load_talker_weights(talker: torch.nn.Module, checkpoint: Path) -> None:
+    expected = set(talker.state_dict())
+    state_dict: dict[str, torch.Tensor] = {}
+    weight_files = sorted(checkpoint.glob("*.safetensors"))
+    if not weight_files:
+        raise ValueError(f"Qwen3-TTS checkpoint has no safetensors in {checkpoint}")
+
+    for weight_file in weight_files:
+        with safe_open(weight_file, framework="pt", device="cpu") as weights:
+            for checkpoint_name in weights.keys():
+                if not checkpoint_name.startswith("talker."):
+                    continue
+                model_name = checkpoint_name.removeprefix("talker.")
+                if model_name in expected:
+                    state_dict[model_name] = weights.get_tensor(checkpoint_name)
+
+    missing = expected - set(state_dict)
+    if missing:
+        raise ValueError(
+            "Qwen3-TTS Torch MPS talker checkpoint is incomplete: "
+            f"{sorted(missing)[:10]}"
+        )
+    talker.load_state_dict(state_dict, strict=True, assign=True)
+    _materialize_rotary_buffers(talker)
+
+
+def install_torch_mps_talker(model: Any, model_path: str) -> None:
+    """Replace SGLang execution modules with the upstream Torch talker."""
+    apply_qwen_tts_transformers_compatibility_patches()
+    from qwen_tts.core.models.modeling_qwen3_tts import (
+        Qwen3TTSTalkerForConditionalGeneration,
+    )
+
+    checkpoint = _resolve_model_path(model_path)
+    old_parameter = next(model.parameters())
+    device, dtype = old_parameter.device, old_parameter.dtype
+    config = model.config
+    # qwen-tts 0.1.1 omits this inherited field. The talker embedding is in
+    # codec space, so the text-domain TTS pad id would be out of range.
+    if getattr(config, "pad_token_id", None) is None:
+        config.pad_token_id = int(config.codec_pad_id)
+
+    for name in ("model", "text_projection", "codec_head", "code_predictor"):
+        delattr(model, name)
+    # SGLang caches every parameter for its custom weight loader. Keeping the
+    # mapping would retain the complete replaced talker even after its modules
+    # are detached.
+    model._cached_params_dict = {}
+    gc.collect()
+    if device.type == "mps":
+        torch.mps.empty_cache()
+
+    with torch.device("meta"):
+        talker = Qwen3TTSTalkerForConditionalGeneration(config)
+    _load_talker_weights(talker, checkpoint)
+    talker = talker.eval().to(device=device, dtype=dtype)
+
+    # The prompt-builder mixin continues to use these public components. They
+    # alias the modules owned by the canonical talker, so there is one copy of
+    # every parameter shared by preprocessing and generation.
+    model.torch_mps_talker = talker
+    model.model = talker.model
+    model.text_projection = talker.text_projection
+    model.codec_head = talker.codec_head
+    model.code_predictor = talker.code_predictor
+    model.model._feedback_buffer = torch.empty(0, device=device, dtype=dtype)
+    logger.info("Installed upstream Qwen3-TTS Torch talker on %s (%s)", device, dtype)
+
+
+@dataclass
+class _TorchMpsRequestState:
+    past_key_values: Any
+    past_hidden: torch.Tensor
+    generation_step: int
+    trailing_text_hidden: torch.Tensor
+    tts_pad_embed: torch.Tensor
+    attention_mask: torch.Tensor
+    next_logits: torch.Tensor
+    semantic_generator: torch.Generator
+
+
+class Qwen3TTSTorchMpsModelRunner(ModelRunner):
+    """Run one request through the upstream eager Torch talker and its PKV."""
+
+    def __init__(self, tp_worker: Any, output_processor: Any):
+        super().__init__(tp_worker, output_processor)
+        self._request_states: dict[str, _TorchMpsRequestState] = {}
+
+    @property
+    def talker(self) -> Any:
+        return self.model.torch_mps_talker
+
+    def lookahead_eligible(self, batch: Any) -> bool:
+        del batch
+        return False
+
+    @staticmethod
+    def _one_request(requests: list[Any]) -> Any:
+        if len(requests) != 1:
+            raise RuntimeError(
+                "Qwen3-TTS Torch MPS currently requires max_running_requests=1"
+            )
+        return requests[0]
+
+    @staticmethod
+    def _batch_result(next_token_ids: torch.Tensor) -> Any:
+        from sglang.srt.managers.scheduler import GenerationBatchResult
+
+        return GenerationBatchResult(
+            logits_output=None,
+            next_token_ids=next_token_ids,
+            can_run_cuda_graph=False,
+        )
+
+    @staticmethod
+    def _trailing_text(data: Any, pad_embed: torch.Tensor) -> torch.Tensor:
+        rows = list(data.pending_text_queue)
+        if not rows:
+            return pad_embed.new_empty((1, 0, pad_embed.shape[-1]))
+        return torch.stack(rows, dim=0).unsqueeze(0)
+
+    @staticmethod
+    def _seed_subtalker(data: Any, device: torch.device) -> None:
+        seed = int(data.subtalker_sampling_seed)
+        torch.manual_seed(seed)
+        if device.type == "mps":
+            torch.mps.manual_seed(seed)
+
+    def _sample_semantic(
+        self,
+        logits: torch.Tensor,
+        data: Any,
+        generator: torch.Generator,
+    ) -> torch.Tensor:
+        sampling = data.req.sampling_params
+        scores = logits.detach().float().reshape(-1).cpu().clone()
+        vocab_size = min(int(self.model.config.vocab_size), int(scores.numel()))
+        scores = scores[:vocab_size]
+
+        suppress_start = max(0, vocab_size - 1024)
+        eos_id = int(self.model.config.codec_eos_token_id)
+        if suppress_start < vocab_size:
+            eos_score = scores[eos_id].clone() if 0 <= eos_id < vocab_size else None
+            scores[suppress_start:vocab_size] = float("-inf")
+            if eos_score is not None:
+                scores[eos_id] = eos_score
+
+        penalty = float(sampling.repetition_penalty)
+        if penalty != 1.0:
+            for token_id in set(int(token) for token in data.req.output_ids):
+                if not 0 <= token_id < vocab_size:
+                    continue
+                scores[token_id] = (
+                    scores[token_id] * penalty
+                    if scores[token_id] < 0
+                    else scores[token_id] / penalty
+                )
+
+        temperature = float(sampling.temperature)
+        if temperature <= 0:
+            token = int(scores.argmax())
+        else:
+            scores.div_(temperature)
+            top_k = int(sampling.top_k)
+            if 0 < top_k < vocab_size:
+                threshold = torch.topk(scores, top_k).values[-1]
+                scores[scores < threshold] = float("-inf")
+            top_p = float(sampling.top_p)
+            if top_p < 1.0:
+                sorted_scores, sorted_indices = torch.sort(scores, descending=True)
+                cumulative = torch.softmax(sorted_scores, dim=-1).cumsum(dim=-1)
+                remove = cumulative > top_p
+                remove[1:] = remove[:-1].clone()
+                remove[0] = False
+                scores[sorted_indices[remove]] = float("-inf")
+            probabilities = torch.softmax(scores, dim=-1)
+            token = int(
+                torch.multinomial(
+                    probabilities,
+                    1,
+                    generator=generator,
+                ).item()
+            )
+        return torch.tensor([token], dtype=torch.long, device=self.device)
+
+    def _advance_frame(
+        self,
+        scheduler_request: Any,
+        state: _TorchMpsRequestState,
+        semantic_id: torch.Tensor,
+    ) -> None:
+        data = scheduler_request.data
+        if int(semantic_id.item()) == int(self.model.config.codec_eos_token_id):
+            return
+
+        attention_mask = torch.cat(
+            [state.attention_mask, state.attention_mask.new_ones((1, 1))], dim=1
+        )
+        cache_position = torch.tensor(
+            [state.attention_mask.shape[1]], dtype=torch.long, device=self.device
+        )
+        output = self.talker(
+            input_ids=semantic_id.reshape(1, 1),
+            attention_mask=attention_mask,
+            past_key_values=state.past_key_values,
+            past_hidden=state.past_hidden,
+            trailing_text_hidden=state.trailing_text_hidden,
+            tts_pad_embed=state.tts_pad_embed,
+            generation_step=state.generation_step,
+            subtalker_dosample=bool(data.subtalker_dosample),
+            subtalker_top_p=float(data.subtalker_top_p),
+            subtalker_top_k=int(data.subtalker_top_k),
+            subtalker_temperature=float(data.subtalker_temperature),
+            use_cache=True,
+            cache_position=cache_position,
+            return_dict=True,
+        )
+        codec_ids = output.hidden_states[1]
+        if codec_ids is None or codec_ids.shape[0] != 1:
+            raise RuntimeError("Qwen3-TTS Torch MPS talker returned no codec frame")
+        data.output_codes.append(codec_ids[0].detach().clone())
+        state.past_key_values = output.past_key_values
+        state.past_hidden = output.past_hidden
+        state.generation_step = int(output.generation_step)
+        state.attention_mask = attention_mask
+        state.next_logits = output.logits[:, -1, :]
+
+    @torch.inference_mode()
+    def custom_prefill_forward(
+        self,
+        forward_batch: Any,
+        schedule_batch: Any,
+        requests: list[Any],
+    ) -> Any:
+        del forward_batch, schedule_batch
+        scheduler_request = self._one_request(requests)
+        data = scheduler_request.data
+        prompt = data.prompt_input_embeds
+        if prompt is None:
+            raise RuntimeError("Qwen3-TTS Torch MPS prefill requires prompt embeddings")
+        prompt = prompt.to(device=self.device, dtype=self.talker.dtype).unsqueeze(0)
+        attention_mask = torch.ones(
+            (1, prompt.shape[1]), dtype=torch.long, device=self.device
+        )
+        pad_embed = data.tts_pad_embed.to(
+            device=self.device, dtype=prompt.dtype
+        ).reshape(1, 1, -1)
+        trailing = self._trailing_text(data, pad_embed).to(
+            device=self.device, dtype=prompt.dtype
+        )
+        output = self.talker(
+            inputs_embeds=prompt,
+            attention_mask=attention_mask,
+            trailing_text_hidden=trailing,
+            tts_pad_embed=pad_embed,
+            use_cache=True,
+            return_dict=True,
+        )
+        generator = torch.Generator(device="cpu")
+        generator.manual_seed(int(data.semantic_sampling_seed))
+        state = _TorchMpsRequestState(
+            past_key_values=output.past_key_values,
+            past_hidden=output.past_hidden,
+            generation_step=int(output.generation_step),
+            trailing_text_hidden=trailing,
+            tts_pad_embed=pad_embed,
+            attention_mask=attention_mask,
+            next_logits=output.logits[:, -1, :],
+            semantic_generator=generator,
+        )
+        self._request_states[scheduler_request.request_id] = state
+        self._seed_subtalker(data, self.device)
+        semantic_id = self._sample_semantic(
+            state.next_logits, data, state.semantic_generator
+        )
+        self._advance_frame(scheduler_request, state, semantic_id)
+        return self._batch_result(semantic_id)
+
+    @torch.inference_mode()
+    def custom_decode_forward(
+        self,
+        forward_batch: Any,
+        schedule_batch: Any,
+        requests: list[Any],
+    ) -> Any:
+        del forward_batch, schedule_batch
+        scheduler_request = self._one_request(requests)
+        try:
+            state = self._request_states[scheduler_request.request_id]
+        except KeyError as exc:
+            raise RuntimeError(
+                "Qwen3-TTS Torch MPS decode has no request state for "
+                f"{scheduler_request.request_id}"
+            ) from exc
+        semantic_id = self._sample_semantic(
+            state.next_logits,
+            scheduler_request.data,
+            state.semantic_generator,
+        )
+        self._advance_frame(scheduler_request, state, semantic_id)
+        return self._batch_result(semantic_id)
+
+    def on_request_finished(self, request_id: str, req_data: Any) -> None:
+        del req_data
+        self._request_states.pop(request_id, None)
+
+    def abort_request(self, request_id: str) -> None:
+        self._request_states.pop(request_id, None)
+
+
+__all__ = ["Qwen3TTSTorchMpsModelRunner", "install_torch_mps_talker"]

--- a/sglang_omni/models/qwen3_tts/torch_mps_vocoder.py
+++ b/sglang_omni/models/qwen3_tts/torch_mps_vocoder.py
@@ -1,0 +1,52 @@
+# SPDX-License-Identifier: Apache-2.0
+"""Conservative final-only Qwen3-TTS vocoder for Torch MPS."""
+
+from __future__ import annotations
+
+from typing import Any
+
+import torch
+
+from sglang_omni.models.qwen3_tts.payload_types import Qwen3TTSState
+from sglang_omni.proto import StagePayload
+from sglang_omni.scheduling.pipeline_state import build_usage
+from sglang_omni.scheduling.simple_scheduler import SimpleScheduler
+from sglang_omni.utils.audio_payload import audio_waveform_payload
+
+
+def create_torch_mps_vocoder_scheduler(tokenizer: Any) -> SimpleScheduler:
+    """Decode one complete codec sequence without CUDA streaming machinery."""
+
+    def vocode(payload: StagePayload) -> StagePayload:
+        params = payload.request.params
+        if isinstance(params, dict) and params.get("stream", False):
+            raise ValueError(
+                "Qwen3-TTS Torch MPS currently supports non-streaming only"
+            )
+        state = Qwen3TTSState.from_dict(payload.data)
+        if state.audio_codes is None:
+            raise RuntimeError("Qwen3-TTS vocoder requires audio_codes from tts_engine")
+        codes = torch.as_tensor(state.audio_codes, dtype=torch.long)
+        waveforms, sample_rate = tokenizer.decode([{"audio_codes": codes}])
+        if len(waveforms) != 1 or waveforms[0] is None:
+            raise RuntimeError("Qwen3-TTS speech tokenizer did not return audio")
+        waveform = waveforms[0]
+        if state.ref_code_len:
+            cut = int(state.ref_code_len / max(len(codes), 1) * int(waveform.shape[0]))
+            waveform = waveform[cut:]
+        data = audio_waveform_payload(
+            waveform,
+            sample_rate=int(sample_rate),
+            modality="audio",
+            source_hint="Qwen3-TTS Torch MPS",
+        )
+        usage = build_usage(state)
+        if usage is not None:
+            data["usage"] = usage
+        payload.data = data
+        return payload
+
+    return SimpleScheduler(vocode)
+
+
+__all__ = ["create_torch_mps_vocoder_scheduler"]

--- a/tests/unit_test/model_runner/test_mlx_runner_registry.py
+++ b/tests/unit_test/model_runner/test_mlx_runner_registry.py
@@ -1,0 +1,51 @@
+# SPDX-License-Identifier: Apache-2.0
+"""Architecture dispatch for Omni's MLX worker."""
+
+from __future__ import annotations
+
+import pytest
+
+from sglang_omni.model_runner import mlx_model_worker
+
+
+def test_qwen3_asr_resolves_to_its_runner_factory() -> None:
+    pytest.importorskip("mlx.core")
+    from sglang_omni.models.qwen3_asr.mlx.runner import make_qwen3_asr_mlx_runner_class
+
+    factory = mlx_model_worker.resolve_mlx_runner_factory(
+        "Qwen3ASRForConditionalGeneration"
+    )
+    assert factory is make_qwen3_asr_mlx_runner_class
+
+
+def test_unregistered_architecture_lists_the_supported_ones() -> None:
+    with pytest.raises(NotImplementedError) as excinfo:
+        mlx_model_worker.resolve_mlx_runner_factory("SomeOtherArch")
+
+    message = str(excinfo.value)
+    assert "SomeOtherArch" in message
+    assert "Qwen3ASRForConditionalGeneration" in message
+
+
+def test_missing_architecture_is_rejected() -> None:
+    with pytest.raises(NotImplementedError):
+        mlx_model_worker.resolve_mlx_runner_factory(None)
+
+
+def test_registration_adds_an_architecture(monkeypatch: pytest.MonkeyPatch) -> None:
+    monkeypatch.setattr(
+        mlx_model_worker,
+        "_MLX_RUNNER_FACTORIES",
+        dict(mlx_model_worker._MLX_RUNNER_FACTORIES),
+    )
+    mlx_model_worker.register_mlx_runner_factory(
+        "FakeArch", f"{__name__}:_fake_runner_factory"
+    )
+
+    assert (
+        mlx_model_worker.resolve_mlx_runner_factory("FakeArch") is _fake_runner_factory
+    )
+
+
+def _fake_runner_factory() -> type:
+    return object

--- a/tests/unit_test/qwen3_tts/test_backend.py
+++ b/tests/unit_test/qwen3_tts/test_backend.py
@@ -1,0 +1,44 @@
+# SPDX-License-Identifier: Apache-2.0
+"""Qwen3-TTS execution-backend boundaries."""
+
+from __future__ import annotations
+
+import pytest
+
+from sglang_omni.models.qwen3_tts.backend import Qwen3TTSBackend, get_qwen3_tts_backend
+
+
+def test_non_mlx_execution_keeps_the_canonical_torch_backend(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    from sglang.srt.utils import tensor_bridge
+
+    monkeypatch.setattr(tensor_bridge, "use_mlx", lambda: False)
+
+    # CPU, CUDA, and a future MPS path are devices within this backend.
+    assert get_qwen3_tts_backend() is Qwen3TTSBackend.TORCH
+
+
+def test_mlx_opt_in_selects_the_native_backend(monkeypatch: pytest.MonkeyPatch) -> None:
+    from sglang.srt.utils import tensor_bridge
+
+    monkeypatch.setattr(tensor_bridge, "use_mlx", lambda: True)
+
+    assert get_qwen3_tts_backend() is Qwen3TTSBackend.MLX
+
+
+def test_mlx_defaults_disable_torch_only_optimizations(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    from sglang.srt.utils import tensor_bridge
+
+    from sglang_omni.models.qwen3_tts.engine_builder import Qwen3TtsEngineBuilder
+
+    monkeypatch.setattr(tensor_bridge, "use_mlx", lambda: True)
+
+    defaults = Qwen3TtsEngineBuilder().generation_defaults(dtype="bfloat16")
+
+    assert defaults["disable_cuda_graph"] is True
+    assert defaults["disable_radix_cache"] is True
+    assert defaults["chunked_prefill_size"] == -1
+    assert defaults["enable_torch_compile"] is False

--- a/tests/unit_test/qwen3_tts/test_backend.py
+++ b/tests/unit_test/qwen3_tts/test_backend.py
@@ -3,6 +3,8 @@
 
 from __future__ import annotations
 
+from types import SimpleNamespace
+
 import pytest
 
 from sglang_omni.models.qwen3_tts.backend import Qwen3TTSBackend, get_qwen3_tts_backend
@@ -42,3 +44,51 @@ def test_mlx_defaults_disable_torch_only_optimizations(
     assert defaults["disable_radix_cache"] is True
     assert defaults["chunked_prefill_size"] == -1
     assert defaults["enable_torch_compile"] is False
+
+
+def test_torch_mps_uses_eager_native_profile(monkeypatch: pytest.MonkeyPatch) -> None:
+    from sglang.srt.utils import tensor_bridge
+
+    from sglang_omni.models.qwen3_tts.engine_builder import Qwen3TtsEngineBuilder
+
+    monkeypatch.setattr(tensor_bridge, "use_mlx", lambda: False)
+    builder = Qwen3TtsEngineBuilder()
+    builder.device = "mps"
+
+    defaults = builder.generation_defaults(dtype="float16")
+
+    assert defaults == {
+        "max_running_requests": 1,
+        "max_queued_requests": 1,
+        "dtype": "float16",
+        "disable_cuda_graph": True,
+        "disable_overlap_schedule": True,
+        "disable_radix_cache": True,
+        "enable_torch_compile": False,
+        "context_length": 2048,
+        "max_total_tokens": 2048,
+        "max_prefill_tokens": 2048,
+        "chunked_prefill_size": -1,
+        "attention_backend": "torch_native",
+        "sampling_backend": "pytorch",
+        "trust_remote_code": True,
+    }
+
+    builder.adjust_overrides(defaults)
+    assert builder.context_length == 2048
+    assert "context_length" not in defaults
+
+
+def test_torch_mps_rejects_more_than_one_running_request(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    from sglang.srt.utils import tensor_bridge
+
+    from sglang_omni.models.qwen3_tts.engine_builder import Qwen3TtsEngineBuilder
+
+    monkeypatch.setattr(tensor_bridge, "use_mlx", lambda: False)
+    builder = Qwen3TtsEngineBuilder()
+    builder.device = "mps"
+
+    with pytest.raises(ValueError, match="max_running_requests=1"):
+        builder.validate_before_infrastructure(SimpleNamespace(max_running_requests=2))

--- a/tests/unit_test/qwen3_tts/test_mlx_prompt.py
+++ b/tests/unit_test/qwen3_tts/test_mlx_prompt.py
@@ -1,0 +1,381 @@
+# SPDX-License-Identifier: Apache-2.0
+"""Tests for MLX-native Qwen3-TTS prompt construction and preprocessing."""
+
+from __future__ import annotations
+
+from types import SimpleNamespace
+
+import pytest
+
+mx = pytest.importorskip("mlx.core")
+
+from sglang_omni.models.qwen3_tts.mlx.config import (  # noqa: E402
+    CodePredictorConfig,
+    ModelConfig,
+    TalkerConfig,
+)
+from sglang_omni.models.qwen3_tts.mlx.prompt import (  # noqa: E402
+    ROLE_TOKENS,
+    Qwen3TTSMlxPromptBuilder,
+)
+from sglang_omni.models.qwen3_tts.mlx.talker import (  # noqa: E402
+    Qwen3TTSTalkerForConditionalGeneration,
+)
+
+HIDDEN = 8
+GROUPS = 4
+
+
+class _StubTokenizer:
+    """Emits one id per character so slice offsets stay easy to reason about."""
+
+    def encode(self, text: str) -> list[int]:
+        return [(ord(ch) % 30) + 1 for ch in text]
+
+
+def _model_config() -> ModelConfig:
+    talker = TalkerConfig(
+        code_predictor_config=CodePredictorConfig(
+            vocab_size=32,
+            hidden_size=HIDDEN,
+            intermediate_size=16,
+            num_hidden_layers=1,
+            num_attention_heads=2,
+            num_key_value_heads=1,
+            head_dim=4,
+            num_code_groups=GROUPS,
+        ),
+        vocab_size=64,
+        hidden_size=HIDDEN,
+        intermediate_size=16,
+        num_hidden_layers=1,
+        num_attention_heads=2,
+        num_key_value_heads=1,
+        head_dim=8,
+        text_hidden_size=6,
+        text_vocab_size=64,
+        num_code_groups=GROUPS,
+        codec_language_id={"english": 40, "chinese": 41},
+        spk_id={"serena": 50, "vivian": 51},
+        spk_is_dialect={"vivian": "chinese"},
+        # These default to ~2150, which would index past a 64-entry codec
+        # embedding. MLX segfaults on an out-of-range lookup rather than
+        # raising, so keep every id inside vocab_size.
+        codec_eos_token_id=56,
+        codec_think_id=57,
+        codec_nothink_id=60,
+        codec_think_bos_id=61,
+        codec_think_eos_id=62,
+        codec_pad_id=58,
+        codec_bos_id=59,
+    )
+    # The TTS special ids default to ~151672, past this tiny text vocab.
+    return ModelConfig(
+        talker_config=talker,
+        tts_bos_token_id=10,
+        tts_eos_token_id=11,
+        tts_pad_token_id=12,
+    )
+
+
+def _builder() -> Qwen3TTSMlxPromptBuilder:
+    mx.random.seed(0)
+    config = _model_config()
+    talker = Qwen3TTSTalkerForConditionalGeneration(config.talker_config)
+    mx.eval(talker.parameters())
+    return Qwen3TTSMlxPromptBuilder(talker, config, _StubTokenizer())
+
+
+# --------------------------------------------------------------------------
+# Control prefix
+# --------------------------------------------------------------------------
+
+
+def test_explicit_language_adds_one_control_position() -> None:
+    """A language id makes the think prefix 4 tokens instead of 3."""
+    builder = _builder()
+    auto = builder.build_custom_voice(text="hi", voice="serena", language="auto")
+    english = builder.build_custom_voice(text="hi", voice="serena", language="english")
+    mx.eval(auto.input_embeds, english.input_embeds)
+    assert english.input_embeds.shape[1] == auto.input_embeds.shape[1] + 1
+
+
+def test_dialect_voice_implies_its_language_on_auto() -> None:
+    """spk_is_dialect resolves a language even when the caller said auto."""
+    builder = _builder()
+    plain = builder.build_custom_voice(text="hi", voice="serena", language="auto")
+    dialect = builder.build_custom_voice(text="hi", voice="vivian", language="auto")
+    mx.eval(plain.input_embeds, dialect.input_embeds)
+    assert dialect.input_embeds.shape[1] == plain.input_embeds.shape[1] + 1
+
+
+def test_unknown_language_is_rejected_with_the_supported_list() -> None:
+    builder = _builder()
+    with pytest.raises(ValueError, match="Supported: chinese, english"):
+        builder.build_custom_voice(text="hi", voice="serena", language="klingon")
+
+
+# --------------------------------------------------------------------------
+# CustomVoice
+# --------------------------------------------------------------------------
+
+
+def test_unknown_voice_is_rejected() -> None:
+    builder = _builder()
+    with pytest.raises(ValueError, match="Supported speakers: serena, vivian"):
+        builder.build_custom_voice(text="hi", voice="nobody")
+
+
+def test_voice_lookup_is_case_insensitive() -> None:
+    builder = _builder()
+    lower = builder.build_custom_voice(text="hi", voice="serena")
+    upper = builder.build_custom_voice(text="hi", voice="SERENA")
+    mx.eval(lower.input_embeds, upper.input_embeds)
+    assert float(mx.abs(lower.input_embeds - upper.input_embeds).max()) == 0.0
+
+
+def test_different_voices_produce_different_prompts() -> None:
+    builder = _builder()
+    a = builder.build_custom_voice(text="hi", voice="serena", language="english")
+    b = builder.build_custom_voice(text="hi", voice="vivian", language="english")
+    mx.eval(a.input_embeds, b.input_embeds)
+    assert a.input_embeds.shape == b.input_embeds.shape
+    assert float(mx.abs(a.input_embeds - b.input_embeds).max()) > 0.0
+
+
+def test_missing_speaker_table_is_rejected() -> None:
+    config = _model_config()
+    config.talker_config.spk_id = None
+    talker = Qwen3TTSTalkerForConditionalGeneration(config.talker_config)
+    mx.eval(talker.parameters())
+    builder = Qwen3TTSMlxPromptBuilder(talker, config, _StubTokenizer())
+    with pytest.raises(ValueError, match="configured spk_id"):
+        builder.build_custom_voice(text="hi", voice="serena")
+
+
+# --------------------------------------------------------------------------
+# Streaming vs non-streaming text placement
+# --------------------------------------------------------------------------
+
+
+def test_streaming_leaves_the_text_for_the_decode_loop() -> None:
+    builder = _builder()
+    text = "hello world"
+    streaming = builder.build_custom_voice(
+        text=text, voice="serena", non_streaming_mode=False
+    )
+    non_streaming = builder.build_custom_voice(
+        text=text, voice="serena", non_streaming_mode=True
+    )
+    mx.eval(
+        streaming.input_embeds,
+        streaming.trailing_text_embeds,
+        non_streaming.input_embeds,
+        non_streaming.trailing_text_embeds,
+    )
+    # Non-streaming puts the whole text in the prefill; streaming keeps one row
+    # there and streams the rest.
+    assert non_streaming.input_embeds.shape[1] > streaming.input_embeds.shape[1]
+    assert non_streaming.trailing_text_embeds.shape[1] == 1
+    assert streaming.trailing_text_embeds.shape[1] > 1
+
+
+def test_streaming_trailing_length_tracks_the_text() -> None:
+    builder = _builder()
+    short = builder.build_custom_voice(text="ab", voice="serena")
+    longer = builder.build_custom_voice(text="abcd", voice="serena")
+    mx.eval(short.trailing_text_embeds, longer.trailing_text_embeds)
+    assert (
+        longer.trailing_text_embeds.shape[1] - short.trailing_text_embeds.shape[1] == 2
+    )
+
+
+# --------------------------------------------------------------------------
+# Instructions and VoiceDesign
+# --------------------------------------------------------------------------
+
+
+def test_instructions_are_prepended() -> None:
+    builder = _builder()
+    plain = builder.build_custom_voice(text="hi", voice="serena")
+    guided = builder.build_custom_voice(text="hi", voice="serena", instructions="calm")
+    mx.eval(plain.input_embeds, guided.input_embeds)
+    assert guided.input_embeds.shape[1] > plain.input_embeds.shape[1]
+    # The original prompt is the suffix; instructions sit in front of it.
+    tail = guided.input_embeds[:, -plain.input_embeds.shape[1] :, :]
+    assert float(mx.abs(tail - plain.input_embeds).max()) == 0.0
+
+
+def test_voice_design_requires_instructions() -> None:
+    builder = _builder()
+    with pytest.raises(ValueError, match="requires instructions"):
+        builder.build_voice_design(text="hi", instructions="")
+
+
+def test_voice_design_has_no_speaker_token() -> None:
+    """VoiceDesign conditions on words, so its control prefix is shorter."""
+    builder = _builder()
+    design = builder.build_voice_design(text="hi", instructions="x", language="english")
+    custom = builder.build_custom_voice(
+        text="hi", voice="serena", language="english", instructions="x"
+    )
+    mx.eval(design.input_embeds, custom.input_embeds)
+    assert design.input_embeds.shape[1] == custom.input_embeds.shape[1] - 1
+
+
+# --------------------------------------------------------------------------
+# Voice cloning
+# --------------------------------------------------------------------------
+
+
+def test_voice_clone_prompt_grows_with_the_reference() -> None:
+    builder = _builder()
+    codes_short = mx.zeros((1, GROUPS, 3), dtype=mx.int32)
+    codes_long = mx.zeros((1, GROUPS, 7), dtype=mx.int32)
+    short = builder.build_voice_clone(
+        text="hi", ref_codes=codes_short, ref_text="ref", speaker_embed=None
+    )
+    long = builder.build_voice_clone(
+        text="hi", ref_codes=codes_long, ref_text="ref", speaker_embed=None
+    )
+    mx.eval(short.input_embeds, long.input_embeds)
+    assert long.input_embeds.shape[1] - short.input_embeds.shape[1] == 4
+
+
+def test_voice_clone_streams_only_padding() -> None:
+    builder = _builder()
+    prompt = builder.build_voice_clone(
+        text="hello",
+        ref_codes=mx.zeros((1, GROUPS, 2), dtype=mx.int32),
+        ref_text="ref",
+        speaker_embed=None,
+    )
+    mx.eval(prompt.trailing_text_embeds, prompt.pad_embed)
+    # ICL is non-streaming: the text is all in the prefill.
+    assert prompt.trailing_text_embeds.shape[1] == 1
+    assert float(mx.abs(prompt.trailing_text_embeds - prompt.pad_embed).max()) == 0.0
+
+
+def test_float32_speaker_embedding_does_not_promote_the_prompt() -> None:
+    """The speaker encoder runs in float32; the prompt must stay bf16."""
+    builder = _builder()
+    builder.talker.set_dtype(mx.bfloat16)
+    mx.eval(builder.talker.parameters())
+    speaker = mx.ones((1, HIDDEN), dtype=mx.float32)
+    prompt = builder.build_voice_clone(
+        text="hi",
+        ref_codes=mx.zeros((1, GROUPS, 2), dtype=mx.int32),
+        ref_text="ref",
+        speaker_embed=speaker,
+    )
+    mx.eval(prompt.input_embeds)
+    assert prompt.input_embeds.dtype == mx.bfloat16
+
+
+def test_speaker_embedding_adds_one_position() -> None:
+    builder = _builder()
+    codes = mx.zeros((1, GROUPS, 2), dtype=mx.int32)
+    without = builder.build_voice_clone(
+        text="hi", ref_codes=codes, ref_text="ref", speaker_embed=None
+    )
+    with_speaker = builder.build_voice_clone(
+        text="hi",
+        ref_codes=codes,
+        ref_text="ref",
+        speaker_embed=mx.zeros((1, HIDDEN)),
+    )
+    mx.eval(without.input_embeds, with_speaker.input_embeds)
+    assert with_speaker.input_embeds.shape[1] == without.input_embeds.shape[1] + 1
+
+
+def test_role_tokens_open_every_prompt() -> None:
+    """All three tasks start with the same role prefix."""
+    builder = _builder()
+    prompts = [
+        builder.build_custom_voice(text="hi", voice="serena"),
+        builder.build_voice_design(text="hi", instructions="x"),
+        builder.build_voice_clone(
+            text="hi",
+            ref_codes=mx.zeros((1, GROUPS, 2), dtype=mx.int32),
+            ref_text="r",
+            speaker_embed=None,
+        ),
+    ]
+    for prompt in prompts:
+        mx.eval(prompt.input_embeds)
+        assert prompt.input_embeds.shape[1] > ROLE_TOKENS
+        assert prompt.input_embeds.shape[-1] == HIDDEN
+
+
+# --------------------------------------------------------------------------
+# Preprocessor dispatch
+# --------------------------------------------------------------------------
+
+
+def test_preprocessor_dispatches_on_task_type() -> None:
+    from sglang_omni.models.qwen3_tts.mlx.preprocessing import Qwen3TTSMlxPreprocessor
+
+    builder = _builder()
+    pre = Qwen3TTSMlxPreprocessor(
+        builder.talker, builder.model_config, _StubTokenizer(), checkpoint_dir="/nope"
+    )
+
+    custom = pre.prepare(
+        SimpleNamespace(
+            task_type="CustomVoice",
+            text="hi",
+            voice="serena",
+            language="auto",
+            non_streaming_mode=False,
+            instructions=None,
+        )
+    )
+    mx.eval(custom.input_embeds)
+    assert custom.input_embeds.shape[1] > 0
+
+    design = pre.prepare(
+        SimpleNamespace(
+            task_type="VoiceDesign",
+            text="hi",
+            voice=None,
+            language="auto",
+            non_streaming_mode=False,
+            instructions="warm",
+        )
+    )
+    mx.eval(design.input_embeds)
+    assert design.input_embeds.shape[1] > 0
+
+    with pytest.raises(ValueError, match="Unhandled Qwen3-TTS task type"):
+        pre.prepare(
+            SimpleNamespace(
+                task_type="Nope",
+                text="hi",
+                voice=None,
+                language="auto",
+                non_streaming_mode=False,
+                instructions=None,
+            )
+        )
+
+
+def test_base_task_requires_reference_audio_and_text() -> None:
+    from sglang_omni.models.qwen3_tts.mlx.preprocessing import Qwen3TTSMlxPreprocessor
+
+    builder = _builder()
+    pre = Qwen3TTSMlxPreprocessor(
+        builder.talker, builder.model_config, _StubTokenizer(), checkpoint_dir="/nope"
+    )
+    with pytest.raises(ValueError, match="ref_audio and ref_text"):
+        pre.prepare(
+            SimpleNamespace(
+                task_type="Base",
+                text="hi",
+                voice=None,
+                language="auto",
+                non_streaming_mode=False,
+                instructions=None,
+                ref_audio=None,
+                ref_text=None,
+            )
+        )

--- a/tests/unit_test/qwen3_tts/test_mlx_runner.py
+++ b/tests/unit_test/qwen3_tts/test_mlx_runner.py
@@ -1,0 +1,504 @@
+# SPDX-License-Identifier: Apache-2.0
+"""Tests for the MLX Qwen3-TTS scheduler runner."""
+
+from __future__ import annotations
+
+from types import SimpleNamespace
+
+import pytest
+
+mx = pytest.importorskip("mlx.core")
+import numpy as np  # noqa: E402
+
+from sglang_omni.models.qwen3_tts.mlx.config import (  # noqa: E402
+    CodePredictorConfig,
+    TalkerConfig,
+)
+from sglang_omni.models.qwen3_tts.mlx.runner import (  # noqa: E402
+    Qwen3TTSMlxModelRunner,
+    Qwen3TTSRequestSpec,
+)
+from sglang_omni.models.qwen3_tts.mlx.sampling import SamplingParams  # noqa: E402
+from sglang_omni.models.qwen3_tts.mlx.talker import (  # noqa: E402
+    Qwen3TTSTalkerForConditionalGeneration,
+)
+
+HIDDEN = 8
+GROUPS = 4
+
+
+def _talker() -> Qwen3TTSTalkerForConditionalGeneration:
+    mx.random.seed(0)
+    config = TalkerConfig(
+        code_predictor_config=CodePredictorConfig(
+            vocab_size=32,
+            hidden_size=8,
+            intermediate_size=16,
+            num_hidden_layers=1,
+            num_attention_heads=2,
+            num_key_value_heads=1,
+            head_dim=4,
+            num_code_groups=GROUPS,
+        ),
+        vocab_size=1040,  # > 1024 so the reserved special block exists
+        hidden_size=HIDDEN,
+        intermediate_size=16,
+        num_hidden_layers=1,
+        num_attention_heads=2,
+        num_key_value_heads=1,
+        head_dim=8,
+        text_hidden_size=6,
+        text_vocab_size=40,
+        num_code_groups=GROUPS,
+        codec_eos_token_id=1030,
+    )
+    model = Qwen3TTSTalkerForConditionalGeneration(config)
+    mx.eval(model.parameters())
+    return model
+
+
+class _FakeBase:
+    """Stands in for MlxModelRunner.
+
+    Real SGLang attention caches and a real ``BatchedDecodeContext`` are used so
+    the batched decode path under test is the production one, not a stub.
+    """
+
+    def __init__(self, model) -> None:
+        from sglang.srt.hardware_backend.mlx import kv_cache as kv
+
+        self._kv = kv
+        kv.patch_model_attention(model)
+        layers, _ = kv.find_attention_layers(model)
+        self._cache_layout = SimpleNamespace(
+            num_layers=len(layers),
+            attention_layer_indices=tuple(range(len(layers))),
+            attention_pool_index_by_layer={i: i for i in range(len(layers))},
+            full_kv_pool_index_by_layer={i: i for i in range(len(layers))},
+            has_auxiliary_state=False,
+        )
+        self.model = model
+        self.disable_radix_cache = True
+        self._req_caches: dict[str, list] = {}
+        self._req_token_ids: dict[str, list[int]] = {}
+        self._req_pool_idx: dict[str, int] = {}
+        self._req_synced_offset: dict[str, int] = {}
+        self._decode_step_ct = 0
+        self._clear_steps = 0
+        self.removed: list[str] = []
+
+    def _acquire_cache(self):
+        config = self.model.config
+        return [
+            self._kv.ContiguousAttentionKVCache(
+                n_kv_heads=config.num_key_value_heads,
+                head_dim=config.head_dim,
+                max_seq_len=64,
+                dtype=mx.float32,
+            )
+            for _ in range(self._cache_layout.num_layers)
+        ]
+
+    def _build_batched_decode_context(self, caches, req_ids):
+        num_layers = self._cache_layout.num_layers
+        return self._kv.BatchedDecodeContext(
+            batch_size=len(req_ids),
+            seq_lens=[cache[0].offset for cache in caches],
+            attention_layer_caches=[
+                [per_req[layer] for per_req in caches] for layer in range(num_layers)
+            ],
+        )
+
+    def _store_auxiliary_state(self, req_pool_idx, cache) -> None:
+        pass
+
+    def prefill_finalize(self, pending) -> int:
+        token = int(pending.lazy_token.item())
+        self._req_token_ids[pending.req_id] = list(pending.full_token_ids) + [token]
+        self._req_caches[pending.req_id] = pending.cache
+        self._req_pool_idx[pending.req_id] = pending.req_pool_idx
+        return token
+
+    def decode_batch_finalize(self, pending) -> list[int]:
+        raw = pending.lazy_tokens.tolist()
+        tokens = [int(t) for t in (raw if isinstance(raw, list) else [raw])]
+        for rid, token in zip(pending.req_ids, tokens):
+            self._req_token_ids[rid].append(token)
+        return tokens
+
+    def remove_request(self, req_id: str) -> None:
+        self.removed.append(req_id)
+        self._req_caches.pop(req_id, None)
+        self._req_token_ids.pop(req_id, None)
+
+    def clear(self) -> None:
+        self._req_caches.clear()
+        self._req_token_ids.clear()
+
+
+class _Runner(Qwen3TTSMlxModelRunner, _FakeBase):
+    pass
+
+
+def _spec(*, temperature: float = 0.0, seed: int | None = None, trailing=None):
+    mx.random.seed(1)
+    prompt = mx.random.normal((1, 5, HIDDEN))
+    pad = mx.random.normal((1, 1, HIDDEN))
+    params = SamplingParams(temperature=temperature, top_k=0, top_p=1.0)
+    return Qwen3TTSRequestSpec(
+        prompt_embeds=prompt,
+        trailing_text_embeds=trailing,
+        pad_embed=pad,
+        semantic=params,
+        subtalker=params,
+        seed=seed,
+    )
+
+
+def _prefill(runner: _Runner, req_id: str, spec) -> int:
+    runner.register_request(req_id, spec)
+    pending = runner.prefill_start(
+        req_id=req_id,
+        new_token_ids=[1, 2],
+        full_token_ids=[1, 2],
+        prefix_slot_ids=[],
+        new_slot_ids=[0, 1],
+        req_pool_idx=0,
+    )
+    mx.eval(pending.lazy_token)
+    return runner.prefill_finalize(pending)
+
+
+# --------------------------------------------------------------------------
+
+
+def test_prefill_emits_one_frame_and_a_group_zero_token() -> None:
+    runner = _Runner(_talker())
+    token = _prefill(runner, "r0", _spec())
+
+    frames = runner.drain_frames("r0")
+    assert len(frames) == 1
+    assert frames[0].shape == (GROUPS,)
+    # Group 0 of the frame is exactly the token reported to the scheduler.
+    assert int(frames[0][0]) == token
+    # Draining is destructive.
+    assert runner.drain_frames("r0") == []
+
+
+def test_prefill_requires_a_registered_prompt() -> None:
+    runner = _Runner(_talker())
+    with pytest.raises(RuntimeError, match="register_request"):
+        runner.prefill_start(
+            req_id="missing",
+            new_token_ids=[],
+            full_token_ids=[],
+            prefix_slot_ids=[],
+            new_slot_ids=[],
+            req_pool_idx=0,
+        )
+
+
+def test_prefill_rejects_a_radix_prefix() -> None:
+    runner = _Runner(_talker())
+    runner.register_request("r0", _spec())
+    with pytest.raises(NotImplementedError, match="radix prefix"):
+        runner.prefill_start(
+            req_id="r0",
+            new_token_ids=[1],
+            full_token_ids=[1],
+            prefix_slot_ids=[7],
+            new_slot_ids=[1],
+            req_pool_idx=0,
+        )
+
+
+def test_decode_produces_one_frame_per_step() -> None:
+    runner = _Runner(_talker())
+    _prefill(runner, "r0", _spec())
+    runner.drain_frames("r0")
+
+    for _ in range(3):
+        pending = runner.decode_batch_start(["r0"])
+        mx.eval(pending.lazy_tokens, pending.lazy_codes, pending.lazy_feedback)
+        tokens = runner.decode_batch_finalize(pending)
+        assert len(tokens) == 1
+
+    frames = runner.drain_frames("r0")
+    assert len(frames) == 3
+    assert all(frame.shape == (GROUPS,) for frame in frames)
+
+
+def test_chained_decode_matches_stepwise_decode() -> None:
+    """A chained step must equal building the step after finalising."""
+    stepwise = _Runner(_talker())
+    _prefill(stepwise, "r0", _spec())
+    first = stepwise.decode_batch_start(["r0"])
+    mx.eval(first.lazy_tokens, first.lazy_feedback)
+    stepwise.decode_batch_finalize(first)
+    second = stepwise.decode_batch_start(["r0"])
+    mx.eval(second.lazy_tokens)
+    expected = second.lazy_tokens.tolist()
+
+    chained = _Runner(_talker())
+    _prefill(chained, "r0", _spec())
+    root = chained.decode_batch_start(["r0"])
+    nxt = chained.decode_batch_start_chained(root)
+    mx.eval(root.lazy_tokens, nxt.lazy_tokens)
+    chained.decode_batch_finalize(root)
+    got = nxt.lazy_tokens.tolist()
+
+    assert got == expected
+
+
+def test_trailing_text_is_consumed_once_then_padded() -> None:
+    trailing = mx.random.normal((1, 2, HIDDEN))
+    spec = _spec(trailing=trailing)
+    runner = _Runner(_talker())
+    _prefill(runner, "r0", spec)
+
+    # Prefill consumed row 0; two decode steps consume row 1 then fall back.
+    assert spec.trailing_index == 1
+    for _ in range(2):
+        pending = runner.decode_batch_start(["r0"])
+        mx.eval(pending.lazy_tokens, pending.lazy_feedback)
+        runner.decode_batch_finalize(pending)
+    assert spec.trailing_index == 2
+
+
+def test_batched_decode_keeps_frames_per_request() -> None:
+    runner = _Runner(_talker())
+    for req_id in ("a", "b"):
+        _prefill(runner, req_id, _spec())
+        runner.drain_frames(req_id)
+
+    pending = runner.decode_batch_start(["a", "b"])
+    mx.eval(pending.lazy_tokens, pending.lazy_codes, pending.lazy_feedback)
+    tokens = runner.decode_batch_finalize(pending)
+
+    assert len(tokens) == 2
+    assert pending.lazy_codes.shape == (2, GROUPS)
+    for index, req_id in enumerate(("a", "b")):
+        frames = runner.drain_frames(req_id)
+        assert len(frames) == 1
+        assert int(frames[0][0]) == tokens[index]
+
+
+def test_codec_history_excludes_the_prompt_text_ids() -> None:
+    """The repetition penalty must see codec tokens, not prompt text ids."""
+    runner = _Runner(_talker())
+    token = _prefill(runner, "r0", _spec())
+
+    # The base class's list starts with the prompt's text ids.
+    assert runner._req_token_ids["r0"][:2] == [1, 2]
+    # The codec history holds only what the talker emitted.
+    assert runner._tts_emitted["r0"] == [token]
+
+
+def test_special_codec_tokens_are_suppressed() -> None:
+    runner = _Runner(_talker())
+    suppressed = set(runner._suppress_tokens())
+    assert 1030 not in suppressed  # EOS stays sampleable
+    assert 1039 in suppressed and 16 in suppressed
+    # Cached, not rebuilt per row.
+    assert runner._suppress_tokens() is runner._suppress_tokens()
+
+
+def test_removing_a_request_drops_all_of_its_state() -> None:
+    runner = _Runner(_talker())
+    _prefill(runner, "r0", _spec())
+    runner.remove_request("r0")
+
+    assert "r0" not in runner._tts_specs
+    assert "r0" not in runner._tts_frames
+    assert "r0" not in runner._tts_emitted
+    assert runner.removed == ["r0"]
+
+
+def test_seed_makes_sampled_generation_reproducible() -> None:
+    tokens = []
+    for _ in range(2):
+        runner = _Runner(_talker())
+        _prefill(runner, "r0", _spec(temperature=0.9, seed=4321))
+        step = []
+        for _ in range(3):
+            pending = runner.decode_batch_start(["r0"])
+            mx.eval(pending.lazy_tokens, pending.lazy_feedback)
+            step.extend(runner.decode_batch_finalize(pending))
+        tokens.append(step)
+    assert tokens[0] == tokens[1]
+
+
+def test_unsupported_decode_features_are_rejected() -> None:
+    runner = _Runner(_talker())
+    _prefill(runner, "r0", _spec())
+    with pytest.raises(NotImplementedError):
+        runner.decode_batch_start(["r0"], logprob_spec=object())
+    with pytest.raises(NotImplementedError):
+        runner.decode_batch_start(["r0"], logits_hook=lambda x: x)
+
+
+# --------------------------------------------------------------------------
+# request-spec adapter
+# --------------------------------------------------------------------------
+
+
+def test_request_spec_converts_torch_prompt_and_trailing_rows() -> None:
+    torch = pytest.importorskip("torch")
+    from sglang_omni.models.qwen3_tts.mlx.request_spec import build_request_spec
+
+    data = SimpleNamespace(
+        prefill_input_embeds=torch.zeros(5, HIDDEN, dtype=torch.bfloat16),
+        prompt_input_embeds=None,
+        tts_pad_embed=torch.ones(1, HIDDEN, dtype=torch.bfloat16),
+        pending_text_queue=SimpleNamespace(
+            rows=torch.zeros(3, HIDDEN, dtype=torch.bfloat16), cursor=1, _chunks=[]
+        ),
+        temperature=0.7,
+        top_k=20,
+        top_p=0.9,
+        repetition_penalty=1.1,
+        subtalker_dosample=True,
+        subtalker_temperature=0.5,
+        subtalker_top_k=10,
+        subtalker_top_p=0.8,
+        semantic_sampling_seed=99,
+    )
+    spec = build_request_spec(data)
+
+    assert spec.prompt_embeds.shape == (1, 5, HIDDEN)
+    assert spec.prompt_embeds.dtype == mx.bfloat16
+    assert spec.pad_embed.shape == (1, 1, HIDDEN)
+    # cursor=1 means one row was already consumed.
+    assert spec.trailing_text_embeds.shape == (1, 2, HIDDEN)
+    assert spec.semantic.temperature == pytest.approx(0.7)
+    assert spec.semantic.repetition_penalty == pytest.approx(1.1)
+    assert spec.subtalker.top_k == 10
+    assert spec.seed == 99
+
+
+def test_request_spec_is_none_before_the_prompt_exists() -> None:
+    from sglang_omni.models.qwen3_tts.mlx.request_spec import build_request_spec
+
+    data = SimpleNamespace(prefill_input_embeds=None, prompt_input_embeds=None)
+    assert build_request_spec(data) is None
+
+
+def test_greedy_subtalker_when_sampling_is_disabled() -> None:
+    torch = pytest.importorskip("torch")
+    from sglang_omni.models.qwen3_tts.mlx.request_spec import build_request_spec
+
+    data = SimpleNamespace(
+        prefill_input_embeds=torch.zeros(2, HIDDEN),
+        tts_pad_embed=torch.zeros(1, HIDDEN),
+        pending_text_queue=None,
+        subtalker_dosample=False,
+    )
+    spec = build_request_spec(data)
+    assert spec.subtalker.greedy
+    assert spec.trailing_text_embeds is None
+    assert np.asarray(spec.prompt_embeds).shape == (1, 2, HIDDEN)
+
+
+# --------------------------------------------------------------------------
+# scheduler-side bridge
+# --------------------------------------------------------------------------
+
+
+class _StubMlxRunner:
+    def __init__(self, frames: dict[str, list], eos_id: int = 1030) -> None:
+        self._frames = frames
+        self._tts_specs: dict[str, object] = {}
+        self._talker_config = SimpleNamespace(codec_eos_token_id=eos_id)
+        self.registered: list[str] = []
+
+    def drain_frames(self, req_id):
+        return self._frames.pop(req_id, [])
+
+    def has_request(self, req_id):
+        return False
+
+    def register_request(self, req_id, spec):
+        self.registered.append(req_id)
+        self._tts_specs[req_id] = spec
+
+
+def _sched_req(req_id: str):
+    data = SimpleNamespace(
+        output_codes=[],
+        latest_stream_code_chunk=None,
+        prefill_input_embeds=None,
+        prompt_input_embeds=None,
+    )
+    return SimpleNamespace(request_id=req_id, data=data)
+
+
+def _bridge(stub):
+    from sglang_omni.models.qwen3_tts.mlx.scheduler_runner import (
+        Qwen3TTSMlxSchedulerModelRunner,
+    )
+
+    bridge = Qwen3TTSMlxSchedulerModelRunner.__new__(Qwen3TTSMlxSchedulerModelRunner)
+    object.__setattr__(bridge, "tp_worker", SimpleNamespace(_mlx_runner=stub))
+    return bridge
+
+
+def test_bridge_appends_frames_to_request_output_codes() -> None:
+    frame_a = np.array([5, 6, 7, 8])
+    frame_b = np.array([1, 2, 3, 4])
+    stub = _StubMlxRunner({"r0": [frame_a, frame_b]})
+    bridge = _bridge(stub)
+
+    sched_req = _sched_req("r0")
+    outputs = {"r0": SimpleNamespace(data=42)}
+    bridge.post_process_outputs(None, SimpleNamespace(requests=[sched_req]), outputs)
+
+    assert len(sched_req.data.output_codes) == 2
+    assert np.array_equal(sched_req.data.output_codes[0], frame_a)
+    assert np.array_equal(sched_req.data.latest_stream_code_chunk, frame_b)
+
+
+def test_bridge_drops_the_frame_of_an_eos_step() -> None:
+    stub = _StubMlxRunner({"r0": [np.array([1, 2, 3, 4])]}, eos_id=1030)
+    bridge = _bridge(stub)
+
+    sched_req = _sched_req("r0")
+    outputs = {"r0": SimpleNamespace(data=1030)}
+    bridge.post_process_outputs(None, SimpleNamespace(requests=[sched_req]), outputs)
+
+    assert sched_req.data.output_codes == []
+    assert sched_req.data.latest_stream_code_chunk is None
+
+
+def test_bridge_is_a_noop_when_no_frames_were_produced() -> None:
+    stub = _StubMlxRunner({})
+    bridge = _bridge(stub)
+    sched_req = _sched_req("r0")
+    bridge.post_process_outputs(
+        None, SimpleNamespace(requests=[sched_req]), {"r0": SimpleNamespace(data=7)}
+    )
+    assert sched_req.data.output_codes == []
+
+
+def test_bridge_registers_prompts_before_launch() -> None:
+    torch = pytest.importorskip("torch")
+    stub = _StubMlxRunner({})
+    bridge = _bridge(stub)
+
+    sched_req = _sched_req("r0")
+    sched_req.data.prefill_input_embeds = torch.zeros(4, HIDDEN)
+    sched_req.data.tts_pad_embed = torch.zeros(1, HIDDEN)
+    sched_req.data.pending_text_queue = None
+
+    bridge._register_requests([sched_req])
+    assert stub.registered == ["r0"]
+
+    # Registration is idempotent: a second pass must not re-register.
+    bridge._register_requests([sched_req])
+    assert stub.registered == ["r0"]
+
+
+def test_bridge_skips_requests_without_a_prompt_yet() -> None:
+    stub = _StubMlxRunner({})
+    bridge = _bridge(stub)
+    bridge._register_requests([_sched_req("r0")])
+    assert stub.registered == []

--- a/tests/unit_test/qwen3_tts/test_mlx_speech_tokenizer.py
+++ b/tests/unit_test/qwen3_tts/test_mlx_speech_tokenizer.py
@@ -1,0 +1,420 @@
+# SPDX-License-Identifier: Apache-2.0
+"""Unit tests for the MLX Qwen3-TTS speech tokenizer, DSP, and sampling."""
+
+from __future__ import annotations
+
+import pytest
+
+mx = pytest.importorskip("mlx.core")
+import mlx.nn as nn  # noqa: E402
+import numpy as np  # noqa: E402
+
+from sglang_omni.models.qwen3_tts.mlx.config import (  # noqa: E402
+    SpeakerEncoderConfig,
+    TokenizerConfig,
+    TokenizerDecoderConfig,
+    TokenizerEncoderConfig,
+)
+from sglang_omni.models.qwen3_tts.mlx.dsp import (  # noqa: E402
+    mel_filters,
+    mel_spectrogram,
+)
+from sglang_omni.models.qwen3_tts.mlx.sampling import (  # noqa: E402
+    SamplingParams,
+    apply_repetition_penalty,
+    apply_top_k,
+    apply_top_p,
+    sample_codec_token,
+    special_codec_token_ids,
+    suppress,
+)
+from sglang_omni.models.qwen3_tts.mlx.speaker_encoder import (  # noqa: E402
+    Qwen3TTSSpeakerEncoder,
+)
+from sglang_omni.models.qwen3_tts.mlx.speech_tokenizer import (  # noqa: E402
+    Qwen3TTSSpeechTokenizer,
+    sliding_causal_mask,
+)
+from sglang_omni.models.qwen3_tts.mlx.weights import align_conv_weights  # noqa: E402
+
+
+def _tiny_tokenizer_config(*, with_encoder: bool = True) -> TokenizerConfig:
+    decoder = TokenizerDecoderConfig(
+        latent_dim=16,
+        codebook_dim=8,
+        codebook_size=32,
+        decoder_dim=16,
+        hidden_size=8,
+        intermediate_size=16,
+        head_dim=4,
+        num_attention_heads=2,
+        num_hidden_layers=1,
+        num_key_value_heads=2,
+        num_quantizers=4,
+        num_semantic_quantizers=1,
+        sliding_window=6,
+        upsample_rates=[2, 2],
+        upsampling_ratios=[2],
+    )
+    encoder = (
+        TokenizerEncoderConfig(
+            hidden_size=8,
+            intermediate_size=16,
+            head_dim=4,
+            num_attention_heads=2,
+            num_key_value_heads=2,
+            num_hidden_layers=1,
+            num_filters=4,
+            num_quantizers=4,
+            num_semantic_quantizers=1,
+            codebook_size=32,
+            vector_quantization_hidden_dimension=8,
+            upsampling_ratios=[2, 2],
+            sliding_window=5,
+            frame_rate=1500.0,
+            sampling_rate=24000,
+        )
+        if with_encoder
+        else None
+    )
+    return TokenizerConfig(
+        encoder_config=encoder,
+        decoder_config=decoder,
+        encoder_valid_num_quantizers=4,
+        decode_upsample_rate=8,
+    )
+
+
+# --------------------------------------------------------------------------
+# Sliding-window mask
+# --------------------------------------------------------------------------
+
+
+def test_sliding_causal_mask_keeps_only_the_trailing_window() -> None:
+    mask = sliding_causal_mask(4, 4, window=2, dtype=mx.float32)
+    allowed = np.array(mask == 0.0)
+    # Query i may see keys i and i-1 only.
+    expected = np.array(
+        [
+            [True, False, False, False],
+            [True, True, False, False],
+            [False, True, True, False],
+            [False, False, True, True],
+        ]
+    )
+    assert np.array_equal(allowed, expected)
+
+
+def test_sliding_causal_mask_offsets_queries_to_the_end() -> None:
+    """With a cache, queries are the last rows of the key range."""
+    mask = sliding_causal_mask(1, 5, window=3, dtype=mx.float32)
+    allowed = np.array(mask == 0.0)
+    # The single query is at absolute position 4 and sees keys 2, 3, 4.
+    assert np.array_equal(allowed, np.array([[False, False, True, True, True]]))
+
+
+def test_sliding_causal_mask_is_skipped_when_the_window_cannot_bind() -> None:
+    assert sliding_causal_mask(1, 3, window=8, dtype=mx.float32) is None
+    assert sliding_causal_mask(1, 3, window=None, dtype=mx.float32) is None
+    # A window shorter than the history must still produce a mask.
+    assert sliding_causal_mask(1, 9, window=8, dtype=mx.float32) is not None
+
+
+def test_windowed_attention_ignores_history_beyond_the_window() -> None:
+    """Perturbing positions outside the window must not move the last output.
+
+    With a single layer the window is exactly ``sliding_window`` positions, so
+    the final position cannot see anything before it -- while an unwindowed
+    causal model would.
+    """
+    config = _tiny_tokenizer_config(with_encoder=False)
+    mx.random.seed(0)
+    tokenizer = Qwen3TTSSpeechTokenizer(config)
+    transformer = tokenizer.decoder.pre_transformer
+    mx.eval(tokenizer.parameters())
+    assert len(transformer.layers) == 1
+
+    window = config.decoder_config.sliding_window
+    outside = 4
+    latent = mx.random.normal((1, window + outside, config.decoder_config.latent_dim))
+    perturbed = mx.concatenate(
+        [
+            mx.random.normal((1, outside, config.decoder_config.latent_dim)),
+            latent[:, outside:, :],
+        ],
+        axis=1,
+    )
+
+    base = transformer(latent)
+    changed = transformer(perturbed)
+    mx.eval(base, changed)
+
+    # Last position: unaffected by anything older than the window.
+    assert float(mx.abs(base[:, -1, :] - changed[:, -1, :]).max()) < 1e-5
+    # First position: it *is* one of the perturbed ones, so it must move.
+    assert float(mx.abs(base[:, 0, :] - changed[:, 0, :]).max()) > 1e-4
+
+
+# --------------------------------------------------------------------------
+# Weight handling
+# --------------------------------------------------------------------------
+
+
+def test_sanitize_folds_codebook_statistics_into_a_table() -> None:
+    tokenizer = Qwen3TTSSpeechTokenizer(_tiny_tokenizer_config(with_encoder=False))
+    weights = {
+        "decoder.quantizer.rvq_first.vq.layers.0._codebook.embedding_sum": mx.array(
+            [[2.0, 4.0], [9.0, 3.0]]
+        ),
+        "decoder.quantizer.rvq_first.vq.layers.0._codebook.cluster_usage": mx.array(
+            [2.0, 3.0]
+        ),
+        "decoder.quantizer.rvq_first.vq.layers.0._codebook.initialized": mx.array(
+            [1.0]
+        ),
+        "decoder.pre_conv.conv.bias": mx.zeros((4,)),
+    }
+    out = tokenizer.sanitize(weights)
+
+    key = "decoder.quantizer.rvq_first.vq.layers.0.codebook.embed.weight"
+    assert set(out) == {key, "decoder.pre_conv.conv.bias"}
+    assert np.allclose(np.array(out[key]), [[1.0, 2.0], [3.0, 1.0]])
+
+
+def test_sanitize_accepts_the_encoder_spelling_of_the_codebook() -> None:
+    tokenizer = Qwen3TTSSpeechTokenizer(_tiny_tokenizer_config())
+    weights = {
+        "encoder.quantizer.semantic_residual_vector_quantizer.layers.0."
+        "codebook.embed_sum": mx.array([[4.0, 2.0]]),
+        "encoder.quantizer.semantic_residual_vector_quantizer.layers.0."
+        "codebook.cluster_usage": mx.array([4.0]),
+    }
+    out = tokenizer.sanitize(weights)
+    assert list(out) == [
+        "encoder.quantizer.semantic_residual_vector_quantizer.layers.0."
+        "codebook.embed.weight"
+    ]
+    assert np.allclose(np.array(next(iter(out.values()))), [[1.0, 0.5]])
+
+
+def test_sanitize_drops_the_encoder_when_the_model_has_none() -> None:
+    tokenizer = Qwen3TTSSpeechTokenizer(_tiny_tokenizer_config(with_encoder=False))
+    assert not tokenizer.has_encoder
+    out = tokenizer.sanitize(
+        {
+            "encoder.downsample.conv.weight": mx.zeros((4, 4, 2)),
+            "decoder.pre_conv.conv.bias": mx.zeros((4,)),
+        }
+    )
+    assert list(out) == ["decoder.pre_conv.conv.bias"]
+
+
+def test_align_conv_weights_uses_module_type_not_shape() -> None:
+    """A square transposed conv is ambiguous by shape; type resolves it."""
+
+    class Net(nn.Module):
+        def __init__(self):
+            super().__init__()
+            self.up = nn.ConvTranspose1d(4, 4, 2, stride=2)
+            self.down = nn.Conv1d(4, 6, 3)
+
+    net = Net()
+    mx.eval(net.parameters())
+    # PyTorch layouts: ConvTranspose1d [in, out, k]; Conv1d [out, in, k].
+    torch_up = mx.random.normal((4, 4, 2))
+    torch_down = mx.random.normal((6, 4, 3))
+    aligned = align_conv_weights(
+        {"up.weight": torch_up, "down.weight": torch_down}, net
+    )
+
+    assert aligned["up.weight"].shape == net.up.weight.shape
+    assert aligned["down.weight"].shape == net.down.weight.shape
+    assert np.allclose(
+        np.array(aligned["up.weight"]), np.array(mx.transpose(torch_up, (1, 2, 0)))
+    )
+    assert np.allclose(
+        np.array(aligned["down.weight"]), np.array(mx.transpose(torch_down, (0, 2, 1)))
+    )
+    # Already-MLX weights pass through untouched.
+    again = align_conv_weights(aligned, net)
+    assert np.allclose(np.array(again["up.weight"]), np.array(aligned["up.weight"]))
+
+
+# --------------------------------------------------------------------------
+# Decoder / encoder shapes and streaming
+# --------------------------------------------------------------------------
+
+
+def test_decode_upsamples_by_the_product_of_every_rate() -> None:
+    config = _tiny_tokenizer_config(with_encoder=False)
+    tokenizer = Qwen3TTSSpeechTokenizer(config)
+    mx.eval(tokenizer.parameters())
+
+    frames = 7
+    groups = config.decoder_config.num_quantizers
+    codes = mx.random.randint(1, 32, (1, frames, groups))
+    waveform, lengths = tokenizer.decode(codes)
+    mx.eval(waveform, lengths)
+
+    upsample = tokenizer.decoder.total_upsample
+    assert upsample == 2 * 2 * 2
+    assert waveform.shape == (1, frames * upsample)
+    assert int(lengths[0]) == frames * config.decode_upsample_rate
+
+
+def test_decoder_rejects_the_wrong_number_of_codebooks() -> None:
+    config = _tiny_tokenizer_config(with_encoder=False)
+    tokenizer = Qwen3TTSSpeechTokenizer(config)
+    with pytest.raises(ValueError, match="codebooks"):
+        tokenizer.decoder(mx.zeros((1, 2, 5), dtype=mx.int32))
+
+
+def test_streaming_decode_yields_the_same_total_length() -> None:
+    config = _tiny_tokenizer_config(with_encoder=False)
+    tokenizer = Qwen3TTSSpeechTokenizer(config)
+    mx.eval(tokenizer.parameters())
+    codes = mx.random.randint(1, 32, (1, 9, config.decoder_config.num_quantizers))
+
+    full, _ = tokenizer.decode(codes)
+    chunks = list(tokenizer.streaming_decode(codes, chunk_tokens=3))
+    streamed = mx.concatenate(chunks, axis=-1)
+    mx.eval(full, streamed)
+
+    assert len(chunks) == 3
+    assert streamed.shape[-1] == full.shape[-1]
+
+
+def test_encode_produces_valid_quantizer_count_and_frame_rate() -> None:
+    config = _tiny_tokenizer_config()
+    tokenizer = Qwen3TTSSpeechTokenizer(config)
+    mx.eval(tokenizer.parameters())
+
+    # upsampling_ratios [2, 2] -> stride 4; encoder frame rate 24000/4 = 6000,
+    # downsampled by 6000/1500 = 4, so 64 samples -> 4 frames.
+    codes = tokenizer.encode(mx.random.normal((1, 1, 64)))
+    mx.eval(codes)
+    assert codes.shape == (1, config.encoder_valid_num_quantizers, 4)
+    assert int(codes.min()) >= 0
+    assert int(codes.max()) < config.encoder_config.codebook_size
+
+
+def test_encode_raises_without_an_encoder() -> None:
+    tokenizer = Qwen3TTSSpeechTokenizer(_tiny_tokenizer_config(with_encoder=False))
+    with pytest.raises(ValueError, match="no encoder"):
+        tokenizer.encode(mx.zeros((1, 1, 64)))
+
+
+# --------------------------------------------------------------------------
+# Speaker encoder and DSP
+# --------------------------------------------------------------------------
+
+
+def test_speaker_encoder_pools_time_into_one_embedding() -> None:
+    config = SpeakerEncoderConfig(
+        mel_dim=16,
+        enc_dim=12,
+        # Final width is the sum of the three SE-Res2Net widths, as released.
+        enc_channels=[16, 16, 16, 16, 48],
+        enc_kernel_sizes=[3, 3, 3, 3, 1],
+        enc_dilations=[1, 2, 3, 4, 1],
+        enc_attention_channels=8,
+        enc_res2net_scale=4,
+        enc_se_channels=8,
+    )
+    encoder = Qwen3TTSSpeakerEncoder(config)
+    mx.eval(encoder.parameters())
+
+    for frames in (20, 57):
+        embedding = encoder(mx.random.normal((1, frames, 16)))
+        mx.eval(embedding)
+        assert embedding.shape == (1, 12)
+
+
+def test_speaker_encoder_rejects_an_inconsistent_channel_plan() -> None:
+    with pytest.raises(ValueError, match="sum of the"):
+        Qwen3TTSSpeakerEncoder(
+            SpeakerEncoderConfig(
+                mel_dim=16,
+                enc_channels=[16, 16, 24],
+                enc_kernel_sizes=[3, 3, 1],
+                enc_dilations=[1, 2, 1],
+            )
+        )
+
+
+def test_mel_filterbank_matches_librosa() -> None:
+    librosa_filters = pytest.importorskip("librosa.filters")
+    reference = librosa_filters.mel(
+        sr=24000, n_fft=1024, n_mels=128, fmin=0, fmax=12000
+    )
+    ours = np.array(mel_filters(24000, 1024, 128, 0.0, 12000.0))
+    assert ours.shape == reference.shape
+    assert np.abs(ours - reference).max() < 1e-6
+
+
+def test_mel_spectrogram_frame_count_follows_the_hop() -> None:
+    audio = mx.zeros((24000,))
+    mels = mel_spectrogram(audio)
+    mx.eval(mels)
+    # (n_fft - hop) // 2 padding each side, then floor((len - n_fft)/hop) + 1.
+    padded = 24000 + 2 * ((1024 - 256) // 2)
+    assert mels.shape == (1, (padded - 1024) // 256 + 1, 128)
+
+
+# --------------------------------------------------------------------------
+# Sampling
+# --------------------------------------------------------------------------
+
+
+def test_top_k_keeps_exactly_k_entries() -> None:
+    logits = mx.array([[3.0, 1.0, 2.0, 0.0]])
+    kept = np.array(~np.isinf(np.array(apply_top_k(logits, 2))))
+    assert kept.tolist() == [[True, False, True, False]]
+    # A k at or beyond the vocabulary is a no-op.
+    assert not np.isinf(np.array(apply_top_k(logits, 4))).any()
+
+
+def test_top_p_keeps_the_token_that_crosses_the_threshold() -> None:
+    # softmax([2, 1, 0]) ~ [0.665, 0.245, 0.090]
+    logits = mx.array([[2.0, 1.0, 0.0]])
+    kept = np.array(~np.isinf(np.array(apply_top_p(logits, 0.7))))
+    assert kept.tolist() == [[True, True, False]]
+    assert not np.isinf(np.array(apply_top_p(logits, 1.0))).any()
+
+
+def test_repetition_penalty_divides_positive_and_scales_negative() -> None:
+    logits = mx.array([[4.0, -4.0, 1.0]])
+    out = np.array(apply_repetition_penalty(logits, [0, 1], 2.0, 64))
+    assert np.allclose(out, [[2.0, -8.0, 1.0]])
+
+
+def test_repetition_penalty_only_looks_at_the_recent_window() -> None:
+    logits = mx.array([[4.0, 4.0]])
+    out = np.array(apply_repetition_penalty(logits, [0, 1], 2.0, context_size=1))
+    assert np.allclose(out, [[4.0, 2.0]])
+
+
+def test_suppressed_tokens_are_never_sampled() -> None:
+    logits = mx.array([[10.0, 0.0, 0.0]])
+    out = np.array(suppress(logits, [0]))
+    assert np.isinf(out[0, 0]) and out[0, 0] < 0
+    token = sample_codec_token(
+        logits, SamplingParams(temperature=0.0), suppress_tokens=[0]
+    )
+    mx.eval(token)
+    assert int(token[0, 0]) != 0
+
+
+def test_greedy_sampling_is_argmax_and_shape_is_batch_by_one() -> None:
+    logits = mx.array([[1.0, 5.0, 2.0], [7.0, 0.0, 1.0]])
+    token = sample_codec_token(logits, SamplingParams(temperature=0.0))
+    mx.eval(token)
+    assert token.shape == (2, 1)
+    assert [int(token[i, 0]) for i in range(2)] == [1, 0]
+
+
+def test_special_codec_token_ids_spans_the_reserved_block_minus_eos() -> None:
+    ids = special_codec_token_ids(3072, keep=2150)
+    assert min(ids) == 2048 and max(ids) == 3071
+    assert 2150 not in ids
+    assert len(ids) == 1023

--- a/tests/unit_test/qwen3_tts/test_mlx_streaming_vocoder.py
+++ b/tests/unit_test/qwen3_tts/test_mlx_streaming_vocoder.py
@@ -1,0 +1,284 @@
+# SPDX-License-Identifier: Apache-2.0
+"""Tests for the MLX Qwen3-TTS streaming vocoder stage."""
+
+from __future__ import annotations
+
+import pytest
+
+mx = pytest.importorskip("mlx.core")
+import numpy as np  # noqa: E402
+import torch  # noqa: E402
+
+from sglang_omni.models.qwen3_tts.mlx.config import (  # noqa: E402
+    TokenizerConfig,
+    TokenizerDecoderConfig,
+)
+from sglang_omni.models.qwen3_tts.mlx.speech_tokenizer import (  # noqa: E402
+    Qwen3TTSSpeechTokenizer,
+)
+from sglang_omni.models.qwen3_tts.mlx.streaming_vocoder import (  # noqa: E402
+    Qwen3TTSMlxStreamingVocoder,
+)
+
+GROUPS = 4
+
+
+def _tokenizer() -> Qwen3TTSSpeechTokenizer:
+    mx.random.seed(0)
+    config = TokenizerConfig(
+        encoder_config=None,
+        decoder_config=TokenizerDecoderConfig(
+            latent_dim=16,
+            codebook_dim=8,
+            codebook_size=32,
+            decoder_dim=16,
+            hidden_size=8,
+            intermediate_size=16,
+            head_dim=4,
+            num_attention_heads=2,
+            num_hidden_layers=1,
+            num_key_value_heads=2,
+            num_quantizers=GROUPS,
+            num_semantic_quantizers=1,
+            sliding_window=6,
+            upsample_rates=[2, 2],
+            upsampling_ratios=[2],
+        ),
+        decode_upsample_rate=8,
+    )
+    tokenizer = Qwen3TTSSpeechTokenizer(config)
+    mx.eval(tokenizer.parameters())
+    return tokenizer
+
+
+def _vocoder(**kwargs) -> Qwen3TTSMlxStreamingVocoder:
+    return Qwen3TTSMlxStreamingVocoder(_tokenizer(), stream_stride=2, **kwargs)
+
+
+def _codes(frames: int, seed: int = 1) -> torch.Tensor:
+    rng = np.random.default_rng(seed)
+    return torch.from_numpy(rng.integers(1, 32, size=(frames, GROUPS)).astype(np.int64))
+
+
+def _feed(vocoder, request_id, state, codes):
+    """Validate + ingest one chunk, mirroring the base class."""
+    checked = vocoder.validate_chunk(request_id, state, codes)
+    vocoder.ingest(request_id, state, checked)
+
+
+# --------------------------------------------------------------------------
+# Session isolation — the property concurrent requests depend on
+# --------------------------------------------------------------------------
+
+
+def test_interleaved_requests_do_not_corrupt_each_other() -> None:
+    """Two streams decoded turn-by-turn must equal each decoded alone."""
+    vocoder = _vocoder()
+    codes_a = [_codes(3, seed=1), _codes(3, seed=2)]
+    codes_b = [_codes(3, seed=3), _codes(3, seed=4)]
+
+    def solo(chunks):
+        state = vocoder.create_stream_state("solo")
+        out = []
+        for chunk in chunks:
+            _feed(vocoder, "solo", state, chunk)
+            delta = vocoder.decode_delta("solo", state, is_final=False)
+            out.append(delta)
+        return out
+
+    expected_a = solo(codes_a)
+    expected_b = solo(codes_b)
+
+    state_a = vocoder.create_stream_state("a")
+    state_b = vocoder.create_stream_state("b")
+    got_a, got_b = [], []
+    for index in range(2):
+        _feed(vocoder, "a", state_a, codes_a[index])
+        got_a.append(vocoder.decode_delta("a", state_a, is_final=False))
+        _feed(vocoder, "b", state_b, codes_b[index])
+        got_b.append(vocoder.decode_delta("b", state_b, is_final=False))
+
+    for expected, got in ((expected_a, got_a), (expected_b, got_b)):
+        for want, have in zip(expected, got):
+            assert torch.allclose(want, have, atol=1e-5)
+
+
+def test_a_session_is_independent_of_decoder_module_state() -> None:
+    """Leaving a session must restore whatever was installed before it."""
+    vocoder = _vocoder()
+    decoder = vocoder._decoder
+    decoder.reset_streaming_state()
+
+    state = vocoder.create_stream_state("a")
+    _feed(vocoder, "a", state, _codes(3))
+    vocoder.decode_delta("a", state, is_final=False)
+
+    # The request's buffers live in its session, not on the module.
+    assert decoder._transformer_cache is None
+    assert state.session["cache"] is not None
+    assert any(value is not None for value in state.session["buffers"].values())
+
+
+# --------------------------------------------------------------------------
+# Streaming behaviour
+# --------------------------------------------------------------------------
+
+
+def test_streamed_deltas_concatenate_to_the_one_shot_decode() -> None:
+    vocoder = _vocoder()
+    frames = _codes(8, seed=7)
+
+    state = vocoder.create_stream_state("a")
+    deltas = []
+    for start in range(0, 8, 2):
+        _feed(vocoder, "a", state, frames[start : start + 2])
+        delta = vocoder.decode_delta("a", state, is_final=False)
+        if delta is not None:
+            deltas.append(delta)
+    streamed = torch.cat(deltas)
+
+    whole = vocoder._decode_whole(frames.numpy().astype(np.int32), ref_frames=0)
+    assert streamed.shape == whole.shape
+    # Stateful streaming is the same computation as one pass, up to float noise.
+    assert torch.allclose(streamed, whole, atol=2e-3)
+
+
+def test_output_length_is_frames_times_upsample() -> None:
+    vocoder = _vocoder()
+    state = vocoder.create_stream_state("a")
+    _feed(vocoder, "a", state, _codes(5))
+    delta = vocoder.decode_delta("a", state, is_final=False)
+    assert delta.shape[0] == 5 * vocoder._decoder.total_upsample
+
+
+def test_should_decode_waits_for_the_stride() -> None:
+    vocoder = _vocoder()
+    state = vocoder.create_stream_state("a")
+
+    _feed(vocoder, "a", state, _codes(1))
+    assert not vocoder.should_decode(state, is_final=False)
+    _feed(vocoder, "a", state, _codes(1, seed=9))
+    assert vocoder.should_decode(state, is_final=False)
+    # The final flush never waits.
+    assert vocoder.should_decode(vocoder.create_stream_state("b"), is_final=True)
+
+
+def test_decode_delta_is_none_without_buffered_frames() -> None:
+    vocoder = _vocoder()
+    state = vocoder.create_stream_state("a")
+    assert vocoder.decode_delta("a", state, is_final=True) is None
+
+
+# --------------------------------------------------------------------------
+# Reference priming (voice cloning)
+# --------------------------------------------------------------------------
+
+
+def test_reference_frames_prime_the_decoder_without_being_emitted() -> None:
+    vocoder = _vocoder()
+    state = vocoder.create_stream_state("a")
+    vocoder.latch_stream_contract(
+        "a", state, {"ref_code_len": 3}, origin="stream metadata"
+    )
+
+    _feed(vocoder, "a", state, _codes(5))
+    delta = vocoder.decode_delta("a", state, is_final=False)
+
+    upsample = vocoder._decoder.total_upsample
+    # 5 frames in, 3 of them reference: only 2 frames of audio come out.
+    assert delta.shape[0] == 2 * upsample
+    assert state.ref_frames_consumed == 3
+    assert state.emitted_frames == 2
+
+
+def test_reference_priming_spans_chunks() -> None:
+    vocoder = _vocoder()
+    state = vocoder.create_stream_state("a")
+    vocoder.latch_stream_contract(
+        "a", state, {"ref_code_len": 4}, origin="stream metadata"
+    )
+    upsample = vocoder._decoder.total_upsample
+
+    _feed(vocoder, "a", state, _codes(2))
+    assert vocoder.decode_delta("a", state, is_final=False) is None
+    assert state.ref_frames_consumed == 2
+
+    _feed(vocoder, "a", state, _codes(3, seed=5))
+    delta = vocoder.decode_delta("a", state, is_final=False)
+    assert state.ref_frames_consumed == 4
+    assert delta.shape[0] == 1 * upsample
+
+
+def test_reference_frames_do_not_count_toward_the_stride() -> None:
+    vocoder = _vocoder()
+    state = vocoder.create_stream_state("a")
+    vocoder.latch_stream_contract(
+        "a", state, {"ref_code_len": 4}, origin="stream metadata"
+    )
+    _feed(vocoder, "a", state, _codes(4))
+    # All four frames are priming, so nothing is emittable yet.
+    assert not vocoder.should_decode(state, is_final=False)
+
+
+def test_ref_code_len_cannot_change_after_ingestion() -> None:
+    vocoder = _vocoder()
+    state = vocoder.create_stream_state("a")
+    vocoder.latch_stream_contract(
+        "a", state, {"ref_code_len": 2}, origin="stream metadata"
+    )
+    _feed(vocoder, "a", state, _codes(3))
+    with pytest.raises(ValueError, match="changed after"):
+        vocoder.latch_stream_contract(
+            "a", state, {"ref_code_len": 5}, origin="stream metadata"
+        )
+
+
+def test_negative_ref_code_len_is_rejected() -> None:
+    vocoder = _vocoder()
+    state = vocoder.create_stream_state("a")
+    with pytest.raises(ValueError, match="negative"):
+        vocoder.latch_stream_contract(
+            "a", state, {"ref_code_len": -1}, origin="stream metadata"
+        )
+
+
+# --------------------------------------------------------------------------
+# Chunk validation
+# --------------------------------------------------------------------------
+
+
+def test_chunk_must_be_two_dimensional() -> None:
+    vocoder = _vocoder()
+    state = vocoder.create_stream_state("a")
+    with pytest.raises(ValueError, match=r"\[frames, quantizers\]"):
+        vocoder.validate_chunk("a", state, torch.zeros(3, dtype=torch.long))
+
+
+def test_quantizer_count_must_stay_constant() -> None:
+    vocoder = _vocoder()
+    state = vocoder.create_stream_state("a")
+    vocoder.validate_chunk("a", state, _codes(2))
+    with pytest.raises(ValueError, match="quantizers"):
+        vocoder.validate_chunk("a", state, torch.ones(2, GROUPS + 1, dtype=torch.long))
+
+
+def test_out_of_range_codec_ids_are_rejected() -> None:
+    vocoder = _vocoder()
+    state = vocoder.create_stream_state("a")
+    bad = torch.full((2, GROUPS), 9999, dtype=torch.long)
+    with pytest.raises(ValueError, match="outside"):
+        vocoder.validate_chunk("a", state, bad)
+    negative = torch.full((2, GROUPS), -1, dtype=torch.long)
+    with pytest.raises(ValueError, match="outside"):
+        vocoder.validate_chunk("a", state, negative)
+
+
+def test_releasing_resources_drops_the_session() -> None:
+    vocoder = _vocoder()
+    state = vocoder.create_stream_state("a")
+    _feed(vocoder, "a", state, _codes(3))
+    vocoder.decode_delta("a", state, is_final=False)
+
+    vocoder.release_stream_resources("a", state)
+    assert state.session == {}
+    assert state.pending == []

--- a/tests/unit_test/qwen3_tts/test_mlx_talker.py
+++ b/tests/unit_test/qwen3_tts/test_mlx_talker.py
@@ -1,0 +1,587 @@
+# SPDX-License-Identifier: Apache-2.0
+"""Differential tests for the MLX Qwen3-TTS talker port.
+
+The port swaps two things out of the mlx-audio reference: externally computed
+interleaved MRoPE becomes ``nn.RoPE`` on the attention module (SGLang's MLX
+attention contract), and the code predictor's two priming tokens are issued as
+one two-token call instead of two single-token calls (SGLang's CUDA form).
+Both reference algorithms are reimplemented here rather than imported, because
+mlx-audio is deliberately not a dependency of this package.
+"""
+
+from __future__ import annotations
+
+import math
+
+import pytest
+
+mx = pytest.importorskip("mlx.core")
+import mlx.nn as nn  # noqa: E402
+
+from sglang_omni.models.qwen3_tts.mlx.config import (  # noqa: E402
+    CodePredictorConfig,
+    ModelConfig,
+    TalkerConfig,
+)
+from sglang_omni.models.qwen3_tts.mlx.model import Qwen3TTSTalkerModel  # noqa: E402
+from sglang_omni.models.qwen3_tts.mlx.talker import (  # noqa: E402
+    Qwen3TTSTalkerForConditionalGeneration,
+    reset_code_cache,
+)
+
+
+def _talker_config(**overrides) -> TalkerConfig:
+    """A tiny talker whose head_dim // 2 matches the MRoPE section sum."""
+    predictor = CodePredictorConfig(
+        vocab_size=32,
+        hidden_size=12,
+        intermediate_size=16,
+        num_hidden_layers=2,
+        num_attention_heads=3,
+        num_key_value_heads=1,
+        head_dim=4,
+        num_code_groups=4,
+        rope_theta=10000.0,
+    )
+    config = TalkerConfig(
+        code_predictor_config=predictor,
+        vocab_size=32,
+        hidden_size=8,
+        intermediate_size=16,
+        num_hidden_layers=2,
+        num_attention_heads=2,
+        num_key_value_heads=1,
+        head_dim=8,
+        text_hidden_size=6,
+        text_vocab_size=40,
+        max_position_embeddings=128,
+        rope_theta=10000.0,
+        rope_scaling={
+            "interleaved": True,
+            # head_dim // 2 == 4 frequencies split across temporal/height/width
+            "mrope_section": [2, 1, 1],
+            "rope_type": "default",
+        },
+        num_code_groups=4,
+    )
+    for key, value in overrides.items():
+        setattr(config, key, value)
+    return config
+
+
+def _build(dtype=mx.float32) -> Qwen3TTSTalkerForConditionalGeneration:
+    mx.random.seed(0)
+    model = Qwen3TTSTalkerForConditionalGeneration(_talker_config())
+    model.set_dtype(dtype)
+    mx.eval(model.parameters())
+    return model
+
+
+# --------------------------------------------------------------------------
+# mlx-audio reference: interleaved MRoPE computed outside attention
+# --------------------------------------------------------------------------
+
+
+def _reference_mrope_cos_sin(
+    *,
+    head_dim: int,
+    base: float,
+    mrope_section: list[int],
+    position_ids: mx.array,
+    dtype,
+) -> tuple[mx.array, mx.array]:
+    """mlx-audio ``TalkerRotaryEmbedding``: 3-D positions -> combined cos/sin.
+
+    ``position_ids`` is ``[3, batch, seq_len]``.
+    """
+    inv_freq = 1.0 / (base ** (mx.arange(0, head_dim, 2, dtype=mx.float32) / head_dim))
+    pos = mx.expand_dims(position_ids.astype(mx.float32), axis=2)
+    inv = mx.broadcast_to(
+        inv_freq[None, None, :, None],
+        (3, position_ids.shape[1], inv_freq.shape[0], 1),
+    )
+    freqs = mx.swapaxes(inv @ pos, 2, 3)  # [3, batch, seq_len, head_dim // 2]
+
+    # apply_interleaved_mrope: H takes indices 3k+1, W takes 3k+2, T keeps rest.
+    indices = mx.arange(freqs.shape[-1])
+    h_mask = ((indices % 3 == 1) & (indices < mrope_section[1] * 3)).reshape(1, 1, -1)
+    w_mask = ((indices % 3 == 2) & (indices < mrope_section[2] * 3)).reshape(1, 1, -1)
+    combined = mx.where(h_mask, freqs[1], freqs[0])
+    combined = mx.where(w_mask, freqs[2], combined)
+
+    emb = mx.concatenate([combined, combined], axis=-1)
+    return mx.cos(emb).astype(dtype), mx.sin(emb).astype(dtype)
+
+
+def _rotate_half(x: mx.array) -> mx.array:
+    half = x.shape[-1] // 2
+    return mx.concatenate([-x[..., half:], x[..., :half]], axis=-1)
+
+
+class _ReferenceMRoPEAttention(nn.Module):
+    """mlx-audio ``TalkerAttention``, sharing the ported module's weights."""
+
+    def __init__(self, inner, mrope_section: list[int]) -> None:
+        super().__init__()
+        self.inner = inner
+        self.mrope_section = mrope_section
+
+    def __call__(self, x: mx.array, mask=None, cache=None) -> mx.array:
+        inner = self.inner
+        B, L, _ = x.shape
+        offset = 0 if cache is None else cache.offset
+
+        q = inner.q_proj(x).reshape(B, L, inner.num_heads, inner.head_dim)
+        k = inner.k_proj(x).reshape(B, L, inner.num_kv_heads, inner.head_dim)
+        v = inner.v_proj(x).reshape(B, L, inner.num_kv_heads, inner.head_dim)
+        q = inner.q_norm(q).transpose(0, 2, 1, 3)
+        k = inner.k_norm(k).transpose(0, 2, 1, 3)
+        v = v.transpose(0, 2, 1, 3)
+
+        # The talker is always driven with three identical position rows.
+        pos = mx.broadcast_to(mx.arange(offset, offset + L)[None, :], (B, L))
+        cos, sin = _reference_mrope_cos_sin(
+            head_dim=inner.head_dim,
+            base=inner.config.rope_theta,
+            mrope_section=self.mrope_section,
+            position_ids=mx.stack([pos, pos, pos], axis=0),
+            dtype=x.dtype,
+        )
+        cos = mx.expand_dims(cos, axis=1)
+        sin = mx.expand_dims(sin, axis=1)
+        q = (q * cos) + (_rotate_half(q) * sin)
+        k = (k * cos) + (_rotate_half(k) * sin)
+
+        if cache is not None:
+            k, v = cache.update_and_fetch(k, v)
+
+        # mlx-audio always builds an explicit additive causal mask; comparing
+        # against it also pins mlx-lm's "causal" shorthand as equivalent.
+        additive = None
+        if k.shape[2] > 1 and L > 1:
+            additive = nn.MultiHeadAttention.create_additive_causal_mask(L).astype(
+                x.dtype
+            )
+        out = mx.fast.scaled_dot_product_attention(
+            q, k, v, scale=inner.scale, mask=additive
+        )
+        return inner.o_proj(out.transpose(0, 2, 1, 3).reshape(B, L, -1))
+
+
+def _swap_in_reference_attention(model) -> None:
+    section = model.config.rope_scaling["mrope_section"]
+    for layer in model.model.layers:
+        layer.self_attn = _ReferenceMRoPEAttention(layer.self_attn, section)
+
+
+def _max_abs_diff(a: mx.array, b: mx.array) -> float:
+    return float(mx.abs(a.astype(mx.float32) - b.astype(mx.float32)).max())
+
+
+# --------------------------------------------------------------------------
+# RoPE equivalence
+# --------------------------------------------------------------------------
+
+
+def test_interleaved_mrope_collapses_to_plain_rope_for_equal_rows() -> None:
+    head_dim, base = 8, 10000.0
+    pos = mx.arange(5)[None, :]
+    equal_rows = mx.stack([pos, pos, pos], axis=0)
+    cos, sin = _reference_mrope_cos_sin(
+        head_dim=head_dim,
+        base=base,
+        mrope_section=[2, 1, 1],
+        position_ids=equal_rows,
+        dtype=mx.float32,
+    )
+
+    # nn.RoPE(traditional=False) is exactly x*cos + rotate_half(x)*sin.
+    mx.random.seed(1)
+    x = mx.random.normal((1, 2, 5, head_dim))
+    rope = nn.RoPE(head_dim, traditional=False, base=base)
+    expected = (x * cos[:, None]) + (_rotate_half(x) * sin[:, None])
+    assert _max_abs_diff(rope(x), expected) < 1e-5
+
+
+def test_interleaved_mrope_diverges_when_rows_differ() -> None:
+    """Pins the assumption: the collapse is a property of equal rows only."""
+    pos = mx.arange(5)[None, :]
+    diverged = mx.stack([pos, pos + 1, pos + 2], axis=0)
+    cos, _ = _reference_mrope_cos_sin(
+        head_dim=8,
+        base=10000.0,
+        mrope_section=[2, 1, 1],
+        position_ids=diverged,
+        dtype=mx.float32,
+    )
+    equal, _ = _reference_mrope_cos_sin(
+        head_dim=8,
+        base=10000.0,
+        mrope_section=[2, 1, 1],
+        position_ids=mx.broadcast_to(pos[None], (3, 1, 5)),
+        dtype=mx.float32,
+    )
+    assert _max_abs_diff(cos, equal) > 1e-3
+
+
+# --------------------------------------------------------------------------
+# SGLang MLX attention contract
+# --------------------------------------------------------------------------
+
+
+def test_talker_attention_satisfies_the_sglang_attention_contract() -> None:
+    contract = pytest.importorskip(
+        "sglang.srt.hardware_backend.mlx.kv_cache.attention_contract"
+    )
+    model = _build()
+    attn = model.model.layers[0].self_attn
+
+    assert contract.is_attention_module(attn)
+    assert contract.get_num_heads(attn) == 2
+    assert contract.get_num_kv_heads(attn) == 1
+    assert contract.get_head_dim(attn) == 8
+    assert contract.get_attention_scale(attn) == pytest.approx(1.0 / math.sqrt(8))
+    # A sliding-window marker on the container would make batched decode drop
+    # KV past the window; the talker must not declare one.
+    assert contract.get_container_window_size(model) is None
+    assert contract.get_layer_window_sizes(model) == {}
+
+
+def test_attention_discovery_covers_the_talker_and_not_the_code_predictor() -> None:
+    patching = pytest.importorskip(
+        "sglang.srt.hardware_backend.mlx.kv_cache.model_patching"
+    )
+    model = _build()
+
+    layers, attrs = patching.find_attention_layers(model)
+    assert list(layers) == list(model.model.layers)
+    assert attrs == ["self_attn"] * len(model.model.layers)
+
+    patched = patching.patch_model_attention(model)
+    assert patched == len(model.model.layers)
+    # The predictor keeps its own untouched attention: its KV is frame-local.
+    predictor_attn = model.code_predictor.model.layers[0].self_attn
+    assert not isinstance(predictor_attn, patching.MLXAttentionWrapper)
+    assert patching.patch_model_attention(model) == 0
+
+
+# --------------------------------------------------------------------------
+# Talker numerical parity
+# --------------------------------------------------------------------------
+
+
+@pytest.mark.parametrize("batch_size", [1, 2])
+def test_prefill_and_decode_match_the_mrope_reference(batch_size: int) -> None:
+    model = _build()
+    config = model.config
+    mx.random.seed(2)
+    prompt = mx.random.normal((batch_size, 6, config.hidden_size))
+    step = mx.random.normal((batch_size, 1, config.hidden_size))
+
+    port_cache = model.make_cache()
+    port_logits, port_hidden = model(prompt, cache=port_cache)
+    port_step_logits, port_step_hidden = model(step, cache=port_cache)
+    mx.eval(port_logits, port_hidden, port_step_logits, port_step_hidden)
+
+    _swap_in_reference_attention(model)
+    ref_cache = model.make_cache()
+    ref_logits, ref_hidden = model(prompt, cache=ref_cache)
+    ref_step_logits, ref_step_hidden = model(step, cache=ref_cache)
+    mx.eval(ref_logits, ref_hidden, ref_step_logits, ref_step_hidden)
+
+    assert _max_abs_diff(port_hidden, ref_hidden) < 1e-4
+    assert _max_abs_diff(port_logits, ref_logits) < 1e-4
+    assert _max_abs_diff(port_step_hidden, ref_step_hidden) < 1e-4
+    assert _max_abs_diff(port_step_logits, ref_step_logits) < 1e-4
+
+
+def test_batched_decode_through_the_sglang_wrapper_matches_per_request_decode() -> None:
+    """The reason for conforming to the contract: generic ragged batched decode.
+
+    Two requests with different prefill lengths must decode identically whether
+    stepped one at a time or fused into one batched attention call.
+    """
+    kv = pytest.importorskip("sglang.srt.hardware_backend.mlx.kv_cache")
+    model = _build()
+    kv.patch_model_attention(model)
+    config = model.config
+    num_layers = len(model.model.layers)
+
+    def new_caches() -> list:
+        return [
+            kv.ContiguousAttentionKVCache(
+                n_kv_heads=config.num_key_value_heads,
+                head_dim=config.head_dim,
+                max_seq_len=64,
+                dtype=mx.float32,
+            )
+            for _ in range(num_layers)
+        ]
+
+    mx.random.seed(8)
+    prompts = [
+        mx.random.normal((1, 6, config.hidden_size)),
+        mx.random.normal((1, 3, config.hidden_size)),
+    ]
+    steps = [mx.random.normal((1, 1, config.hidden_size)) for _ in prompts]
+
+    stepwise_caches = [new_caches() for _ in prompts]
+    batched_caches = [new_caches() for _ in prompts]
+    for caches in (stepwise_caches, batched_caches):
+        for prompt, cache in zip(prompts, caches):
+            mx.eval(model(prompt, cache=cache))
+
+    stepwise = mx.concatenate(
+        [
+            model(step, cache=cache)[0][:, -1, :]
+            for step, cache in zip(steps, stepwise_caches)
+        ],
+        axis=0,
+    )
+
+    context = kv.BatchedDecodeContext(
+        batch_size=len(prompts),
+        seq_lens=[cache[0].offset for cache in batched_caches],
+        attention_layer_caches=[
+            [caches[layer_idx] for caches in batched_caches]
+            for layer_idx in range(num_layers)
+        ],
+    )
+    assert context.seq_lens == [6, 3] and context.needs_padding
+    kv.set_context(context)
+    try:
+        # The model still needs an offset to build its mask; SGLang hands it a
+        # shim while the wrapper reads real KV from the context.
+        shim = [
+            kv.AttentionOffsetCache(offset=max(context.seq_lens))
+            for _ in range(num_layers)
+        ]
+        batched = model(mx.concatenate(steps, axis=0), cache=shim)[0][:, -1, :]
+        mx.eval(batched)
+    finally:
+        kv.clear_context()
+
+    mx.eval(stepwise)
+    assert _max_abs_diff(batched, stepwise) < 1e-4
+    assert [cache[0].offset for cache in batched_caches] == [7, 4]
+
+
+def test_decode_offsets_come_from_the_cache() -> None:
+    """One 6-token prefill must equal six single-token steps."""
+    model = _build()
+    mx.random.seed(3)
+    prompt = mx.random.normal((1, 6, model.config.hidden_size))
+
+    bulk_cache = model.make_cache()
+    bulk_logits, _ = model(prompt, cache=bulk_cache)
+
+    step_cache = model.make_cache()
+    step_logits = [
+        model(prompt[:, i : i + 1, :], cache=step_cache)[0] for i in range(6)
+    ]
+    stepwise = mx.concatenate(step_logits, axis=1)
+    mx.eval(bulk_logits, stepwise)
+
+    assert _max_abs_diff(bulk_logits, stepwise) < 1e-4
+    assert bulk_cache[0].offset == step_cache[0].offset == 6
+
+
+# --------------------------------------------------------------------------
+# Code predictor
+# --------------------------------------------------------------------------
+
+
+def _reference_predict_codes(model, first_code: mx.array, talker_hidden: mx.array):
+    """SGLang's CUDA form: two single-token priming calls, then one per group."""
+    predictor = model.code_predictor
+    num_groups = model.config.code_predictor_config.num_code_groups
+    cache = predictor.make_cache()
+
+    codes = [first_code]
+    summed = model.get_input_embeddings()(first_code)
+
+    predictor.model(predictor.project_input(talker_hidden[:, -1:, :]), cache=cache)
+    layer0_embed = model.get_input_embeddings()(first_code)
+    hidden = predictor.model(predictor.project_input(layer0_embed), cache=cache)
+
+    for group_index in range(num_groups - 1):
+        logits = predictor.lm_head[group_index](hidden)
+        code = mx.argmax(logits[:, -1, :], axis=-1, keepdims=True)
+        codes.append(code)
+        embed = predictor.codec_embedding[group_index](code)
+        summed = summed + embed
+        if group_index < num_groups - 2:
+            hidden = predictor.model(predictor.project_input(embed), cache=cache)
+
+    return mx.concatenate(codes, axis=1), summed
+
+
+@pytest.mark.parametrize("batch_size", [1, 2])
+def test_predict_codes_matches_the_sequential_reference(batch_size: int) -> None:
+    model = _build()
+    mx.random.seed(4)
+    hidden = mx.random.normal((batch_size, 3, model.config.hidden_size))
+    first_code = mx.array([[5]] * batch_size, dtype=mx.int32)
+
+    codes, summed = model.predict_codes(first_code, hidden)
+    ref_codes, ref_summed = _reference_predict_codes(model, first_code, hidden)
+    mx.eval(codes, summed, ref_codes, ref_summed)
+
+    assert codes.shape == (batch_size, model.config.num_code_groups)
+    assert summed.shape == (batch_size, 1, model.config.hidden_size)
+    assert (codes == ref_codes).all().item()
+    assert _max_abs_diff(summed, ref_summed) < 1e-4
+
+
+def test_predict_codes_keeps_group_zero_and_echoes_the_first_code() -> None:
+    model = _build()
+    mx.random.seed(5)
+    hidden = mx.random.normal((1, 1, model.config.hidden_size))
+    first_code = mx.array([[7]], dtype=mx.int32)
+
+    codes, summed = model.predict_codes(first_code, hidden)
+    mx.eval(codes, summed)
+
+    assert codes[0, 0].item() == 7
+    # Group 0 embeds through the talker's table, groups 1.. through the
+    # predictor's; the sum is the codec half of the next talker input.
+    expected = model.get_input_embeddings()(codes[:, 0:1])
+    for index in range(1, model.config.num_code_groups):
+        expected = expected + model.code_predictor.codec_embedding[index - 1](
+            codes[:, index : index + 1]
+        )
+    mx.eval(expected)
+    assert _max_abs_diff(summed, expected) < 1e-4
+
+
+def test_reused_predictor_cache_is_reset_between_frames() -> None:
+    model = _build()
+    mx.random.seed(6)
+    hidden = mx.random.normal((1, 1, model.config.hidden_size))
+    first_code = mx.array([[3]], dtype=mx.int32)
+
+    fresh, _ = model.predict_codes(first_code, hidden)
+    cache = model.code_predictor.make_cache()
+    first, _ = model.predict_codes(first_code, hidden, cache=cache)
+    second, _ = model.predict_codes(first_code, hidden, cache=cache)
+    mx.eval(fresh, first, second)
+
+    assert (fresh == first).all().item()
+    assert (first == second).all().item()
+
+    reset_code_cache(cache)
+    assert all(entry.offset == 0 for entry in cache)
+    assert all(entry.keys is None for entry in cache)
+
+
+def test_code_sampler_receives_last_position_logits_and_group_index() -> None:
+    model = _build()
+    mx.random.seed(7)
+    hidden = mx.random.normal((1, 1, model.config.hidden_size))
+    seen: list[tuple[int, tuple[int, ...]]] = []
+
+    def sampler(logits: mx.array, group_index: int) -> mx.array:
+        seen.append((group_index, tuple(logits.shape)))
+        return mx.zeros((logits.shape[0], 1), dtype=mx.int32)
+
+    codes, _ = model.predict_codes(
+        mx.array([[1]], dtype=mx.int32), hidden, sampler=sampler
+    )
+    mx.eval(codes)
+
+    vocab = model.config.code_predictor_config.vocab_size
+    assert seen == [(i, (1, vocab)) for i in range(model.config.num_code_groups - 1)]
+    assert codes[0, 0].item() == 1
+    assert [codes[0, i].item() for i in range(1, model.config.num_code_groups)] == [
+        0
+    ] * (model.config.num_code_groups - 1)
+
+
+# --------------------------------------------------------------------------
+# dtype and weights
+# --------------------------------------------------------------------------
+
+
+def test_bfloat16_is_preserved_through_the_talker_and_its_cache() -> None:
+    model = _build(dtype=mx.bfloat16)
+    prompt = mx.random.normal((1, 4, model.config.hidden_size)).astype(mx.bfloat16)
+
+    cache = model.make_cache()
+    logits, hidden = model(prompt, cache=cache)
+    codes, summed = model.predict_codes(
+        mx.array([[2]], dtype=mx.int32), hidden, cache=model.code_predictor.make_cache()
+    )
+    mx.eval(logits, hidden, codes, summed)
+
+    assert hidden.dtype == mx.bfloat16
+    assert logits.dtype == mx.bfloat16
+    assert summed.dtype == mx.bfloat16
+    assert cache[0].keys.dtype == mx.bfloat16
+    assert cache[0].values.dtype == mx.bfloat16
+
+
+def test_sanitize_scopes_weights_to_the_talker_subtree() -> None:
+    sanitize = Qwen3TTSTalkerForConditionalGeneration.sanitize
+    weights = {
+        "talker.model.layers.0.self_attn.q_proj.weight": mx.zeros((2, 2)),
+        "talker.codec_head.weight": mx.zeros((2, 2)),
+        "speech_tokenizer.decoder.conv.weight": mx.zeros((2, 2)),
+        "speaker_encoder.fc.weight": mx.zeros((2, 2)),
+    }
+    assert set(sanitize(weights)) == {
+        "model.layers.0.self_attn.q_proj.weight",
+        "codec_head.weight",
+    }
+
+    already_scoped = {"codec_head.weight": mx.zeros((2, 2))}
+    assert set(sanitize(already_scoped)) == {"codec_head.weight"}
+
+
+def test_loader_model_accepts_a_whole_checkpoint_config() -> None:
+    config = ModelConfig(
+        talker_config=_talker_config(),
+        tts_model_type="custom_voice",
+        speaker_encoder_config={"mel_dim": 128},
+    )
+    model = Qwen3TTSTalkerModel(config)
+
+    assert model.tts_model_type == "custom_voice"
+    assert len(model.model.layers) == config.talker_config.num_hidden_layers
+    assert len(model.code_predictor.lm_head) == config.talker_config.num_code_groups - 1
+
+
+def test_talker_weight_keys_match_the_checkpoint_layout() -> None:
+    from mlx.utils import tree_flatten
+
+    model = _build()
+    keys = {key for key, _ in tree_flatten(model.parameters())}
+
+    for expected in (
+        "model.codec_embedding.weight",
+        "model.text_embedding.weight",
+        "model.layers.0.self_attn.q_norm.weight",
+        "model.norm.weight",
+        "text_projection.linear_fc1.weight",
+        "text_projection.linear_fc2.bias",
+        "codec_head.weight",
+        "code_predictor.model.layers.0.self_attn.q_proj.weight",
+        "code_predictor.model.codec_embedding.0.weight",
+        "code_predictor.lm_head.0.weight",
+    ):
+        assert expected in keys, expected
+    # The predictor is wider than the talker here, so the CustomVoice-style
+    # projection exists and carries checkpoint weights of its own.
+    assert model.code_predictor.small_to_mtp_projection is not None
+    assert "code_predictor.small_to_mtp_projection.bias" in keys
+
+
+def test_matched_hidden_sizes_omit_the_predictor_projection() -> None:
+    config = _talker_config()
+    config.code_predictor_config.hidden_size = config.hidden_size
+    model = Qwen3TTSTalkerForConditionalGeneration(config)
+
+    assert model.code_predictor.small_to_mtp_projection is None
+    hidden = mx.random.normal((1, 1, config.hidden_size))
+    codes, _ = model.predict_codes(mx.array([[1]], dtype=mx.int32), hidden)
+    mx.eval(codes)
+    assert codes.shape == (1, config.num_code_groups)

--- a/tests/unit_test/qwen3_tts/test_torch_mps.py
+++ b/tests/unit_test/qwen3_tts/test_torch_mps.py
@@ -1,0 +1,324 @@
+# SPDX-License-Identifier: Apache-2.0
+"""Contract tests for the eager Qwen3-TTS Torch MPS path."""
+
+from __future__ import annotations
+
+from types import SimpleNamespace
+
+import numpy as np
+import pytest
+import torch
+
+from sglang_omni.models.qwen3_omni.pending_text_queue import PendingTextTensorQueue
+from sglang_omni.models.qwen3_tts.payload_types import Qwen3TTSState
+from sglang_omni.models.qwen3_tts.torch_mps_runner import (
+    Qwen3TTSTorchMpsModelRunner,
+    _materialize_rotary_buffers,
+)
+from sglang_omni.models.qwen3_tts.torch_mps_vocoder import (
+    create_torch_mps_vocoder_scheduler,
+)
+
+
+def _logits(token_id: int) -> torch.Tensor:
+    logits = torch.zeros((1, 1, 1030))
+    logits[..., token_id] = 9.0
+    return logits
+
+
+class _FakeTalker:
+    dtype = torch.float32
+
+    def __init__(self) -> None:
+        self.calls: list[dict] = []
+
+    def __call__(self, **kwargs):
+        self.calls.append(kwargs)
+        if "inputs_embeds" in kwargs:
+            return SimpleNamespace(
+                logits=_logits(2),
+                past_key_values="prefill-cache",
+                past_hidden=torch.ones((1, 1, 4)),
+                generation_step=0,
+            )
+        semantic = int(kwargs["input_ids"].item())
+        return SimpleNamespace(
+            logits=_logits(3),
+            past_key_values=f"cache-{semantic}",
+            past_hidden=torch.full((1, 1, 4), float(semantic)),
+            generation_step=int(kwargs["generation_step"]) + 1,
+            hidden_states=(
+                None,
+                torch.tensor([[semantic, semantic + 10, semantic + 20]]),
+            ),
+        )
+
+
+def _runner() -> Qwen3TTSTorchMpsModelRunner:
+    runner = Qwen3TTSTorchMpsModelRunner.__new__(Qwen3TTSTorchMpsModelRunner)
+    runner.device = torch.device("cpu")
+    runner.model = SimpleNamespace(
+        torch_mps_talker=_FakeTalker(),
+        config=SimpleNamespace(vocab_size=1030, codec_eos_token_id=1029),
+    )
+    runner._request_states = {}
+    return runner
+
+
+def _request() -> SimpleNamespace:
+    sampling = SimpleNamespace(
+        temperature=0.0,
+        top_k=0,
+        top_p=1.0,
+        repetition_penalty=1.0,
+    )
+    req = SimpleNamespace(rid="r0", output_ids=[], sampling_params=sampling)
+    data = SimpleNamespace(
+        req=req,
+        prompt_input_embeds=torch.ones((2, 4)),
+        pending_text_queue=PendingTextTensorQueue.from_tensor(torch.ones((2, 4))),
+        tts_pad_embed=torch.zeros(4),
+        semantic_sampling_seed=11,
+        subtalker_sampling_seed=12,
+        subtalker_dosample=False,
+        subtalker_top_p=1.0,
+        subtalker_top_k=50,
+        subtalker_temperature=0.9,
+        output_codes=[],
+    )
+    return SimpleNamespace(request_id="r0", data=data)
+
+
+def test_torch_mps_runner_uses_upstream_talker_for_complete_frames() -> None:
+    runner = _runner()
+    request = _request()
+
+    prefill = runner.custom_prefill_forward(None, None, [request])
+    request.data.req.output_ids.append(int(prefill.next_token_ids.item()))
+    decode = runner.custom_decode_forward(None, None, [request])
+
+    assert prefill.next_token_ids.tolist() == [2]
+    assert decode.next_token_ids.tolist() == [3]
+    assert [codes.tolist() for codes in request.data.output_codes] == [
+        [2, 12, 22],
+        [3, 13, 23],
+    ]
+    talker = runner.talker
+    assert len(talker.calls) == 3
+    assert talker.calls[1]["past_key_values"] == "prefill-cache"
+    assert talker.calls[2]["past_key_values"] == "cache-2"
+    assert talker.calls[1]["cache_position"].tolist() == [2]
+    assert talker.calls[2]["cache_position"].tolist() == [3]
+
+
+def test_torch_mps_runner_does_not_generate_a_frame_for_eos() -> None:
+    runner = _runner()
+    request = _request()
+    runner.talker.calls.clear()
+    original = runner.talker
+
+    def eos_prefill(**kwargs):
+        original.calls.append(kwargs)
+        return SimpleNamespace(
+            logits=_logits(1029),
+            past_key_values="cache",
+            past_hidden=torch.ones((1, 1, 4)),
+            generation_step=0,
+        )
+
+    # Special methods are resolved on the class, so use a minimal callable type.
+    runner.model.torch_mps_talker = type(
+        "EosTalker",
+        (),
+        {"dtype": torch.float32, "__call__": staticmethod(eos_prefill)},
+    )()
+
+    result = runner.custom_prefill_forward(None, None, [request])
+
+    assert result.next_token_ids.tolist() == [1029]
+    assert request.data.output_codes == []
+
+
+def test_torch_mps_runner_drives_the_upstream_talker_forward() -> None:
+    from sglang_omni.models.qwen3_tts.compat import (
+        apply_qwen_tts_transformers_compatibility_patches,
+    )
+
+    apply_qwen_tts_transformers_compatibility_patches()
+    from qwen_tts.core.models.configuration_qwen3_tts import Qwen3TTSTalkerConfig
+    from qwen_tts.core.models.modeling_qwen3_tts import (
+        Qwen3TTSTalkerForConditionalGeneration,
+    )
+
+    predictor = {
+        "vocab_size": 32,
+        "hidden_size": 8,
+        "intermediate_size": 16,
+        "num_hidden_layers": 1,
+        "num_attention_heads": 2,
+        "num_key_value_heads": 1,
+        "head_dim": 4,
+        "num_code_groups": 3,
+        "pad_token_id": 0,
+    }
+    config = Qwen3TTSTalkerConfig(
+        code_predictor_config=predictor,
+        vocab_size=1030,
+        hidden_size=8,
+        intermediate_size=16,
+        num_hidden_layers=1,
+        num_attention_heads=2,
+        num_key_value_heads=1,
+        head_dim=4,
+        text_hidden_size=8,
+        text_vocab_size=40,
+        num_code_groups=3,
+        codec_eos_token_id=1029,
+        codec_pad_id=1028,
+        codec_bos_id=1027,
+        pad_token_id=1028,
+        rope_scaling={
+            "rope_type": "default",
+            "mrope_section": [1, 1],
+            "interleaved": True,
+        },
+    )
+    runner = _runner()
+    talker = Qwen3TTSTalkerForConditionalGeneration(config).eval()
+    with torch.no_grad():
+        talker.codec_head.weight.zero_()
+    runner.model.torch_mps_talker = talker
+    request = _request()
+    request.data.prompt_input_embeds = torch.ones((2, 8))
+    request.data.pending_text_queue = PendingTextTensorQueue.from_tensor(
+        torch.ones((2, 8))
+    )
+    request.data.tts_pad_embed = torch.zeros(8)
+
+    result = runner.custom_prefill_forward(None, None, [request])
+
+    assert result.next_token_ids.shape == (1,)
+    assert len(request.data.output_codes) == 1
+    assert request.data.output_codes[0].shape == (3,)
+    state = runner._request_states["r0"]
+    assert state.generation_step == 1
+    assert state.attention_mask.shape == (1, 3)
+
+
+def test_torch_mps_talker_materializes_meta_rotary_buffers() -> None:
+    from sglang_omni.models.qwen3_tts.compat import (
+        apply_qwen_tts_transformers_compatibility_patches,
+    )
+
+    apply_qwen_tts_transformers_compatibility_patches()
+    from qwen_tts.core.models.configuration_qwen3_tts import Qwen3TTSTalkerConfig
+    from qwen_tts.core.models.modeling_qwen3_tts import (
+        Qwen3TTSTalkerForConditionalGeneration,
+    )
+
+    predictor = {
+        "vocab_size": 32,
+        "hidden_size": 8,
+        "intermediate_size": 16,
+        "num_hidden_layers": 1,
+        "num_attention_heads": 2,
+        "num_key_value_heads": 1,
+        "head_dim": 4,
+        "num_code_groups": 3,
+        "pad_token_id": 0,
+    }
+    config = Qwen3TTSTalkerConfig(
+        code_predictor_config=predictor,
+        vocab_size=1030,
+        hidden_size=8,
+        intermediate_size=16,
+        num_hidden_layers=1,
+        num_attention_heads=2,
+        num_key_value_heads=1,
+        head_dim=4,
+        text_hidden_size=8,
+        text_vocab_size=40,
+        num_code_groups=3,
+        codec_eos_token_id=1029,
+        codec_pad_id=1028,
+        codec_bos_id=1027,
+        pad_token_id=1028,
+        rope_scaling={
+            "rope_type": "default",
+            "mrope_section": [1, 1],
+            "interleaved": True,
+        },
+    )
+    with torch.device("meta"):
+        talker = Qwen3TTSTalkerForConditionalGeneration(config)
+
+    assert [name for name, value in talker.named_buffers() if value.is_meta]
+    _materialize_rotary_buffers(talker)
+
+    assert not [name for name, value in talker.named_buffers() if value.is_meta]
+    rotary_modules = [
+        module for module in talker.modules() if hasattr(module, "inv_freq")
+    ]
+    assert len(rotary_modules) == 2
+    assert all(not module.original_inv_freq.is_meta for module in rotary_modules)
+
+
+class _FakeTokenizer:
+    def decode(self, items):
+        assert items[0]["audio_codes"].tolist() == [[1, 2], [3, 4]]
+        return [torch.arange(8, dtype=torch.float32)], 24000
+
+
+def _payload(*, stream: bool = False):
+    from sglang_omni.proto import OmniRequest, StagePayload
+
+    return StagePayload(
+        request_id="r0",
+        request=OmniRequest(inputs="hello", params={"stream": stream}),
+        data=Qwen3TTSState(
+            audio_codes=torch.tensor([[1, 2], [3, 4]]),
+            ref_code_len=1,
+        ).to_dict(),
+    )
+
+
+def test_torch_mps_vocoder_decodes_one_final_payload() -> None:
+    scheduler = create_torch_mps_vocoder_scheduler(_FakeTokenizer())
+
+    result = scheduler._fn(_payload())
+
+    assert result.data["sample_rate"] == 24000
+    assert result.data["modality"] == "audio"
+    waveform = np.frombuffer(result.data["audio_waveform"], dtype=np.float32)
+    assert waveform.tolist() == [4.0, 5.0, 6.0, 7.0]
+
+
+def test_torch_mps_vocoder_rejects_streaming() -> None:
+    scheduler = create_torch_mps_vocoder_scheduler(_FakeTokenizer())
+
+    with pytest.raises(ValueError, match="non-streaming only"):
+        scheduler._fn(_payload(stream=True))
+
+
+def test_vocoder_factory_selects_torch_mps_compatibility_path(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    from sglang.srt.utils import tensor_bridge
+
+    from sglang_omni.models.qwen3_tts import stages
+    from sglang_omni.models.qwen3_tts import torch_mps_vocoder
+
+    tokenizer = object()
+    scheduler = object()
+    monkeypatch.setattr(tensor_bridge, "use_mlx", lambda: False)
+    monkeypatch.setattr(stages, "resolve_device_spec", lambda device, gpu_id: "mps")
+    monkeypatch.setattr(
+        stages, "_load_qwen3_tts_tokenizer", lambda *args, **kwargs: tokenizer
+    )
+    monkeypatch.setattr(
+        torch_mps_vocoder,
+        "create_torch_mps_vocoder_scheduler",
+        lambda loaded: scheduler if loaded is tokenizer else None,
+    )
+
+    assert stages.create_vocoder_executor("model") is scheduler

--- a/tests/unit_test/qwen3_tts/test_torch_mps.py
+++ b/tests/unit_test/qwen3_tts/test_torch_mps.py
@@ -305,8 +305,7 @@ def test_vocoder_factory_selects_torch_mps_compatibility_path(
 ) -> None:
     from sglang.srt.utils import tensor_bridge
 
-    from sglang_omni.models.qwen3_tts import stages
-    from sglang_omni.models.qwen3_tts import torch_mps_vocoder
+    from sglang_omni.models.qwen3_tts import stages, torch_mps_vocoder
 
     tokenizer = object()
     scheduler = object()


### PR DESCRIPTION
Runs Qwen3-TTS on Apple Silicon through two deliberately separate paths:

- **MLX**: the optimized native Apple backend, ported from [mlx-audio](https://github.com/Blaizzy/mlx-audio) without taking it as a dependency (`mlx-audio` requires `transformers>=5.14.0`; we pin `5.12.1`).
- **Torch MPS**: a conservative B=1 compatibility/reference path using the canonical upstream PyTorch talker and speech tokenizer.

Draft: **not ready to merge.** Opening it for review of the approach, and it may still want splitting. The commits are reviewable in order.

## Architecture direction

MLX is an optional optimized backend. PyTorch remains the canonical model semantics and owns device selection:

```text
Qwen3-TTS scheduler
├── torch
│   ├── cuda  SGLang-optimized serving
│   ├── mps   upstream Torch talker, eager/SDPA, B=1
│   └── cpu
└── mlx       native optimized Apple backend
```

This follows the Qwen3-ASR precedent: MPS is a Torch device, not a third model backend, and it bypasses the CUDA-specific execution core instead of accumulating MPS exceptions in it. The shared scheduler, request construction, prompt state, and result adapters remain unchanged.

The Torch MPS path replaces the SGLang CUDA-oriented generation modules with upstream `Qwen3TTSTalkerForConditionalGeneration`. Its `forward()` remains responsible for `DynamicCache`, feedback state, generation step, and groups 1..15 through the canonical code predictor. Only B=1 semantic sampling is implemented locally. This preserves a canonical Torch model suitable for future `torch.export` / `coreai-torch` work.

## Torch MPS qualification boundary

The initial path is intentionally narrow:

- one running/queued request;
- eager execution with `torch_native` attention and PyTorch sampling;
- no CUDA graph, compile, radix cache, overlap schedule, or chunked prefill;
- final/non-streaming official Torch speech-tokenizer decode;
- streaming requests are rejected explicitly.

CUDA and MLX behavior are unchanged.

## Commits

1. `[MLX]` Dispatch the MLX worker runner by architecture (registry; ASR behaviour unchanged)
2. `[Qwen3-TTS]` Talker + code predictor
3. `[Qwen3-TTS]` Speech tokenizer, speaker encoder, DSP
4. `[Qwen3-TTS]` Native prompt construction, CLI, playground
5. `[Qwen3-TTS]` Scheduler + vocoder-stage wiring
6. `[Qwen3-TTS]` Separate model backend selection from Torch device selection
7. `[Qwen3-TTS]` Add canonical Torch MPS serving path

MLX activation is `SGLANG_USE_MLX=1` plus importable MLX. Torch MPS is selected through the normal Torch backend with an MPS device.

## Two upstream bugs found

**The code2wav decoder is sliding-window attention, window 72.** The official config exposes `layer_types` as a computed property, so it never appears in `config.json`, and mlx-audio stores the window without ever masking with it. Invisible in short chunks; diverges once a pass exceeds 72 frames, which is the voice-cloning path where reference and generated codes decode in one pass. Measured divergence at 96 frames is **0.59** on a waveform in [-1, 1]. Honouring the window also makes chunked decoding exact at left context >= 71 rather than approximate.

**Codec tables have a load-order trap.** mlx-audio recomputes them in an overridden `update()` that `load_weights` never calls, so its loader patches around it. Folding `embedding_sum / cluster_usage` at sanitize removes the trap.

## Verified

- **MLX talker bit-identical to mlx-audio** on `Qwen3-TTS-12Hz-0.6B-CustomVoice`: all 402 tensors load strict; prefill hidden/logits, the 16-group frame, summed codec embedding, and post-feedback step all have `max|diff| == 0.0` in bf16 at B=1 and B=2.
- **Encoder matches the official Torch `MimiModel`** on 100% of codes at 2s/8s/24s.
- Speaker encoder is bit-identical; the mel filterbank is closer to librosa than mlx-audio's.
- Streamed MLX vocoder deltas concatenate to the one-shot decode; two interleaved streams each match being decoded alone.
- CustomVoice prompts generate speech codes rather than immediate EOS; preset voices diverge; an explicit language adds exactly one control position.
- MLX voice cloning runs end to end and writes a WAV via `examples/qwen3_tts_mlx_clone.py` and the Gradio playground.
- **Canonical Torch talker smoke** on the real 0.6B CustomVoice checkpoint: all 402 `talker.*` tensors strict-load into 905,788,672 parameters; no meta tensors remain; a two-token prefill followed by one decode produces finite `(1, 2, 3072)` logits and a complete `(1, 16)` codec frame.
- Current Qwen3-TTS unit suite: **381 passed, 5 skipped**. Focused Torch-MPS/backend checks: **12 passed**. Pre-commit passes on all files.

## Not verified

- **No real Apple Silicon / MPS run was possible on this Linux host.** The MPS runtime profile, upstream state machine, strict real-weight load, sampling contract, and final vocoder adapter are covered, but Metal operator support and end-to-end audio quality still require Mac qualification.
- **No end-to-end `sgl-omni serve` run, on any host.** Every stage is unit-tested and model components are checked against real weights, but the assembled pipeline is not.
- **No Apple Silicon timings.** MLX model checks ran on x86-64 CPU MLX (`mlx[cpu]`), which validates correctness but not Metal performance.
- `_rope_safe` guards a Metal `mx.fast.rope` bug that does not reproduce on CPU, so that path remains untested here.
- Still absent: Torch MPS streaming vocoder, Torch MPS B>1, Core AI export qualification, continuous MLX batching beyond SGLang's batched decode, incremental MLX streaming output, and an HTTP-backed playground.

Generated with AI coding assistance.
