### PR TITLE
[Qwen3-Omni Perf] Add hybrid prefill routing and staged token readback

### DIFF
--- a/sglang_omni/model_runner/base.py
+++ b/sglang_omni/model_runner/base.py
@@ -97,6 +97,10 @@ class ModelRunner:
       - decode hooks for single-step autoregressive decode processing
     """
 
+    _stage_sync_token_ids: bool = False
+    _token_id_copy_stream: Any | None = None
+    _stage_ready_event: Any | None = None
+
     def __init__(self, tp_worker: Any, output_processor: Any):
         self.tp_worker = tp_worker
         self.output_processor = output_processor
@@ -120,17 +124,25 @@ class ModelRunner:
         self._suppress_tensor_cache: dict[tuple, tuple[Any, torch.Tensor | None]] = {}
 
     def _stage_token_ids(self, result: Any, ids: torch.Tensor) -> None:
-        # Note (wenyao): pinned host copy staged once at sample time so downstream
-        # .tolist() never triggers a blocking pageable D2H; next_token_ids stays device-side
+        # Note (wenyao): Waiting only on the sampling and copy events keeps token readback
+        # from fencing unrelated work on the shared default stream.
         if not (isinstance(ids, torch.Tensor) and ids.is_cuda):
             result._host_token_ids = ids
             result._host_token_ids_event = None
             return
         n = ids.shape[0]
         buf = self._next_token_id_host_buf(ids, n)
-        buf[:n].copy_(ids[:n], non_blocking=True)
-        event = torch.cuda.Event()
-        event.record()
+        copy_stream = self._token_id_copy_stream
+        if copy_stream is None:
+            copy_stream = torch.cuda.Stream(device=ids.device)
+            self._token_id_copy_stream = copy_stream
+            self._stage_ready_event = torch.cuda.Event()
+        self._stage_ready_event.record()
+        copy_stream.wait_event(self._stage_ready_event)
+        with torch.cuda.stream(copy_stream):
+            buf[:n].copy_(ids[:n], non_blocking=True)
+            event = torch.cuda.Event()
+            event.record()
         result._host_token_ids = buf[:n]
         result._host_token_ids_event = event
 
@@ -335,6 +347,8 @@ class ModelRunner:
                 schedule_batch,
                 scheduler_output,
             )
+            if self._stage_sync_token_ids:
+                self._stage_token_ids(batch_result, batch_result.next_token_ids)
             self._publish_next_tokens(
                 batch_result,
                 forward_batch,

--- a/sglang_omni/model_runner/hybrid_prefill_router.py
+++ b/sglang_omni/model_runner/hybrid_prefill_router.py
@@ -78,6 +78,8 @@ class HybridPrefillGraphRouter:
     def _select(self, forward_batch: Any) -> Any:
         if self.breakable_runner.can_run_graph(forward_batch):
             return self.breakable_runner
+        if forward_batch.forward_mode.is_mixed():
+            return None
         if self.full_runner.can_run_graph(forward_batch):
             return self.full_runner
         return None
@@ -138,7 +140,8 @@ def install_hybrid_full_prefill(model_worker: Any, full_bs: Sequence[int]) -> No
     if model_worker.enable_prefill_input_embeds:
         model_config.is_multimodal = True
     try:
-        full_runner = PrefillCudaGraphRunner(model_runner)
+        with get_schedule().override(enable_mixed_chunk=False):
+            full_runner = PrefillCudaGraphRunner(model_runner)
     finally:
         model_config.is_multimodal = saved_is_multimodal
         (

--- a/sglang_omni/model_runner/hybrid_prefill_router.py
+++ b/sglang_omni/model_runner/hybrid_prefill_router.py
@@ -1,0 +1,164 @@
+# SPDX-License-Identifier: Apache-2.0
+"""Shape-scoped hybrid prefill CUDA graphs: BREAKABLE small, FULL large."""
+
+from __future__ import annotations
+
+import logging
+from typing import Any, Sequence
+
+logger = logging.getLogger(__name__)
+
+_HYBRID_PREFILL_BACKEND = "hybrid"
+_HYBRID_FULL_BS_KEY = "cuda_graph_bs_prefill_full"
+
+
+def extract_hybrid_prefill_overrides(
+    server_args_overrides: dict[str, Any] | None,
+) -> tuple[dict[str, Any] | None, list[int] | None]:
+    """Rewrite prefill ``backend: hybrid`` into the BREAKABLE config SGLang sees.
+
+    ``hybrid`` is an omni-level policy: ServerArgs gets a plain BREAKABLE
+    prefill config (the production small-batch path), and the FULL big-bucket
+    ladder (``cuda_graph_bs_prefill_full``) is returned for a second capture
+    after attestation. Returns ``(overrides, None)`` untouched when hybrid is
+    not selected.
+    """
+    from sglang_omni.scheduling.generation_batch_policy import (
+        CudaGraphBackend,
+        CudaGraphConfig,
+        nested_prefill_overrides,
+    )
+
+    if (
+        server_args_overrides
+        and server_args_overrides.get("cuda_graph_backend_prefill")
+        == _HYBRID_PREFILL_BACKEND
+    ):
+        raise ValueError(
+            "backend 'hybrid' must be set via cuda_graph_config prefill, "
+            "not cuda_graph_backend_prefill"
+        )
+    nested = nested_prefill_overrides(server_args_overrides or {})
+    if nested.get("backend") != _HYBRID_PREFILL_BACKEND:
+        if server_args_overrides and _HYBRID_FULL_BS_KEY in server_args_overrides:
+            raise ValueError(
+                f"{_HYBRID_FULL_BS_KEY} requires cuda_graph_config prefill "
+                f"backend {_HYBRID_PREFILL_BACKEND!r}"
+            )
+        return server_args_overrides, None
+    overrides = dict(server_args_overrides)
+    full_bs = overrides.pop(_HYBRID_FULL_BS_KEY, None)
+    if not full_bs:
+        raise ValueError(
+            f"cuda_graph_config prefill backend {_HYBRID_PREFILL_BACKEND!r} "
+            f"requires {_HYBRID_FULL_BS_KEY} buckets"
+        )
+    config = overrides["cuda_graph_config"]
+    config = config.to_dict() if isinstance(config, CudaGraphConfig) else dict(config)
+    prefill = dict(config["prefill"])
+    prefill["backend"] = CudaGraphBackend.BREAKABLE
+    config["prefill"] = prefill
+    overrides["cuda_graph_config"] = config
+    return overrides, [int(b) for b in full_bs]
+
+
+class HybridPrefillGraphRouter:
+    # Note (wenyao): BREAKABLE retains the production buckets; each runner owns
+    # eligibility, so routing needs no second copy of its shape thresholds.
+
+    def __init__(self, breakable_runner: Any, full_runner: Any) -> None:
+        self.breakable_runner = breakable_runner
+        self.full_runner = full_runner
+        # Note (wenyao): ModelWorker bisects capture_num_tokens when accounting
+        # for replays, so it needs a sorted union of both runners' buckets.
+        self.capture_num_tokens = sorted(
+            [*breakable_runner.capture_num_tokens, *full_runner.capture_num_tokens]
+        )
+
+    def _select(self, forward_batch: Any) -> Any:
+        if self.breakable_runner.can_run_graph(forward_batch):
+            return self.breakable_runner
+        if self.full_runner.can_run_graph(forward_batch):
+            return self.full_runner
+        return None
+
+    def can_run_graph(self, forward_batch: Any) -> bool:
+        return self._select(forward_batch) is not None
+
+    def execute(self, forward_batch: Any, **kwargs: Any) -> Any:
+        runner = self._select(forward_batch)
+        assert runner is not None, "execute() without a passing can_run_graph()"
+        return runner.execute(forward_batch, **kwargs)
+
+
+def install_hybrid_full_prefill(model_worker: Any, full_bs: Sequence[int]) -> None:
+    """Capture the FULL big-bucket runner and install the hybrid router.
+
+    Runs after ``attest_prefill_cuda_graphs`` validated the production
+    BREAKABLE runner. PrefillCudaGraphRunner snapshots its whole policy from
+    ``get_exec().graph.cuda_graph_config.prefill`` at ``__init__``, so the FULL
+    runner is constructed under a temporary view of that config (backend,
+    buckets, request slots, multimodal flag) and every field is restored:
+    the rest of the process keeps seeing the production BREAKABLE config.
+    """
+    from sglang.srt.model_executor.cuda_graph_config import Backend
+    from sglang.srt.model_executor.runner.prefill_cuda_graph_runner import (
+        PrefillCudaGraphRunner,
+    )
+    from sglang.srt.runtime_context import get_exec, get_schedule
+
+    model_runner = model_worker.model_runner
+    breakable_runner = model_runner.prefill_cuda_graph_runner
+    if not isinstance(breakable_runner, PrefillCudaGraphRunner):
+        raise RuntimeError(
+            "hybrid prefill requires the BREAKABLE runner to have captured; "
+            f"got {type(breakable_runner).__name__}"
+        )
+    full_bs = sorted(int(b) for b in full_bs)
+    if full_bs[0] <= breakable_runner.max_num_tokens:
+        raise ValueError(
+            "hybrid FULL buckets must exceed the breakable ladder: "
+            f"{full_bs[0]} <= {breakable_runner.max_num_tokens}"
+        )
+
+    prefill_cfg = get_exec().graph.cuda_graph_config.prefill
+    model_config = model_runner.model_config
+    saved = (prefill_cfg.backend, prefill_cfg.bs, prefill_cfg.full_prefill_max_req)
+    saved_is_multimodal = model_config.is_multimodal
+
+    max_req = prefill_cfg.full_prefill_max_req
+    if max_req is None:
+        chunked = get_schedule().chunked_prefill_size
+        max_req = max(chunked // 512, 1) if chunked and chunked > 0 else 1
+    max_req = min(int(max_req), model_runner.req_to_token_pool.size)
+
+    prefill_cfg.backend = Backend.FULL
+    prefill_cfg.bs = full_bs
+    prefill_cfg.full_prefill_max_req = max_req
+    if model_worker.enable_prefill_input_embeds:
+        model_config.is_multimodal = True
+    try:
+        full_runner = PrefillCudaGraphRunner(model_runner)
+    finally:
+        model_config.is_multimodal = saved_is_multimodal
+        (
+            prefill_cfg.backend,
+            prefill_cfg.bs,
+            prefill_cfg.full_prefill_max_req,
+        ) = saved
+
+    if list(full_runner.capture_num_tokens) != full_bs:
+        raise RuntimeError(
+            "hybrid FULL capture shapes differ from the declared ladder: "
+            f"declared={full_bs}, captured={list(full_runner.capture_num_tokens)}"
+        )
+    model_runner.prefill_cuda_graph_runner = HybridPrefillGraphRouter(
+        breakable_runner, full_runner
+    )
+    logger.info(
+        "hybrid prefill CUDA graphs installed: breakable buckets=%s, "
+        "full buckets=%s (req slots=%d)",
+        list(breakable_runner.capture_num_tokens),
+        list(full_runner.capture_num_tokens),
+        max_req,
+    )

--- a/sglang_omni/model_runner/model_worker.py
+++ b/sglang_omni/model_runner/model_worker.py
@@ -335,19 +335,41 @@ class ModelWorker:
         from sglang.srt.model_executor.runner.prefill_cuda_graph_runner import (
             PrefillCudaGraphRunner,
         )
+        from sglang.srt.runtime_context import get_exec
+
+        from sglang_omni.model_runner.hybrid_prefill_router import (
+            HybridPrefillGraphRouter,
+        )
 
         runner = self.model_runner.prefill_cuda_graph_runner
+        backend = get_exec().graph.cuda_graph_config.prefill.backend
+        hybrid_backends = None
         if isinstance(runner, PrefillCudaGraphRunner):
             capture_num_tokens = [int(value) for value in runner.capture_num_tokens]
             backend_runner = type(runner.backend).__name__
             input_embeds_slot = runner.buffer_registry.has_slot("input_embeds")
+        elif isinstance(runner, HybridPrefillGraphRouter):
+            backend = "hybrid"
+            capture_num_tokens = [int(value) for value in runner.capture_num_tokens]
+            backend_runner = type(runner).__name__
+            hybrid_backends = {
+                name: {
+                    "backend_runner": type(child.backend).__name__,
+                    "capture_num_tokens": [int(v) for v in child.capture_num_tokens],
+                    "input_embeds_slot": child.buffer_registry.has_slot("input_embeds"),
+                }
+                for name, child in (
+                    ("breakable", runner.breakable_runner),
+                    ("full", runner.full_runner),
+                )
+            }
+            input_embeds_slot = all(
+                info["input_embeds_slot"] for info in hybrid_backends.values()
+            )
         else:
             capture_num_tokens, backend_runner, input_embeds_slot = None, None, False
-        from sglang.srt.runtime_context import get_exec
-
-        backend = get_exec().graph.cuda_graph_config.prefill.backend
         usage = self._prefill_cuda_graph_usage
-        return {
+        info = {
             "backend": backend,
             "runner": type(runner).__name__ if runner is not None else None,
             "backend_runner": backend_runner,
@@ -361,6 +383,9 @@ class ModelWorker:
                 for bucket, count in sorted(usage.replay_buckets.items())
             },
         }
+        if hybrid_backends is not None:
+            info["hybrid_backends"] = hybrid_backends
+        return info
 
     def model_info(self) -> dict[str, Any]:
         from sglang.srt.runtime_context import get_model, get_parallel, get_serving

--- a/sglang_omni/model_runner/thinker_model_runner.py
+++ b/sglang_omni/model_runner/thinker_model_runner.py
@@ -21,6 +21,8 @@ logger = logging.getLogger(__name__)
 
 
 class ThinkerModelRunner(ModelRunner):
+    _stage_sync_token_ids = True
+
     def __init__(self, tp_worker: Any, output_processor: Any):
         super().__init__(tp_worker, output_processor)
 

--- a/sglang_omni/models/qwen3_omni/bootstrap.py
+++ b/sglang_omni/models/qwen3_omni/bootstrap.py
@@ -20,6 +20,7 @@ def create_thinker_scheduler(
     prefill_coalesce_wait_ms: float = 60.0,
     prefill_coalesce_when_idle: bool = False,
     operator_selected_prefill_backend: bool = False,
+    hybrid_full_bs: list[int] | None = None,
 ):
     """Create the Qwen thinker scheduler."""
     from sglang.srt.arg_groups.model_override_base import resolved_view
@@ -84,6 +85,17 @@ def create_thinker_scheduler(
         cuda_graph_batch_validator.attest_prefill_cuda_graphs(
             model_worker.model_runner,
             operator_selected=operator_selected_prefill_backend,
+        )
+        if hybrid_full_bs is not None:
+            from sglang_omni.model_runner.hybrid_prefill_router import (
+                install_hybrid_full_prefill,
+            )
+
+            install_hybrid_full_prefill(model_worker, hybrid_full_bs)
+    elif hybrid_full_bs is not None:
+        raise RuntimeError(
+            "prefill backend 'hybrid' was declared but the thinker prefill "
+            "graph backend resolved to a non-BREAKABLE mode"
         )
 
     def _should_generate_qwen_audio_output(request: Any) -> bool:

--- a/sglang_omni/models/qwen3_omni/stages.py
+++ b/sglang_omni/models/qwen3_omni/stages.py
@@ -1035,6 +1035,13 @@ def create_sglang_thinker_executor_from_config(
     # the streaming-SST thinker path benefits out of the box; either key can be
     # overridden via server_args_overrides (set enable_mixed_chunk=False to opt
     # out). Note: mixed-chunk only engages when chunked_prefill_size > 0.
+    from sglang_omni.model_runner.hybrid_prefill_router import (
+        extract_hybrid_prefill_overrides,
+    )
+
+    server_args_overrides, hybrid_full_bs = extract_hybrid_prefill_overrides(
+        server_args_overrides
+    )
     overrides = build_generation_batch_overrides(
         max_running_requests=64,
         server_args_overrides=server_args_overrides,
@@ -1133,6 +1140,7 @@ def create_sglang_thinker_executor_from_config(
         operator_selected_prefill_backend=operator_selected_prefill_backend(
             server_args_overrides
         ),
+        hybrid_full_bs=hybrid_full_bs,
     )
     from sglang.srt.runtime_context import get_schedule
 

--- a/sglang_omni/scheduling/engine_factory.py
+++ b/sglang_omni/scheduling/engine_factory.py
@@ -109,6 +109,13 @@ class SGLangGenerationEngineBuilder(ABC):
             model_name=self.model_name,
         )
 
+        from sglang_omni.model_runner.hybrid_prefill_router import (
+            extract_hybrid_prefill_overrides,
+        )
+
+        server_args_overrides, hybrid_full_bs = extract_hybrid_prefill_overrides(
+            server_args_overrides
+        )
         operator_selected = operator_selected_prefill_backend(server_args_overrides)
         overrides = build_generation_batch_overrides(
             server_args_overrides=server_args_overrides,
@@ -222,6 +229,17 @@ class SGLangGenerationEngineBuilder(ABC):
                     model_worker.model_runner,
                     operator_selected=operator_selected,
                 )
+            if hybrid_full_bs is not None:
+                from sglang_omni.model_runner.hybrid_prefill_router import (
+                    install_hybrid_full_prefill,
+                )
+
+                install_hybrid_full_prefill(model_worker, hybrid_full_bs)
+        elif hybrid_full_bs is not None:
+            raise RuntimeError(
+                "prefill backend 'hybrid' was declared but CUDA graphs are "
+                "disabled for this stage"
+            )
 
         try:
             # Model-local encoder graphs and caches must be initialized after

--- a/tests/README.md
+++ b/tests/README.md
@@ -82,6 +82,7 @@ tests/
     ├── model_runner/
     │   ├── test_arch_override.py
     │   ├── test_hidden_capture.py
+    │   ├── test_hybrid_prefill_router.py
     │   └── test_prefill_cuda_graph_usage.py
     ├── audar_tts/
     │   └── test_pipeline.py
@@ -505,6 +506,11 @@ that happened to contain an older version of the test.
     Graph replay without exposing padded rows.
   - prefill CUDA Graph usage: isolated counter state, replay/eager phase
     classification, executed-bucket counts, and JSON-safe model-info output.
+  - `test_hybrid_prefill_router.py`: configuration isolation, disjoint
+    bucket validation, breakable/full/eager routing, capture rollback,
+    and complete-capture publication. Together with hybrid attestation
+    in `test_prefill_cuda_graph_usage.py`, these CPU tests use fake
+    runners and do not capture real CUDA graphs.
 - `unit_test/models/`: Model registry and cross-model contract tests:
   - static TTS `ModelCapabilities` declarations, registry lookup, aliases, and
     launcher startup logging.

--- a/tests/unit_test/model_runner/test_hybrid_prefill_router.py
+++ b/tests/unit_test/model_runner/test_hybrid_prefill_router.py
@@ -6,10 +6,19 @@ from copy import deepcopy
 from types import SimpleNamespace
 
 import pytest
+from sglang.srt import runtime_context
 from sglang.srt.model_executor import cuda_graph_config
+from sglang.srt.model_executor.forward_batch_info import ForwardMode
 from sglang.srt.model_executor.runner import prefill_cuda_graph_runner
 
 from sglang_omni.model_runner import hybrid_prefill_router as hybrid
+
+
+def _schedule_config(enable_mixed_chunk):
+    schedule = runtime_context._ConfigBag("schedule")
+    schedule._set("chunked_prefill_size", 4096)
+    schedule._set("enable_mixed_chunk", enable_mixed_chunk)
+    return schedule
 
 
 @pytest.mark.parametrize("structured", [False, True])
@@ -59,24 +68,46 @@ def test_router_prefers_breakable_then_full_and_rejects_eager_shapes():
     def runner(buckets):
         return SimpleNamespace(
             capture_num_tokens=buckets,
-            can_run_graph=lambda batch: batch <= buckets[-1],
-            execute=lambda batch, **kwargs: (buckets, batch, kwargs),
+            can_run_graph=lambda batch: batch.num_tokens <= buckets[-1],
+            execute=lambda batch, **kwargs: (buckets, batch.num_tokens, kwargs),
         )
+
+    def batch(num_tokens):
+        return SimpleNamespace(num_tokens=num_tokens, forward_mode=ForwardMode.EXTEND)
 
     router = hybrid.HybridPrefillGraphRouter(runner([8, 16]), runner([32, 64]))
     assert router.capture_num_tokens == [8, 16, 32, 64]
-    assert router.execute(8, key="value") == ([8, 16], 8, {"key": "value"})
-    assert router.execute(32) == ([32, 64], 32, {})
-    assert not router.can_run_graph(65)
+    assert router.execute(batch(8), key="value") == ([8, 16], 8, {"key": "value"})
+    assert router.execute(batch(32)) == ([32, 64], 32, {})
+    assert not router.can_run_graph(batch(65))
     with pytest.raises(AssertionError, match="can_run_graph"):
-        router.execute(65)
+        router.execute(batch(65))
+
+
+def test_mixed_batches_use_breakable_or_eager_without_trying_full():
+    breakable = SimpleNamespace(
+        capture_num_tokens=[8, 16],
+        can_run_graph=lambda batch: batch.num_tokens <= 16,
+        execute=lambda batch: "breakable",
+    )
+    full = SimpleNamespace(
+        capture_num_tokens=[32, 64],
+        can_run_graph=lambda batch: pytest.fail("MIXED must not try FULL"),
+    )
+    router = hybrid.HybridPrefillGraphRouter(breakable, full)
+    batch = SimpleNamespace(num_tokens=8, forward_mode=ForwardMode.MIXED)
+    assert router.execute(batch) == "breakable"
+    batch.num_tokens = 32
+    assert not router.can_run_graph(batch)
 
 
 @pytest.mark.parametrize("outcome", ["success", "capture_failure", "wrong_ladder"])
+@pytest.mark.parametrize("enable_mixed_chunk", [False, True])
 def test_install_restores_configuration_and_publishes_only_complete_capture(
-    monkeypatch, outcome
+    monkeypatch, outcome, enable_mixed_chunk
 ):
     cfg = SimpleNamespace(backend="breakable", bs=[8, 16], full_prefill_max_req=None)
+    schedule = _schedule_config(enable_mixed_chunk)
     model_cfg = SimpleNamespace(is_multimodal=False)
     model_runner = SimpleNamespace(
         model_config=model_cfg, req_to_token_pool=SimpleNamespace(size=3)
@@ -89,7 +120,7 @@ def test_install_restores_configuration_and_publishes_only_complete_capture(
     )
     monkeypatch.setattr(
         "sglang.srt.runtime_context.get_schedule",
-        lambda: SimpleNamespace(chunked_prefill_size=4096),
+        lambda: schedule,
     )
     worker = SimpleNamespace(
         model_runner=model_runner, enable_prefill_input_embeds=True
@@ -104,6 +135,7 @@ def test_install_restores_configuration_and_publishes_only_complete_capture(
                 3,
             )
             assert model_cfg.is_multimodal
+            assert not schedule.enable_mixed_chunk
             if outcome == "capture_failure":
                 raise RuntimeError("injected capture failure")
             self.capture_num_tokens = [32] if outcome == "wrong_ladder" else [32, 64]
@@ -137,6 +169,64 @@ def test_install_restores_configuration_and_publishes_only_complete_capture(
         None,
     )
     assert not model_cfg.is_multimodal
+    assert schedule.enable_mixed_chunk is enable_mixed_chunk
+
+
+def test_full_capture_passes_runtime_mixed_chunk_guard_and_restores_on_failure(
+    monkeypatch,
+):
+    cfg = SimpleNamespace(backend="breakable", bs=[8, 16], full_prefill_max_req=3)
+    schedule = _schedule_config(True)
+    monkeypatch.setattr(
+        "sglang.srt.runtime_context.get_exec",
+        lambda: SimpleNamespace(
+            graph=SimpleNamespace(cuda_graph_config=SimpleNamespace(prefill=cfg))
+        ),
+    )
+    monkeypatch.setattr("sglang.srt.runtime_context.get_schedule", lambda: schedule)
+    monkeypatch.setattr(prefill_cuda_graph_runner, "get_schedule", lambda: schedule)
+    monkeypatch.setattr(
+        prefill_cuda_graph_runner,
+        "get_exec",
+        lambda: SimpleNamespace(
+            graph=SimpleNamespace(cuda_graph_config=SimpleNamespace(prefill=cfg))
+        ),
+    )
+
+    def stop_before_gpu_setup(self, model_runner):
+        assert cfg.backend == "full"
+        assert not schedule.enable_mixed_chunk
+        raise RuntimeError("capture reached base init")
+
+    monkeypatch.setattr(
+        prefill_cuda_graph_runner.BaseCudaGraphRunner,
+        "__init__",
+        stop_before_gpu_setup,
+    )
+    breakable = object.__new__(prefill_cuda_graph_runner.PrefillCudaGraphRunner)
+    breakable.capture_num_tokens = [8, 16]
+    breakable.max_num_tokens = 16
+    model_cfg = SimpleNamespace(is_multimodal=False)
+    worker = SimpleNamespace(
+        model_runner=SimpleNamespace(
+            model_config=model_cfg,
+            req_to_token_pool=SimpleNamespace(size=3),
+            prefill_cuda_graph_runner=breakable,
+        ),
+        enable_prefill_input_embeds=True,
+    )
+
+    with pytest.raises(RuntimeError, match="capture reached base init"):
+        hybrid.install_hybrid_full_prefill(worker, [32, 64])
+
+    assert schedule.enable_mixed_chunk
+    assert (cfg.backend, cfg.bs, cfg.full_prefill_max_req) == (
+        "breakable",
+        [8, 16],
+        3,
+    )
+    assert not model_cfg.is_multimodal
+    assert worker.model_runner.prefill_cuda_graph_runner is breakable
 
 
 def test_install_rejects_missing_breakable_capture_and_overlapping_ladders(monkeypatch):

--- a/tests/unit_test/model_runner/test_hybrid_prefill_router.py
+++ b/tests/unit_test/model_runner/test_hybrid_prefill_router.py
@@ -1,0 +1,155 @@
+# SPDX-License-Identifier: Apache-2.0
+
+from __future__ import annotations
+
+from copy import deepcopy
+from types import SimpleNamespace
+
+import pytest
+from sglang.srt.model_executor import cuda_graph_config
+from sglang.srt.model_executor.runner import prefill_cuda_graph_runner
+
+from sglang_omni.model_runner import hybrid_prefill_router as hybrid
+
+
+@pytest.mark.parametrize("structured", [False, True])
+def test_hybrid_extraction_preserves_callers_configuration(monkeypatch, structured):
+    monkeypatch.setattr(
+        cuda_graph_config, "default_prefill_backend", lambda: "breakable"
+    )
+    config = {"prefill": {"backend": "hybrid", "bs": [8, 16]}}
+    if structured:
+        config = cuda_graph_config.CudaGraphConfig.from_dict(config)
+    overrides = {
+        "cuda_graph_config": config,
+        "cuda_graph_bs_prefill_full": [32, 64],
+    }
+    before = deepcopy(overrides)
+
+    rewritten, full_bs = hybrid.extract_hybrid_prefill_overrides(overrides)
+
+    assert overrides == before
+    assert rewritten["cuda_graph_config"]["prefill"]["backend"] == "breakable"
+    assert rewritten["cuda_graph_config"]["prefill"]["bs"] == [8, 16]
+    assert "cuda_graph_bs_prefill_full" not in rewritten
+    assert full_bs == [32, 64]
+
+
+@pytest.mark.parametrize(
+    "overrides, message",
+    [
+        ({"cuda_graph_backend_prefill": "hybrid"}, "must be set via"),
+        ({"cuda_graph_bs_prefill_full": [32]}, "requires cuda_graph_config"),
+        ({"cuda_graph_config": {"prefill": {"backend": "hybrid"}}}, "requires"),
+    ],
+)
+def test_hybrid_extraction_rejects_incomplete_policy(overrides, message):
+    with pytest.raises(ValueError, match=message):
+        hybrid.extract_hybrid_prefill_overrides(overrides)
+
+
+@pytest.mark.parametrize("overrides", [None, {}, {"chunked_prefill_size": 1024}])
+def test_other_prefill_policies_are_returned_unchanged(overrides):
+    rewritten, full_bs = hybrid.extract_hybrid_prefill_overrides(overrides)
+    assert rewritten is overrides
+    assert full_bs is None
+
+
+def test_router_prefers_breakable_then_full_and_rejects_eager_shapes():
+    def runner(buckets):
+        return SimpleNamespace(
+            capture_num_tokens=buckets,
+            can_run_graph=lambda batch: batch <= buckets[-1],
+            execute=lambda batch, **kwargs: (buckets, batch, kwargs),
+        )
+
+    router = hybrid.HybridPrefillGraphRouter(runner([8, 16]), runner([32, 64]))
+    assert router.capture_num_tokens == [8, 16, 32, 64]
+    assert router.execute(8, key="value") == ([8, 16], 8, {"key": "value"})
+    assert router.execute(32) == ([32, 64], 32, {})
+    assert not router.can_run_graph(65)
+    with pytest.raises(AssertionError, match="can_run_graph"):
+        router.execute(65)
+
+
+@pytest.mark.parametrize("outcome", ["success", "capture_failure", "wrong_ladder"])
+def test_install_restores_configuration_and_publishes_only_complete_capture(
+    monkeypatch, outcome
+):
+    cfg = SimpleNamespace(backend="breakable", bs=[8, 16], full_prefill_max_req=None)
+    model_cfg = SimpleNamespace(is_multimodal=False)
+    model_runner = SimpleNamespace(
+        model_config=model_cfg, req_to_token_pool=SimpleNamespace(size=3)
+    )
+    monkeypatch.setattr(
+        "sglang.srt.runtime_context.get_exec",
+        lambda: SimpleNamespace(
+            graph=SimpleNamespace(cuda_graph_config=SimpleNamespace(prefill=cfg))
+        ),
+    )
+    monkeypatch.setattr(
+        "sglang.srt.runtime_context.get_schedule",
+        lambda: SimpleNamespace(chunked_prefill_size=4096),
+    )
+    worker = SimpleNamespace(
+        model_runner=model_runner, enable_prefill_input_embeds=True
+    )
+
+    class CapturedRunner:
+        def __init__(self, actual_runner):
+            assert actual_runner is model_runner
+            assert (cfg.backend, cfg.bs, cfg.full_prefill_max_req) == (
+                "full",
+                [32, 64],
+                3,
+            )
+            assert model_cfg.is_multimodal
+            if outcome == "capture_failure":
+                raise RuntimeError("injected capture failure")
+            self.capture_num_tokens = [32] if outcome == "wrong_ladder" else [32, 64]
+
+    breakable = object.__new__(CapturedRunner)
+    breakable.capture_num_tokens = [8, 16]
+    breakable.max_num_tokens = 16
+    model_runner.prefill_cuda_graph_runner = breakable
+    monkeypatch.setattr(
+        prefill_cuda_graph_runner, "PrefillCudaGraphRunner", CapturedRunner
+    )
+
+    if outcome == "success":
+        hybrid.install_hybrid_full_prefill(worker, [32, 64])
+        installed = model_runner.prefill_cuda_graph_runner
+        assert isinstance(installed, hybrid.HybridPrefillGraphRouter)
+        assert installed.breakable_runner is breakable
+        assert installed.full_runner.capture_num_tokens == [32, 64]
+    else:
+        message = (
+            "injected capture failure"
+            if outcome == "capture_failure"
+            else "shapes differ"
+        )
+        with pytest.raises(RuntimeError, match=message):
+            hybrid.install_hybrid_full_prefill(worker, [32, 64])
+        assert model_runner.prefill_cuda_graph_runner is breakable
+    assert (cfg.backend, cfg.bs, cfg.full_prefill_max_req) == (
+        "breakable",
+        [8, 16],
+        None,
+    )
+    assert not model_cfg.is_multimodal
+
+
+def test_install_rejects_missing_breakable_capture_and_overlapping_ladders(monkeypatch):
+    class CapturedRunner:
+        max_num_tokens = 16
+
+    monkeypatch.setattr(
+        prefill_cuda_graph_runner, "PrefillCudaGraphRunner", CapturedRunner
+    )
+    model_runner = SimpleNamespace(prefill_cuda_graph_runner=None)
+    worker = SimpleNamespace(model_runner=model_runner)
+    with pytest.raises(RuntimeError, match="BREAKABLE runner"):
+        hybrid.install_hybrid_full_prefill(worker, [32])
+    model_runner.prefill_cuda_graph_runner = CapturedRunner()
+    with pytest.raises(ValueError, match="must exceed"):
+        hybrid.install_hybrid_full_prefill(worker, [16, 32])

--- a/tests/unit_test/model_runner/test_prefill_cuda_graph_usage.py
+++ b/tests/unit_test/model_runner/test_prefill_cuda_graph_usage.py
@@ -4,12 +4,14 @@ from __future__ import annotations
 import json
 from types import SimpleNamespace
 
+import pytest
 import torch
 from sglang.srt.model_executor.forward_batch_info import ForwardMode
 from sglang.srt.model_executor.runner.prefill_cuda_graph_runner import (
     PrefillCudaGraphRunner,
 )
 
+from sglang_omni.model_runner.hybrid_prefill_router import HybridPrefillGraphRouter
 from sglang_omni.model_runner.model_worker import ModelWorker, _PrefillCudaGraphUsage
 
 
@@ -137,3 +139,44 @@ def test_model_worker_reports_actual_prefill_graph_replays_by_bucket(
     assert stats["custom_eager_count"] == 1
     assert stats["replay_buckets"] == {"16": 1, "32": 1}
     assert json.loads(json.dumps(stats)) == stats
+
+
+@pytest.mark.parametrize("full_has_input_embeds", [False, True])
+def test_model_info_attests_both_hybrid_prefill_captures(
+    full_has_input_embeds, monkeypatch
+):
+    def runner(buckets, has_input_embeds):
+        return SimpleNamespace(
+            capture_num_tokens=buckets,
+            backend=SimpleNamespace(),
+            buffer_registry=SimpleNamespace(has_slot=lambda name: has_input_embeds),
+        )
+
+    worker = object.__new__(ModelWorker)
+    worker.model_runner = SimpleNamespace(
+        prefill_cuda_graph_runner=HybridPrefillGraphRouter(
+            runner([8, 16], True), runner([32, 64], full_has_input_embeds)
+        )
+    )
+    monkeypatch.setattr(
+        "sglang.srt.runtime_context.get_exec",
+        lambda: SimpleNamespace(
+            graph=SimpleNamespace(
+                cuda_graph_config=SimpleNamespace(
+                    prefill=SimpleNamespace(backend="breakable")
+                )
+            )
+        ),
+    )
+    worker._prefill_cuda_graph_usage = _PrefillCudaGraphUsage()
+
+    info = worker._prefill_cuda_graph_info()
+
+    assert info["backend"] == "hybrid"
+    assert info["runner"] == "HybridPrefillGraphRouter"
+    assert info["capture_num_tokens"] == [8, 16, 32, 64]
+    assert info["input_embeds_slot"] is full_has_input_embeds
+    assert info["hybrid_backends"]["breakable"]["capture_num_tokens"] == [8, 16]
+    assert info["hybrid_backends"]["full"]["capture_num_tokens"] == [32, 64]
+    assert info["hybrid_backends"]["full"]["input_embeds_slot"] is full_has_input_embeds
+    assert json.loads(json.dumps(info)) == info


### PR DESCRIPTION
## Motivation

Thinker prefill uses one graph backend. This adds hybrid routing and event-ordered sampled-token readback.

## Modifications

- Route eligible small prefills through BREAKABLE, larger prefills through FULL, and unsupported shapes through eager execution.
- Expose capture/replay accounting and stage sampled tokens on a dedicated CUDA stream. Token staging is independent of the hybrid setting.

## Related Issues

N/A

## Accuracy Test

Recorded H100 validation: **697 CPU + 6 CUDA tests passed**, no selected skips. One WER pair fails the +0.5 pp degradation guard: **1.9007% → 2.6459% (+0.7452 pp)** at c32. All candidate corpus WER values are below 5%. A separate text-prefill diagnostic passed 108 exact tensor comparisons.

## Benchmark & Profiling

Measured [ef46cea9](https://github.com/edwingao28/sglang-omni/commit/ef46cea9590769567da13c7b9dcbbe39b29bff09) against main [50db4a55](https://github.com/sgl-project/sglang-omni/commit/50db4a550374239400139841451cc7b48a3e85c2).

BF16 Qwen3-Omni-30B-A3B-Instruct, 2× H100 80 GB per pair, three GPU-paired runs. Each concurrency uses all 1,088 English SeedTTS samples with reference audio and native Ethan output, streaming, temperature 0.7, no fixed seed, max new tokens 1,024. Zero generation/scoring failures; preconditioning and warmup excluded.

`backend=hybrid`, `full_prefill_max_req=64`.

**Main → candidate (improvement %):**

| Metric | c1 | c16 | c32 |
| --- | ---: | ---: | ---: |
| QPS | 2.131 → 2.129 (-0.14%) | 10.793 → 10.662 (-1.21%) | 11.040 → 11.236 (-1.42%) |
| TTFT p50 (ms) | 37.34 → 38.09 (-4.28%) | 54.19 → 51.07 (+5.76%) | 63.17 → 60.19 (+8.06%) |
| TTFA p50 (ms) | 96.11 → 97.02 (-0.62%) | 308.46 → 310.01 (+0.21%) | 622.11 → 627.74 (+8.58%) |
| TTFA p95 (ms) | 103.82 → 103.92 (-0.07%) | 650.13 → 608.06 (+6.47%) | 1372.57 → 1388.61 (-1.68%) |
| RTF p50 | 0.1239 → 0.1238 (+0.08%) | 0.4087 → 0.4121 (-0.83%) | 0.8003 → 0.7934 (-2.11%) |
| E2E p95 (s) | 0.661 → 0.667 (-0.91%) | 1.955 → 2.003 (-2.97%) | 3.917 → 3.844 (-2.30%) |
| WER (%) | 1.968 → 2.001 (-1.70%) | 2.026 → 1.825 (+9.50%) | 1.926 → 2.018 (-4.78%) |

Values are separate medians across three GPU groups; percentages are median same-pair improvements. **Positive means better**, including WER reduction. Percentages need not equal changes between displayed medians. TTFT ends at first text; TTFA at first validated nonempty PCM. E2E includes WAV/metadata; RTF is generation elapsed/audio duration, before WAV saving.

The measured serving windows had zero FULL replays and no median QPS gain; the diagnostic does not resolve the WER failure.

## Checklist

- [ ] Format your code according with pre-commit.
- [x] Add unit tests.
- [x] Update documentation / docstrings / example tutorials as needed.
- [x] Provide throughput / latency benchmark results and accuracy evaluation results as needed.
- [ ] For reviewers: If you haven't made any contributions to this PR and are only assisting with merging the main branch, please remove yourself as a co-author when merging the PR.

## CI

CI runs on self-hosted GPU runners and requires a maintainer to add the
`run-ci` label. Once labeled, every subsequent push re-triggers CI as
long as the label remains. Use `/tag-and-rerun-ci higgs` or
`/tag-and-rerun-ci moss` or `/tag-and-rerun-ci qwen3-tts` to select a TTS CI
model, and
`/tag-and-rerun-ci fun-asr`, `/tag-and-rerun-ci qwen3-asr` or
`/tag-and-rerun-ci whisper-asr` to select an ASR CI model. One selector from
each family can be combined, for example `/tag-and-rerun-ci moss fun-asr`.
Draft PRs are skipped even if labeled.
