### PR TITLE
fix(audar-tts): reset default seed between requests

### DIFF
--- a/sglang_omni/models/audar_tts/stages.py
+++ b/sglang_omni/models/audar_tts/stages.py
@@ -233,7 +233,7 @@ def create_tts_engine_executor(
     n_gpu_layers: int = -1,
 ) -> SimpleScheduler:
     try:
-        from llama_cpp import LLAMA_SPLIT_MODE_NONE, Llama
+        from llama_cpp import LLAMA_DEFAULT_SEED, LLAMA_SPLIT_MODE_NONE, Llama
     except ImportError as exc:
         raise RuntimeError(
             "Audar-TTS requires the 'audar-tts' optional dependencies"
@@ -272,8 +272,7 @@ def create_tts_engine_executor(
             raise ValueError("Audar-TTS prompt exceeds the llama.cpp context window")
         llm.reset()
         seed = state.generation_kwargs.get("seed")
-        if seed is not None:
-            llm.set_seed(int(seed))
+        llm.set_seed(int(seed) if seed is not None else LLAMA_DEFAULT_SEED)
 
         generated: list[int] = []
         pieces: list[str] = []

--- a/tests/unit_test/audar_tts/test_pipeline.py
+++ b/tests/unit_test/audar_tts/test_pipeline.py
@@ -732,6 +732,7 @@ def test_llama_cpp_stage_matches_official_generation_loop(
             self.kwargs = kwargs
             self.generate_kwargs: dict[str, Any] | None = None
             self.seed: int | None = None
+            self.seed_calls: list[int] = []
             self.reset_calls = 0
             FakeLlama.instance = self
 
@@ -753,6 +754,7 @@ def test_llama_cpp_stage_matches_official_generation_loop(
 
         def set_seed(self, seed: int) -> None:
             self.seed = seed
+            self.seed_calls.append(seed)
 
         def reset(self) -> None:
             self.reset_calls += 1
@@ -760,7 +762,11 @@ def test_llama_cpp_stage_matches_official_generation_loop(
     monkeypatch.setitem(
         sys.modules,
         "llama_cpp",
-        types.SimpleNamespace(LLAMA_SPLIT_MODE_NONE=0, Llama=FakeLlama),
+        types.SimpleNamespace(
+            LLAMA_DEFAULT_SEED=0xFFFFFFFF,
+            LLAMA_SPLIT_MODE_NONE=0,
+            Llama=FakeLlama,
+        ),
     )
     monkeypatch.setattr(stages, "_resolve_gguf", lambda *args: "/model.gguf")
     payload = make_payload(
@@ -795,6 +801,22 @@ def test_llama_cpp_stage_matches_official_generation_loop(
         "top_p": 0.9,
         "repeat_penalty": 1.1,
     }
+
+    unseeded_payload = make_payload(
+        state=AudarTTSState(
+            prompt="prompt",
+            generation_kwargs={
+                "max_new_tokens": 16,
+                "temperature": 1.0,
+                "top_k": 40,
+                "top_p": 0.9,
+                "repetition_penalty": 1.1,
+            },
+        )
+    )
+    scheduler._fn(unseeded_payload)
+
+    assert FakeLlama.instance.seed_calls == [23, 0xFFFFFFFF]
     assert scheduler._max_concurrency == 1
 
 


### PR DESCRIPTION
## Motivation

Audar-TTS reuses one `llama_cpp.Llama` instance across requests. `Llama.reset()` does not reset its seed, so an unseeded request can inherit the previous request's explicit seed.

## Modifications

- Set either the request seed or `LLAMA_DEFAULT_SEED` on every request.
- Extend the existing executor test with sequential seeded and unseeded requests.

## Related Issues

Fixes #1975

## Accuracy Test

No model math or weights change. A real GGUF inference run was not performed because the Audar optional dependencies and model are not installed on this host.

## Benchmark & Profiling

Not applicable; this adds one existing llama.cpp setter call per request.

## Testing

- Dependency-free harness against the actual function: failed before the fix (`[23]`), passed after (`[23, LLAMA_DEFAULT_SEED]`), repeated twice.
- `python3 -m py_compile sglang_omni/models/audar_tts/stages.py tests/unit_test/audar_tts/test_pipeline.py`
- `git diff --check`
- `ruff format --check` (2 files already formatted)

Full pytest was not run because this host lacks pytest and the Audar optional dependencies. Ruff lint reports six existing upgrade warnings on untouched lines; the changed lines add no warning.

## Checklist

- [x] Format your code according with pre-commit.
- [x] Add unit tests.
- [x] Documentation / docstrings / example tutorials are not needed for this behavior-only fix.
- [x] Throughput / latency benchmarks and accuracy evaluation are not needed for this seed-state fix.
- [x] For reviewers: no merge-only co-author applies.