### PR TITLE
[Higgs-TTS] Import sgl_kernel lazily so the sampler loads without CUDA

### DIFF
--- a/sglang_omni/models/higgs_tts/sampler.py
+++ b/sglang_omni/models/higgs_tts/sampler.py
@@ -13,8 +13,6 @@ from __future__ import annotations
 from dataclasses import dataclass
 
 import torch
-from sgl_kernel import top_k_renorm_prob as _fused_top_k_renorm
-from sgl_kernel import top_p_renorm_prob as _fused_top_p_renorm
 from sglang.srt.layers.sampler import multinomial_with_seed
 
 from sglang_omni.models.higgs_tts.utils import BOC_ID, EOC_ID
@@ -257,6 +255,8 @@ def _sample_independent_batched(
     # convention. Inputs MUST be contiguous fp32 for the flashinfer renorm kernels.
     probs = logits.float().softmax(dim=-1).reshape(B * N, V).contiguous()
     if top_k_buf is not None:
+        from sgl_kernel import top_k_renorm_prob as _fused_top_k_renorm
+
         tk = (
             top_k_buf.view(B, 1)
             .expand(B, N)
@@ -267,6 +267,8 @@ def _sample_independent_batched(
         )
         probs = _fused_top_k_renorm(probs, tk)
     if top_p is not None:
+        from sgl_kernel import top_p_renorm_prob as _fused_top_p_renorm
+
         tp = top_p.view(B, 1).expand(B, N).reshape(B * N).to(torch.float32).contiguous()
         probs = _fused_top_p_renorm(probs, tp)
 


### PR DESCRIPTION
## Motivation

`models/higgs_tts/sampler.py` imports `sgl_kernel` at module scope. It's CUDA-only and
the Apple installer skips it by design, so six `higgs_tts` test modules fail to import
on macOS arm64.

These are the only two module-scope `sgl_kernel` imports in the tree —
`platforms/cuda.py:86`, `platforms/xpu.py:39`, `relay/cuda_ipc.py:1144` and
`fishaudio_s2_pro/.../audio_decoder.py:144` are already function-local.

## Modifications

Moves both into the branches of `_sample_independent_batched` that use them. No
numeric change: same kernels, same arguments.

`pytest tests/unit_test/higgs_tts` on macOS 26.5.2 arm64, main @ `50db4a55`: 6
collection errors before, 130 collected and 117 passed after (1 unrelated failure, a
macOS socket path limit).

`platforms/xpu.py:39` uses try/except with a fallback, which would be stronger here,
but the pure-torch path this function had before #816 is gone so a fallback means
reimplementing it. Happy to switch if you'd rather have the guard.

## Related Issues

Same symptom as #1890, different cause; #1918 doesn't cover this. Full collection on
macOS arm64 goes 23 errors → 18 with this alone (all of them #1890) → 1 with #1918 as
well, so this removes one of two blockers rather than fixing the suite. Recorded in
#1992.

## Accuracy Test

Not applicable, no kernel or model change.

## Benchmark & Profiling

Not applicable, no hot-path change.

## Checklist

- [x] Format your code according with pre-commit.
- [ ] Add unit tests. — the regression is "the module imports at all", covered by
      every existing `higgs_tts` test
- [ ] Update documentation / docstrings / example tutorials as needed. — n/a
- [ ] Provide throughput / latency benchmark results and accuracy evaluation results
      as needed. — n/a

No NVIDIA machine here, so CUDA-side confirmation needs a maintainer.