### PR TITLE
fix(profiler): TorchProfiler.start() raises UnboundLocalError on re-start (`rank` read before assignment)

### DIFF
--- a/sglang_omni/profiler/torch_profiler.py
+++ b/sglang_omni/profiler/torch_profiler.py
@@ -43,6 +43,7 @@ class TorchProfiler(ProfilerBase):
         Start the profiler with the given trace path template.
         """
         with cls._lock:
+            rank = cls._get_rank()
 
             # 1. Cleanup any existing profiler
             if cls._profiler is not None:
@@ -64,8 +65,6 @@ class TorchProfiler(ProfilerBase):
                 cls._profiler = None
                 cls._active_run_id = None
                 cls._trace_template = ""
-
-            rank = cls._get_rank()
 
             # 2. Make path absolute
             trace_path_template = os.path.abspath(trace_path_template)


### PR DESCRIPTION
## Problem

`TorchProfiler.start()` reads `rank` three times inside the "profiler already active" cleanup branch, but only binds it *after* that branch:

```python
# sglang_omni/profiler/torch_profiler.py
with cls._lock:

    # 1. Cleanup any existing profiler
    if cls._profiler is not None:
        if run_id is not None and cls._active_run_id == run_id:
            return f"{cls._trace_template}_rank{rank}.trace.json.gz"   # <- rank

        logger.warning(
            "[Rank %s] Torch profiler already active (run_id=%s), restarting for run_id=%s",
            rank,                                                       # <- rank
            ...
        )
        try:
            cls._profiler.stop()
        except Exception as e:
            logger.warning(
                "[Rank %s] Failed to stop existing profiler: %s", rank, e   # <- rank
            )
        ...

    rank = cls._get_rank()          # bound here, 18 lines too late
```

Because `rank` is assigned somewhere in the function, it is a local for the whole body, so every one of those three reads raises:

```
UnboundLocalError: cannot access local variable 'rank' where it is not associated with a value
```

Both sub-branches are affected: the idempotent "same `run_id`, return the existing path" early return, and the "different `run_id`, restart" path. Neither can ever complete — the branch raises before it can either return the path or emit the restart warning.

The sibling `stop()` in the same class already does it the right way — `rank = cls._get_rank()` is the first statement after the early return, ahead of every read. That is the spec this change follows.

## How it is reached

`TorchProfiler.start()` is the public implementation of the abstract `ProfilerBase.start()`, so any caller can hit it. Within the repo today the only call site is `StageRuntime._on_profiler_start`, which guards with `not TorchProfiler.is_active()` — but `is_active()` is read outside `cls._lock`, while `start()` takes it, so two concurrent `ProfilerStartMessage`s can both pass the guard and the second one lands in this branch. That the class holds a `threading.Lock` at all is an acknowledgement that concurrent entry is expected.

Either way the branch is dead weight as written: it exists to make a re-`start()` idempotent/restarting, and it can only ever raise.

## Fix

Hoist the existing `rank = cls._get_rank()` to the top of the `with cls._lock:` block, matching `stop()`. `_get_rank()` is a pure `int(os.getenv("RANK", "0"))`, so moving it earlier has no side effects and no ordering constraint.

+1 / −2, no behaviour change on the first-`start()` path.

## Verification

`start()` was pulled out of both the current file and the patched file with `ast.get_source_segment` (nothing hand-copied), grafted onto a class carrying the real class attributes and the real `_get_rank` body, and driven with only `torch.profiler.profile` stubbed:

| check | before | after |
|---|---|---|
| AST: line `rank` is bound vs. first read in `start()` | bound 68, first read 50 | bound 46, first read 51 |
| AST: same for the sibling `stop()` | bound 140, first read 146 | (unchanged) |
| first `start(tpl, run_id="r1")` | `run_rank0.trace.json.gz` | `run_rank0.trace.json.gz` (identical) |
| `start(run_id="r1")` then `start(run_id="r2")` | `UnboundLocalError: cannot access local variable 'rank'` | returns the path, logs `[Rank 0] Torch profiler already active (run_id=r1), restarting for run_id=r2`, `_active_run_id == "r2"` |
| `start(run_id="r1")` twice | `UnboundLocalError` | returns the same path as the first call |
| `RANK=3` in env, then the restart path | — | `run_rank3.trace.json.gz` |

`black` at the pinned `24.10.0` from `.pre-commit-config.yaml` reports the file unchanged; the diff touches no imports, so `isort` / `autoflake` are unaffected.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
