### PR TITLE
refactor(higgs): route codec checkpoint resolution through shared helper

### DIFF
--- a/sglang_omni/models/higgs_tts/audio_codec.py
+++ b/sglang_omni/models/higgs_tts/audio_codec.py
@@ -23,9 +23,10 @@ import numpy as np
 import torch
 import torch.nn.functional as F
 import torchaudio
-from huggingface_hub import snapshot_download
 from safetensors import safe_open
 from transformers import HiggsAudioV2TokenizerConfig, HiggsAudioV2TokenizerModel
+
+from sglang_omni.utils.checkpoint import resolve_checkpoint
 
 WaveformInput = torch.Tensor | np.ndarray
 logger = logging.getLogger(__name__)
@@ -86,14 +87,6 @@ def _to_mono_3d(waveform: WaveformInput) -> torch.Tensor:
             raise ValueError(f"audio must be mono, got shape {tuple(wav.shape)}")
         return wav
     raise ValueError(f"waveform must be 1-, 2- or 3-D, got {wav.ndim}-D")
-
-
-def _resolve_ckpt_dir(model_path: str | Path) -> str:
-    """Local dir or HF repo id → local snapshot dir."""
-    p = str(model_path)
-    if os.path.isdir(p):
-        return p
-    return snapshot_download(p)
 
 
 def _load_codec_state_dict(tts_ckpt_dir: str) -> dict[str, torch.Tensor]:
@@ -166,7 +159,7 @@ class HiggsAudioCodec:
         — opt in only if you've validated quality at your sample rate.
         """
         device = torch.device(device)
-        ckpt_dir = _resolve_ckpt_dir(model_path)
+        ckpt_dir = resolve_checkpoint(str(model_path))
 
         config = HiggsAudioV2TokenizerConfig.from_json_file(_BUNDLED_CODEC_CONFIG_PATH)
         model = HiggsAudioV2TokenizerModel(config).to(dtype=dtype).eval()


### PR DESCRIPTION
## Motivation

<!-- Explain the purpose of this PR and the goals it aims to achieve. -->

Checkpoint resolution is duplicated per model family (#1877). HiggsAudioCodec.from_pretrained resolves its checkpoint with a private _resolve_ckpt_dir that duplicates sglang_omni.utils.checkpoint.resolve_checkpoint line-for-line (local dir passthrough, else snapshot_download).

## Modifications

<!-- Describe the changes made in this PR. -->

Call the shared resolver instead; drop the duplicate helper and its now-unused snapshot_download import (−10/+3).

## Related Issues

<!-- Link to any related issues here. e.g. "Fixes #123" or "Closes #456" -->

Part of #1877. The ASR families are covered by #1808/#1878; this closes the higgs_tts site.

## Accuracy Test

<!-- If this PR affects model-side code (e.g., kernels, model architecture), please provide accuracy test results. Ref: https://docs.sglang.ai/references/accuracy_evaluation.html -->

N/A — no model-side math or weights change; behavior-preserving refactor.

## Benchmark & Profiling

<!-- If this PR is expected to impact performance, please provide benchmark and profiling results. Ref: https://docs.sglang.ai/references/benchmark_and_profiling.html -->

N/A — no runtime code-path change beyond one checkpoint-resolution call swapping to an identical shared helper.

## Checklist

- [x] Format your code according with pre-commit.
- [ ] Add unit tests. (Structural swap — covered by existing higgs codec/serve paths; no new behavior to pin.)
- [ ] Update documentation / docstrings / example tutorials as needed. (N/A — internal refactor, no user-facing docs affected.)
- [ ] Provide throughput / latency benchmark results and accuracy evaluation results as needed. (N/A — behavior-preserving.)
- [ ] For reviewers: If you haven't made any contributions to this PR and are only assisting with merging the main branch, please remove yourself as a co-author when merging the PR.


## CI

CI runs on self-hosted GPU runners and requires a maintainer to add the
`run-ci` label. Once labeled, every subsequent push re-triggers CI as
long as the label remains. Use `/tag-and-rerun-ci higgs` or
`/tag-and-rerun-ci moss` or `/tag-and-rerun-ci qwen3-tts` to select a TTS CI
model, and
`/tag-and-rerun-ci fun-asr`, `/tag-and-rerun-ci qwen3-asr` or
`/tag-and-rerun-ci whisper-asr` to select an ASR CI model. One selector from
each family can be combined, for example `/tag-and-rerun-ci moss fun-asr`.
Draft PRs are skipped even if labeled.
