### PR TITLE
[dots.tts] Pin the canonical config to a checkpoint snapshot revision

### DIFF
--- a/benchmarks/benchmarker/utils.py
+++ b/benchmarks/benchmarker/utils.py
@@ -260,6 +260,7 @@ def managed_omni_server(
 ) -> Iterator[None]:
     """Start an ``sglang_omni.cli serve`` process and clean it up on exit."""
     _ensure_port_available(host, port)
+    model_path = _pinned_model_path(model_path, server_config)
     cmd = [
         sys.executable,
         "-m",
@@ -301,6 +302,19 @@ def managed_omni_server(
         stop_server(proc)
         if wait_for_gpu_release:
             wait_for_gpu_memory_release()
+
+
+def _pinned_model_path(model_path: str, server_config: str | None) -> str:
+    # note (db-ol): --model-path outranks the config, so a bare repo id would
+    # drop the revision a config pins for that same repo. Serve the pin.
+    if server_config is None:
+        return model_path
+    from sglang_omni.config.manager import ConfigManager
+
+    pinned = ConfigManager.from_file(server_config).config.model_path
+    if pinned and pinned.startswith(f"{model_path}@"):
+        return pinned
+    return model_path
 
 
 def _resolve_managed_server_engine_stage(

--- a/docs/cookbook/dots_tts.md
+++ b/docs/cookbook/dots_tts.md
@@ -26,14 +26,18 @@ dots.tts is a continuous-latent model, not a codec model. The backbone emits no 
 Install `sglang-omni` by following [Installation](../get_started/installation.md), then download and launch the server:
 
 ```bash
-hf download dots-studio/dots.tts-mf
+hf download dots-studio/dots.tts-mf --revision c28105adc8228143392b4e346994ff613ee48a06
 
 sgl-omni serve \
-  --model-path dots-studio/dots.tts-mf \
   --config examples/configs/dots_tts.yaml \
   --allowed-local-media-path docs/_static/audio \
   --port 8000
 ```
+
+`examples/configs/dots_tts.yaml` pins the checkpoint to the snapshot it was
+validated against, so the launch above takes `model_path` from the config.
+`--model-path` overrides that pin, pass it only to serve a different checkpoint
+or revision.
 
 To serve SOAR instead, swap both the checkpoint and the config:
 

--- a/examples/configs/dots_tts.yaml
+++ b/examples/configs/dots_tts.yaml
@@ -1,5 +1,8 @@
 config_cls: DotsTTSPipelineConfig
-model_path: dots-studio/dots.tts-mf
+# The checkpoint is pinned to the snapshot this config was validated
+# against, the same <repo-id>@<revision> spec ensure_hf_models.sh uses.
+# Bump the revision deliberately after revalidating the pipeline.
+model_path: dots-studio/dots.tts-mf@c28105adc8228143392b4e346994ff613ee48a06
 
 # The solver settings feed two consumers: the latent AR engine solves with
 # them, and preprocessing sizes its generation schedule from them. The

--- a/sglang_omni/config/manager.py
+++ b/sglang_omni/config/manager.py
@@ -1,3 +1,4 @@
+import os
 from collections.abc import Iterable, Mapping
 from typing import Any
 
@@ -17,17 +18,24 @@ from sglang_omni.utils import (
 
 def resolve_config_cls_for_model_path(model_path: str):
     """Resolve a PipelineConfig class from HF config metadata."""
+    # note (db-ol): a pinned <repo-id>@<revision> spec resolves metadata at
+    # the pinned revision without materializing the snapshot. The weights
+    # download happens later, when resolve_checkpoint loads a stage.
+    repo_id, revision = model_path, None
+    if "@" in model_path and not os.path.isdir(model_path):
+        repo_id, _, pinned = model_path.partition("@")
+        revision = pinned or None
     hf_config = None
     try:
-        hf_config = AutoConfig.from_pretrained(model_path)
+        hf_config = AutoConfig.from_pretrained(repo_id, revision=revision)
     except (OSError, ValueError, KeyError):
         hf_config = None
 
     arch = architecture_from_hf_config(hf_config) if hf_config is not None else None
     if arch is None:
-        arch = try_resolve_arch_from_raw_config(model_path)
+        arch = try_resolve_arch_from_raw_config(repo_id, revision=revision)
     if arch is None:
-        arch = try_resolve_arch_from_mistral_config(model_path)
+        arch = try_resolve_arch_from_mistral_config(repo_id, revision=revision)
     if arch is None:
         raise ValueError(f"Could not resolve model architecture for {model_path!r}")
     return PIPELINE_CONFIG_REGISTRY.get_config(arch)

--- a/sglang_omni/config/manager.py
+++ b/sglang_omni/config/manager.py
@@ -25,9 +25,10 @@ def resolve_config_cls_for_model_path(model_path: str):
     if "@" in model_path and not os.path.isdir(model_path):
         repo_id, _, pinned = model_path.partition("@")
         revision = pinned or None
+    hf_kwargs = {"revision": revision} if revision else {}
     hf_config = None
     try:
-        hf_config = AutoConfig.from_pretrained(repo_id, revision=revision)
+        hf_config = AutoConfig.from_pretrained(repo_id, **hf_kwargs)
     except (OSError, ValueError, KeyError):
         hf_config = None
 

--- a/sglang_omni/config/manager.py
+++ b/sglang_omni/config/manager.py
@@ -38,7 +38,10 @@ def resolve_config_cls_for_model_path(model_path: str):
     if arch is None:
         arch = try_resolve_arch_from_mistral_config(repo_id, revision=revision)
     if arch is None:
-        raise ValueError(f"Could not resolve model architecture for {model_path!r}")
+        hint = f", check that revision {revision} exists" if revision else ""
+        raise ValueError(
+            f"Could not resolve model architecture for {model_path!r}{hint}"
+        )
     return PIPELINE_CONFIG_REGISTRY.get_config(arch)
 
 

--- a/sglang_omni/utils/checkpoint.py
+++ b/sglang_omni/utils/checkpoint.py
@@ -11,4 +11,8 @@ def resolve_checkpoint(checkpoint: str) -> str:
         return checkpoint
     from huggingface_hub import snapshot_download
 
-    return snapshot_download(checkpoint)
+    # note (db-ol): a checkpoint spec may pin a snapshot as
+    # <repo-id>@<revision>, the format .github/scripts/ensure_hf_models.sh
+    # uses. Without the @ the latest revision is resolved.
+    repo_id, _, revision = checkpoint.partition("@")
+    return snapshot_download(repo_id, revision=revision or None)

--- a/sglang_omni/utils/hf.py
+++ b/sglang_omni/utils/hf.py
@@ -52,7 +52,9 @@ def architecture_from_hf_config(hf_config: Any) -> str | None:
     return None
 
 
-def load_mistral_params_json(model_path: str) -> dict | None:
+def load_mistral_params_json(
+    model_path: str, revision: str | None = None
+) -> dict | None:
     """Load Mistral-format ``params.json`` from a local dir or Hugging Face hub id.
     Official Voxtral TTS checkpoints ship without ``config.json``; architecture is
     only indicated by ``model_type`` inside ``params.json`` (see Hub repo files).
@@ -67,23 +69,29 @@ def load_mistral_params_json(model_path: str) -> dict | None:
     try:
         from huggingface_hub import hf_hub_download
 
-        cached = hf_hub_download(repo_id=model_path, filename="params.json")
+        cached = hf_hub_download(
+            repo_id=model_path, filename="params.json", revision=revision
+        )
         with open(cached) as f:
             return json.load(f)
     except Exception:
         return None
 
 
-def try_resolve_arch_from_mistral_config(model_path: str) -> str | None:
+def try_resolve_arch_from_mistral_config(
+    model_path: str, revision: str | None = None
+) -> str | None:
     """Resolve architecture from Mistral-format params.json (local or Hub)."""
-    params = load_mistral_params_json(model_path)
+    params = load_mistral_params_json(model_path, revision=revision)
     if params is None:
         return None
     model_type = params.get("model_type", "")
     return _CONFIG_MODEL_TYPE_TO_ARCH.get(model_type)
 
 
-def try_resolve_arch_from_raw_config(model_path: str) -> str | None:
+def try_resolve_arch_from_raw_config(
+    model_path: str, revision: str | None = None
+) -> str | None:
     """Resolve architecture by reading raw ``config.json`` as plain JSON.
 
     This is useful when ``AutoConfig.from_pretrained`` fails (e.g. because the
@@ -103,7 +111,9 @@ def try_resolve_arch_from_raw_config(model_path: str) -> str | None:
         try:
             from huggingface_hub import hf_hub_download
 
-            cached = hf_hub_download(repo_id=model_path, filename="config.json")
+            cached = hf_hub_download(
+                repo_id=model_path, filename="config.json", revision=revision
+            )
             with open(cached) as f:
                 raw = json.load(f)
         except Exception:

--- a/tests/unit_test/benchmarks/test_managed_server_pin.py
+++ b/tests/unit_test/benchmarks/test_managed_server_pin.py
@@ -1,0 +1,31 @@
+# SPDX-License-Identifier: Apache-2.0
+
+from __future__ import annotations
+
+from types import SimpleNamespace
+
+from benchmarks.benchmarker import utils
+from sglang_omni.config.manager import ConfigManager
+
+
+def _config_with(model_path: str | None):
+    return SimpleNamespace(config=SimpleNamespace(model_path=model_path))
+
+
+def test_managed_server_serves_the_config_pin_for_the_same_repo(monkeypatch) -> None:
+    monkeypatch.setattr(
+        ConfigManager, "from_file", lambda path: _config_with("org/model@abc123")
+    )
+    assert utils._pinned_model_path("org/model", "cfg.yaml") == "org/model@abc123"
+    assert utils._pinned_model_path("org/other", "cfg.yaml") == "org/other"
+    assert (
+        utils._pinned_model_path("org/model@def456", "cfg.yaml") == "org/model@def456"
+    )
+
+
+def test_managed_server_keeps_the_flag_without_a_config_or_pin(monkeypatch) -> None:
+    assert utils._pinned_model_path("org/model", None) == "org/model"
+    monkeypatch.setattr(
+        ConfigManager, "from_file", lambda path: _config_with("org/model")
+    )
+    assert utils._pinned_model_path("org/model", "cfg.yaml") == "org/model"

--- a/tests/unit_test/utils/test_checkpoint.py
+++ b/tests/unit_test/utils/test_checkpoint.py
@@ -1,0 +1,112 @@
+# SPDX-License-Identifier: Apache-2.0
+
+from __future__ import annotations
+
+from pathlib import Path
+
+import huggingface_hub
+import yaml
+
+from sglang_omni.utils.checkpoint import resolve_checkpoint
+
+_REPO_ROOT = Path(__file__).resolve().parents[3]
+
+
+def test_resolve_checkpoint_returns_local_directory(tmp_path) -> None:
+    assert resolve_checkpoint(str(tmp_path)) == str(tmp_path)
+
+
+def test_resolve_checkpoint_downloads_latest_without_pin(monkeypatch) -> None:
+    captured: dict[str, object] = {}
+
+    def fake_snapshot_download(repo_id, revision=None):
+        captured.update({"repo_id": repo_id, "revision": revision})
+        return "/snapshots/latest"
+
+    monkeypatch.setattr(huggingface_hub, "snapshot_download", fake_snapshot_download)
+
+    assert resolve_checkpoint("org/model") == "/snapshots/latest"
+    assert captured == {"repo_id": "org/model", "revision": None}
+
+
+def test_resolve_checkpoint_honors_pinned_revision(monkeypatch) -> None:
+    captured: dict[str, object] = {}
+
+    def fake_snapshot_download(repo_id, revision=None):
+        captured.update({"repo_id": repo_id, "revision": revision})
+        return "/snapshots/pinned"
+
+    monkeypatch.setattr(huggingface_hub, "snapshot_download", fake_snapshot_download)
+
+    assert resolve_checkpoint("org/model@abc123") == "/snapshots/pinned"
+    assert captured == {"repo_id": "org/model", "revision": "abc123"}
+
+
+def test_pinned_spec_resolves_architecture_without_snapshot(
+    monkeypatch, tmp_path
+) -> None:
+    from types import SimpleNamespace
+
+    from sglang_omni.config import manager
+    from sglang_omni.models.dots_tts.config import DotsTTSPipelineConfig
+
+    def fail_snapshot(*args, **kwargs):
+        raise AssertionError("architecture discovery must not download weights")
+
+    monkeypatch.setattr(huggingface_hub, "snapshot_download", fail_snapshot)
+    captured: dict[str, object] = {}
+
+    def fake_auto_config(path, revision=None, **kwargs):
+        captured["auto"] = (path, revision)
+        raise OSError("metadata offline in this test")
+
+    monkeypatch.setattr(
+        manager,
+        "AutoConfig",
+        SimpleNamespace(from_pretrained=fake_auto_config),
+    )
+
+    def fake_hub_download(repo_id, filename, revision=None, **kwargs):
+        captured["raw"] = (repo_id, filename, revision)
+        path = tmp_path / filename
+        path.write_text('{"architectures": ["DotsTTSForConditionalGeneration"]}')
+        return str(path)
+
+    monkeypatch.setattr(huggingface_hub, "hf_hub_download", fake_hub_download)
+
+    config_cls = manager.resolve_config_cls_for_model_path(
+        "dots-studio/dots.tts-mf@c28105adc8228143392b4e346994ff613ee48a06"
+    )
+
+    assert config_cls is DotsTTSPipelineConfig
+    revision = "c28105adc8228143392b4e346994ff613ee48a06"
+    assert captured["auto"] == ("dots-studio/dots.tts-mf", revision)
+    assert captured["raw"] == ("dots-studio/dots.tts-mf", "config.json", revision)
+
+
+def test_local_model_path_skips_snapshot_resolution(monkeypatch, tmp_path) -> None:
+    from sglang_omni.config import manager
+    from sglang_omni.models.dots_tts.config import DotsTTSPipelineConfig
+
+    def fail_snapshot(*args, **kwargs):
+        raise AssertionError("local paths must not resolve a snapshot")
+
+    monkeypatch.setattr(huggingface_hub, "snapshot_download", fail_snapshot)
+    (tmp_path / "config.json").write_text(
+        '{"architectures": ["DotsTTSForConditionalGeneration"]}'
+    )
+
+    config_cls = manager.resolve_config_cls_for_model_path(str(tmp_path))
+
+    assert config_cls is DotsTTSPipelineConfig
+
+
+def test_dots_tts_canonical_config_pins_snapshot_revision() -> None:
+    config = yaml.safe_load(
+        (_REPO_ROOT / "examples" / "configs" / "dots_tts.yaml").read_text()
+    )
+    repo_id, _, revision = str(config["model_path"]).partition("@")
+
+    assert repo_id == "dots-studio/dots.tts-mf"
+    assert len(revision) == 40
+    assert all(c in "0123456789abcdef" for c in revision)

--- a/tests/unit_test/utils/test_checkpoint.py
+++ b/tests/unit_test/utils/test_checkpoint.py
@@ -84,6 +84,24 @@ def test_pinned_spec_resolves_architecture_without_snapshot(
     assert captured["raw"] == ("dots-studio/dots.tts-mf", "config.json", revision)
 
 
+def test_unresolvable_pinned_spec_names_the_revision(monkeypatch) -> None:
+    import pytest
+
+    from sglang_omni.config import manager
+
+    def fail_metadata(*args, **kwargs):
+        raise OSError("metadata offline in this test")
+
+    monkeypatch.setattr(manager.AutoConfig, "from_pretrained", fail_metadata)
+    monkeypatch.setattr(huggingface_hub, "hf_hub_download", fail_metadata)
+
+    with pytest.raises(ValueError, match="check that revision c28105ad"):
+        manager.resolve_config_cls_for_model_path("org/model@c28105ad")
+    with pytest.raises(ValueError) as unpinned:
+        manager.resolve_config_cls_for_model_path("org/model")
+    assert "revision" not in str(unpinned.value)
+
+
 def test_local_model_path_skips_snapshot_resolution(monkeypatch, tmp_path) -> None:
     from sglang_omni.config import manager
     from sglang_omni.models.dots_tts.config import DotsTTSPipelineConfig


### PR DESCRIPTION
## Motivation

examples/configs/dots_tts.yaml currently resolves the moving dots-studio/dots.tts-mf Hub revision at download time. As a result, calibrated numbers attached to this config, including the profile in #1882, gate results, and future CI thresholds, can become disconnected from the checkpoint they were measured against.

Fun-ASR pinned its checkpoint in #1866 using a `<repo-id>@<revision>` spec. This PR applies the same convention to dots.tts and makes the serving stack honor the pinned revision.

## Modifications

- examples/configs/dots_tts.yaml pins model_path to `dots-studio/dots.tts-mf@c28105adc8228143392b4e346994ff613ee48a06`, the snapshot used for the #1882 profile and the refs/main revision observed during verification.
- sglang_omni/utils/checkpoint.py: resolve_checkpoint understands the `<repo-id>@<revision>` spec, matching the format accepted by .github/scripts/ensure_hf_models.sh, and passes the revision to snapshot_download. Local directory paths are unchanged.
- Architecture discovery (resolve_config_cls_for_model_path) parses the pin and resolves config metadata at that revision through AutoConfig and the raw config fallbacks without materializing the snapshot. Weights are downloaded only when a stage actually loads the checkpoint.
- Verified live in the serving container: the canonical dots.tts server boots with the pinned spec and loads its tokenizer and weights from snapshot c28105ad.
- docs/cookbook/dots_tts.md: the launch command takes model_path from the config instead of passing `--model-path` next to `--config`, since the flag outranks the file and would bypass the pin, and the download line names the pinned revision.
- benchmarks/benchmarker/utils.py: managed_omni_server passes `--model-path` before `--config`, and the flag outranks the file, so a benchmark run against the canonical config served the bare repo. When the config pins the same repo the caller named, the managed server now launches with the pinned spec. A different repo or an explicit revision from the caller still wins. Verified on one H200 by launching benchmark_tts_seedtts with `--model dots-studio/dots.tts-mf --server-config examples/configs/dots_tts.yaml`: before, the server command carried the bare repo id, after, it carries the pinned spec and the stage sockets are named with the revision.

## Related Issues

Follow up to the dots.tts profiling thread #1882 (item Q3 in the PR map). Pin convention follows #1866.

## Accuracy Test

This PR changes config and checkpoint resolution behavior only. No model code is modified.

`python -m pytest tests/unit_test/utils/ tests/unit_test/config/ -q` in the serving container:

237 passed, 4 skipped

The skipped tests are the existing CUDA weight sharing tests. New tests cover local paths, unpinned repos, pinned repos, a guard ensuring architecture discovery never calls snapshot_download, and the canonical YAML carrying a 40 character hexadecimal revision.

## Benchmark & Profiling

Not applicable. This PR does not change model execution.

## Checklist

- [x] Format your code according with pre-commit.
- [x] Add unit tests.
- [ ] Update documentation / docstrings / example tutorials as needed.
- [ ] Provide throughput / latency benchmark results and accuracy evaluation results as needed.
- [ ] For reviewers: If you haven't made any contributions to this PR and are only assisting with merging the main branch, please remove yourself as a co-author when merging the PR.
