### PR TITLE
fix(audio): preserve PyAV decoded duration and amplitude

### DIFF
--- a/sglang_omni/preprocessing/audio.py
+++ b/sglang_omni/preprocessing/audio.py
@@ -31,25 +31,31 @@ def _decode_audio_bytes_av(data: bytes) -> tuple[np.ndarray, int]:
         sample_rate = audio_stream.rate
         frames = []
         for frame in container.decode(audio_stream):
-            arr = frame.to_ndarray()  # shape varies by format
-            if arr.ndim == 2:
-                # Planar formats (fltp, s16p, etc.): shape is (channels, samples)
-                # Average channels to mono
-                arr = arr.mean(axis=0)
-            frames.append(arr.flatten().astype(np.float32))
+            arr = frame.to_ndarray()
+            if np.issubdtype(arr.dtype, np.integer):
+                dtype_info = np.iinfo(arr.dtype)
+                if dtype_info.min == 0:
+                    midpoint = float(dtype_info.max + 1) / 2.0
+                    arr = (arr.astype(np.float32) - midpoint) / midpoint
+                else:
+                    scale = float(max(-int(dtype_info.min), int(dtype_info.max)))
+                    arr = arr.astype(np.float32) / scale
+            else:
+                arr = arr.astype(np.float32, copy=False)
+
+            channels = len(frame.layout.channels)
+            if frame.format.is_planar:
+                arr = arr.reshape(channels, -1).mean(axis=0)
+            else:
+                arr = arr.reshape(-1, channels).mean(axis=1)
+            frames.append(arr.astype(np.float32, copy=False))
     finally:
         container.close()
 
     if not frames:
         raise ValueError("No audio frames decoded")
 
-    audio = np.concatenate(frames)
-    # Normalize integer formats to [-1, 1] float range
-    if audio.max() > 1.0 or audio.min() < -1.0:
-        peak = max(abs(audio.max()), abs(audio.min()))
-        if peak > 0:
-            audio = audio / peak
-    return audio, int(sample_rate)
+    return np.concatenate(frames), int(sample_rate)
 
 
 def _parse_wav_bytes(data: bytes, source: str = "bytes") -> tuple[np.ndarray, int]:

--- a/tests/unit_test/preprocessing/test_audio.py
+++ b/tests/unit_test/preprocessing/test_audio.py
@@ -1,0 +1,45 @@
+# SPDX-License-Identifier: Apache-2.0
+"""Tests for model-agnostic audio decoding."""
+
+import io
+
+import numpy as np
+import pytest
+import soundfile as sf
+
+from sglang_omni.preprocessing.audio import _decode_audio_bytes_av, _parse_wav_bytes
+
+
+def _encode_audio(
+    audio: np.ndarray, sample_rate: int, container_format: str, subtype: str
+) -> bytes:
+    buffer = io.BytesIO()
+    sf.write(buffer, audio, sample_rate, format=container_format, subtype=subtype)
+    return buffer.getvalue()
+
+
+@pytest.mark.parametrize("channels", [1, 2])
+def test_flac_decode_matches_pcm_wav_duration_and_amplitude(channels: int) -> None:
+    sample_rate = 16_000
+    signal = np.where(np.arange(sample_rate) % 2, -0.125, 0.125).astype(np.float32)
+    source = signal if channels == 1 else np.column_stack((signal, signal / 2))
+
+    flac = _encode_audio(source, sample_rate, "FLAC", "PCM_16")
+    wav = _encode_audio(source, sample_rate, "WAV", "PCM_16")
+    decoded_flac, flac_rate = _decode_audio_bytes_av(flac)
+    decoded_wav, wav_rate = _parse_wav_bytes(wav)
+
+    assert flac_rate == wav_rate == sample_rate
+    assert decoded_flac.shape == decoded_wav.shape == (sample_rate,)
+    np.testing.assert_array_equal(decoded_flac, decoded_wav)
+
+
+def test_av_decode_preserves_float_amplitude() -> None:
+    sample_rate = 8_000
+    source = np.where(np.arange(sample_rate) % 2, -1.5, 1.5).astype(np.float32)
+    wav = _encode_audio(source, sample_rate, "WAV", "FLOAT")
+
+    decoded, decoded_rate = _decode_audio_bytes_av(wav)
+
+    assert decoded_rate == sample_rate
+    np.testing.assert_array_equal(decoded, source)


### PR DESCRIPTION
## Motivation

PyAV exposes packed multichannel frames as one interleaved row. The decoder treated every two-dimensional frame as planar, so stereo FLAC input produced twice the expected number of mono samples. It also normalized integer audio by the signal peak, changing the source gain.

## Modifications

- Scale integer samples by their dtype range while preserving floating-point amplitude.
- Downmix planar and packed frames according to the PyAV frame format and channel layout.
- Add CPU tests comparing mono and stereo PCM16 FLAC decoding with the WAV path, plus a floating-point amplitude regression test.

## Related Issues

N/A

## Accuracy Test

```text
pytest -q tests/unit_test/preprocessing/test_audio.py
3 passed
```

The mono and stereo FLAC fixtures now match the equivalent WAV samples exactly.

## Benchmark & Profiling

N/A. This fixes decoding correctness without changing the inference path.

## Checklist

- [x] Format your code according with pre-commit.
- [x] Add unit tests.
- [x] Update documentation / docstrings / example tutorials as needed.
- [x] Provide throughput / latency benchmark results and accuracy evaluation results as needed.
- [ ] For reviewers: If you haven't made any contributions to this PR and are only assisting with merging the main branch, please remove yourself as a co-author when merging the PR.
