### PR TITLE
fix(pipeline): recover TP admin collection after timeout

### DIFF
--- a/sglang_omni/pipeline/tp_control.py
+++ b/sglang_omni/pipeline/tp_control.py
@@ -13,6 +13,7 @@ from __future__ import annotations
 import asyncio
 import logging
 import queue as queue_mod
+import time
 from dataclasses import dataclass
 from typing import Any
 
@@ -83,26 +84,41 @@ class TPLeaderFanout:
             return []
 
         loop = asyncio.get_running_loop()
+        deadline = time.monotonic() + timeout_s
+
+        def get_matching_result(q: Any) -> AdminResultMessage:
+            while True:
+                remaining_s = deadline - time.monotonic()
+                if remaining_s <= 0:
+                    raise queue_mod.Empty
+                msg = q.get(timeout=remaining_s)
+                if not isinstance(msg, AdminResultMessage):
+                    raise ValueError(
+                        f"Unexpected TP follower admin result: {type(msg).__name__}"
+                    )
+                if msg.result.op_id == op_id:
+                    return msg
+                logger.warning(
+                    "Discarding stale TP follower admin result for op %s "
+                    "while waiting for op %s",
+                    msg.result.op_id,
+                    op_id,
+                )
+
         tasks = [
             loop.run_in_executor(
                 None,
-                lambda q=q: q.get(timeout=timeout_s),
+                get_matching_result,
+                q,
             )
             for q in self._follower_admin_result_queues
         ]
-        raw_results = await asyncio.gather(*tasks)
+        raw_results = await asyncio.gather(*tasks, return_exceptions=True)
         results: list[AdminResultMessage] = []
-        for msg in raw_results:
-            if not isinstance(msg, AdminResultMessage):
-                raise ValueError(
-                    f"Unexpected TP follower admin result: {type(msg).__name__}"
-                )
-            if msg.result.op_id != op_id:
-                raise ValueError(
-                    "Unexpected TP follower admin op id: "
-                    f"{msg.result.op_id} != {op_id}"
-                )
-            results.append(msg)
+        for result in raw_results:
+            if isinstance(result, BaseException):
+                raise result
+            results.append(result)
         return results
 
     def close(self) -> None:

--- a/tests/unit_test/pipeline/test_tp_control.py
+++ b/tests/unit_test/pipeline/test_tp_control.py
@@ -1,0 +1,162 @@
+# SPDX-License-Identifier: Apache-2.0
+
+from __future__ import annotations
+
+import asyncio
+import queue
+import threading
+import time
+
+import pytest
+
+from sglang_omni.pipeline.tp_control import TPLeaderFanout
+from sglang_omni.proto import AdminResult, AdminResultMessage
+
+
+def _result(op_id: str) -> AdminResultMessage:
+    return AdminResultMessage(
+        AdminResult(
+            op_id=op_id,
+            stage="decode",
+            action="model_info",
+            success=True,
+        )
+    )
+
+
+def test_collect_admin_results_discards_result_from_timed_out_operation() -> None:
+    async def _run() -> None:
+        result_queue: queue.Queue = queue.Queue()
+        fanout = TPLeaderFanout(
+            "decode",
+            follower_work_queues=[],
+            follower_abort_queues=[],
+            follower_admin_result_queues=[result_queue],
+        )
+
+        with pytest.raises(queue.Empty):
+            await fanout.collect_admin_results("op-1", timeout_s=0.01)
+
+        result_queue.put_nowait(_result("op-1"))
+        result_queue.put_nowait(_result("op-2"))
+        results = await fanout.collect_admin_results("op-2", timeout_s=1.0)
+        assert [msg.result.op_id for msg in results] == ["op-2"]
+
+        result_queue.put_nowait(_result("op-3"))
+        results = await fanout.collect_admin_results("op-3", timeout_s=1.0)
+        assert [msg.result.op_id for msg in results] == ["op-3"]
+
+    asyncio.run(_run())
+
+
+def test_collect_admin_results_rejects_unexpected_message() -> None:
+    async def _run() -> None:
+        result_queue: queue.Queue = queue.Queue()
+        result_queue.put_nowait(object())
+        fanout = TPLeaderFanout(
+            "decode",
+            follower_work_queues=[],
+            follower_abort_queues=[],
+            follower_admin_result_queues=[result_queue],
+        )
+
+        with pytest.raises(
+            ValueError,
+            match="Unexpected TP follower admin result: object",
+        ):
+            await fanout.collect_admin_results("op-1", timeout_s=1.0)
+
+    asyncio.run(_run())
+
+
+def test_collect_admin_results_keeps_deadline_after_stale_result() -> None:
+    class StaleThenEmptyQueue:
+        def __init__(self) -> None:
+            self.timeouts: list[float] = []
+
+        def get(self, *, timeout: float) -> AdminResultMessage:
+            self.timeouts.append(timeout)
+            if len(self.timeouts) == 1:
+                time.sleep(0.02)
+                return _result("op-1")
+            raise queue.Empty
+
+    async def _run() -> None:
+        result_queue = StaleThenEmptyQueue()
+        fanout = TPLeaderFanout(
+            "decode",
+            follower_work_queues=[],
+            follower_abort_queues=[],
+            follower_admin_result_queues=[result_queue],
+        )
+
+        with pytest.raises(queue.Empty):
+            await fanout.collect_admin_results("op-2", timeout_s=0.1)
+
+        assert len(result_queue.timeouts) == 2
+        assert result_queue.timeouts[1] < result_queue.timeouts[0] - 0.01
+
+    asyncio.run(_run())
+
+
+def test_invalid_result_does_not_leave_other_follower_collector_running() -> None:
+    class GatedFirstGetQueue:
+        def __init__(self) -> None:
+            self._items: queue.Queue = queue.Queue()
+            self._lock = threading.Lock()
+            self._calls = 0
+            self.first_get_started = threading.Event()
+            self.release_first_get = threading.Event()
+            self.first_get_finished = threading.Event()
+
+        def put_nowait(self, item: AdminResultMessage) -> None:
+            self._items.put_nowait(item)
+
+        def get(self, *, timeout: float) -> AdminResultMessage:
+            with self._lock:
+                self._calls += 1
+                call_number = self._calls
+            if call_number == 1:
+                self.first_get_started.set()
+                if not self.release_first_get.wait(timeout):
+                    self.first_get_finished.set()
+                    raise queue.Empty
+            try:
+                return self._items.get(timeout=timeout)
+            finally:
+                if call_number == 1:
+                    self.first_get_finished.set()
+
+    async def _run() -> None:
+        invalid_queue: queue.Queue = queue.Queue()
+        gated_queue = GatedFirstGetQueue()
+        fanout = TPLeaderFanout(
+            "decode",
+            follower_work_queues=[],
+            follower_abort_queues=[],
+            follower_admin_result_queues=[invalid_queue, gated_queue],
+        )
+
+        collection = asyncio.create_task(
+            fanout.collect_admin_results("op-1", timeout_s=0.1)
+        )
+        while not gated_queue.first_get_started.is_set():
+            await asyncio.sleep(0)
+        invalid_queue.put_nowait(object())
+
+        with pytest.raises(
+            ValueError,
+            match="Unexpected TP follower admin result: object",
+        ):
+            await collection
+
+        invalid_queue.put_nowait(_result("op-2"))
+        gated_queue.put_nowait(_result("op-2"))
+        gated_queue.release_first_get.set()
+        while not gated_queue.first_get_finished.is_set():
+            await asyncio.sleep(0)
+
+        results = await fanout.collect_admin_results("op-2", timeout_s=0.1)
+        assert [msg.result.op_id for msg in results] == ["op-2", "op-2"]
+
+    asyncio.run(_run())


### PR DESCRIPTION
## Motivation

When a TP follower returns an admin result after the leader's collection timeout, that stale result remains at the front of its queue. Each later admin operation then reads the previous operation's result and fails with an `op_id` mismatch, preventing recovery after a transient timeout.

## Modifications

- Discard stale follower results while waiting for the current `op_id` under the original shared deadline.
- Finish all queue readers before propagating an error so none can consume a later operation's result in the background.
- Add CPU tests for timeout recovery, deadline preservation, malformed results, and two-follower cleanup.

## Related Issues

N/A

## Accuracy Test

```text
pytest -q tests/unit_test/pipeline/test_tp_control.py
4 passed
```

## Benchmark & Profiling

N/A. This only changes TP admin result collection after a timeout.

## Checklist

- [x] Format your code according with pre-commit.
- [x] Add unit tests.
- [x] Update documentation / docstrings / example tutorials as needed.
- [x] Provide throughput / latency benchmark results and accuracy evaluation results as needed.
- [ ] For reviewers: If you haven't made any contributions to this PR and are only assisting with merging the main branch, please remove yourself as a co-author when merging the PR.
