### PR TITLE
fix(installation): Use CPU ONNX Runtime on Apple Silicon

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -66,7 +66,8 @@ dependencies = [
     "mistral_common[audio]>=1.11.0",
     # /v1/realtime — server-side turn detection
     "silero-vad>=5.1",
-    "onnxruntime-gpu>=1.17",  # CUDAExecutionProvider for the FP32 Smart Turn model
+    "onnxruntime-gpu>=1.17; sys_platform != 'darwin' or platform_machine != 'arm64'",  # CUDAExecutionProvider for the FP32 Smart Turn model
+    "onnxruntime>=1.17; sys_platform == 'darwin' and platform_machine == 'arm64'",  # CPUExecutionProvider on Apple Silicon
     "websockets>=12.0",       # FastAPI WebSocket library + example clients
     # Testing
     "pytest>=7.0.0",


### PR DESCRIPTION
## Motivation

`./install.sh` is failing on Apple Silicon because `onnxruntime-gpu>=1.17` is unconditional and has no macOS arm64 wheel.
```
  × No solution found when resolving dependencies:
  ╰─▶ Because onnxruntime-gpu>=1.17.0 has no wheels with a matching platform tag (e.g., `macosx_14_0_arm64`) and
      sglang-omni==0.1.4 depends on onnxruntime-gpu>=1.17, we can conclude that sglang-omni==0.1.4 cannot be used.
      And because only sglang-omni==0.1.4 is available and you require sglang-omni, we can conclude that your
      requirements are unsatisfiable.
```

## Modifications

Select `onnxruntime>=1.17` on Darwin arm64 and retain `onnxruntime-gpu>=1.17` elsewhere, following the existing Apple Silicon dependency markers. This keeps ONNX Runtime available for Smart Turn on Apple Silicon. Smart Turn already lists CPUExecutionProvider after CUDAExecutionProvider, so no runtime change is needed.

## Related Issues

No linked issue; encountered during local Apple Silicon installation.

## Accuracy Test

Dependency-only change; no model code changes or formal accuracy evaluation.

Validation on Apple Silicon with Python 3.12.12:

- `./install.sh` completed successfully.
```
sglang_omni 0.1.4
Failed to import torchada: No module named 'torchada'. MUSA platform compatibility will not work.
MLX Metal and TorchCodec FFmpeg loading are available

Installation complete.
Virtual environment: /Users/yihua/dev/sglang-omni/.venv-apple
Activate it with:
  source "/Users/yihua/dev/sglang-omni/.venv-apple/bin/activate"

For TorchCodec/FFmpeg audio decoding, export:
  export DYLD_LIBRARY_PATH="/opt/homebrew/opt/ffmpeg@7/lib${DYLD_LIBRARY_PATH:+:$DYLD_LIBRARY_PATH}"

The Apple Silicon Qwen3-ASR examples are documented at:
  /Users/yihua/dev/sglang-omni/docs/cookbook/qwen3_asr.md
```

- Served `mlx-community/Qwen3-ASR-0.6B-4bit` with the MLX backend
```
curl --fail-with-body http://localhost:8000/v1/audio/transcriptions \
  -F model=Qwen/Qwen3-ASR-0.6B \
  -F file=@tests/data/query_to_cars.wav \
  -F response_format=json
{"text":"How many cars are there in the picture?","usage":{"type":"duration","seconds":5}}
```

## Benchmark & Profiling

Not applicable: dependency selection only; no inference implementation changes.

## Checklist

- [x] Format your code according with pre-commit.
- [ ] Add unit tests. Not added for this metadata-only change; marker checks and manual installation/inference validation are listed above.
- [x] Update documentation / docstrings / example tutorials as needed. No update needed: this fixes the existing documented installer.
- [x] Provide throughput / latency benchmark results and accuracy evaluation results as needed. Not applicable to this dependency-only change.
- [ ] For reviewers: If you haven't made any contributions to this PR and are only assisting with merging the main branch, please remove yourself as a co-author when merging the PR.

## CI

GPU CI requires a maintainer to add the `run-ci` label. Draft PRs are skipped even if labeled.
