### PR TITLE
[CI] Add macOS arm64 unit-test workflow for Apple Silicon paths

### DIFF
--- a/.github/workflows/apple-ci.yaml
+++ b/.github/workflows/apple-ci.yaml
@@ -1,0 +1,52 @@
+name: Apple Silicon CI
+
+# Runs the Apple Silicon (macOS arm64) unit-test subset on a GitHub-hosted M1
+# runner: ./install.sh builds the .venv-apple environment (SGLang v0.5.18 from
+# source with all_mps, MLX, torchcodec) and pytest covers the platform and
+# Qwen3-ASR MLX/Torch-MPS paths tracked in RFC #1967.
+#
+# macOS runners are free for public repos, so unlike omni-ci this workflow is
+# not gated by the run-ci label; path filters keep it off unrelated PRs.
+
+on:
+  pull_request:
+    paths:
+      - "install.sh"
+      - "pyproject.toml"
+      - "sglang_omni/platforms/**"
+      - "sglang_omni/models/qwen3_asr/**"
+      - "tests/unit_test/platforms/**"
+      - "tests/unit_test/qwen3_asr/**"
+      - ".github/workflows/apple-ci.yaml"
+  workflow_dispatch:
+
+concurrency:
+  group: apple-ci-${{ github.event.pull_request.number || github.ref }}
+  cancel-in-progress: true
+
+permissions:
+  contents: read
+
+jobs:
+  unit-test:
+    name: unit-test (macOS arm64)
+    runs-on: macos-14
+    timeout-minutes: 120
+    steps:
+      - name: Checkout code
+        uses: actions/checkout@v4
+
+      # install.sh detects the checkout next to it and installs it editable,
+      # so the venv tests the PR's code, not a fresh clone of main.
+      - name: Install Apple Silicon environment
+        run: ./install.sh --non-interactive
+
+      - name: Run test
+        timeout-minutes: 30
+        shell: bash
+        run: |
+          source .venv-apple/bin/activate
+          export DYLD_LIBRARY_PATH="$(brew --prefix ffmpeg@7)/lib${DYLD_LIBRARY_PATH:+:$DYLD_LIBRARY_PATH}"
+          export PYTHONPATH=$PWD
+          pytest tests/unit_test/platforms tests/unit_test/qwen3_asr \
+            -v -m "not benchmark and not accelerator"

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -66,7 +66,11 @@ dependencies = [
     "mistral_common[audio]>=1.11.0",
     # /v1/realtime — server-side turn detection
     "silero-vad>=5.1",
-    "onnxruntime-gpu>=1.17",  # CUDAExecutionProvider for the FP32 Smart Turn model
+    "onnxruntime-gpu>=1.17; sys_platform != 'darwin' or platform_machine != 'arm64'",  # CUDAExecutionProvider for the FP32 Smart Turn model
+    # ponytail: no macOS arm64 wheel exists for onnxruntime-gpu; the CPU build
+    # provides the same `onnxruntime` import and every call site already falls
+    # back to CPUExecutionProvider.
+    "onnxruntime>=1.17; sys_platform == 'darwin' and platform_machine == 'arm64'",
     "websockets>=12.0",       # FastAPI WebSocket library + example clients
     # Testing
     "pytest>=7.0.0",


### PR DESCRIPTION
## Motivation

The Apple Silicon support contributed by #1730 (Qwen3-ASR MLX and Torch-MPS paths) shipped with a full unit-test suite — `tests/unit_test/platforms/` and `tests/unit_test/qwen3_asr/` — but the repo's CI is entirely Linux/CUDA self-hosted, so those 622 tests have never run in any automated environment. They only execute on a Mac (the MLX tests are skipped elsewhere via `importorskip("mlx.core")`), meaning any change to shared scheduler/platform/engine-builder code can break the Apple paths while CI stays green.

RFC #1967 (Apple Silicon support roadmap) calls for exactly this under "Performance/validation": arm64/macOS CI coverage.

## Modifications

- Add `.github/workflows/omni-metal-ci.yaml` (naming follows the accelerator-based convention of `omni-xpu-ci.yaml`):
  - Runs on GitHub-hosted `macos-14` (M1 arm64, free for public repos)
  - Builds the `.venv-apple` environment via `./install.sh --non-interactive` (SGLang v0.5.18 from source with `all_mps`, MLX, torchcodec); install.sh detects the PR checkout and installs it editable
  - Runs the Apple-path unit-test subset: `tests/unit_test/platforms` + `tests/unit_test/qwen3_asr` — the only models with validated Apple paths today; the set can grow with the #1967 support matrix (e.g. fun_cosyvoice3 after #1964)
  - Triggered by `pull_request` path filters + `workflow_dispatch`; not gated by the `run-ci` label since macOS runners are free, unlike the GPU omni-ci flow
- `pyproject.toml`: gate `onnxruntime-gpu` to non-Apple platforms and add CPU `onnxruntime` for macOS arm64. `onnxruntime-gpu` has no macOS arm64 wheel, which made `pip install -e .` fail on any Apple machine (including this workflow's environment). All call sites already fall back to `CPUExecutionProvider`, so behavior on other platforms is unchanged.

## Related Issues

Ref #1967

## Accuracy Test

N/A — CI infrastructure and dependency marker change only. No model-side code touched.

## Benchmark & Profiling

N/A

## Checklist

- [x] Format your code according with pre-commit.
- [ ] Add unit tests. (existing suite from #1730 now runs under the new workflow)
- [ ] Update documentation / docstrings / example tutorials as needed. (Apple Silicon docs to follow per RFC #1967 roadmap item 5)
- [ ] Provide throughput / latency benchmark results and accuracy evaluation results as needed. → N/A

## CI

Verified end-to-end before opening this PR:
- Local M1 Mac: `./install.sh --non-interactive` + test subset — **622 passed**
- GitHub-hosted M1 runner ([fork run](https://github.com/zero-piB/sglang-omni/actions/runs/34027202215)): **green**

This workflow runs on GitHub-hosted macOS runners and does not require the `run-ci` label.

🤖 Generated with [Claude Code](https://claude.com/claude-code)