### PR TITLE
[Qwen3-Omni Perf] Add guarded Code2Wav SnakeBeta hoisting and BF16 fusion

### DIFF
--- a/sglang_omni/models/qwen3_omni/components/code2wav_scheduler.py
+++ b/sglang_omni/models/qwen3_omni/components/code2wav_scheduler.py
@@ -152,6 +152,7 @@ class Code2WavScheduler(StreamingVocoderBase[Code2WavStreamState, "list[int]"]):
         _cuda_graph_runner: Code2WavCudaGraphRunner | None = None,
     ):
         self._model = model
+        self._snake_beta_guard = getattr(model, "_omni_snake_beta_guard", None)
         self._device = torch.device(device)
         self._stream_chunk_size = max(int(stream_chunk_size), 1)
         self._left_context_size = max(int(left_context_size), 0)
@@ -561,6 +562,9 @@ class Code2WavScheduler(StreamingVocoderBase[Code2WavStreamState, "list[int]"]):
         graph_eligible: bool = False,
     ) -> tuple[torch.Tensor, dict[str, Any]]:
         with torch.no_grad():
+            # Note (wenyao): Graph replay bypasses Python forwards and their state guards.
+            if self._snake_beta_guard is not None:
+                self._snake_beta_guard()
             if self._device.type != "cpu":
                 torch.get_device_module(self._device).set_device(self._device)
             if self._cuda_graph_runner is None:
@@ -970,8 +974,17 @@ def create_code2wav_scheduler(
     enable_output_overlap: bool = True,
     enable_cuda_graph: bool = False,
     total_gpu_memory_fraction: float | None = None,
+    snake_beta_implementation: str = "eager",
 ):
     """Factory: returns Code2WavScheduler."""
+    if type(snake_beta_implementation) is not str or snake_beta_implementation not in (
+        "eager",
+        "hoist",
+        "fused",
+    ):
+        raise ValueError(
+            "snake_beta_implementation must be 'eager', 'hoist', or 'fused'"
+        )
     if enable_cuda_graph and total_gpu_memory_fraction is None:
         raise ValueError(
             "Code2Wav device graph requires gpu_memory_fraction "
@@ -986,6 +999,10 @@ def create_code2wav_scheduler(
     stream_chunk_size = max(int(stream_chunk_size), 1)
     left_context_size = max(int(left_context_size), 0)
     model = load_code2wav_model(model_path, device=device, dtype=dtype)
+    if snake_beta_implementation != "eager":
+        from .snake_beta import install_code2wav_snake_beta
+
+        install_code2wav_snake_beta(model, snake_beta_implementation)
     cuda_graph_runner = None
     if enable_cuda_graph:
         if enable_batching:

--- a/sglang_omni/models/qwen3_omni/components/fused_snake_beta.py
+++ b/sglang_omni/models/qwen3_omni/components/fused_snake_beta.py
@@ -1,0 +1,110 @@
+# SPDX-License-Identifier: Apache-2.0
+"""Inference-only SnakeBeta data path with explicit eager BF16 round points.
+
+Constants must already contain the original PyTorch BF16 expressions
+``exp(alpha)`` and ``1.0 / (exp(beta) + eps)``. This module does not change
+parameters, convolution geometry, or the caller's stream. Numerical equality
+with a given CUDA/PyTorch runtime must be qualified before enabling it.
+"""
+
+from functools import lru_cache
+
+import torch
+
+
+@lru_cache(maxsize=1)
+def _get_triton_kernel():
+    # Note (wenyao): the default model path must not import or initialize Triton.
+    global _tl, _libdevice
+
+    import triton
+    import triton.language as _tl
+    from triton.language.extra.cuda import libdevice as _libdevice
+
+    @triton.jit
+    def _kernel(
+        x_ptr,
+        alpha_ptr,
+        inverse_ptr,
+        output_ptr,
+        numel,
+        channels,
+        time_steps,
+        BLOCK: _tl.constexpr,
+    ):
+        offsets = _tl.program_id(0) * BLOCK + _tl.arange(0, BLOCK)
+        mask = offsets < numel
+        channel = (offsets // time_steps) % channels
+        x = _tl.load(x_ptr + offsets, mask=mask, other=0).to(_tl.float32)
+        alpha = _tl.load(alpha_ptr + channel, mask=mask, other=0).to(_tl.float32)
+        inverse = _tl.load(inverse_ptr + channel, mask=mask, other=0).to(_tl.float32)
+
+        # Note (wenyao): every eager BF16 intermediate rounds before the next op.
+        scaled = (
+            (x * alpha).to(_tl.bfloat16, fp_downcast_rounding="rtne").to(_tl.float32)
+        )
+        sine = (
+            _libdevice.sin(scaled)
+            .to(_tl.bfloat16, fp_downcast_rounding="rtne")
+            .to(_tl.float32)
+        )
+        squared = (
+            (sine * sine).to(_tl.bfloat16, fp_downcast_rounding="rtne").to(_tl.float32)
+        )
+        periodic = (
+            (inverse * squared)
+            .to(_tl.bfloat16, fp_downcast_rounding="rtne")
+            .to(_tl.float32)
+        )
+        result = (x + periodic).to(_tl.bfloat16, fp_downcast_rounding="rtne")
+        _tl.store(output_ptr + offsets, result, mask=mask)
+
+    return _kernel
+
+
+def fused_snake_beta(
+    x: torch.Tensor,
+    exp_alpha: torch.Tensor,
+    inv_beta_safe: torch.Tensor,
+) -> torch.Tensor:
+    """Return a fresh contiguous NCT output; reject unsupported inputs explicitly."""
+    values = (x, exp_alpha, inv_beta_safe)
+    if not all(isinstance(value, torch.Tensor) for value in values):
+        raise TypeError("fused SnakeBeta expects three tensors")
+    if torch.version.hip is not None or not all(value.is_cuda for value in values):
+        raise ValueError("fused SnakeBeta requires NVIDIA CUDA tensors")
+    if any(value.dtype != torch.bfloat16 for value in values):
+        raise ValueError("fused SnakeBeta requires BF16 inputs and constants")
+    if any(value.device != x.device for value in values):
+        raise ValueError("fused SnakeBeta tensors must share one CUDA device")
+    if x.ndim != 3 or any(size <= 0 for size in x.shape):
+        raise ValueError("fused SnakeBeta requires a nonempty NCT tensor")
+    expected = (1, x.shape[1], 1)
+    if exp_alpha.shape != expected or inv_beta_safe.shape != expected:
+        raise ValueError("fused SnakeBeta constants must have shape [1, C, 1]")
+    if any(
+        value.layout != torch.strided or not value.is_contiguous() for value in values
+    ):
+        raise ValueError("fused SnakeBeta requires contiguous strided tensors")
+    if x.numel() > 2**31 - 1:
+        raise ValueError("fused SnakeBeta exceeds the supported indexing range")
+    if torch.is_grad_enabled() and any(value.requires_grad for value in values):
+        raise RuntimeError("fused SnakeBeta does not implement autograd")
+
+    kernel = _get_triton_kernel()
+    output = torch.empty_like(x, memory_format=torch.contiguous_format)
+    numel = x.numel()
+    with torch.cuda.device(x.device):
+        kernel[((numel + 255) // 256,)](
+            x,
+            exp_alpha,
+            inv_beta_safe,
+            output,
+            numel,
+            x.shape[1],
+            x.shape[2],
+            BLOCK=256,
+            num_warps=4,
+            enable_fp_fusion=False,
+        )
+    return output

--- a/sglang_omni/models/qwen3_omni/components/snake_beta.py
+++ b/sglang_omni/models/qwen3_omni/components/snake_beta.py
@@ -1,0 +1,252 @@
+# SPDX-License-Identifier: Apache-2.0
+"""Opt-in inference-only constants for HF's Apache-2.0 SnakeBeta formula.
+
+Install on a loaded, eval-mode model before capture. Parameters and checkpoint
+keys stay unchanged. Hot reload, concurrent mutation and unsafe ``.data`` writes
+are unsupported; the scheduler checks tracked state before each graph replay.
+"""
+
+from __future__ import annotations
+
+from collections import Counter
+from dataclasses import dataclass
+from types import MethodType
+
+import torch
+from torch import nn
+
+_STATE = "_omni_snake_beta_state"
+_MODULES = "_omni_snake_beta_modules"
+_LINKS = "_omni_snake_beta_links"
+_GUARD = "_omni_snake_beta_guard"
+_HOOKS = (
+    "_forward_hooks",
+    "_forward_pre_hooks",
+    "_backward_hooks",
+    "_backward_pre_hooks",
+    "_state_dict_hooks",
+    "_state_dict_pre_hooks",
+    "_load_state_dict_pre_hooks",
+    "_load_state_dict_post_hooks",
+)
+
+
+@dataclass(frozen=True, eq=False)
+class _State:
+    implementation: str
+    alpha_stamp: tuple
+    beta_stamp: tuple
+    exp_alpha: torch.Tensor
+    inv_beta_safe: torch.Tensor
+
+
+def _stamp(tensor: torch.Tensor) -> tuple:
+    return (
+        id(tensor),
+        tensor._version,
+        tensor.untyped_storage()._cdata,
+        tensor.data_ptr(),
+        tensor.device,
+        tensor.dtype,
+        tuple(tensor.shape),
+        tensor.stride(),
+    )
+
+
+def _plain_eval(module: nn.Module) -> None:
+    if module.training:
+        raise RuntimeError("SnakeBeta optimization requires eval mode")
+    if (
+        getattr(module, "_hf_hook", None) is not None
+        or getattr(module, "_compiled_call_impl", None) is not None
+    ):
+        raise RuntimeError("SnakeBeta optimization forbids offload/compiled modules")
+    if any(getattr(module, name, None) for name in _HOOKS):
+        raise RuntimeError("SnakeBeta optimization forbids custom module hooks")
+
+
+def _no_global_hooks() -> None:
+    if any(
+        getattr(nn.modules.module, name, None)
+        for name in (
+            "_global_forward_hooks",
+            "_global_forward_pre_hooks",
+            "_global_backward_hooks",
+            "_global_backward_pre_hooks",
+        )
+    ):
+        raise RuntimeError("SnakeBeta optimization forbids global module hooks")
+
+
+def _check_state(module: nn.Module, state: _State) -> None:
+    _plain_eval(module)
+    if (
+        getattr(module.forward, "__func__", None) is not _forward
+        or module.no_div_by_zero != 1e-9
+        or _stamp(module.alpha) != state.alpha_stamp
+        or _stamp(module.beta) != state.beta_stamp
+    ):
+        raise RuntimeError(
+            "SnakeBeta static parameters or forward changed; rebuild model"
+        )
+
+
+def _guard_model(model: nn.Module) -> None:
+    if torch.is_grad_enabled():
+        raise RuntimeError("SnakeBeta optimization requires disabled gradients")
+    _plain_eval(model)
+    _no_global_hooks()
+    for parent, name, child in vars(model)[_LINKS]:
+        if getattr(parent, name, None) is not child:
+            raise RuntimeError("SnakeBeta installed module changed; rebuild model")
+    for _, module, state in vars(model)[_MODULES]:
+        if vars(module).get(_STATE) is not state:
+            raise RuntimeError("SnakeBeta installed module changed; rebuild model")
+        _check_state(module, state)
+
+
+def _forward(module: nn.Module, hidden_states: torch.Tensor) -> torch.Tensor:
+    if torch.is_grad_enabled():
+        raise RuntimeError("SnakeBeta optimization requires disabled gradients")
+    state = vars(module)[_STATE]
+    _check_state(module, state)
+    if (
+        type(hidden_states) is not torch.Tensor
+        or hidden_states.ndim != 3
+        or any(size < 1 for size in hidden_states.shape)
+        or hidden_states.shape[1] != state.exp_alpha.shape[1]
+        or hidden_states.layout != torch.strided
+        or not hidden_states.is_contiguous()
+        or hidden_states.device != state.exp_alpha.device
+        or hidden_states.dtype != state.exp_alpha.dtype
+    ):
+        raise ValueError(
+            "SnakeBeta requires contiguous NCT input matching loaded parameters"
+        )
+    if state.implementation == "fused":
+        from .fused_snake_beta import fused_snake_beta
+
+        return fused_snake_beta(hidden_states, state.exp_alpha, state.inv_beta_safe)
+    # Note (wenyao): Keep all five HF input operations and their dtype roundings.
+    return hidden_states + state.inv_beta_safe * torch.pow(
+        torch.sin(hidden_states * state.exp_alpha), 2
+    )
+
+
+def install_code2wav_snake_beta(
+    model: nn.Module, implementation: str
+) -> tuple[str, ...]:
+    """Atomically install ``hoist`` or CUDA-BF16 ``fused`` before graph capture.
+
+    Cached tensors are private state, not Parameters or persistent buffers.
+    Moving/reloading the model afterward must fail, never refresh captured state.
+    """
+    from transformers.models.qwen3_omni_moe.modeling_qwen3_omni_moe import SnakeBeta
+
+    if type(implementation) is not str or implementation not in ("hoist", "fused"):
+        raise ValueError("SnakeBeta installer requires 'hoist' or 'fused'")
+    _no_global_hooks()
+    modules = tuple(model.named_modules(remove_duplicate=False))
+    counts = Counter(id(module) for _, module in modules)
+    for _, module in modules:
+        _plain_eval(module)
+        if any(
+            name in vars(module)
+            for name in (_STATE, _MODULES, _LINKS, _GUARD, "forward")
+        ):
+            raise ValueError(
+                "SnakeBeta optimization requires unmodified, not installed modules"
+            )
+    selected = [(path, m) for path, m in modules if isinstance(m, SnakeBeta)]
+    if not selected:
+        raise ValueError("No HF SnakeBeta modules found")
+    plan = []
+    parameter_ids = set()
+    for path, module in selected:
+        if (
+            type(module) is not SnakeBeta
+            or counts[id(module)] != 1
+            or set(module._parameters) != {"alpha", "beta"}
+            or module._modules
+            or module._buffers
+            or type(module.in_features) is not int
+            or module.in_features < 1
+            or type(module.no_div_by_zero) is not float
+            or module.no_div_by_zero != 1e-9
+        ):
+            raise ValueError("Unsupported or shared HF SnakeBeta module")
+        for parameter in (module.alpha, module.beta):
+            if (
+                type(parameter) is not nn.Parameter
+                or id(parameter) in parameter_ids
+                or parameter.is_meta
+                or parameter.device.type not in ("cpu", "cuda")
+                or parameter.layout != torch.strided
+                or parameter.dtype
+                not in (torch.float16, torch.bfloat16, torch.float32, torch.float64)
+                or parameter.shape != (module.in_features,)
+                or not parameter.is_contiguous()
+            ):
+                raise ValueError(
+                    "SnakeBeta requires loaded, unshared, contiguous floating parameters"
+                )
+            parameter_ids.add(id(parameter))
+        if (
+            module.alpha.device != module.beta.device
+            or module.alpha.dtype != module.beta.dtype
+        ):
+            raise ValueError("SnakeBeta parameter device/dtype mismatch")
+        if implementation == "fused" and (
+            module.alpha.device.type != "cuda"
+            or module.alpha.dtype != torch.bfloat16
+            or torch.version.hip is not None
+        ):
+            raise ValueError("Fused SnakeBeta requires CUDA BF16 parameters")
+        alpha_stamp, beta_stamp = _stamp(module.alpha), _stamp(module.beta)
+        with torch.inference_mode(False), torch.no_grad():
+            exp_alpha = torch.exp(module.alpha.unsqueeze(0).unsqueeze(-1))
+            beta = torch.exp(module.beta.unsqueeze(0).unsqueeze(-1))
+            # Note (wenyao): Preserve HF reciprocal/scalar-multiply roundings.
+            inv_beta_safe = 1.0 / (beta + module.no_div_by_zero)
+        plan.append(
+            (
+                path,
+                module,
+                _State(
+                    implementation, alpha_stamp, beta_stamp, exp_alpha, inv_beta_safe
+                ),
+            )
+        )
+    for _, module, state in plan:
+        if (
+            _stamp(module.alpha) != state.alpha_stamp
+            or _stamp(module.beta) != state.beta_stamp
+        ):
+            raise RuntimeError("SnakeBeta parameters changed during installation")
+    links = {}
+    for path, module, _ in plan:
+        parent = model
+        for name in path.split(".") if path else ():
+            child = getattr(parent, name)
+            links[id(parent), name] = (parent, name, child)
+            parent = child
+        if parent is not module:
+            raise RuntimeError("SnakeBeta hierarchy changed during installation")
+    bound = []
+    try:
+        for _, module, state in plan:
+            bound.append(module)
+            vars(module)[_STATE] = state
+            module.forward = MethodType(_forward, module)
+        vars(model)[_MODULES] = tuple(plan)
+        vars(model)[_LINKS] = tuple(links.values())
+        vars(model)[_GUARD] = MethodType(_guard_model, model)
+    except BaseException:
+        for module in bound:
+            vars(module).pop(_STATE, None)
+            vars(module).pop("forward", None)
+        vars(model).pop(_MODULES, None)
+        vars(model).pop(_LINKS, None)
+        vars(model).pop(_GUARD, None)
+        raise
+    return tuple(path for path, _, _ in plan)

--- a/tests/README.md
+++ b/tests/README.md
@@ -91,6 +91,7 @@ tests/
     │   ├── test_code2wav.py
     │   ├── test_code2wav_batching.py
     │   ├── test_code2wav_cuda_graph.py
+    │   ├── test_code2wav_snake_beta.py
     │   ├── test_colocation_config.py
     │   ├── test_config_manager.py
     │   ├── test_fp8_backend_config.py
@@ -633,7 +634,18 @@ that happened to contain an older version of the test.
     tensor storage/slicing, decode feedback/text FIFO consumption, and replay
     of generated-token input embeds after decode retract
   - Code2Wav streaming/cleanup behavior plus bounded batching deadlines,
-    fire rules, sub-batch decomposition, output equivalence, and lifecycle
+    fire rules, sub-batch decomposition, output equivalence, and lifecycle.
+  - `test_code2wav_snake_beta.py`: CPU hoist parity, checkpoint parameter
+    preservation, atomic installation/rollback, unsupported-input
+    rejection, and hierarchy/parameter guards before graph dispatch.
+    Fused BF16 parity, side-stream graph replay, and CUDA input guards
+    are marked `accelerator` and require NVIDIA CUDA with BF16 support.
+    These cases use small synthetic models, without a model checkpoint:
+
+    ```bash
+    pytest tests/unit_test/qwen3_omni/test_code2wav_snake_beta.py -m "not accelerator" -q
+    pytest tests/unit_test/qwen3_omni/test_code2wav_snake_beta.py -m accelerator -q
+    ```
   - Code2Wav CUDA Graph lifecycle, exact-shape replay, atomic rollback, memory
     budget enforcement, eager fallbacks, replay failures, and JSON-safe stats;
     the `accelerator`-marked cases exercise real CUDA stream restoration and

--- a/tests/unit_test/qwen3_omni/test_code2wav_snake_beta.py
+++ b/tests/unit_test/qwen3_omni/test_code2wav_snake_beta.py
@@ -1,0 +1,348 @@
+# SPDX-License-Identifier: Apache-2.0
+
+from __future__ import annotations
+
+from types import SimpleNamespace
+
+import pytest
+import torch
+from torch import nn
+from transformers.models.qwen3_omni_moe.modeling_qwen3_omni_moe import SnakeBeta
+
+from sglang_omni.models.qwen3_omni.components import fused_snake_beta, snake_beta
+
+
+def _model(dtype=torch.float32, device="cpu"):
+    model = (
+        nn.Sequential(SnakeBeta(4), SnakeBeta(4)).to(device=device, dtype=dtype).eval()
+    )
+    with torch.no_grad():
+        for index, module in enumerate(model):
+            module.alpha.copy_(torch.linspace(-1, 1, 4, device=device) + index / 4)
+            module.beta.copy_(torch.linspace(-0.5, 0.5, 4, device=device))
+    return model
+
+
+@pytest.mark.parametrize(
+    "dtype", [torch.float16, torch.bfloat16, torch.float32, torch.float64]
+)
+def test_hoist_preserves_eager_values_and_checkpoint_parameters(dtype):
+    model = _model(dtype)
+    inputs = torch.linspace(-5, 5, 104, dtype=dtype).reshape(2, 4, 13)
+    parameters = tuple(model.parameters())
+    checkpoint = {name: value.clone() for name, value in model.state_dict().items()}
+    with torch.no_grad():
+        expected = model(inputs)
+
+    assert snake_beta.install_code2wav_snake_beta(model, "hoist") == ("0", "1")
+
+    with torch.no_grad():
+        model._omni_snake_beta_guard()
+        assert torch.equal(model(inputs), expected)
+    assert all(left is right for left, right in zip(parameters, model.parameters()))
+    assert model.state_dict().keys() == checkpoint.keys()
+    for name, value in model.state_dict().items():
+        assert torch.equal(value, checkpoint[name])
+
+
+@pytest.mark.parametrize("implementation", ["eager", "unknown", None, True])
+def test_installer_rejects_unknown_implementations(implementation):
+    with pytest.raises(ValueError, match="requires 'hoist' or 'fused'"):
+        snake_beta.install_code2wav_snake_beta(_model(), implementation)
+
+
+@pytest.mark.parametrize(
+    "change", ["training", "hook", "shared_module", "shared_parameter"]
+)
+def test_installer_rejects_unsupported_models_without_partial_installation(change):
+    model = _model()
+    if change == "training":
+        model[1].train()
+    elif change == "hook":
+        model[1].register_forward_hook(lambda *args: None)
+    elif change == "shared_module":
+        model[1] = model[0]
+    else:
+        model[1].alpha = model[0].alpha
+
+    with pytest.raises((ValueError, RuntimeError)):
+        snake_beta.install_code2wav_snake_beta(model, "hoist")
+
+    assert "_omni_snake_beta_guard" not in vars(model)
+    assert all("_omni_snake_beta_state" not in vars(module) for module in model)
+    assert all("forward" not in vars(module) for module in model)
+
+
+def test_installer_rolls_back_when_binding_the_second_module_fails(monkeypatch):
+    model = _model()
+    original_bind = snake_beta.MethodType
+    calls = 0
+
+    def bind(function, module):
+        nonlocal calls
+        calls += 1
+        if calls == 2:
+            raise RuntimeError("injected binding failure")
+        return original_bind(function, module)
+
+    monkeypatch.setattr(snake_beta, "MethodType", bind)
+    with pytest.raises(RuntimeError, match="injected binding failure"):
+        snake_beta.install_code2wav_snake_beta(model, "hoist")
+    assert "_omni_snake_beta_guard" not in vars(model)
+    assert "_omni_snake_beta_modules" not in vars(model)
+    for module in model:
+        assert "_omni_snake_beta_state" not in vars(module)
+        assert "forward" not in vars(module)
+        assert module.forward.__func__ is SnakeBeta.forward
+
+
+@pytest.mark.parametrize(
+    "change", ["inplace", "replace_parameter", "dtype", "replace_module", "forward"]
+)
+def test_guard_rejects_parameter_or_module_changes_before_replay(change):
+    model = _model()
+    snake_beta.install_code2wav_snake_beta(model, "hoist")
+    with torch.no_grad():
+        model._omni_snake_beta_guard()
+        if change == "inplace":
+            model[0].alpha.add_(1)
+        elif change == "replace_parameter":
+            model[0].beta = nn.Parameter(model[0].beta.clone())
+        elif change == "dtype":
+            model.to(dtype=torch.float64)
+        elif change == "replace_module":
+            model[0] = SnakeBeta(4).eval()
+        else:
+            model[0].forward = lambda value: value
+        with pytest.raises(RuntimeError, match="changed"):
+            model._omni_snake_beta_guard()
+
+
+def test_hoist_requires_inference_and_cannot_be_installed_twice():
+    model = _model()
+    snake_beta.install_code2wav_snake_beta(model, "hoist")
+    with torch.enable_grad(), pytest.raises(RuntimeError, match="disabled gradients"):
+        model(torch.zeros(1, 4, 2))
+    with pytest.raises(ValueError, match="not installed"):
+        snake_beta.install_code2wav_snake_beta(model, "hoist")
+
+
+@pytest.mark.parametrize("shape", [(4, 2), (1, 0, 2), (1, 3, 2)])
+def test_hoist_rejects_invalid_input_shapes(shape):
+    model = _model()
+    snake_beta.install_code2wav_snake_beta(model, "hoist")
+    with torch.no_grad(), pytest.raises(ValueError, match="contiguous NCT"):
+        model(torch.zeros(shape))
+
+
+@pytest.mark.parametrize("kind", ["strided", "dtype", "non_tensor"])
+def test_hoist_rejects_incompatible_inputs(kind):
+    model = _model()
+    snake_beta.install_code2wav_snake_beta(model, "hoist")
+    inputs = {
+        "strided": torch.zeros(1, 4, 4)[:, :, ::2],
+        "dtype": torch.zeros(1, 4, 2, dtype=torch.float64),
+        "non_tensor": [[[0, 0]] * 4],
+    }
+    with torch.no_grad(), pytest.raises(ValueError, match="contiguous NCT"):
+        model(inputs[kind])
+
+
+def test_fused_rejects_cpu_installation_without_mutating_model():
+    model = _model(torch.bfloat16)
+    with pytest.raises(ValueError, match="CUDA BF16"):
+        snake_beta.install_code2wav_snake_beta(model, "fused")
+    assert all("forward" not in vars(module) for module in model)
+
+
+def test_scheduler_checks_installed_state_before_graph_dispatch():
+    # Note (wenyao): graph replay bypasses Python forwards, so the state guard
+    # must run before graph dispatch.
+    from sglang_omni.models.qwen3_omni.components.code2wav_scheduler import (
+        Code2WavScheduler,
+    )
+
+    model = _model()
+    snake_beta.install_code2wav_snake_beta(model, "hoist")
+    scheduler = object.__new__(Code2WavScheduler)
+    scheduler._device = torch.device("cpu")
+    scheduler._snake_beta_guard = model._omni_snake_beta_guard
+    dispatched = []
+    scheduler._cuda_graph_runner = SimpleNamespace(
+        run=lambda *a, **k: dispatched.append(a)
+    )
+    with torch.no_grad():
+        model[0].alpha.add_(1)
+    with pytest.raises(RuntimeError, match="changed"):
+        scheduler._forward_codes(torch.zeros(1, 4, 2), graph_eligible=True)
+    assert dispatched == []
+
+
+@pytest.fixture
+def cuda_device():
+    if not torch.cuda.is_available() or torch.version.hip is not None:
+        pytest.skip("NVIDIA CUDA is required")
+    if not torch.cuda.is_bf16_supported():
+        pytest.skip("CUDA BF16 is required")
+    return torch.device("cuda")
+
+
+@pytest.mark.accelerator
+@pytest.mark.parametrize(
+    "batch,length,scale", [(1, 2, 0.01), (16, 22, 1.0), (32, 129, 10.0)]
+)
+def test_fused_installed_model_matches_eager_bf16(cuda_device, batch, length, scale):
+    model = _model(torch.bfloat16, cuda_device)
+    generator = torch.Generator(device=cuda_device).manual_seed(20260905)
+    inputs = (
+        torch.randn(
+            batch,
+            4,
+            length,
+            device=cuda_device,
+            dtype=torch.bfloat16,
+            generator=generator,
+        )
+        * scale
+    )
+    with torch.no_grad():
+        expected = model(inputs)
+    snake_beta.install_code2wav_snake_beta(model, "fused")
+    with torch.no_grad():
+        actual = model(inputs)
+    assert torch.equal(actual, expected)
+    assert actual.data_ptr() != inputs.data_ptr()
+
+
+@pytest.mark.accelerator
+def test_fused_graph_replay_on_a_side_stream_matches_eager(cuda_device):
+    model = _model(torch.bfloat16, cuda_device)
+    eager = _model(torch.bfloat16, cuda_device)
+    snake_beta.install_code2wav_snake_beta(model, "fused")
+    inputs = torch.zeros(4, 4, 17, device=cuda_device, dtype=torch.bfloat16)
+    stream = torch.cuda.Stream(device=cuda_device)
+    stream.wait_stream(torch.cuda.current_stream(cuda_device))
+    with torch.cuda.stream(stream), torch.no_grad():
+        for _ in range(2):
+            model(inputs)
+        graph = torch.cuda.CUDAGraph()
+        with torch.cuda.graph(graph, stream=stream):
+            actual = model(inputs)
+        for value in (0.1, -3.0):
+            inputs.fill_(value)
+            model._omni_snake_beta_guard()
+            graph.replay()
+            expected = eager(inputs)
+            stream.synchronize()
+            assert torch.equal(actual, expected)
+
+
+@pytest.mark.accelerator
+@pytest.mark.parametrize("kind", ["dtype", "shape", "strided", "grad"])
+def test_fused_rejects_unsupported_cuda_inputs(cuda_device, kind):
+    inputs = torch.zeros(1, 4, 6, device=cuda_device, dtype=torch.bfloat16)
+    alpha = inverse = torch.ones(1, 4, 1, device=cuda_device, dtype=torch.bfloat16)
+    if kind == "dtype":
+        inputs = inputs.float()
+    elif kind == "shape":
+        alpha = alpha.flatten()
+    elif kind == "strided":
+        inputs = inputs[:, :, ::2]
+    else:
+        inputs.requires_grad_(True)
+    with torch.enable_grad(), pytest.raises((ValueError, RuntimeError)):
+        fused_snake_beta.fused_snake_beta(inputs, alpha, inverse)
+
+
+def _nested_snake_model():
+    return nn.Sequential(
+        nn.ModuleDict(
+            {"left": nn.Sequential(SnakeBeta(4)), "right": nn.Sequential(SnakeBeta(4))}
+        )
+    ).eval()
+
+
+@pytest.mark.parametrize("change", ["ancestor", "shadow", "leaf", "parameter"])
+def test_guard_rejects_nested_changes_before_replay(change):
+    model = _nested_snake_model()
+    snake_beta.install_code2wav_snake_beta(model, "hoist")
+    with torch.no_grad():
+        model._omni_snake_beta_guard()
+        if change == "ancestor":
+            model[0] = nn.ModuleDict(
+                {
+                    "left": nn.Sequential(SnakeBeta(4)),
+                    "right": nn.Sequential(SnakeBeta(4)),
+                }
+            ).eval()
+        elif change == "shadow":
+            object.__setattr__(model[0], "left", nn.Sequential(SnakeBeta(4)).eval())
+        elif change == "leaf":
+            model[0]["right"][0] = SnakeBeta(4).eval()
+        else:
+            model[0]["right"][0].beta.add_(1)
+        with pytest.raises(RuntimeError, match="changed"):
+            model._omni_snake_beta_guard()
+
+
+def test_guard_accepts_equivalent_nested_registration_mapping():
+    model = _nested_snake_model()
+    snake_beta.install_code2wav_snake_beta(model, "hoist")
+    model[0]._modules = dict(model[0]._modules)
+    with torch.no_grad():
+        model._omni_snake_beta_guard()
+
+
+def test_guard_handles_root_snake_and_parameter_mutation():
+    model = SnakeBeta(4).eval()
+    assert snake_beta.install_code2wav_snake_beta(model, "hoist") == ("",)
+    with torch.no_grad():
+        model._omni_snake_beta_guard()
+        model.alpha.add_(1)
+        with pytest.raises(RuntimeError, match="changed"):
+            model._omni_snake_beta_guard()
+
+
+@pytest.mark.parametrize("nested", [False, True])
+def test_installer_rejects_existing_hierarchy_state_without_mutation(nested):
+    model = _nested_snake_model()
+    target = model[0]["left"][0] if nested else model
+    sentinel = object()
+    vars(target)[snake_beta._LINKS] = sentinel
+    with pytest.raises(ValueError, match="not installed"):
+        snake_beta.install_code2wav_snake_beta(model, "hoist")
+    assert vars(target)[snake_beta._LINKS] is sentinel
+    assert "_omni_snake_beta_guard" not in vars(model)
+    assert all("forward" not in vars(module) for module in model.modules())
+
+
+def test_installer_rolls_back_hierarchy_state_on_guard_binding_failure(monkeypatch):
+    model = _nested_snake_model()
+    original_bind = snake_beta.MethodType
+
+    def bind(function, module):
+        if function is snake_beta._guard_model:
+            raise RuntimeError("guard binding failed")
+        return original_bind(function, module)
+
+    monkeypatch.setattr(snake_beta, "MethodType", bind)
+    with pytest.raises(RuntimeError, match="guard binding failed"):
+        snake_beta.install_code2wav_snake_beta(model, "hoist")
+    assert snake_beta._LINKS not in vars(model)
+    assert "_omni_snake_beta_modules" not in vars(model)
+    assert "_omni_snake_beta_guard" not in vars(model)
+    for module in model.modules():
+        assert "_omni_snake_beta_state" not in vars(module)
+        assert "forward" not in vars(module)
+
+
+def test_installer_rejects_preexisting_shadowed_hierarchy_without_mutation():
+    model = _nested_snake_model()
+    object.__setattr__(model[0], "left", nn.Sequential(SnakeBeta(4)).eval())
+    with pytest.raises(RuntimeError, match="hierarchy"):
+        snake_beta.install_code2wav_snake_beta(model, "hoist")
+    assert snake_beta._LINKS not in vars(model)
+    assert "_omni_snake_beta_guard" not in vars(model)
+    for module in model.modules():
+        assert "_omni_snake_beta_state" not in vars(module)
+        assert "forward" not in vars(module)


### PR DESCRIPTION
## Motivation

Code2Wav SnakeBeta repeatedly transforms static parameters and launches several elementwise operations.

## Modifications

- Add eager (default), hoisted, and CUDA BF16 fused implementations before graph capture.
- Preserve eager BF16 rounding points and checkpoint parameters, with state/layout guards and installation rollback.

## Related Issues

N/A

## Accuracy Test

Recorded H100 validation: **480 CPU + 23 CUDA tests passed**, no selected skips. One WER pair fails the +0.5 pp degradation guard: **1.5909% → 2.1435% (+0.5526 pp)** at c16. All candidate corpus WER values are below 5%; component equality tests do not resolve this failure.

## Benchmark & Profiling

Measured [80ddcfc8](https://github.com/edwingao28/sglang-omni/commit/80ddcfc8940db81beb6db5fd5febd3a4513556bb) against main [50db4a55](https://github.com/sgl-project/sglang-omni/commit/50db4a550374239400139841451cc7b48a3e85c2).

BF16 Qwen3-Omni-30B-A3B-Instruct, 2× H100 80 GB per pair, three GPU-paired runs. Each concurrency uses all 1,088 English SeedTTS samples with reference audio and native Ethan output, streaming, temperature 0.7, no fixed seed, max new tokens 1,024. Zero generation/scoring failures; preconditioning and warmup excluded.

`snake_beta_implementation=fused`; eager remains the default.

**Main → candidate (improvement %):**

| Metric | c1 | c16 | c32 |
| --- | ---: | ---: | ---: |
| QPS | 2.131 → 2.155 (+1.13%) | 10.793 → 11.507 (+6.62%) | 11.040 → 12.120 (+9.78%) |
| TTFT p50 (ms) | 37.34 → 36.95 (+1.04%) | 54.19 → 51.20 (+5.52%) | 63.17 → 64.25 (-1.71%) |
| TTFA p50 (ms) | 96.11 → 95.33 (+0.81%) | 308.46 → 303.08 (+1.74%) | 622.11 → 571.06 (+8.21%) |
| TTFA p95 (ms) | 103.82 → 102.01 (+1.74%) | 650.13 → 552.37 (+15.04%) | 1372.57 → 1162.95 (+15.27%) |
| RTF p50 | 0.1239 → 0.1212 (+2.18%) | 0.4087 → 0.3790 (+7.27%) | 0.8003 → 0.7339 (+8.30%) |
| E2E p95 (s) | 0.661 → 0.657 (+0.61%) | 1.955 → 1.878 (+3.94%) | 3.917 → 3.614 (+7.74%) |
| WER (%) | 1.968 → 2.026 (-2.95%) | 2.026 → 2.135 (-5.38%) | 1.926 → 2.144 (-11.32%) |

Values are separate medians across three GPU groups. Percentages are calculated directly from the displayed baseline and candidate values: `(candidate - baseline) / baseline × 100` for QPS and `(baseline - candidate) / baseline × 100` for latency, RTF, and WER. **Positive means better**; WER improvement is a relative percentage, not a percentage-point change. TTFT ends at first text; TTFA at first validated nonempty PCM. E2E includes WAV/metadata; RTF is generation elapsed/audio duration, before WAV saving.

Hoist and eager modes were not separate candidate benchmark arms.

## Checklist

- [ ] Format your code according with pre-commit.
- [x] Add unit tests.
- [x] Update documentation / docstrings / example tutorials as needed.
- [x] Provide throughput / latency benchmark results and accuracy evaluation results as needed.
- [ ] For reviewers: If you haven't made any contributions to this PR and are only assisting with merging the main branch, please remove yourself as a co-author when merging the PR.

## CI

CI runs on self-hosted GPU runners and requires a maintainer to add the
`run-ci` label. Once labeled, every subsequent push re-triggers CI as
long as the label remains. Use `/tag-and-rerun-ci higgs` or
`/tag-and-rerun-ci moss` or `/tag-and-rerun-ci qwen3-tts` to select a TTS CI
model, and
`/tag-and-rerun-ci fun-asr`, `/tag-and-rerun-ci qwen3-asr` or
`/tag-and-rerun-ci whisper-asr` to select an ASR CI model. One selector from
each family can be combined, for example `/tag-and-rerun-ci moss fun-asr`.
Draft PRs are skipped even if labeled.
