### PR TITLE
[Pipeline] Name the resolved platform when a stage process cannot select its device

### DIFF
--- a/sglang_omni/pipeline/stage_workers.py
+++ b/sglang_omni/pipeline/stage_workers.py
@@ -581,6 +581,41 @@ def _reclaim_process_cuda_memory(
         )
 
 
+def _describe_set_device_failure(
+    spec: StageLaunchConfig, gpu_id: int, exc: Exception
+) -> str:
+    """Explain why a stage process could not select the device it is placed on.
+
+    SGLang falls back to its generic platform when it finds no CUDA/ROCm/XPU
+    device and no platform plugin, and that platform's set_device is a stub
+    raising NotImplementedError. A real set_device raises RuntimeError when the
+    accelerator cannot be initialized or the ordinal does not exist. Both are
+    reported with the stage, the device visibility the process runs with, and
+    the platform this pipeline resolved, since the platform may have been
+    inherited from the launcher rather than resolved in this process.
+    """
+    placed_on = f"gpu_id={gpu_id}"
+    if spec.placement_gpu_id is not None and spec.placement_gpu_id != gpu_id:
+        placed_on += f" (placement gpu_id={spec.placement_gpu_id})"
+    platform_spec = get_platform_spec(current_platform)
+    if isinstance(exc, NotImplementedError):
+        import torch
+
+        reason = (
+            f"the platform resolved for this pipeline is {platform_spec}, which does "
+            "not implement set_device. SGLang resolves that platform when no accelerator "
+            "is visible to the process (or to the launcher it inherited the platform "
+            f"from); in this process torch.cuda.is_available() is {torch.cuda.is_available()}"
+        )
+    else:
+        reason = f"{platform_spec}.set_device failed: {exc}"
+    return (
+        f"Stage {spec.stage_name!r} is placed on {placed_on}, but {reason}. "
+        f"CUDA_VISIBLE_DEVICES={os.environ.get('CUDA_VISIBLE_DEVICES')!r}, "
+        f"SGLANG_OMNI_PLATFORM_SPEC={os.environ.get('SGLANG_OMNI_PLATFORM_SPEC')!r}."
+    )
+
+
 def _construct_stage(
     spec: StageLaunchConfig,
     log: logging.Logger,
@@ -588,7 +623,12 @@ def _construct_stage(
 ) -> Stage:
     gpu_id = spec.gpu_id
     if gpu_id is not None:
-        current_platform.set_device(int(gpu_id))
+        try:
+            current_platform.set_device(int(gpu_id))
+        except (NotImplementedError, RuntimeError) as exc:
+            raise RuntimeError(
+                _describe_set_device_failure(spec, int(gpu_id), exc)
+            ) from exc
         log.info("Set current device to %s for stage %s", gpu_id, spec.stage_name)
 
     # --- Build scheduler via factory ---

--- a/tests/unit_test/pipeline/test_stage_process_env.py
+++ b/tests/unit_test/pipeline/test_stage_process_env.py
@@ -367,6 +367,87 @@ def test_construct_stage_uses_placement_gpu_id_for_device_and_startup_lock(
     assert seen_gpu_ids == [0, 0]
 
 
+def test_construct_stage_names_the_platform_when_set_device_is_a_stub(
+    monkeypatch,
+) -> None:
+    """A platform without set_device (SGLang's generic fallback) is reported by
+    name together with the process's device visibility, not as a bare
+    NotImplementedError from the stub (#1697)."""
+
+    class _GenericPlatform(platforms.OmniPlatform):
+        _omni_platform_qualname = "sglang.srt.platforms.interface.SRTPlatform"
+
+    monkeypatch.setattr(stage_workers, "current_platform", _GenericPlatform())
+    monkeypatch.setenv("CUDA_VISIBLE_DEVICES", "1")
+    monkeypatch.delenv("SGLANG_OMNI_PLATFORM_SPEC", raising=False)
+    spec = StageLaunchConfig(
+        stage_name="minimax_music3_dit_dav",
+        factory=fake_factory_path("make_scheduler_accepting_gpu_id"),
+        factory_arg_defaults={"gpu_id": 1},
+        gpu_id=1,
+    )
+
+    with pytest.raises(RuntimeError) as excinfo:
+        stage_workers._construct_stage(spec, _RecordingLog())
+
+    message = str(excinfo.value)
+    assert "'minimax_music3_dit_dav'" in message
+    assert "gpu_id=1" in message
+    assert "placement gpu_id" not in message
+    assert "sglang.srt.platforms.interface.SRTPlatform" in message
+    assert "does not implement set_device" in message
+    assert f"torch.cuda.is_available() is {torch.cuda.is_available()}" in message
+    assert "CUDA_VISIBLE_DEVICES='1'" in message
+    assert "SGLANG_OMNI_PLATFORM_SPEC=None" in message
+    assert isinstance(excinfo.value.__cause__, NotImplementedError)
+
+
+def test_construct_stage_reports_placement_when_set_device_fails(
+    monkeypatch,
+) -> None:
+    """A real set_device that cannot initialize the accelerator (#1697, torch's
+    "no NVIDIA driver") is reported with the stage, its placement and the
+    visibility the process runs with, and keeps the original error as cause."""
+
+    class _DriverlessPlatform(platforms.OmniPlatform):
+        _omni_platform_qualname = "sglang_omni.platforms.cuda.CUDAOmniPlatform"
+
+        def set_device(self, device) -> None:
+            raise RuntimeError("Found no NVIDIA driver on your system.")
+
+    monkeypatch.setattr(stage_workers, "current_platform", _DriverlessPlatform())
+    monkeypatch.setenv("CUDA_VISIBLE_DEVICES", "1")
+    monkeypatch.setenv(
+        "SGLANG_OMNI_PLATFORM_SPEC", "sglang_omni.platforms.cuda.CUDAOmniPlatform"
+    )
+    spec = StageLaunchConfig(
+        stage_name="minimax_music3_dit_dav",
+        factory=fake_factory_path("make_scheduler_accepting_gpu_id"),
+        factory_arg_defaults={"gpu_id": 0},
+        gpu_id=0,
+        placement_gpu_id=1,
+    )
+
+    with pytest.raises(RuntimeError) as excinfo:
+        stage_workers._construct_stage(spec, _RecordingLog())
+
+    message = str(excinfo.value)
+    assert "'minimax_music3_dit_dav'" in message
+    assert "gpu_id=0 (placement gpu_id=1)" in message
+    assert (
+        "sglang_omni.platforms.cuda.CUDAOmniPlatform.set_device failed: "
+        "Found no NVIDIA driver on your system." in message
+    )
+    assert "torch.cuda.is_available()" not in message
+    assert "CUDA_VISIBLE_DEVICES='1'" in message
+    assert (
+        "SGLANG_OMNI_PLATFORM_SPEC='sglang_omni.platforms.cuda.CUDAOmniPlatform'"
+        in message
+    )
+    assert isinstance(excinfo.value.__cause__, RuntimeError)
+    assert str(excinfo.value.__cause__) == "Found no NVIDIA driver on your system."
+
+
 def test_cpu_scheduler_construction_skips_startup_lock(monkeypatch) -> None:
     def _unexpected_lock(gpu_id: int):
         raise AssertionError(f"unexpected GPU lock for {gpu_id}")


### PR DESCRIPTION
## Motivation

#1697 reports the MiniMax Music 3 `dit_dav` stage dying at startup with a bare `NotImplementedError` from `sglang/srt/platforms/device_mixin.py::set_device`. That stub is only reachable when the pipeline resolved SGLang's generic platform, which SGLang falls back to when it finds no CUDA/ROCm/XPU device and no platform plugin. `CUDAOmniPlatform` inherits a real `set_device` from `CudaDeviceMixin`, so on a host where the accelerator is visible the stub is never called. The report's second symptom, `torch.cuda.set_device()` failing with "no NVIDIA driver" once the stub was patched, is the same condition seen from the other side, and that traceback does not say which stage or placement it came from either.

`_construct_stage` is the one place that knows the stage, the requested `gpu_id`, the placement it was narrowed from, and the platform spec the pipeline resolved, so it should say what happened.

## Modifications

- `sglang_omni/pipeline/stage_workers.py`: `_construct_stage` wraps the `set_device` call. `NotImplementedError` (the stub) and `RuntimeError` (a real `set_device` that cannot initialize the accelerator or select the ordinal) become a `RuntimeError` naming the stage, the `gpu_id` (plus `placement_gpu_id` when the process was narrowed to one card), `get_platform_spec(current_platform)`, and the `CUDA_VISIBLE_DEVICES` / `SGLANG_OMNI_PLATFORM_SPEC` the process runs with, chained from the original. For the stub case the message also states `torch.cuda.is_available()` for the process, which is the probe SGLang's platform detection consults. A `set_device` that succeeds is untouched.
- `tests/unit_test/pipeline/test_stage_process_env.py`: two tests drive `_construct_stage` with an `OmniPlatform` that has no `set_device` and with one whose `set_device` raises torch's driver error, and check every field of both messages and the chained cause.

This does not fix the environment in #1697 (an accelerator the stage process cannot see); it makes the failure say so.

## Related Issues

#1697

## Accuracy Test

Not applicable: startup error path only. `pytest tests/unit_test/pipeline`: 553 passed, 14 skipped (pre-existing GPU-only cases) on the branch merged into current main. `black --check` (24.10.0) and `isort --check-only` pass on both files.

## Benchmark & Profiling

Not applicable.

## Checklist

- [x] Format your code according with pre-commit.
- [x] Add unit tests.
- [ ] Update documentation / docstrings / example tutorials as needed.
- [x] Provide throughput / latency benchmark results and accuracy evaluation results as needed.
- [ ] For reviewers: If you haven't made any contributions to this PR and are only assisting with merging the main branch, please remove yourself as a co-author when merging the PR.
