### PR TITLE
fix(fun-asr): clamp requests to scheduler capacity

### DIFF
--- a/sglang_omni/models/fun_asr/request_builders.py
+++ b/sglang_omni/models/fun_asr/request_builders.py
@@ -42,6 +42,7 @@ _MIN_GENERATION_TOKENS = 16
 
 @dataclass
 class FunASRRequestData(SGLangARRequestData):
+    enforce_request_limits: bool = True
     prompt_token_ids: list[int] | None = None
     output_ids: list[int] | None = None
     num_audio_tokens: int = 0

--- a/tests/unit_test/fun_asr/test_request_builders.py
+++ b/tests/unit_test/fun_asr/test_request_builders.py
@@ -319,6 +319,35 @@ def test_fun_asr_request_builder_rejects_audio_over_vad_limit(monkeypatch) -> No
         request_builder(payload)
 
 
+def test_fun_asr_request_builder_enforces_scheduler_request_limits(
+    monkeypatch,
+) -> None:
+    # PR #1788 clamps requests that pass the surface token-budget check but
+    # cannot satisfy scheduler page reserves. That clamp only runs when
+    # enforce_request_limits is True; Fun-ASR must opt in like the other
+    # pipelines (Qwen3-ASR, Qwen3-TTS, ...) or admission mismatches slip
+    # through uncaught.
+    monkeypatch.setattr(
+        transcription,
+        "load_audio",
+        lambda source, **kwargs: np.zeros(1600, dtype=np.float32),
+    )
+    request_builder, _ = request_builders.make_fun_asr_scheduler_adapters(
+        tokenizer=_FakeTokenizer(),
+        max_new_tokens=16,
+        feature_extractor=_feature_extractor(17),
+    )
+    payload = StagePayload(
+        request_id="req-fun-asr-request-limits",
+        request=OmniRequest(inputs={"audio_bytes": b"wav"}, params={}),
+        data={},
+    )
+
+    data = request_builder(payload)
+
+    assert data.enforce_request_limits is True
+
+
 def test_fun_asr_request_builder_rejects_explicit_token_budget_over_cap(
     monkeypatch,
 ) -> None:


### PR DESCRIPTION
## Summary
- Fun-ASR's `FunASRRequestData` never set `enforce_request_limits`, so it inherited the base default of `False` and silently skipped the scheduler admission clamp added in #1788 for Qwen3-ASR.
- A request whose `max_new_tokens` passes the surface token-budget check can still fail to satisfy scheduler page reserves; without this flag the clamp never runs and the mismatch slips through uncaught.
- Every other pipeline already opts in (`Qwen3ASRRequestData`, `Qwen3TTSRequestData`, `MossTTSRequestData`, etc.) — Fun-ASR was the outlier.

## Rebase status (2026-09-10)

Rebased onto current `main` (`80b5aaed`) as `615ccb5f`; the previous tip `ec71aa14` was based on `1f542ee` and had gone stale. No conflicts. The copy of this commit carried inside #1982/#1983 has an identical patch-id, so it drops out of those stacks cleanly when this merges.

Revalidated on a freshly built SGLang `v0.5.19` Apple environment: `pytest tests/unit_test/fun_asr tests/unit_test/pipeline/test_scheduler.py -q` — **159 passed**.

## Test plan
- [x] Added `test_fun_asr_request_builder_enforces_scheduler_request_limits`, mirroring the Qwen3-ASR regression test from #1788.
- [x] `pytest tests/unit_test/fun_asr/ tests/unit_test/pipeline/test_scheduler.py -q` — 153 passed.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
