### PR TITLE
[CosyVoice3] Log Flow solve time and restore INFO logging in the shared engine process

### DIFF
--- a/sglang_omni/models/fun_cosyvoice3/stages.py
+++ b/sglang_omni/models/fun_cosyvoice3/stages.py
@@ -3,6 +3,7 @@
 
 from __future__ import annotations
 
+import importlib
 import logging
 import time
 from collections import defaultdict
@@ -593,6 +594,26 @@ def _prepare_hift_for_inference(hift: Any) -> None:
     )
 
 
+def _import_modelscope_preserving_root_handlers() -> None:
+    # note (db-ol): the first modelscope import sets every root StreamHandler
+    # to ERROR once torch.distributed is initialized, which silences the stage
+    # process that hosts both the engine and this vocoder. Undo that change.
+    saved = [(handler, handler.level) for handler in logging.getLogger().handlers]
+    try:
+        importlib.import_module("modelscope")
+    except ImportError:
+        # cosyvoice imports modelscope itself and raises a clearer error below.
+        pass
+    for handler, level in saved:
+        if handler.level != level:
+            handler.setLevel(level)
+            logger.info(
+                "Restored root log handler level to %s after the modelscope "
+                "import changed it",
+                logging.getLevelName(level),
+            )
+
+
 def _load_cosyvoice3_flow_hift(
     checkpoint_dir: str,
     device: str,
@@ -600,6 +621,7 @@ def _load_cosyvoice3_flow_hift(
     *,
     enable_flow_estimator_trt: bool = False,
 ) -> tuple[Any, Any]:
+    _import_modelscope_preserving_root_handlers()
     try:
         from cosyvoice.cli.cosyvoice import CosyVoice3
     except ImportError as exc:

--- a/sglang_omni/models/fun_cosyvoice3/stages.py
+++ b/sglang_omni/models/fun_cosyvoice3/stages.py
@@ -297,6 +297,44 @@ def _solve_flow_euler(
     return x.float()
 
 
+class _FlowSolveTimer:
+    """Elapsed time of one Euler solve, read back without waiting on the device.
+
+    On an accelerator two stream events bracket the solve and the elapsed time
+    is only available once the end event has completed. On CPU the ops run
+    synchronously, so perf_counter around the call is already exact.
+    """
+
+    def __init__(self, device: torch.device) -> None:
+        self._on_device = device.type != "cpu"
+        if self._on_device:
+            self._stream = torch.accelerator.current_stream(device)
+            self._start = torch.Event(device=device, enable_timing=True)
+            self._end = torch.Event(device=device, enable_timing=True)
+        else:
+            self._start = self._end = 0.0
+
+    def start(self) -> None:
+        if self._on_device:
+            self._start.record(self._stream)
+        else:
+            self._start = time.perf_counter()
+
+    def stop(self) -> None:
+        if self._on_device:
+            self._end.record(self._stream)
+        else:
+            self._end = time.perf_counter()
+
+    def elapsed_ms(self) -> float | None:
+        """Return the solve time, or None while the end event is still pending."""
+        if not self._on_device:
+            return (self._end - self._start) * 1000.0
+        if not self._end.query():
+            return None
+        return self._start.elapsed_time(self._end)
+
+
 @torch.inference_mode()
 def _generate_flow(
     flow: Any,
@@ -304,7 +342,8 @@ def _generate_flow(
     *,
     streaming: bool = False,
     finalize: bool = True,
-) -> tuple[torch.Tensor, Any, Any]:
+    timer: _FlowSolveTimer | None = None,
+) -> torch.Tensor:
     embedding = flow.spk_embed_affine_layer(F.normalize(packed.embedding, dim=1))
     token_embedding = flow.input_embedding(torch.clamp(packed.token, min=0))
     token_embedding = token_embedding * packed.token_mask.to(token_embedding.dtype)
@@ -359,24 +398,14 @@ def _generate_flow(
     t_span = torch.linspace(0, 1, 11, device=mu.device, dtype=mu.dtype)
     if decoder.t_scheduler == "cosine":
         t_span = 1 - torch.cos(t_span * 0.5 * torch.pi)
-    # note (db-ol): the solve is timed only while the debug record can be seen,
-    # with stream events on CUDA and perf_counter on CPU.
-    timed = logger.isEnabledFor(logging.DEBUG)
-    start = end = stream = None
-    if timed and mu.device.type == "cuda":
-        stream = torch.cuda.current_stream(mu.device)
-        start, end = (torch.cuda.Event(enable_timing=True) for _ in range(2))
-        start.record(stream)
-    elif timed:
-        start = time.perf_counter()
+    if timer is not None:
+        timer.start()
     mel = _solve_flow_euler(
         decoder, z, t_span, mu, mask, embedding, cond, streaming=streaming
     )
-    if stream is not None:
-        end.record(stream)
-    elif timed:
-        end = time.perf_counter()
-    return mel, start, end
+    if timer is not None:
+        timer.stop()
+    return mel
 
 
 def _split_generated_mels(
@@ -428,7 +457,7 @@ class FunCosyVoice3Flow:
 
     def __init__(self, flow: Any) -> None:
         self._flow = flow
-        self._last_solve: tuple[int, Any, Any] | None = None
+        self._last_solve: tuple[int, _FlowSolveTimer] | None = None
 
     def __getattr__(self, name: str) -> Any:
         return getattr(self._flow, name)
@@ -449,15 +478,10 @@ class FunCosyVoice3Flow:
         # the host. A still pending end event is skipped, never waited for.
         if self._last_solve is None:
             return
-        items, start, end = self._last_solve
+        items, timer = self._last_solve
         self._last_solve = None
-        if end is None:
-            return
-        if isinstance(end, float):
-            elapsed_ms = (end - start) * 1000.0
-        elif end.query():
-            elapsed_ms = start.elapsed_time(end)
-        else:
+        elapsed_ms = timer.elapsed_ms()
+        if elapsed_ms is None:
             return
         logger.debug(
             "Fun-CosyVoice3 flow solve: batch_items=%d solve_elapsed_ms=%.1f",
@@ -468,8 +492,13 @@ class FunCosyVoice3Flow:
     @torch.inference_mode()
     def inference(self, inputs: Sequence[FlowBatchInput]) -> list[torch.Tensor]:
         packed = _pack_flow_inputs(self._flow, inputs)
-        generated, start, end = _generate_flow(self._flow, packed)
-        self._last_solve = (len(inputs), start, end)
+        # note (db-ol): the solve is timed only while the debug record can be
+        # seen, so the default INFO path runs it untouched.
+        timer = None
+        if logger.isEnabledFor(logging.DEBUG):
+            timer = _FlowSolveTimer(packed.token.device)
+            self._last_solve = (len(inputs), timer)
+        generated = _generate_flow(self._flow, packed, timer=timer)
         return _split_generated_mels(
             self._flow,
             packed,
@@ -485,9 +514,7 @@ class FunCosyVoice3Flow:
         # mixed prompt lengths can share one DiT call. streaming=True
         # keeps the chunk mask aligned with CosyVoice3Model hops.
         packed = _pack_flow_inputs(self._flow, inputs)
-        generated, _, _ = _generate_flow(
-            self._flow, packed, streaming=True, finalize=False
-        )
+        generated = _generate_flow(self._flow, packed, streaming=True, finalize=False)
         lookahead = _flow_lookahead(self._flow)
         target_token_lengths = tuple(
             max(length - lookahead, 0) for length in packed.target_token_lengths

--- a/sglang_omni/models/fun_cosyvoice3/stages.py
+++ b/sglang_omni/models/fun_cosyvoice3/stages.py
@@ -4,6 +4,7 @@
 from __future__ import annotations
 
 import logging
+import time
 from collections import defaultdict
 from collections.abc import Iterator, Sequence
 from dataclasses import dataclass
@@ -302,7 +303,7 @@ def _generate_flow(
     *,
     streaming: bool = False,
     finalize: bool = True,
-) -> torch.Tensor:
+) -> tuple[torch.Tensor, Any, Any]:
     embedding = flow.spk_embed_affine_layer(F.normalize(packed.embedding, dim=1))
     token_embedding = flow.input_embedding(torch.clamp(packed.token, min=0))
     token_embedding = token_embedding * packed.token_mask.to(token_embedding.dtype)
@@ -357,9 +358,24 @@ def _generate_flow(
     t_span = torch.linspace(0, 1, 11, device=mu.device, dtype=mu.dtype)
     if decoder.t_scheduler == "cosine":
         t_span = 1 - torch.cos(t_span * 0.5 * torch.pi)
-    return _solve_flow_euler(
+    # note (db-ol): the solve is timed only while the debug record can be seen,
+    # with stream events on CUDA and perf_counter on CPU.
+    timed = logger.isEnabledFor(logging.DEBUG)
+    start = end = stream = None
+    if timed and mu.device.type == "cuda":
+        stream = torch.cuda.current_stream(mu.device)
+        start, end = (torch.cuda.Event(enable_timing=True) for _ in range(2))
+        start.record(stream)
+    elif timed:
+        start = time.perf_counter()
+    mel = _solve_flow_euler(
         decoder, z, t_span, mu, mask, embedding, cond, streaming=streaming
     )
+    if stream is not None:
+        end.record(stream)
+    elif timed:
+        end = time.perf_counter()
+    return mel, start, end
 
 
 def _split_generated_mels(
@@ -411,6 +427,7 @@ class FunCosyVoice3Flow:
 
     def __init__(self, flow: Any) -> None:
         self._flow = flow
+        self._last_solve: tuple[int, Any, Any] | None = None
 
     def __getattr__(self, name: str) -> Any:
         return getattr(self._flow, name)
@@ -426,10 +443,32 @@ class FunCosyVoice3Flow:
         self._flow.eval()
         return self
 
+    def log_last_solve(self) -> None:
+        # note (db-ol): the vocoder calls this after the bucket's audio reached
+        # the host. A still pending end event is skipped, never waited for.
+        if self._last_solve is None:
+            return
+        items, start, end = self._last_solve
+        self._last_solve = None
+        if end is None:
+            return
+        if isinstance(end, float):
+            elapsed_ms = (end - start) * 1000.0
+        elif end.query():
+            elapsed_ms = start.elapsed_time(end)
+        else:
+            return
+        logger.debug(
+            "Fun-CosyVoice3 flow solve: batch_items=%d solve_elapsed_ms=%.1f",
+            items,
+            elapsed_ms,
+        )
+
     @torch.inference_mode()
     def inference(self, inputs: Sequence[FlowBatchInput]) -> list[torch.Tensor]:
         packed = _pack_flow_inputs(self._flow, inputs)
-        generated = _generate_flow(self._flow, packed)
+        generated, start, end = _generate_flow(self._flow, packed)
+        self._last_solve = (len(inputs), start, end)
         return _split_generated_mels(
             self._flow,
             packed,
@@ -445,7 +484,9 @@ class FunCosyVoice3Flow:
         # mixed prompt lengths can share one DiT call. streaming=True
         # keeps the chunk mask aligned with CosyVoice3Model hops.
         packed = _pack_flow_inputs(self._flow, inputs)
-        generated = _generate_flow(self._flow, packed, streaming=True, finalize=False)
+        generated, _, _ = _generate_flow(
+            self._flow, packed, streaming=True, finalize=False
+        )
         lookahead = _flow_lookahead(self._flow)
         target_token_lengths = tuple(
             max(length - lookahead, 0) for length in packed.target_token_lengths
@@ -846,6 +887,7 @@ class _CosyVoice3Vocoder(BatchVocoderBase):
                     wavs = self._mel2wav_batch([mel for _, mel in group])
                     for (request, _), wav in zip(group, wavs, strict=True):
                         results[request.index] = (wav, request.sample_rate)
+            self._flow.log_last_solve()
 
         if any(result is None for result in results):
             raise RuntimeError("Fun-CosyVoice3 vocoder did not decode every request")

--- a/sglang_omni/models/fun_cosyvoice3/stages.py
+++ b/sglang_omni/models/fun_cosyvoice3/stages.py
@@ -629,7 +629,8 @@ def _import_modelscope_preserving_root_handlers() -> None:
     try:
         importlib.import_module("modelscope")
     except ImportError:
-        # cosyvoice imports modelscope itself and raises a clearer error below.
+        # note (db-ol): cosyvoice imports modelscope itself and raises a
+        # clearer error below.
         pass
     for handler, level in saved:
         if handler.level != level:

--- a/sglang_omni/pipeline/mp_runner.py
+++ b/sglang_omni/pipeline/mp_runner.py
@@ -97,6 +97,8 @@ def _build_stage_groups(
     """
     if ctx is None:
         ctx = multiprocessing.get_context("spawn")
+    # Stage processes log at the level the CLI configured on this root logger.
+    log_level = logging.getLogger().getEffectiveLevel()
     if replica_topology is None:
         replica_topology = ReplicaTopology()
 
@@ -202,6 +204,7 @@ def _build_stage_groups(
                         spec.tp_rank
                     ],
                     stage_specs=[spec],
+                    log_level=log_level,
                 )
                 for spec in specs
             ]
@@ -219,6 +222,7 @@ def _build_stage_groups(
                             single_stage_specs[stage_name]
                             for stage_name in group.stage_names
                         ],
+                        log_level=log_level,
                     )
                 ],
             )

--- a/sglang_omni/pipeline/mp_runner.py
+++ b/sglang_omni/pipeline/mp_runner.py
@@ -97,7 +97,7 @@ def _build_stage_groups(
     """
     if ctx is None:
         ctx = multiprocessing.get_context("spawn")
-    # Stage processes log at the level the CLI configured on this root logger.
+    # note (Dayuxiaoshui): stage processes log at the level the CLI set here.
     log_level = logging.getLogger().getEffectiveLevel()
     if replica_topology is None:
         replica_topology = ReplicaTopology()

--- a/sglang_omni/pipeline/stage_workers.py
+++ b/sglang_omni/pipeline/stage_workers.py
@@ -140,6 +140,9 @@ class StageWorkerProcessSpec:
 
     process_name: str
     stage_specs: list[StageLaunchConfig]
+    # Root logger level for the spawned process. The launcher passes its own
+    # root level so ``--log-level`` reaches every stage, not just the CLI.
+    log_level: int = logging.INFO
 
 
 def _get_worker_process_env(spec: StageWorkerProcessSpec) -> dict[str, str]:
@@ -406,7 +409,12 @@ def stage_process_main(
     startup_error_channel: Any | None = None,
 ) -> None:
     """Subprocess entrypoint: construct stage(s) from *spec* and run them."""
-    logging.basicConfig(level=logging.INFO, stream=sys.stdout)
+    # note (Dayuxiaoshui): a spawned process starts with fresh logging, and
+    # importing sglang already installs a root handler at INFO, which turns
+    # basicConfig into a no-op. Set the level explicitly so the stage follows
+    # the launcher's --log-level.
+    logging.basicConfig(level=spec.log_level, stream=sys.stdout)
+    logging.getLogger().setLevel(spec.log_level)
     if not spec.stage_specs:
         raise ValueError(f"Process {spec.process_name!r} requires at least one stage")
     log = logging.getLogger(f"stage_workers.{spec.process_name}")

--- a/sglang_omni/pipeline/stage_workers.py
+++ b/sglang_omni/pipeline/stage_workers.py
@@ -140,8 +140,8 @@ class StageWorkerProcessSpec:
 
     process_name: str
     stage_specs: list[StageLaunchConfig]
-    # Root logger level for the spawned process. The launcher passes its own
-    # root level so ``--log-level`` reaches every stage, not just the CLI.
+    # note (Dayuxiaoshui): root logger level for the spawned process. The
+    # launcher passes its own root level so --log-level reaches every stage.
     log_level: int = logging.INFO
 
 

--- a/tests/unit_test/fun_cosyvoice3/test_flow_solve_observability.py
+++ b/tests/unit_test/fun_cosyvoice3/test_flow_solve_observability.py
@@ -43,7 +43,7 @@ class _SolvableFlow(torch.nn.Module):
 
 
 class _FakeHiFT(torch.nn.Module):
-    # cosyvoice3.yaml: upsample_rates [8, 5, 3], istft_params.hop_len 4.
+    # note (db-ol): cosyvoice3.yaml has upsample_rates [8, 5, 3] and hop_len 4.
     upsample_rates: ClassVar[list[int]] = [8, 5, 3]
     istft_params: ClassVar[dict[str, int]] = {"n_fft": 16, "hop_len": 4}
 
@@ -63,7 +63,7 @@ def _decode_and_collect(flow: torch.nn.Module, caplog) -> list[str]:
 
 
 def test_decode_batch_logs_one_line_per_solve(caplog) -> None:
-    # Both requests share one frame bucket, so one solve and one line.
+    # note (db-ol): both requests share one frame bucket, one solve, one line.
     [message] = _decode_and_collect(_SolvableFlow(), caplog)
     assert "batch_items=2" in message
     assert float(message.rsplit("solve_elapsed_ms=", 1)[1]) > 0.0

--- a/tests/unit_test/fun_cosyvoice3/test_flow_solve_observability.py
+++ b/tests/unit_test/fun_cosyvoice3/test_flow_solve_observability.py
@@ -1,0 +1,109 @@
+# SPDX-License-Identifier: Apache-2.0
+
+from __future__ import annotations
+
+import asyncio
+import logging
+from typing import ClassVar
+
+import pytest
+import torch
+
+from sglang_omni.models.fun_cosyvoice3 import stages
+from sglang_omni.models.fun_cosyvoice3.payload_types import FunCosyVoice3State
+
+
+class _StubEstimator(torch.nn.Module):
+    def forward(self, x, mask, mu, t, spks, cond, *, streaming):
+        del t, spks, cond, streaming
+        return (0.1 * x + mu) * mask
+
+
+class _SolvableDecoder:
+    def __init__(self, channels: int) -> None:
+        self.rand_noise = torch.zeros(1, channels, 1000)
+        self.t_scheduler = "cosine"
+        self.inference_cfg_rate = 0.7
+        self.estimator = _StubEstimator()
+
+    def forward_estimator(self, x, mask, mu, t, spks, cond, *, streaming):
+        return self.estimator(x, mask, mu, t, spks, cond, streaming=streaming)
+
+
+class _SolvableFlow(torch.nn.Module):
+    def __init__(self, channels: int = 80) -> None:
+        super().__init__()
+        self.output_size = channels
+        self.token_mel_ratio = 2
+        self.input_embedding = torch.nn.Embedding(32, channels)
+        self.spk_embed_affine_layer = torch.nn.Linear(192, channels)
+        self.pre_lookahead_layer = torch.nn.Identity()
+        self.decoder = _SolvableDecoder(channels)
+
+
+class _FakeHiFT(torch.nn.Module):
+    # cosyvoice3.yaml: upsample_rates [8, 5, 3], istft_params.hop_len 4.
+    upsample_rates: ClassVar[list[int]] = [8, 5, 3]
+    istft_params: ClassVar[dict[str, int]] = {"n_fft": 16, "hop_len": 4}
+
+    def inference(self, *, speech_feat, finalize):
+        del finalize
+        batch, _, frames = speech_feat.shape
+        return speech_feat.new_zeros(batch, frames * 480), None
+
+
+def _decode_and_collect(flow: torch.nn.Module, caplog) -> list[str]:
+    vocoder = stages._CosyVoice3Vocoder(flow, _FakeHiFT())
+    state = FunCosyVoice3State(flow_embedding=torch.ones(1, 192))
+    items = [(state, torch.tensor([1, 2])), (state, torch.tensor([3]))]
+    with caplog.at_level(logging.DEBUG, logger=stages.logger.name):
+        asyncio.run(vocoder.decode_batch(items))
+    return [r.getMessage() for r in caplog.records if "flow solve:" in r.getMessage()]
+
+
+def test_decode_batch_logs_one_line_per_solve(caplog) -> None:
+    # Both requests share one frame bucket, so one solve and one line.
+    [message] = _decode_and_collect(_SolvableFlow(), caplog)
+    assert "batch_items=2" in message
+    assert float(message.rsplit("solve_elapsed_ms=", 1)[1]) > 0.0
+
+
+def test_flow_solve_is_timed_only_when_debug_is_enabled(caplog, monkeypatch) -> None:
+    clock_calls: list[int] = []
+    monkeypatch.setattr(
+        stages.time, "perf_counter", lambda: clock_calls.append(1) or 0.0
+    )
+    vocoder = stages._CosyVoice3Vocoder(_SolvableFlow(), _FakeHiFT())
+    state = FunCosyVoice3State(flow_embedding=torch.ones(1, 192))
+
+    with caplog.at_level(logging.INFO, logger=stages.logger.name):
+        asyncio.run(vocoder.decode_batch([(state, torch.tensor([1, 2]))]))
+    assert clock_calls == []
+    assert not [r for r in caplog.records if "flow solve:" in r.getMessage()]
+
+    with caplog.at_level(logging.DEBUG, logger=stages.logger.name):
+        asyncio.run(vocoder.decode_batch([(state, torch.tensor([1, 2]))]))
+    assert clock_calls == [1, 1]
+
+
+def test_pending_solve_events_are_skipped_not_awaited(caplog) -> None:
+    class _PendingEvent:
+        def query(self) -> bool:
+            return False
+
+        def synchronize(self) -> None:
+            raise AssertionError("must not wait on the device")
+
+    flow = stages.FunCosyVoice3Flow(_SolvableFlow())
+    flow._last_solve = (1, _PendingEvent(), _PendingEvent())
+    with caplog.at_level(logging.DEBUG, logger=stages.logger.name):
+        flow.log_last_solve()
+    assert not [r for r in caplog.records if "flow solve:" in r.getMessage()]
+
+
+@pytest.mark.accelerator
+@pytest.mark.skipif(not torch.cuda.is_available(), reason="requires CUDA")
+def test_decode_batch_logs_stream_event_time_on_cuda(caplog) -> None:
+    [message] = _decode_and_collect(_SolvableFlow().cuda(), caplog)
+    assert "batch_items=2" in message
+    assert float(message.rsplit("solve_elapsed_ms=", 1)[1]) > 0.0

--- a/tests/unit_test/fun_cosyvoice3/test_flow_solve_observability.py
+++ b/tests/unit_test/fun_cosyvoice3/test_flow_solve_observability.py
@@ -4,6 +4,7 @@ from __future__ import annotations
 
 import asyncio
 import logging
+import sys
 from typing import ClassVar
 
 import pytest
@@ -107,3 +108,31 @@ def test_decode_batch_logs_stream_event_time_on_cuda(caplog) -> None:
     [message] = _decode_and_collect(_SolvableFlow().cuda(), caplog)
     assert "batch_items=2" in message
     assert float(message.rsplit("solve_elapsed_ms=", 1)[1]) > 0.0
+
+
+def test_modelscope_guard_restores_changed_root_handler_levels(
+    monkeypatch, tmp_path
+) -> None:
+    root = logging.getLogger()
+    demoted = logging.StreamHandler()
+    demoted.setLevel(logging.INFO)
+    untouched = logging.FileHandler(tmp_path / "log.txt")
+    untouched.setLevel(logging.WARNING)
+    root.addHandler(demoted)
+    root.addHandler(untouched)
+    monkeypatch.delitem(sys.modules, "modelscope", raising=False)
+
+    def _import_like_modelscope(name: str):
+        assert name == "modelscope"
+        demoted.setLevel(logging.ERROR)
+        raise ImportError("side effects happen before the failure too")
+
+    monkeypatch.setattr(stages.importlib, "import_module", _import_like_modelscope)
+    try:
+        stages._import_modelscope_preserving_root_handlers()
+        assert demoted.level == logging.INFO
+        assert untouched.level == logging.WARNING
+    finally:
+        root.removeHandler(demoted)
+        root.removeHandler(untouched)
+        untouched.close()

--- a/tests/unit_test/fun_cosyvoice3/test_flow_solve_observability.py
+++ b/tests/unit_test/fun_cosyvoice3/test_flow_solve_observability.py
@@ -87,18 +87,34 @@ def test_flow_solve_is_timed_only_when_debug_is_enabled(caplog, monkeypatch) -> 
     assert clock_calls == [1, 1]
 
 
+class _PendingEvent:
+    def query(self) -> bool:
+        return False
+
+    def synchronize(self) -> None:
+        raise AssertionError("must not wait on the device")
+
+    def elapsed_time(self, end) -> float:
+        raise AssertionError("must not read a pending event")
+
+
+def _timer_with_pending_end() -> stages._FlowSolveTimer:
+    timer = stages._FlowSolveTimer(torch.device("cpu"))
+    timer._on_device = True
+    timer._start = timer._end = _PendingEvent()
+    return timer
+
+
+def test_pending_solve_timer_reports_no_elapsed_time() -> None:
+    assert _timer_with_pending_end().elapsed_ms() is None
+
+
 def test_pending_solve_events_are_skipped_not_awaited(caplog) -> None:
-    class _PendingEvent:
-        def query(self) -> bool:
-            return False
-
-        def synchronize(self) -> None:
-            raise AssertionError("must not wait on the device")
-
     flow = stages.FunCosyVoice3Flow(_SolvableFlow())
-    flow._last_solve = (1, _PendingEvent(), _PendingEvent())
+    flow._last_solve = (1, _timer_with_pending_end())
     with caplog.at_level(logging.DEBUG, logger=stages.logger.name):
         flow.log_last_solve()
+    assert flow._last_solve is None
     assert not [r for r in caplog.records if "flow solve:" in r.getMessage()]
 
 

--- a/tests/unit_test/pipeline/test_compile.py
+++ b/tests/unit_test/pipeline/test_compile.py
@@ -2,6 +2,7 @@
 
 from __future__ import annotations
 
+import logging
 from typing import Any
 
 import pytest
@@ -517,3 +518,34 @@ def test_mp_runner_keeps_cpu_stage_without_gpu_identity(tmp_path) -> None:
 
     assert group.specs[0].gpu_id is None
     assert "gpu_id" not in group.specs[0].comm_config
+
+
+def test_stage_processes_inherit_the_launcher_root_log_level(tmp_path) -> None:
+    config = PipelineConfig(
+        model_path="global-model",
+        endpoints=EndpointsConfig(base_path=str(tmp_path)),
+        stages=[
+            stage("preprocess", next="talker"),
+            stage("talker", gpu=0, terminal=True),
+        ],
+    )
+    root = logging.getLogger()
+    previous = root.level
+    root.setLevel(logging.DEBUG)
+    prep = prepare_pipeline_runtime(config)
+    try:
+        groups = _build_stage_groups(
+            config,
+            ctx=FakeMpContext(),
+            stages_cfg=prep.stages_cfg,
+            endpoints=prep.endpoints,
+            placement_plan=prep.placement_plan,
+            process_plan=prep.process_plan,
+        )
+    finally:
+        root.setLevel(previous)
+        assert prep.runtime_dir is not None
+        prep.runtime_dir.close()
+
+    levels = {spec.log_level for group in groups for spec in group.process_specs}
+    assert levels == {logging.DEBUG}


### PR DESCRIPTION
## Motivation

The Fun-CosyVoice3 profile (#1883, finding F1) showed the vocoder Flow solve dominating the pipeline, but the serving logs carry no signal about it. A per solve time in the log lets anyone see the effect of DiT changes (torch.compile, vocoder replicas) without a profiler session.

While verifying the new line on a canonical server, a second issue surfaced. In the default topology the vocoder is built inside the engine process, and INFO output through the root stream handler disappears as soon as the vocoder loads, including the SGLang metrics lines. This PR fixes that too, otherwise the new line is invisible in the default configuration.

## Modifications

- One DEBUG line per Flow solve in sglang_omni/models/fun_cosyvoice3/stages.py, for example `Fun-CosyVoice3 flow solve: batch_items=1 solve_elapsed_ms=155.4`. The interval covers the Euler solve only. The vocoder solves each frame bucket separately, so one scheduler batch can produce several lines. The streaming path is not timed here. Whether the DiT estimator is compiled is already logged once at startup, so the line does not repeat it.
- The timing runs only while the logger has DEBUG enabled, so the default serving path runs the solve untouched. When enabled, a small timer brackets the Euler solve with two stream events on the accelerator (perf_counter on CPU). The elapsed time is read after the bucket's audio reached the host, and only if the end event reports complete, otherwise the record is skipped. The instrumentation therefore cannot introduce a device wait.
- Stage processes now start at the launcher's log level (contributed by @Dayuxiaoshui): the process spec carries the root level and the stage sets it explicitly, since importing sglang already installs a root handler at INFO and made the stage's basicConfig a no-op. Without this, `--log-level debug` never reached the vocoder process and the record could not be seen in a deployment.
- Root cause of the logging loss: the first modelscope import, pulled in by cosyvoice, sets every root StreamHandler to ERROR once torch.distributed is initialized. The shared engine plus vocoder process is exactly that case, standalone vocoder processes were unaffected. The loader now wraps that first import and restores any root handler level it changed, also when the import raises after its side effects. When modelscope was imported earlier nothing changes during the import and the guard does nothing.

## Related Issues

Follow up to #1883 (item P1 in the PR map). The modelscope behavior may affect other models that import it inside a process with torch.distributed initialized. This PR scopes the guard to Fun-CosyVoice3.

## Accuracy Test

No numeric operation changed. The Euler solve is untouched, the timing wraps the call to it.

In the serving container on the final commit:

- `CUDA_VISIBLE_DEVICES= python -m pytest -q tests/unit_test/fun_cosyvoice3 tests/unit_test/pipeline tests/unit_test/scheduling`: 985 passed, 19 skipped.
- `python -m pytest -q -m accelerator tests/unit_test/fun_cosyvoice3/test_flow_solve_observability.py tests/unit_test/fun_cosyvoice3/test_dit_compile_gpu.py` on one H200: 2 passed.

New tests: the line through a real decode_batch on a stub flow, on CPU and on CUDA, no timing work below DEBUG, a pending end event being skipped rather than awaited, the guard restoring a changed level while leaving an untouched handler alone, and stage processes inheriting the launcher's root log level.

Live check on one H200 with the canonical config on the final branch: before the guard a full run logged 0 SGLang metrics lines. At the default level the server now logs `Restored root log handler level to NOTSET after the modelscope import changed it` at boot, the SGLang metrics lines are back (44 lines) and no per solve record is emitted. With `--log-level debug` the same load emits one record per solve (16 for 18 requests) and the metrics lines stay.

## Benchmark & Profiling

Nothing at the default INFO level: no events, no query, no record. With DEBUG enabled, two event records per solve, one query() and one log line, with no synchronization added to the request path. The DEBUG overhead was not measured in isolation.

## Checklist

- [x] Format your code according with pre-commit.
- [x] Add unit tests.
- [ ] Update documentation / docstrings / example tutorials as needed.
- [ ] Provide throughput / latency benchmark results and accuracy evaluation results as needed. The default path is untouched, the DEBUG overhead was not measured in isolation.
- [ ] For reviewers: If you haven't made any contributions to this PR and are only assisting with merging the main branch, please remove yourself as a co-author when merging the PR.
