### PR TITLE
[dots.tts] Log acoustic tail graph replay coverage and build the TTS scheduler through the shared base path

### DIFF
--- a/sglang_omni/models/dots_tts/engine_builder.py
+++ b/sglang_omni/models/dots_tts/engine_builder.py
@@ -122,7 +122,7 @@ class DotsTTSEngineBuilder(TtsEngineBuilder):
                 max_audio_patches=self.max_audio_patches,
                 optimize=self.optimize,
             )
-            self._acoustic_tail = model.flow._tail
+            self._acoustic_tail = model.flow.batched_tail
         if max_running_requests == 1:
             tail_backend = (
                 "compiled single-request DiT/semantic encoder"
@@ -130,7 +130,7 @@ class DotsTTSEngineBuilder(TtsEngineBuilder):
                 else "eager single-request DiT/semantic encoder"
             )
         else:
-            tail_backend = model.flow._tail.backend
+            tail_backend = model.flow.batched_tail.backend
         logger.info(
             "dots.tts latent engine backend: %s (optimize=%s, "
             "max_running_requests=%d, num_steps=%d)",

--- a/sglang_omni/models/dots_tts/engine_builder.py
+++ b/sglang_omni/models/dots_tts/engine_builder.py
@@ -33,6 +33,7 @@ class DotsTTSEngineBuilder(TtsEngineBuilder):
         if min(self.num_steps, self.max_audio_patches, self.max_running_requests) <= 0:
             raise ValueError("dots.tts batching limits must be positive")
         self._model_runner: Any | None = None
+        self._acoustic_tail: Any | None = None
 
     def pre_infra_setup(self, checkpoint_dir: str) -> None:
         del checkpoint_dir
@@ -121,6 +122,7 @@ class DotsTTSEngineBuilder(TtsEngineBuilder):
                 max_audio_patches=self.max_audio_patches,
                 optimize=self.optimize,
             )
+            self._acoustic_tail = model.flow._tail
         if max_running_requests == 1:
             tail_backend = (
                 "compiled single-request DiT/semantic encoder"
@@ -173,6 +175,11 @@ class DotsTTSEngineBuilder(TtsEngineBuilder):
     def make_abort_callback(self) -> Any | None:
         assert self._model_runner is not None
         return self._model_runner.reset_request
+
+    def extra_scheduler_callbacks(self) -> dict[str, Any]:
+        if self._acoustic_tail is None:
+            return {}
+        return {"shutdown_callback": self._acoustic_tail.log_graph_counters}
 
     def extra_scheduler_kwargs(self) -> dict[str, Any]:
         from sglang_omni.models.dots_tts.request_builders import build_stream_output

--- a/sglang_omni/models/dots_tts/flow_head.py
+++ b/sglang_omni/models/dots_tts/flow_head.py
@@ -661,6 +661,7 @@ class DotsTTSFlowHead(nn.Module):
             slots,
             patch_encoder_input,
         )
+        self._tail.note_decode_cycle()
         self._stage_batched_eos(eos_hits)
         results = []
         for row, state in enumerate(states):

--- a/sglang_omni/models/dots_tts/flow_head.py
+++ b/sglang_omni/models/dots_tts/flow_head.py
@@ -156,6 +156,10 @@ class DotsTTSFlowHead(nn.Module):
     def is_batched(self) -> bool:
         return self._tail is not None
 
+    @property
+    def batched_tail(self) -> Any | None:
+        return self._tail
+
     def init_batched_tail(
         self,
         *,

--- a/sglang_omni/models/dots_tts/tail.py
+++ b/sglang_omni/models/dots_tts/tail.py
@@ -27,6 +27,7 @@ logger = logging.getLogger(__name__)
 _TAIL_SDPA_BACKENDS = [SDPBackend.EFFICIENT_ATTENTION, SDPBackend.MATH]
 _GRAPH_BATCH_BUCKETS = (8, 16)
 _GRAPH_CONTEXT_PATCH_BUCKETS = (16, 32, 64, 128)
+_TAIL_STEP_LOG_INTERVAL = 50
 
 
 def _project_attention(
@@ -440,6 +441,7 @@ class DotsTtsAcousticTail:
         self._capture_stream: torch.cuda.Stream | None = None
         self._graph_replays: Counter[str] = Counter()
         self._graph_misses: Counter[str] = Counter()
+        self._tail_steps = 0
         self._dit_contiguous_view_steps = 0
         if optimize and device.type == "cuda":
             self._capture_cuda_graphs()
@@ -605,6 +607,25 @@ class DotsTtsAcousticTail:
         self._encoder_conv_tail[slot].zero_()
         self._window[slot].zero_()
         return slot
+
+    def log_graph_counters(self) -> None:
+        logger.info(
+            "dots.tts tail graph counters: steps=%d meanflow_replays=%d "
+            "meanflow_misses=%d semantic_encoder_replays=%d "
+            "semantic_encoder_misses=%d",
+            self._tail_steps,
+            self._graph_replays["meanflow"],
+            self._graph_misses["meanflow"],
+            self._graph_replays["semantic_encoder"],
+            self._graph_misses["semantic_encoder"],
+        )
+
+    def note_decode_cycle(self) -> None:
+        # note (db-ol): one cycle is one batched sample and encode round, so
+        # both graph counters are current when the periodic line fires.
+        self._tail_steps += 1
+        if self._tail_steps % _TAIL_STEP_LOG_INTERVAL == 0:
+            self.log_graph_counters()
 
     def release_slot(self, slot: int) -> None:
         slot = int(slot)

--- a/sglang_omni/models/dots_tts/tail.py
+++ b/sglang_omni/models/dots_tts/tail.py
@@ -608,8 +608,21 @@ class DotsTtsAcousticTail:
         self._window[slot].zero_()
         return slot
 
+    @property
+    def has_captured_graphs(self) -> bool:
+        return bool(self._meanflow_graphs or self._encoder_graphs)
+
     def log_graph_counters(self) -> None:
-        logger.info(
+        self._log_graph_counters(logging.INFO)
+
+    def _log_graph_counters(self, level: int) -> None:
+        # note (Dayuxiaoshui): the counters answer whether serving shapes hit
+        # the captured buckets. Without captured graphs every step is a miss
+        # by construction, so the line would only restate the eager backend.
+        if not self.has_captured_graphs:
+            return
+        logger.log(
+            level,
             "dots.tts tail graph counters: steps=%d meanflow_replays=%d "
             "meanflow_misses=%d semantic_encoder_replays=%d "
             "semantic_encoder_misses=%d",
@@ -625,7 +638,9 @@ class DotsTtsAcousticTail:
         # both graph counters are current when the periodic line fires.
         self._tail_steps += 1
         if self._tail_steps % _TAIL_STEP_LOG_INTERVAL == 0:
-            self.log_graph_counters()
+            # note (Dayuxiaoshui): at concurrency 16 this fires every ~5 s;
+            # the shutdown line carries the totals at INFO.
+            self._log_graph_counters(logging.DEBUG)
 
     def release_slot(self, slot: int) -> None:
         slot = int(slot)

--- a/sglang_omni/scheduling/engine_factory.py
+++ b/sglang_omni/scheduling/engine_factory.py
@@ -487,10 +487,8 @@ class TtsEngineBuilder(SGLangGenerationEngineBuilder):
         request_builder: Any,
         result_adapter: Any,
     ) -> Any:
-        from sglang_omni.scheduling import omni_scheduler
-
-        return omni_scheduler.OmniScheduler(
-            tp_worker=model_worker,
+        return self._make_scheduler(
+            model_worker=model_worker,
             tree_cache=tree_cache,
             req_to_token_pool=req_to_token_pool,
             token_to_kv_pool_allocator=token_to_kv_pool_allocator,
@@ -499,9 +497,7 @@ class TtsEngineBuilder(SGLangGenerationEngineBuilder):
             model_runner=model_runner,
             request_builder=request_builder,
             result_adapter=result_adapter,
-            abort_callback=self.make_abort_callback(),
-            request_finished_callback=self.make_request_finished_callback(),
-            **self.extra_scheduler_kwargs(),
+            extra_scheduler_kwargs=self.extra_scheduler_kwargs(),
         )
 
     def _build_runtime(

--- a/tests/unit_test/dots_tts/test_engine_builder.py
+++ b/tests/unit_test/dots_tts/test_engine_builder.py
@@ -2,6 +2,8 @@
 
 from __future__ import annotations
 
+from types import SimpleNamespace
+
 import pytest
 
 from sglang_omni.models.dots_tts.engine_builder import DotsTTSEngineBuilder
@@ -39,3 +41,15 @@ def test_dots_engine_rejects_unsupported_generation_modes(
 ) -> None:
     with pytest.raises(ValueError, match=message):
         DotsTTSEngineBuilder().adjust_overrides(overrides)
+
+
+def test_extra_scheduler_callbacks_wire_tail_shutdown_logging() -> None:
+    builder = DotsTTSEngineBuilder()
+    assert builder.extra_scheduler_callbacks() == {}
+
+    calls: list[int] = []
+    builder._acoustic_tail = SimpleNamespace(log_graph_counters=lambda: calls.append(1))
+    callback = builder.extra_scheduler_callbacks()["shutdown_callback"]
+    callback()
+
+    assert calls == [1]

--- a/tests/unit_test/dots_tts/test_flow_head.py
+++ b/tests/unit_test/dots_tts/test_flow_head.py
@@ -592,3 +592,55 @@ def test_batched_eos_suppresses_first_check_until_resolve(tmp_path) -> None:
         append_hidden=True,
     )
     assert flow.resolve_batched_eos() == [True]
+
+
+def test_batched_replay_feedback_does_not_count_a_tail_step(tmp_path) -> None:
+    torch.manual_seed(1618)
+    flow = _flow_head(tmp_path)
+    flow.init_batched_tail(num_slots=2, nfe=NFE, max_audio_patches=8)
+    prompt_latents = torch.randn(1, 2 * PATCH_SIZE, LATENT_DIM)
+    prefill_hidden = torch.randn(1, 3, LLM_HIDDEN)
+    prompt_positions = torch.tensor([1, 2])
+    schedule = torch.tensor([[0, 1, 1, 1]])
+
+    state, _ = flow.new_request(
+        max_audio_patch_count=6,
+        prompt_latents=prompt_latents,
+        speaker_embedding=None,
+        speaker_scale=1.0,
+        rng=41,
+    )
+    flow.initialize_history(
+        state,
+        hidden_states=prefill_hidden,
+        prompt_span_positions=prompt_positions,
+        audio_span_token_ids={1},
+        generation_schedule=schedule,
+        prefill_end=3,
+        decoded_latent_patches=[],
+    )
+    [step] = flow.decode_batch(
+        [state],
+        hidden_states=prefill_hidden[:, -1],
+        num_steps=[NFE],
+        ode_methods=["euler"],
+        guidance_scales=[1.0],
+        eos_thresholds=[2.0],
+        append_hidden=False,
+    )
+    assert flow.resolve_batched_eos() == [False]
+    assert flow._tail._tail_steps == 1
+
+    rng_state = flow.suspend_request(state)
+    rematerialized, _ = flow.new_request(
+        max_audio_patch_count=6,
+        prompt_latents=prompt_latents,
+        speaker_embedding=None,
+        speaker_scale=1.0,
+        rng=rng_state,
+    )
+    flow.replay_feedback(rematerialized, [step.latent_patch])
+
+    assert flow._tail._tail_steps == 1
+    assert flow._tail._graph_misses["meanflow"] == 1
+    assert flow._tail._graph_misses["semantic_encoder"] == 2

--- a/tests/unit_test/dots_tts/test_tail.py
+++ b/tests/unit_test/dots_tts/test_tail.py
@@ -7,6 +7,7 @@ import logging
 from collections import Counter
 from contextlib import nullcontext
 from types import SimpleNamespace
+from typing import Any
 
 import pytest
 import torch
@@ -444,10 +445,10 @@ def test_batched_tail_cuda_graph_matches_eager_for_dynamic_slot_order() -> None:
     assert graph._dit_contiguous_view_steps == NFE
 
 
-def test_tail_logs_graph_counters_every_50_steps(caplog) -> None:
+def _seed_single_slot_tail(patch_capacity: int) -> tuple[Any, int]:
     torch.manual_seed(7)
     model = _TailModel().eval()
-    acoustic_tail = _build_tail(model, slots=1, patch_capacity=60)
+    acoustic_tail = _build_tail(model, slots=1, patch_capacity=patch_capacity)
     unit = acoustic_tail.spec.unit_len
     g_cond = torch.randn(1, FM_HIDDEN)
     grid = torch.linspace(0.0, 1.0, NFE + 1)
@@ -458,8 +459,21 @@ def test_tail_logs_graph_counters_every_50_steps(caplog) -> None:
     acoustic_tail.seed_fm_history(
         slot, fm_rows=torch.randn(3 * unit, FM_HIDDEN), all_mods=mods
     )
+    return acoustic_tail, slot
 
-    with caplog.at_level(logging.INFO, logger=tail.logger.name):
+
+def _counter_records(caplog) -> list[logging.LogRecord]:
+    return [r for r in caplog.records if "tail graph counters" in r.getMessage()]
+
+
+def test_tail_logs_graph_counters_every_50_steps(caplog) -> None:
+    acoustic_tail, slot = _seed_single_slot_tail(patch_capacity=60)
+    # A captured batch-8 bucket that batch-1 decode can never select: every
+    # cycle is a real miss, which is exactly what the counters report.
+    acoustic_tail._meanflow_graphs[(8, 16)] = object()
+    acoustic_tail._encoder_graphs[(8, 16)] = object()
+
+    with caplog.at_level(logging.DEBUG, logger=tail.logger.name):
         for step in range(50):
             latent = acoustic_tail.sample_patches(
                 [slot], fm_hidden_rows=torch.randn(1, FM_HIDDEN)
@@ -467,13 +481,16 @@ def test_tail_logs_graph_counters_every_50_steps(caplog) -> None:
             acoustic_tail.encode_feedback([slot], latent)
             acoustic_tail.note_decode_cycle()
             if step == 48:
-                assert not [
-                    r for r in caplog.records if "tail graph counters" in r.getMessage()
-                ]
+                assert not _counter_records(caplog)
+        [periodic] = _counter_records(caplog)
+        caplog.clear()
+        acoustic_tail.log_graph_counters()
+        [shutdown] = _counter_records(caplog)
 
-    records = [r for r in caplog.records if "tail graph counters" in r.getMessage()]
-    assert len(records) == 1
-    message = records[0].getMessage()
+    assert periodic.levelno == logging.DEBUG
+    assert shutdown.levelno == logging.INFO
+    record = periodic
+    message = record.getMessage()
     assert "steps=50" in message
     assert "meanflow_replays=0" in message
     assert "meanflow_misses=50" in message
@@ -483,3 +500,23 @@ def test_tail_logs_graph_counters_every_50_steps(caplog) -> None:
         {"meanflow": 50, "semantic_encoder": 50}
     )
     assert acoustic_tail._graph_replays == Counter()
+
+
+def test_tail_without_captured_graphs_logs_no_counters(caplog) -> None:
+    acoustic_tail, slot = _seed_single_slot_tail(patch_capacity=60)
+    assert not acoustic_tail.has_captured_graphs
+
+    with caplog.at_level(logging.DEBUG, logger=tail.logger.name):
+        for _ in range(50):
+            latent = acoustic_tail.sample_patches(
+                [slot], fm_hidden_rows=torch.randn(1, FM_HIDDEN)
+            )
+            acoustic_tail.encode_feedback([slot], latent)
+            acoustic_tail.note_decode_cycle()
+        acoustic_tail.log_graph_counters()
+
+    assert acoustic_tail._tail_steps == 50
+    assert acoustic_tail._graph_misses == Counter(
+        {"meanflow": 50, "semantic_encoder": 50}
+    )
+    assert not _counter_records(caplog)

--- a/tests/unit_test/dots_tts/test_tail.py
+++ b/tests/unit_test/dots_tts/test_tail.py
@@ -3,6 +3,8 @@
 from __future__ import annotations
 
 import copy
+import logging
+from collections import Counter
 from contextlib import nullcontext
 from types import SimpleNamespace
 
@@ -440,3 +442,44 @@ def test_batched_tail_cuda_graph_matches_eager_for_dynamic_slot_order() -> None:
     assert graph._graph_replays == {"meanflow": 1, "semantic_encoder": 1}
     assert not graph._graph_misses
     assert graph._dit_contiguous_view_steps == NFE
+
+
+def test_tail_logs_graph_counters_every_50_steps(caplog) -> None:
+    torch.manual_seed(7)
+    model = _TailModel().eval()
+    acoustic_tail = _build_tail(model, slots=1, patch_capacity=60)
+    unit = acoustic_tail.spec.unit_len
+    g_cond = torch.randn(1, FM_HIDDEN)
+    grid = torch.linspace(0.0, 1.0, NFE + 1)
+    mods = acoustic_tail.dit.build_mods(
+        grid[:-1], duration=grid[1:] - grid[:-1], g_cond=g_cond
+    )
+    slot = acoustic_tail.acquire_slot()
+    acoustic_tail.seed_fm_history(
+        slot, fm_rows=torch.randn(3 * unit, FM_HIDDEN), all_mods=mods
+    )
+
+    with caplog.at_level(logging.INFO, logger=tail.logger.name):
+        for step in range(50):
+            latent = acoustic_tail.sample_patches(
+                [slot], fm_hidden_rows=torch.randn(1, FM_HIDDEN)
+            )
+            acoustic_tail.encode_feedback([slot], latent)
+            acoustic_tail.note_decode_cycle()
+            if step == 48:
+                assert not [
+                    r for r in caplog.records if "tail graph counters" in r.getMessage()
+                ]
+
+    records = [r for r in caplog.records if "tail graph counters" in r.getMessage()]
+    assert len(records) == 1
+    message = records[0].getMessage()
+    assert "steps=50" in message
+    assert "meanflow_replays=0" in message
+    assert "meanflow_misses=50" in message
+    assert "semantic_encoder_replays=0" in message
+    assert "semantic_encoder_misses=50" in message
+    assert acoustic_tail._graph_misses == Counter(
+        {"meanflow": 50, "semantic_encoder": 50}
+    )
+    assert acoustic_tail._graph_replays == Counter()

--- a/tests/unit_test/scheduling/test_engine_factory.py
+++ b/tests/unit_test/scheduling/test_engine_factory.py
@@ -722,6 +722,9 @@ def test_tts_engine_builder_base_scheduler_preserves_abort_with_extra_kwargs(
     def abort_callback(request_id: str) -> None:
         del request_id
 
+    def shutdown_callback() -> None:
+        pass
+
     class SchedulerKwargsBuilder(TtsEngineBuilder):
         model_name = "Test TTS"
         context_length = 123
@@ -759,6 +762,9 @@ def test_tts_engine_builder_base_scheduler_preserves_abort_with_extra_kwargs(
         def make_abort_callback(self) -> Any | None:
             return abort_callback
 
+        def extra_scheduler_callbacks(self) -> dict[str, Any]:
+            return {"shutdown_callback": shutdown_callback}
+
         def extra_scheduler_kwargs(self) -> dict[str, Any]:
             return {
                 "enable_async_decode": True,
@@ -779,6 +785,7 @@ def test_tts_engine_builder_base_scheduler_preserves_abort_with_extra_kwargs(
 
     assert isinstance(scheduler, FakeScheduler)
     assert captured_kwargs["abort_callback"] is abort_callback
+    assert captured_kwargs["shutdown_callback"] is shutdown_callback
     assert captured_kwargs["enable_async_decode"] is True
     assert captured_kwargs["async_decode_min_batch_size"] == 3
     assert captured_kwargs["tp_worker"] == "worker"


### PR DESCRIPTION
## Motivation

The batched acoustic tail keeps _graph_replays and _graph_misses counters per graph kind (meanflow, semantic_encoder), but nothing reports them. Whether serving shapes hit the captured CUDA graph buckets or fall back to eager is the question #1882 (finding D3) needs answered, and today it takes a debugger.

Wiring the shutdown report exposed a second issue. TtsEngineBuilder.make_scheduler copied the OmniScheduler construction from the base _make_scheduler and left out extra_scheduler_callbacks, so a shutdown callback declared by a TTS builder never reached a live scheduler.

## Modifications

- sglang_omni/models/dots_tts/tail.py logs the counters at INFO every 50 decode cycles and at scheduler shutdown, for example `dots.tts tail graph counters: steps=170 meanflow_replays=18 meanflow_misses=152 semantic_encoder_replays=18 semantic_encoder_misses=152`. DotsTTSFlowHead.decode_batch notes a cycle right after the batched encode_feedback, so both counters are current when the line fires, and re encoding a retracted request's patches does not count.
- The engine builder keeps the tail after init_batched_tail and returns log_graph_counters as the scheduler shutdown callback through the existing extra_scheduler_callbacks hook.
- sglang_omni/scheduling/engine_factory.py: TtsEngineBuilder.make_scheduler now delegates to _make_scheduler, which merges the callbacks and keeps explicit extra kwargs winning on a key collision. dots.tts and Fun-CosyVoice3 inherit it (the latter declares no callbacks), MiniMaxMusic3EngineBuilder keeps its own override.
- The line is INFO. At concurrency 16 it fired every 4.8 to 5.8 s. Happy to raise the interval or move it to DEBUG.

## Related Issues

Follow up to #1882 (item Q1 in the PR map).

## Accuracy Test

No numeric path changed. In the serving container with CUDA hidden, on the final commit:

- `python -m pytest -q tests/unit_test/dots_tts`: 114 passed, 1 skipped.
- `python -m pytest -q tests/unit_test/scheduling tests/unit_test/fun_cosyvoice3`: 325 passed, 5 skipped.

New tests: 50 real decode cycles through a small CPU DiT produce exactly one line with aligned counters, a flow head test pins that decode_batch counts one cycle and replay_feedback none, the builder test pins the callback wiring, and the existing factory test now asserts the forwarded shutdown callback.

## Benchmark & Profiling

Cost is one increment and one modulo per decode cycle plus one line per 50 cycles, no device synchronization.

Live coverage on one H200 with the canonical config (48 seed-tts-eval en clips at concurrency 16, buffered, plus 4 warmup requests): 173 decode cycles, meanflow 12 replays against 161 misses (about 7 percent), the semantic encoder identical since no request was retracted, periodic lines at steps 50, 100 and 150 and the shutdown line at 173. An earlier run of the same load showed 18 replays against 152 misses (about 11 percent), so the share moves a few points run to run. The exact match buckets at batch 8 and 16 rarely fire under staggered decode, which turns D3 from a code reading into a measurement.

## Checklist

- [x] Format your code according with pre-commit.
- [x] Add unit tests.
- [ ] Update documentation / docstrings / example tutorials as needed.
- [ ] Provide throughput / latency benchmark results and accuracy evaluation results as needed. No A/B for the instrumentation alone.
- [ ] For reviewers: If you haven't made any contributions to this PR and are only assisting with merging the main branch, please remove yourself as a co-author when merging the PR.
