### PR TITLE
[Fun-ASR Perf] Release the prefill-coalesce hold-off when no companion can arrive

### DIFF
--- a/sglang_omni/config/schema.py
+++ b/sglang_omni/config/schema.py
@@ -205,6 +205,7 @@ class FactoryArgs(BaseModel):
     prefill_coalesce_when_idle: bool | None = None
     prefill_coalesce_requires_pending_builds: bool | None = None
     prefill_coalesce_after_builds_during_decode: bool | None = None
+    prefill_coalesce_min_expected_arrivals: float | None = Field(default=None, ge=0)
     request_build_max_workers: int | None = Field(default=None, ge=1)
     request_build_max_pending: int | None = Field(default=None, ge=1)
     encoder_mem_reserve: float | None = Field(default=None, ge=0, lt=1)

--- a/sglang_omni/models/fun_asr/engine_builder.py
+++ b/sglang_omni/models/fun_asr/engine_builder.py
@@ -49,6 +49,7 @@ class FunASREngineBuilder(AsrEngineBuilder):
         prefill_coalesce_when_idle: bool,
         prefill_coalesce_requires_pending_builds: bool,
         prefill_coalesce_after_builds_during_decode: bool,
+        prefill_coalesce_min_expected_arrivals: float,
         mm_attention_backend: str | None,
         enable_pre_lm_encoder: bool,
         pre_lm_cache_max_entries: int,
@@ -76,6 +77,9 @@ class FunASREngineBuilder(AsrEngineBuilder):
         )
         self.prefill_coalesce_after_builds_during_decode = (
             prefill_coalesce_after_builds_during_decode
+        )
+        self.prefill_coalesce_min_expected_arrivals = (
+            prefill_coalesce_min_expected_arrivals
         )
         self.mm_attention_backend = mm_attention_backend
         self.enable_pre_lm_encoder = enable_pre_lm_encoder
@@ -228,6 +232,9 @@ class FunASREngineBuilder(AsrEngineBuilder):
             ),
             "prefill_coalesce_after_builds_during_decode": (
                 self.prefill_coalesce_after_builds_during_decode
+            ),
+            "prefill_coalesce_min_expected_arrivals": (
+                self.prefill_coalesce_min_expected_arrivals
             ),
             "request_build_max_workers": self.request_build_max_workers,
             "request_build_max_pending": self.request_build_max_pending,

--- a/sglang_omni/models/fun_asr/stages.py
+++ b/sglang_omni/models/fun_asr/stages.py
@@ -109,6 +109,9 @@ def create_sglang_fun_asr_executor(
     prefill_coalesce_when_idle: bool = True,
     prefill_coalesce_requires_pending_builds: bool = True,
     prefill_coalesce_after_builds_during_decode: bool = True,
+    # Hold a lone waiting request only if the arrival rate can deliver at least
+    # one companion before the window expires; otherwise it waits for nothing.
+    prefill_coalesce_min_expected_arrivals: float = 1.0,
     mm_attention_backend: str | None = None,
     enable_pre_lm_encoder: bool = True,
     pre_lm_cache_max_entries: int = 4096,
@@ -150,6 +153,7 @@ def create_sglang_fun_asr_executor(
         prefill_coalesce_after_builds_during_decode=(
             prefill_coalesce_after_builds_during_decode
         ),
+        prefill_coalesce_min_expected_arrivals=prefill_coalesce_min_expected_arrivals,
         mm_attention_backend=mm_attention_backend,
         enable_pre_lm_encoder=enable_pre_lm_encoder,
         pre_lm_cache_max_entries=pre_lm_cache_max_entries,

--- a/sglang_omni/scheduling/omni_scheduler.py
+++ b/sglang_omni/scheduling/omni_scheduler.py
@@ -193,6 +193,7 @@ class OmniScheduler:
         prefill_coalesce_when_idle: bool = False,
         prefill_coalesce_requires_pending_builds: bool = False,
         prefill_coalesce_after_builds_during_decode: bool = False,
+        prefill_coalesce_min_expected_arrivals: float = 0.0,
         request_build_max_workers: int = 1,
         request_build_max_pending: int | None = None,
         shutdown_callback: Callable[[], None] | None = None,
@@ -308,6 +309,14 @@ class OmniScheduler:
         self.prefill_coalesce_after_builds_during_decode = bool(
             prefill_coalesce_after_builds_during_decode
         )
+        # 0 keeps the fixed hold-off window; > 0 releases a small queue early
+        # when the observed arrival rate cannot deliver that many companions
+        # before the window expires.
+        self.prefill_coalesce_min_expected_arrivals = float(
+            prefill_coalesce_min_expected_arrivals
+        )
+        self._arrival_gap_ema_s: float | None = None
+        self._last_arrival_t: float | None = None
 
         # Token / memory info (upstream reads from tp_worker.get_worker_info)
         mr = tp_worker.model_runner
@@ -1200,6 +1209,7 @@ class OmniScheduler:
                 event_name="scheduler_queue_enter",
             )
             req._coalesce_enqueue_t = time.perf_counter()
+            self._observe_arrival(now=req._coalesce_enqueue_t)
             req._omni_terminal_claimed = False
             req._omni_data = req_data
             self.waiting_queue.append(req)
@@ -1344,13 +1354,8 @@ class OmniScheduler:
         decode_is_idle = running_batch is None or running_batch.is_empty()
         if not self.prefill_coalesce_when_idle and decode_is_idle:
             return _Upstream.get_new_batch_prefill(self, running_batch)
+        build_work_pending = self._coalesce_build_work_pending()
         if self.prefill_coalesce_requires_pending_builds:
-            with self._request_admission_lock:
-                build_work_pending = bool(
-                    self._pending_request_builds
-                    or self._pending_request_admissions
-                    or self._backlogged_request_build_payloads
-                )
             if not build_work_pending and not (
                 self.prefill_coalesce_after_builds_during_decode and not decode_is_idle
             ):
@@ -1365,9 +1370,50 @@ class OmniScheduler:
             if t is None:
                 t = req._coalesce_enqueue_t = now
             oldest = min(oldest, t)
-        if now - oldest >= self.prefill_coalesce_wait_s:
+        remaining_s = self.prefill_coalesce_wait_s - (now - oldest)
+        if remaining_s <= 0:
+            return _Upstream.get_new_batch_prefill(self, running_batch)
+        # A request still in the build pipeline is a companion that will
+        # arrive; with none pending, only the arrival rate can justify waiting.
+        if not build_work_pending and not self._coalesce_companion_expected(
+            remaining_s=remaining_s
+        ):
             return _Upstream.get_new_batch_prefill(self, running_batch)
         return NextBatchPlan(batch_to_run=None, running_batch=running_batch)
+
+    def _coalesce_build_work_pending(self) -> bool:
+        with self._request_admission_lock:
+            return bool(
+                self._pending_request_builds
+                or self._pending_request_admissions
+                or self._backlogged_request_build_payloads
+            )
+
+    def _coalesce_companion_expected(self, *, remaining_s: float) -> bool:
+        # Expected arrivals in the remaining window = remaining / mean gap.
+        min_expected = self.prefill_coalesce_min_expected_arrivals
+        if min_expected <= 0:
+            return True  # rate check disabled: keep the fixed window
+        gap_s = self._arrival_gap_ema_s
+        if gap_s is None or gap_s <= 0:
+            return False  # no arrival history: nothing says a companion is coming
+        return remaining_s / gap_s >= min_expected
+
+    # Arbitrary smoothing; tracks a closed-loop client's concurrency change
+    # within a handful of requests without reacting to a single gap.
+    _ARRIVAL_GAP_EMA_ALPHA = 0.2
+
+    def _observe_arrival(self, *, now: float) -> None:
+        last = self._last_arrival_t
+        self._last_arrival_t = now
+        if last is None:
+            return
+        gap_s = max(now - last, 0.0)
+        ema = self._arrival_gap_ema_s
+        alpha = self._ARRIVAL_GAP_EMA_ALPHA
+        self._arrival_gap_ema_s = (
+            gap_s if ema is None else (1 - alpha) * ema + alpha * gap_s
+        )
 
     def run_batch(self, batch, pp_proxy_tensors=None):
         try:

--- a/tests/unit_test/fun_asr/test_pipeline.py
+++ b/tests/unit_test/fun_asr/test_pipeline.py
@@ -67,6 +67,7 @@ def test_fun_asr_stage_defaults_enable_pending_build_aware_coalescing() -> None:
         signature.parameters["prefill_coalesce_after_builds_during_decode"].default
         is True
     )
+    assert signature.parameters["prefill_coalesce_min_expected_arrivals"].default == 1.0
     assert signature.parameters["enable_async_decode"].default is True
     assert signature.parameters["async_decode_min_batch_size"].default == 2
 
@@ -288,6 +289,7 @@ def test_fun_asr_threads_generation_batch_and_request_build_policy(monkeypatch) 
     assert scheduler.prefill_coalesce_when_idle is True
     assert scheduler.prefill_coalesce_requires_pending_builds is True
     assert scheduler.prefill_coalesce_after_builds_during_decode is True
+    assert scheduler.prefill_coalesce_min_expected_arrivals == 1.0
     scheduler.shutdown_callback()
     assert encoder_services[0].close_calls == 1
 

--- a/tests/unit_test/scheduling/test_cli_prefill_coalesce.py
+++ b/tests/unit_test/scheduling/test_cli_prefill_coalesce.py
@@ -129,3 +129,7 @@ def test_rejects_invalid_values_eagerly():
         manager.merge_config([("tts_engine.factory.prefill_coalesce_requests", "-1")])
     with pytest.raises(ValueError, match="prefill_coalesce_wait_ms"):
         manager.merge_config([("tts_engine.factory.prefill_coalesce_wait_ms", "0")])
+    with pytest.raises(ValueError, match="prefill_coalesce_min_expected_arrivals"):
+        manager.merge_config(
+            [("tts_engine.factory.prefill_coalesce_min_expected_arrivals", "-1")]
+        )

--- a/tests/unit_test/scheduling/test_prefill_coalesce_gate.py
+++ b/tests/unit_test/scheduling/test_prefill_coalesce_gate.py
@@ -6,8 +6,10 @@ oldest queued request has waited ``prefill_coalesce_wait_ms``. The deadline is
 keyed on each request's enqueue time (``_coalesce_enqueue_t``), so partial
 upstream admission or an aborted request never restarts the window for the
 requests left behind. Chunked prefill in flight and an empty queue pass
-straight through. Tested against a stub scheduler with the upstream call
-patched to a sentinel.
+straight through. With ``prefill_coalesce_min_expected_arrivals`` > 0 and no
+build work pending, the hold-off is released early unless the observed
+arrival gap predicts that many companions inside the remaining window.
+Tested against a stub scheduler with the upstream call patched to a sentinel.
 """
 
 from __future__ import annotations
@@ -45,6 +47,8 @@ class _StubScheduler:
         coalesce_when_idle: bool = False,
         requires_pending_builds: bool = False,
         coalesce_after_builds_during_decode: bool = False,
+        min_expected_arrivals: float = 0.0,
+        arrival_gap_s: float | None = None,
     ) -> None:
         self.prefill_coalesce_requests = coalesce_requests
         self.prefill_coalesce_wait_s = wait_ms / 1e3
@@ -53,6 +57,9 @@ class _StubScheduler:
         self.prefill_coalesce_after_builds_during_decode = (
             coalesce_after_builds_during_decode
         )
+        self.prefill_coalesce_min_expected_arrivals = min_expected_arrivals
+        self._arrival_gap_ema_s = arrival_gap_s
+        self._last_arrival_t = None
         self.chunked_req = None
         self.waiting_queue: list = []
         self.running_batch = SimpleNamespace(is_empty=lambda: False)
@@ -66,6 +73,11 @@ class _StubScheduler:
         # unwrap it so the assertions below stay about the gate decision.
         plan = OmniScheduler.get_new_batch_prefill(self, self.running_batch)
         return plan.batch_to_run
+
+    _ARRIVAL_GAP_EMA_ALPHA = OmniScheduler._ARRIVAL_GAP_EMA_ALPHA
+    _coalesce_build_work_pending = OmniScheduler._coalesce_build_work_pending
+    _coalesce_companion_expected = OmniScheduler._coalesce_companion_expected
+    _observe_arrival = OmniScheduler._observe_arrival
 
 
 @pytest.fixture()
@@ -349,3 +361,108 @@ def test_unstamped_request_is_stamped_and_eventually_released(upstream, clock):
 
     clock.return_value = 200.07  # past the deadline
     assert sched.get_new_batch_prefill() is _UPSTREAM_BATCH
+
+
+# Arrival-rate check (prefill_coalesce_min_expected_arrivals > 0): a small queue
+# is held only while build work is in flight, or while the observed arrival gap
+# predicts at least that many companions inside the remaining window.
+
+
+def test_rate_check_disabled_keeps_fixed_window(upstream, clock):
+    sched = _StubScheduler(coalesce_requests=8, wait_ms=24.0, arrival_gap_s=0.045)
+    sched.waiting_queue = [_req(100.0)]
+    clock.return_value = 100.001
+    assert sched.get_new_batch_prefill() is None
+
+
+def test_sparse_arrivals_release_lone_request_immediately(upstream, clock):
+    # Closed-loop concurrency 2: ~45 ms between arrivals against a 24 ms window.
+    sched = _StubScheduler(
+        coalesce_requests=8,
+        wait_ms=24.0,
+        coalesce_when_idle=True,
+        requires_pending_builds=True,
+        coalesce_after_builds_during_decode=True,
+        min_expected_arrivals=1.0,
+        arrival_gap_s=0.045,
+    )
+    sched.waiting_queue = [_req(100.0)]
+    clock.return_value = 100.001
+    assert sched.get_new_batch_prefill() is _UPSTREAM_BATCH
+
+
+def test_dense_arrivals_still_hold_for_the_window(upstream, clock):
+    # Saturation: ~5 ms between arrivals, so a companion is expected well
+    # inside the 24 ms window and the hold-off behaves as before.
+    sched = _StubScheduler(
+        coalesce_requests=8,
+        wait_ms=24.0,
+        coalesce_when_idle=True,
+        requires_pending_builds=True,
+        coalesce_after_builds_during_decode=True,
+        min_expected_arrivals=1.0,
+        arrival_gap_s=0.005,
+    )
+    sched.waiting_queue = [_req(100.0)]
+    clock.return_value = 100.001
+    assert sched.get_new_batch_prefill() is None
+
+    clock.return_value = 100.021  # 3 ms left: 3/5 < 1 expected arrival
+    assert sched.get_new_batch_prefill() is _UPSTREAM_BATCH
+
+
+def test_pending_build_holds_regardless_of_arrival_rate(upstream, clock):
+    sched = _StubScheduler(
+        coalesce_requests=8,
+        wait_ms=24.0,
+        coalesce_when_idle=True,
+        min_expected_arrivals=1.0,
+        arrival_gap_s=0.045,
+    )
+    sched._pending_request_builds["building"] = object()
+    sched.waiting_queue = [_req(100.0)]
+    clock.return_value = 100.001
+    assert sched.get_new_batch_prefill() is None
+
+
+def test_no_arrival_history_does_not_hold(upstream, clock):
+    sched = _StubScheduler(
+        coalesce_requests=8,
+        wait_ms=24.0,
+        coalesce_when_idle=True,
+        min_expected_arrivals=1.0,
+        arrival_gap_s=None,
+    )
+    sched.waiting_queue = [_req(100.0)]
+    clock.return_value = 100.001
+    assert sched.get_new_batch_prefill() is _UPSTREAM_BATCH
+
+
+def test_higher_threshold_needs_proportionally_denser_arrivals(upstream, clock):
+    # 24 ms window / 10 ms gap = 2.4 expected companions: enough for 2, not 3.
+    kwargs = dict(
+        coalesce_requests=8,
+        wait_ms=24.0,
+        coalesce_when_idle=True,
+        arrival_gap_s=0.010,
+    )
+    sched = _StubScheduler(min_expected_arrivals=2.0, **kwargs)
+    sched.waiting_queue = [_req(100.0)]
+    assert sched.get_new_batch_prefill() is None
+
+    sched = _StubScheduler(min_expected_arrivals=3.0, **kwargs)
+    sched.waiting_queue = [_req(100.0)]
+    assert sched.get_new_batch_prefill() is _UPSTREAM_BATCH
+
+
+def test_observe_arrival_tracks_gap_ema():
+    sched = _StubScheduler(coalesce_requests=8)
+    sched._observe_arrival(now=100.0)
+    assert sched._arrival_gap_ema_s is None  # first arrival: no gap yet
+    sched._observe_arrival(now=100.010)
+    assert sched._arrival_gap_ema_s == pytest.approx(0.010)
+    sched._observe_arrival(now=100.060)  # 50 ms gap
+    alpha = sched._ARRIVAL_GAP_EMA_ALPHA
+    assert sched._arrival_gap_ema_s == pytest.approx(
+        (1 - alpha) * 0.010 + alpha * 0.050
+    )


### PR DESCRIPTION
<!-- PR body draft for branch fun-asr-perf/rate-aware-coalesce (commit 559d7436). Paste into GitHub; do not commit this file. -->

## Motivation

`OmniScheduler.get_new_batch_prefill` holds a small waiting queue for up to `prefill_coalesce_wait_ms` so prefills can be batched. With `prefill_coalesce_after_builds_during_decode=True` the hold-off also applies when no request-build work is pending, as long as decode is busy. At low concurrency that waits for a companion that cannot arrive: on fun_asr at closed-loop c=2 the inter-arrival gap is ~45 ms against a 24 ms window, 99 % of prefill batches were single-request, and p50 doubled versus c=1 (0.053 → 0.089 s).

The obvious fixes trade one end of the concurrency range for the other (measured in the profiling sub-issue): `wait_ms` 24 → 6 gives +57 % throughput at c=2 but −13.6 % at c=32; `after_builds_during_decode=false` gives +87 % at c=2 but −2.7 % at c=32, because the same window is what fills batches at saturation (gap ~5 ms). The fixed window also made an otherwise-good change unsafe: shortening the encoder batch window (`pre_lm_max_batch_wait_ms` 10 → 2, +13 % at c=64) regressed c=2 by 40 %, because the encoder window had been the only thing keeping the two in-flight requests in lockstep through the gate.

Waiting only pays when a companion can arrive. Companions come from two places: requests still in the build pipeline (certain) and requests not yet received (a function of the arrival rate). The gate already sees the first; this PR adds the second.

## Modifications

- `sglang_omni/scheduling/omni_scheduler.py`
  - Track an EMA of inter-arrival gaps at waiting-queue entry (`_observe_arrival`; smoothing constant `_ARRIVAL_GAP_EMA_ALPHA = 0.2`, arbitrary).
  - When no build work is pending, release the hold-off early unless `remaining_window / gap >= prefill_coalesce_min_expected_arrivals` (`_coalesce_companion_expected`). With no arrival history yet, do not hold.
  - New kwarg `prefill_coalesce_min_expected_arrivals: float = 0.0` — 0 keeps the fixed window, so every stage that does not opt in behaves exactly as before. `_coalesce_build_work_pending` extracted; the rest of the gate is unchanged.
- `sglang_omni/config/schema.py`: `FactoryArgs.prefill_coalesce_min_expected_arrivals` (`ge=0`), so it is settable as `--asr.factory.prefill_coalesce_min_expected_arrivals` or under `stages.asr.factory` in YAML.
- `sglang_omni/models/fun_asr/{stages,engine_builder}.py`: fun_asr default 1.0. qwen3_asr (40 ms), arkasr (32 ms) and moss_transcribe_diarize (12 ms) enable the same static window and are candidates once measured; they keep the old behaviour in this PR.
- Tests: `test_prefill_coalesce_gate.py` (sparse arrivals release immediately, dense arrivals still hold for the window, pending build work holds regardless of rate, no history does not hold, disabled keeps the fixed window, threshold scales with density, EMA update), `test_pipeline.py` (fun_asr default reaches the scheduler), `test_cli_prefill_coalesce.py` (negative value refused eagerly). 485 unit tests pass across `tests/unit_test/scheduling` and the ASR pipelines.

Config surface verified end to end: `config resolve` shows an override at `stages.asr.factory.prefill_coalesce_min_expected_arrivals`, `config explain` attributes it (unset = model default), `-1` is refused.

## Related Issues

Part of the Fun-ASR profiling work tracked under #1798 (profiling sub-issue: findings R3 / R5 / R9 / R10 / R16 for the mechanism, R26 for the encoder-window coupling, R33–R43 for this change's A/B).

## Accuracy Test

No numerics change. WER checked in every A/B cell below: 0.0172 on SeedTTS EN (1088 clips) in all 11 cells, hypotheses byte-identical between arms (163,200 samples compared, 0 diffs, 0 failures).

## Benchmark & Profiling

Setup: 1× H200 per server, two live servers (GPU 7 = Arm A, GPU 6 = variant, NUMA-node-local, SMT-disjoint pinning), interleaved pairs with alternating order, warm-up by trajectory (10 c=32 passes), checkpoint snapshot `972ee603`, SeedTTS EN. A/A calibration on the same pair: c=2 +1.1 %, c=32 +0.2 %. Arms run the same code: **A** = knob 0 (old fixed window), **B** = 1.0 (new fun_asr default), **C** = 1.0 + `pre_lm_max_batch_wait_ms 2`. Regimes: **cache-hit** = replayed benchmark inputs (pre-LM embedding cache warm); **miss** = pre-LM cache disabled (encoder runs on every request).

| Cell | Regime | c | Pairs × reps | Δ throughput | Δ p50 | Verdict |
|---|---|---:|---|---|---|---|
| A vs B | cache-hit | 2 | 4 × 1 | **+82.0 %** (sd 0.5 %) | **−51.9 %** (0.089 → 0.043 s) | strong win |
| A vs B | cache-hit | 32 | 3 × 3 | +0.1 % | −1.2 % | null (the `after_builds` variant lost 2.7 % here) |
| A vs B | miss | 1 | 4 × 1 | −1.8 % | +1.4 % | null (band edge, uncalibrated) |
| A vs B | miss | 2 | 4 × 1 | +1.9 % | −0.0 % | null |
| A vs B | miss | 4 | 3 × 1 | −0.5 % | +0.3 % | null |
| A vs B | miss | 8 | 3 × 1 | −1.1 % | +0.7 % | null |
| A vs B | miss | 32 | 6 × 3 | **−2.35 %** (6/6 same sign, min −5.1 %) | +2.5 % | inside ±3 %; batch shapes identical (1154 vs 1158 prefills); not separable from the GPU-6 offset — **re-check with swapped GPUs pending** |
| A vs B | miss | 64 | 3 × 3 | −1.0 % | +1.0 % | null |
| A vs C | miss | 2 | 4 × 1 | **+15.9 %** | **−12.4 %** | was **−40 % / +73 %** under the old gate |
| A vs C | miss | 1 | 3 × 1 | +12.8 % | −11.7 % | as predicted |
| A vs C | miss | 64 | 3 × 3 | +11.8 % | −10.7 % | as predicted (decode running-req 21 → 35) |

Mechanism: at cache-hit c=2, prefill batches go from 1.01 to 1.50 new sequences per batch and decode running-req from 1.1 to 1.7 — the two requests are batched instead of serialized. At c=32 arm B forms fewer, larger prefill batches (968 vs 990), so the window is kept where it pays. Under arm C the two encodes run separately (1.19 items per encoder batch) yet the pair re-merges at the gate (1.88 new-seq per prefill), which is exactly the coupling the fixed window could not survive. py-spy on the scheduler thread at miss c=2 shows identical profiles for A and B (both already paired by the encoder window), consistent with the null.

Two host-contention windows (an external tenant sharing GPU 5/6 for ~15 min) were detected by the cross-GPU utilization sampler, excluded, and the affected servers re-booted on clean cards before any arm ran; recorded in the sub-issue fingerprint.

## Not yet validated (reviewer input welcome)

- The miss-regime c=32 −2.35 % cell with arms swapped across GPUs (single c=32 A/A pair today).
- Other stages sharing the gate (default 0 → unchanged; each needs its own A/B before adopting 1.0).
- Other cards / hosts (`triton_attn` on sm ≥ 100), fully-unique audio (39 % of SeedTTS clips repeat and are single-flight-merged on all arms), long-form (> 30 s rejected by fun_asr), streaming, open-loop (Poisson) arrivals — the benchmark is closed-loop, so arrivals come in bursts of exactly `c`; `_ARRIVAL_GAP_EMA_ALPHA` and the 1.0 threshold were not swept.
- Making `pre_lm_max_batch_wait_ms 2` the fun_asr default is a separate PR; this one removes its blocker.

## Checklist

- [x] Format your code according with pre-commit.
- [x] Add unit tests.
- [x] Update documentation / docstrings / example tutorials as needed. The knob is a free-form factory kwarg like the other coalesce knobs; the gate test module docstring describes the new rule.
- [x] Provide throughput / latency benchmark results and accuracy evaluation results as needed.
- [ ] For reviewers: If you haven't made any contributions to this PR and are only assisting with merging the main branch, please remove yourself as a co-author when merging the PR.

## CI

CI runs on self-hosted GPU runners and requires a maintainer to add the
`run-ci` label. Once labeled, every subsequent push re-triggers CI as
long as the label remains. Use `/tag-and-rerun-ci higgs` or
`/tag-and-rerun-ci moss` or `/tag-and-rerun-ci qwen3-tts` to select a TTS CI
model, and
`/tag-and-rerun-ci fun-asr`, `/tag-and-rerun-ci qwen3-asr` or
`/tag-and-rerun-ci whisper-asr` to select an ASR CI model. One selector from
each family can be combined, for example `/tag-and-rerun-ci moss fun-asr`.
Draft PRs are skipped even if labeled.
