### PR TITLE
[CosyVoice3] Compile the DiT estimator by default

### DIFF
--- a/docs/cookbook/fun_cosyvoice3.md
+++ b/docs/cookbook/fun_cosyvoice3.md
@@ -145,24 +145,23 @@ incompatible Flow structure fails directly instead of using a fallback implement
 ### torch.compile for the DiT backbone
 
 The flow decoder's DiT backbone (`flow.decoder.estimator`, a 22-layer DiT invoked
-once per Euler step) can be compiled with `torch.compile` to reduce per-step
-kernel-launch overhead. It is opt-in because it pays a one-time compile cost at
-startup and is most beneficial under sustained throughput load. The compile uses
-`dynamic=True`, so one symbolic-sequence-length graph serves every utterance
-length.
+once per Euler step) is compiled with `torch.compile` to reduce per-step
+kernel-launch overhead. It is on by default unless the TensorRT estimator below
+is enabled. The compile pays a one-time cost of about 100 s at startup with an
+empty inductor cache and uses `dynamic=True`, so one symbolic-sequence-length
+graph serves every utterance length.
 
-Enable it by overriding the vocoder stage's `factory` args (the `stages.`
-prefix is implied in the CLI dotted path):
+Run the estimator eager instead by overriding the vocoder stage's `factory` args
+(the `stages.` prefix is implied in the CLI dotted path), for example to shorten
+startup during development:
 
 ```bash
 sgl-omni serve \
   --model-path FunAudioLLM/Fun-CosyVoice3-0.5B-2512 \
   --config examples/configs/fun_cosyvoice3_0_5b.yaml \
-  --vocoder.factory.enable_dit_torch_compile true \
+  --vocoder.factory.enable_dit_torch_compile false \
   --port 8000
 ```
-
-Do not enable this together with TensorRT for the same DiT (see below).
 
 ### TensorRT for the DiT backbone
 
@@ -176,7 +175,8 @@ Packed Flow (CFG batch = `2 * request_batch`) still works by chunking
 request-wise cond/uncond pairs into that CFG=2 engine.
 
 TensorRT and `torch.compile` both replace the same DiT, so they are mutually
-exclusive. Enable only one:
+exclusive. Enabling TensorRT skips the default compile on its own, setting both
+flags to true is rejected:
 
 ```bash
 sgl-omni serve \

--- a/sglang_omni/models/fun_cosyvoice3/config.py
+++ b/sglang_omni/models/fun_cosyvoice3/config.py
@@ -63,8 +63,9 @@ class FunCosyVoice3PipelineConfig(PipelineConfig):
                 flow_batch_admission_frames=8000,
                 max_batch_size=16,
                 max_batch_wait_ms=30,
-                # note (guozhihao-224): mutually exclusive DiT accelerators; both default off.
-                enable_dit_torch_compile=False,
+                # note (guozhihao-224): mutually exclusive DiT accelerators.
+                # note (db-ol): the factory compiles the DiT unless TensorRT is
+                # enabled, set enable_dit_torch_compile false to run it eager.
                 enable_flow_estimator_trt=False,
             ),
             gpu=0,

--- a/sglang_omni/models/fun_cosyvoice3/stages.py
+++ b/sglang_omni/models/fun_cosyvoice3/stages.py
@@ -817,7 +817,7 @@ def create_vocoder_executor(
     max_batch_wait_ms: int = 30,
     flow_batch_bucket_frames: int = 50,
     flow_batch_admission_frames: int = _DEFAULT_FLOW_BATCH_ADMISSION_FRAMES,
-    enable_dit_torch_compile: bool = False,
+    enable_dit_torch_compile: bool | None = None,
     enable_flow_estimator_trt: bool = False,
     hift_dtype: str = "float32",
     hift_max_padding_waste: float = 1.5,
@@ -829,6 +829,8 @@ def create_vocoder_executor(
             "enable_flow_estimator_trt and enable_dit_torch_compile both "
             "target flow.decoder.estimator; enable only one"
         )
+    if enable_dit_torch_compile is None:
+        enable_dit_torch_compile = not enable_flow_estimator_trt
     device = resolve_device_spec(device, gpu_id)
     checkpoint_dir = resolve_checkpoint(model_path)
     if dtype not in _AUTOCAST_DTYPES:

--- a/tests/unit_test/fun_cosyvoice3/test_dit_compile.py
+++ b/tests/unit_test/fun_cosyvoice3/test_dit_compile.py
@@ -135,5 +135,5 @@ def test_vocoder_factory_exposes_dit_torch_compile_flag() -> None:
     import inspect
 
     signature = inspect.signature(stages.create_vocoder_executor)
-    assert signature.parameters["enable_dit_torch_compile"].default is False
+    assert signature.parameters["enable_dit_torch_compile"].default is None
     assert signature.parameters["enable_flow_estimator_trt"].default is False

--- a/tests/unit_test/fun_cosyvoice3/test_pipeline.py
+++ b/tests/unit_test/fun_cosyvoice3/test_pipeline.py
@@ -43,7 +43,6 @@ def test_fun_cosyvoice3_config_and_registry_contract() -> None:
     assert vocoder.factory.model_extra == {
         "flow_batch_bucket_frames": 50,
         "flow_batch_admission_frames": 8000,
-        "enable_dit_torch_compile": False,
         "enable_flow_estimator_trt": False,
     }
 
@@ -68,7 +67,6 @@ def test_fun_cosyvoice3_flow_factory_overrides_use_typed_path() -> None:
     assert vocoder.factory.model_extra == {
         "flow_batch_bucket_frames": 100,
         "flow_batch_admission_frames": 4000,
-        "enable_dit_torch_compile": False,
         "enable_flow_estimator_trt": False,
     }
     args = resolve_stage_typed_kwargs(vocoder)

--- a/tests/unit_test/fun_cosyvoice3/test_vocoder.py
+++ b/tests/unit_test/fun_cosyvoice3/test_vocoder.py
@@ -513,6 +513,38 @@ def test_create_vocoder_executor_threads_trt_flag(monkeypatch) -> None:
     }
 
 
+def _executor_compiles(monkeypatch, **kwargs) -> bool:
+    monkeypatch.setattr(stages, "resolve_device_spec", lambda device, gpu_id: "cpu")
+    monkeypatch.setattr(stages, "resolve_checkpoint", lambda model_path: "/checkpoint")
+    monkeypatch.setattr(
+        stages,
+        "_load_cosyvoice3_flow_hift",
+        lambda checkpoint_dir, device, fp16, **_: (
+            _BatchCapableFakeFlow(),
+            _FakeHiFT(),
+        ),
+    )
+    compiled: list[object] = []
+    monkeypatch.setattr(
+        stages,
+        "_compile_dit_backbone",
+        lambda flow, compute_dtype: compiled.append(flow),
+    )
+    stages.create_vocoder_executor("model", device="cpu", **kwargs)
+    return bool(compiled)
+
+
+def test_create_vocoder_executor_compiles_dit_by_default(monkeypatch) -> None:
+    assert _executor_compiles(monkeypatch)
+    assert not _executor_compiles(monkeypatch, enable_dit_torch_compile=False)
+
+
+def test_create_vocoder_executor_trt_alone_skips_the_default_compile(
+    monkeypatch,
+) -> None:
+    assert not _executor_compiles(monkeypatch, enable_flow_estimator_trt=True)
+
+
 def test_create_vocoder_executor_rejects_trt_and_compile() -> None:
     with pytest.raises(ValueError, match="enable only one"):
         stages.create_vocoder_executor(
@@ -616,7 +648,6 @@ def test_pipeline_config_sets_flow_batch_bucket_by_default() -> None:
         "flow_batch_admission_frames": 8000,
         "max_batch_size": 16,
         "max_batch_wait_ms": 30,
-        "enable_dit_torch_compile": False,
         "enable_flow_estimator_trt": False,
     }
 


### PR DESCRIPTION
## Motivation

The Fun-CosyVoice3 profile (#1883, finding F1) found the vocoder thread saturated by eager dispatch of the 22 layer DiT estimator across the Euler steps, with the GPU under 20 percent busy at concurrency 16. #1670 added torch.compile for the estimator as an opt in. This PR measures that knob against the canonical config and proposes turning it on by default, since the gain is large at every concurrency and the only cost is startup time.

## Modifications

- sglang_omni/models/fun_cosyvoice3/stages.py: create_vocoder_executor now defaults enable_dit_torch_compile to None, meaning compile unless enable_flow_estimator_trt is set. So `--vocoder.factory.enable_flow_estimator_trt true` alone keeps working as in #1858, `enable_dit_torch_compile false` runs eager, and setting both flags to true is still rejected.
- sglang_omni/models/fun_cosyvoice3/config.py: the canonical config no longer states enable_dit_torch_compile, following the FactoryArgs convention that an unset field means the factory default.
- docs/cookbook/fun_cosyvoice3.md: the torch.compile section now says it is on by default, states the startup cost, and shows how to switch it off. The TensorRT section from #1858 now switches torch.compile off in its example, since the two estimators are mutually exclusive.
- Two new unit tests pin the default (compiles unless TensorRT is enabled) and the existing ones follow the new default.

No numeric path changed. Rebased on #1858: enable_flow_estimator_trt stays off by default.

## Related Issues

Follow up to the Fun-CosyVoice3 profiling thread #1883 (items P2 and P3 in the PR map). Builds on #1670 by @CAICAIIs, whose review on the default change I would value.

## Accuracy Test

WER on seed-tts-eval en, 96 clips at concurrency 16, whisper-large-v3, two independent server boots per arm. Baseline corpus WER 0.66 percent, compiled 0.85 percent, each value reproduced to the last digit across boots. The gap is one clip where whisper writes "skyjumper" as one token for the compiled arm instead of "sky jumper", scored as one substitution plus one deletion on a corpus of about 1060 words. Same words in both arms, no clip above 50 percent WER in any run.

Unit tests in the serving container on top of #1858: `python -m pytest -q tests/unit_test/fun_cosyvoice3 tests/unit_test/config` gives 251 passed, 1 skipped (the skip needs CUDA).

## Benchmark & Profiling

Paired gate on one H200: two live servers on the same card, alternating 48 clip bursts, order flipped per pair, 10 pairs with the first dropped, at concurrency 1 and 16. The A/A floor measured the same way on this host keeps every median within about 4 percent at concurrency 1 and 6 percent at concurrency 16 (19 pairs).

Compiled against the canonical config, medians over 9 pairs:

| concurrency | throughput | audio throughput | latency mean | latency p95 | rtf | pairs won |
|---|---|---|---|---|---|---|
| 1 | +24.6 percent | +33.7 percent | 19.7 percent lower | 13.4 percent lower | 26.9 percent lower | 9 of 9 on every metric |
| 16 | +59.0 percent | +53.4 percent | 39.1 percent lower | 38.9 percent lower | 40.7 percent lower | 9 of 9 on four metrics, 8 of 9 on latency p95 |

Costs and notes:

- Startup: the baseline server was healthy in 40 s, the compiled one in 140 s on this host with an empty inductor cache.
- Dynamo reports one graph break from a Tensor.item() in cosyvoice/utils/mask.py add_optional_chunk_mask. The compile still applies on both sides of the break. Left as is here.
- The concurrency 16 numbers come from a shared host, so single pairs swing by 20 to 35 percent. The medians and the 9 of 9 win counts are the evidence, and the concurrency 1 result alone already clears the floor by a wide margin.

## Checklist

- [x] Format your code according with pre-commit.
- [ ] Add unit tests. Existing tests updated, no new behavior to test.
- [x] Update documentation / docstrings / example tutorials as needed.
- [x] Provide throughput / latency benchmark results and accuracy evaluation results as needed.
- [ ] For reviewers: If you haven't made any contributions to this PR and are only assisting with merging the main branch, please remove yourself as a co-author when merging the PR.
