### PR TITLE
[Fix] Apply repetition penalty once through SGLang for all shared-sampler models

### DIFF
--- a/docs/cookbook/fun_cosyvoice3.md
+++ b/docs/cookbook/fun_cosyvoice3.md
@@ -363,7 +363,7 @@ curl -X POST http://localhost:8000/v1/audio/speech \
 | `temperature` | `0.7` | Sampling temperature |
 | `top_p` | `0.8` | Top-p sampling |
 | `top_k` | `20` | Top-k sampling |
-| `repetition_penalty` | `1.1` | Repetition penalty |
+| `repetition_penalty` | `1.21` | Repetition penalty |
 | `max_new_tokens` | `min(2048, 20x target text tokens)` | Maximum number of generated speech tokens. If omitted, derived from the target text length (capped at 2048); stop tokens are also suppressed until at least `2x` that length has been generated |
 | `seed` | `null` | Random seed for reproducibility |
 | `stream` | `false` | Incremental causal Flow + HiFT; first PCM chunk after `28 + prompt_pad` speech tokens (`prompt_pad` rounds the prompt length to a multiple of 25) |

--- a/sglang_omni/model_runner/base.py
+++ b/sglang_omni/model_runner/base.py
@@ -7,6 +7,7 @@ pass, sampling, logit post-processing, and output extraction.
 
 from __future__ import annotations
 
+from collections import Counter
 from dataclasses import dataclass, replace
 from typing import Any
 
@@ -196,10 +197,77 @@ class ModelRunner:
         *,
         isolate_sampling: bool = False,
     ):
+        if schedule_batch.forward_mode.is_extend():
+            self._restore_output_penalty_history(schedule_batch)
         return self._execution_bridge.forward_context(
             schedule_batch,
             isolate_sampling=isolate_sampling,
         )
+
+    @staticmethod
+    def _restore_output_penalty_history(schedule_batch: Any) -> None:
+        """Re-seed retained output history into the prepared penalizers."""
+        sampling_info = schedule_batch.sampling_info
+        if sampling_info.penalizer_orchestrator is None:
+            return
+        from sglang.srt.sampling.penaltylib import (
+            BatchedFrequencyPenalizer,
+            BatchedPresencePenalizer,
+            BatchedRepetitionPenalizer,
+        )
+
+        orchestrator = sampling_info.penalizer_orchestrator
+        prepared = []
+        for cls, state_name, param_name in (
+            (
+                BatchedRepetitionPenalizer,
+                "cumulated_repetition_penalties",
+                "repetition_penalty",
+            ),
+            (
+                BatchedFrequencyPenalizer,
+                "cumulated_frequency_penalties",
+                "frequency_penalty",
+            ),
+            (
+                BatchedPresencePenalizer,
+                "cumulated_presence_penalties",
+                "presence_penalty",
+            ),
+        ):
+            penalizer = orchestrator.penalizers.get(cls)
+            if penalizer is not None and penalizer.is_prepared():
+                prepared.append((getattr(penalizer, state_name), param_name))
+        if not prepared:
+            return
+
+        rows, token_ids, counts = [], [], []
+        for row, req in enumerate(schedule_batch.reqs):
+            # Note: (Junnan Li) prepare_for_extend clears req.is_retracted, so
+            # the retained output_ids are the only record of emitted tokens.
+            retained = Counter(
+                token_id
+                for token_id in req.output_ids
+                if 0 <= token_id < orchestrator.vocab_size
+            )
+            rows.extend([row] * len(retained))
+            token_ids.extend(retained)
+            counts.extend(retained.values())
+        if not rows:
+            return
+
+        device = prepared[0][0].device
+        row_indices = torch.tensor(rows, dtype=torch.long, device=device)
+        token_indices = torch.tensor(token_ids, dtype=torch.long, device=device)
+        for state, param_name in prepared:
+            values = [
+                float(getattr(schedule_batch.reqs[row].sampling_params, param_name))
+                * (count if param_name == "frequency_penalty" else 1)
+                for row, count in zip(rows, counts)
+            ]
+            state[row_indices, token_indices] = torch.tensor(
+                values, dtype=state.dtype, device=device
+            )
 
     def _next_host_staging(
         self, shape: tuple[int, ...] | torch.Size, dtype: torch.dtype
@@ -770,7 +838,8 @@ class ModelRunner:
         schedule_batch: Any,
         requests: list,
     ) -> Any:
-        self._apply_repetition_penalty(logits_output, requests)
+        # Note: (Junnan Li) repetition/frequency/presence penalties are already
+        # in the SGLang sampler's state; a second pass here squares them.
         self._apply_codec_suppress_tokens(logits_output, requests)
         self._install_sampling_seeds(forward_batch, requests)
         wants_rollout_logprob = any(sr.data.return_logprob for sr in requests)
@@ -894,63 +963,6 @@ class ModelRunner:
     @staticmethod
     def _req_is_retracted(req: Any) -> bool:
         return bool(req.is_retracted)
-
-    @staticmethod
-    def _rep_penalty_unique_tokens(data: Any, output_ids: list, vocab: int) -> set:
-        # Note: (Jiaxin Deng) rebuilding unique(output_ids) every decode step is
-        # quadratic over the generation; track the consumed prefix and fold in
-        # only new tokens. A shrunk output_ids (retract/restart) resets the state.
-        seen_len = getattr(data, "_rep_seen_len", 0)
-        seen: set | None = getattr(data, "_rep_seen_tokens", None)
-        if seen is None or len(output_ids) < seen_len:
-            seen = set()
-            seen_len = 0
-        for t in output_ids[seen_len:]:
-            tok = int(t)
-            if 0 <= tok < vocab:
-                seen.add(tok)
-        data._rep_seen_tokens = seen
-        data._rep_seen_len = len(output_ids)
-        return seen
-
-    def _apply_repetition_penalty(self, logits_output: Any, requests: list) -> None:
-        logits = logits_output.next_token_logits
-        if logits is None or logits.ndim != 2:
-            return
-        vocab = logits.shape[1]
-        device = logits.device
-        rep_rows: list[int] = []
-        rep_toks: list[int] = []
-        rep_penalties: list[float] = []
-        for row_idx, sched_req in enumerate(requests):
-            data = sched_req.data
-            req = data.req
-            penalty = req.sampling_params.repetition_penalty
-            if penalty == 1.0:
-                continue
-            output_ids = req.output_ids
-            if not output_ids:
-                # Note: (Jiaxin Deng) a retract can replace output_ids with an
-                # empty list; drop the incremental state so a restart does not
-                # inherit stale tokens.
-                if getattr(data, "_rep_seen_len", 0):
-                    data._rep_seen_tokens = set()
-                    data._rep_seen_len = 0
-                continue
-            unique = ModelRunner._rep_penalty_unique_tokens(data, output_ids, vocab)
-            if not unique:
-                continue
-            rep_rows.extend([row_idx] * len(unique))
-            rep_toks.extend(unique)
-            rep_penalties.extend([float(penalty)] * len(unique))
-        if rep_rows:
-            orig_dtype = logits.dtype
-            rows_t = torch.tensor(rep_rows, dtype=torch.long, device=device)
-            toks_t = torch.tensor(rep_toks, dtype=torch.long, device=device)
-            pens_t = torch.tensor(rep_penalties, dtype=torch.float32, device=device)
-            scores = logits[rows_t, toks_t].to(torch.float32)
-            scores = torch.where(scores > 0, scores / pens_t, scores * pens_t)
-            logits[rows_t, toks_t] = scores.to(orig_dtype)
 
     def _apply_codec_suppress_tokens(self, logits_output: Any, requests: list) -> None:
         logits = logits_output.next_token_logits

--- a/sglang_omni/models/fishaudio_s2_pro/model_runner.py
+++ b/sglang_omni/models/fishaudio_s2_pro/model_runner.py
@@ -77,6 +77,12 @@ class FishS2ProModelRunner(ModelRunner):
         self._semantic_end_id = int(self.model._semantic_end_id)
         self._im_end_token_id = int(self.model._im_end_token_id)
 
+    def lookahead_eligible(self, batch: Any) -> bool:
+        # note (Junnan Li): not supported yet; semantic_history_tokens is
+        # appended at resolve, one step late under lookahead.
+        del batch
+        return False
+
     def before_prefill(self, forward_batch, schedule_batch, requests):
         del schedule_batch
         self._sync_decode_state(requests)

--- a/sglang_omni/models/fishaudio_s2_pro/request_builders.py
+++ b/sglang_omni/models/fishaudio_s2_pro/request_builders.py
@@ -131,7 +131,8 @@ def build_sglang_tts_request(
         temperature=state.temperature,
         top_p=state.top_p,
         top_k=state.top_k,
-        repetition_penalty=state.repetition_penalty,
+        # note (Junnan Li): the in-model sampler already penalizes semantic history.
+        repetition_penalty=1.0,
         stop_token_ids=[im_end_token_id],
     )
     sampling_params.normalize(tokenizer)

--- a/sglang_omni/models/fun_cosyvoice3/request_builders.py
+++ b/sglang_omni/models/fun_cosyvoice3/request_builders.py
@@ -64,7 +64,7 @@ _IMPLICIT_SAMPLING_DEFAULTS = {
     "temperature": {1.0, 0.8, 0.7},
     "top_p": {1.0, 0.8},
     "top_k": {-1, 20, 25, 30},
-    "repetition_penalty": {1.0, 1.05, 1.1},
+    "repetition_penalty": {1.0, 1.05, 1.1, 1.21},
 }
 
 _COSYVOICE3_PREPARED_MARKER = "_cosyvoice3_prepared_request"
@@ -777,7 +777,7 @@ def build_sglang_cosyvoice3_request(
         temperature=temperature,
         top_p=float(gen_kwargs.get("top_p", 0.8)),
         top_k=int(gen_kwargs.get("top_k", 20)),
-        repetition_penalty=float(gen_kwargs.get("repetition_penalty", 1.1)),
+        repetition_penalty=float(gen_kwargs.get("repetition_penalty", 1.21)),
         # Stop on any of the 200 ids CosyVoice3 treats as terminal/non-speech
         # control ids, not only EOS_ID — the other 199 never stopped the
         # scheduler when only EOS_ID was registered, so generation could run

--- a/sglang_omni/models/qwen3_tts/model_runner.py
+++ b/sglang_omni/models/qwen3_tts/model_runner.py
@@ -6,7 +6,6 @@ from __future__ import annotations
 from typing import Any
 
 import torch
-from sglang.srt.sampling.penaltylib import BatchedRepetitionPenalizer
 
 from sglang_omni.model_runner.base import ModelRunner
 from sglang_omni.model_runner.prefill_inputs import (
@@ -52,19 +51,6 @@ class Qwen3TTSModelRunner(ModelRunner):
         super().__init__(tp_worker, output_processor)
         self._has_pending_code_step = False
         self._row_ids_cache: torch.Tensor | None = None
-
-    def _execution_context(
-        self,
-        schedule_batch: Any,
-        *,
-        isolate_sampling: bool = False,
-    ):
-        if schedule_batch.forward_mode.is_extend():
-            self._restore_repetition_penalty_history(schedule_batch)
-        return super()._execution_context(
-            schedule_batch,
-            isolate_sampling=isolate_sampling,
-        )
 
     def before_prefill(
         self,
@@ -149,64 +135,6 @@ class Qwen3TTSModelRunner(ModelRunner):
     # ------------------------------------------------------------------
     # Qwen3-TTS logit shaping
     # ------------------------------------------------------------------
-
-    def _apply_repetition_penalty(self, logits_output: Any, requests: list) -> None:
-        """Leave repetition-penalty ownership to SGLang's sampling state.
-
-        ScheduleBatch.prepare_for_decode accumulates committed output tokens
-        in SGLang's device-resident repetition penalizer. ModelRunner.sample
-        applies that state once using the public SamplingParams value.
-        """
-        del logits_output, requests
-
-    @staticmethod
-    def _restore_repetition_penalty_history(schedule_batch: Any) -> None:
-        """Seed a fresh SGLang penalizer before a request is re-prefilled.
-
-        Retraction preserves Qwen3-TTS semantic output_ids so their input
-        embeddings can be replayed, but prepare_for_extend creates a fresh
-        SGLang sampling state. Restore those retained IDs before the re-prefill
-        sample; subsequent decode steps resume SGLang's normal one-token
-        accumulation.
-        """
-        orchestrator = schedule_batch.sampling_info.penalizer_orchestrator
-        if orchestrator is None:
-            return
-
-        penalizer = orchestrator.penalizers.get(BatchedRepetitionPenalizer)
-        if penalizer is None or not penalizer.is_prepared():
-            return
-
-        vocab_size = int(orchestrator.vocab_size)
-        rows: list[int] = []
-        token_ids: list[int] = []
-        penalties: list[float] = []
-        for row, req in enumerate(schedule_batch.reqs):
-            penalty = float(req.sampling_params.repetition_penalty)
-            if penalty == 1.0:
-                continue
-            retained_ids = {
-                token_id
-                for token_id in (int(value) for value in req.output_ids)
-                if 0 <= token_id < vocab_size
-            }
-            rows.extend([row] * len(retained_ids))
-            token_ids.extend(retained_ids)
-            penalties.extend([penalty] * len(retained_ids))
-
-        if not rows:
-            return
-
-        scaling_penalties = penalizer.get_scaling_penalties()
-        device = scaling_penalties.device
-        row_indices = torch.tensor(rows, dtype=torch.long, device=device)
-        token_indices = torch.tensor(token_ids, dtype=torch.long, device=device)
-        penalty_values = torch.tensor(
-            penalties,
-            dtype=scaling_penalties.dtype,
-            device=device,
-        )
-        scaling_penalties[row_indices, token_indices] = penalty_values
 
     def _apply_codec_suppress_tokens(self, logits_output: Any, requests: list) -> None:
         logits = logits_output.next_token_logits

--- a/tests/unit_test/fishaudio_s2_pro/test_tts.py
+++ b/tests/unit_test/fishaudio_s2_pro/test_tts.py
@@ -718,3 +718,19 @@ def test_fish_tts_stream_output_builder_gates_and_clears_chunks() -> None:
         latest_stream_code_chunk=torch.full((11, 1), 8, dtype=torch.long),
     )
     assert stream_output_builder("non-stream", non_stream_data, None) == []
+
+
+def test_lookahead_is_never_eligible_for_fish():
+    """The in-model sampler reads semantic history, so lookahead must stay off
+    even though the SamplingParams the base gate inspects are history-free."""
+    runner = object.__new__(FishS2ProModelRunner)
+    req = SimpleNamespace(
+        sampling_params=SimpleNamespace(
+            repetition_penalty=1.0,
+            frequency_penalty=0.0,
+            presence_penalty=0.0,
+            min_new_tokens=0,
+        ),
+        custom_logit_processor=None,
+    )
+    assert runner.lookahead_eligible(SimpleNamespace(reqs=[req])) is False

--- a/tests/unit_test/fishaudio_s2_pro/test_tts.py
+++ b/tests/unit_test/fishaudio_s2_pro/test_tts.py
@@ -573,6 +573,8 @@ def test_fish_tts_request_builder_maps_finish_contract_onto_req() -> None:
     data = request_builder(payload)
 
     assert data.req.rid == "req-contract"
+    assert data.req.sampling_params.repetition_penalty == 1.0
+    assert data.repetition_penalty == 1.05
     assert data.req.sampling_params.stop_token_ids == {99}
     assert data.req.eos_token_ids == {99}
     assert data.req.sampling_params.max_new_tokens == 4

--- a/tests/unit_test/fun_cosyvoice3/test_request_builders.py
+++ b/tests/unit_test/fun_cosyvoice3/test_request_builders.py
@@ -309,7 +309,7 @@ def test_generation_kwargs_omit_implicit_sampling_defaults_but_keep_explicit_val
         "temperature": 0.7,
         "top_p": 0.8,
         "top_k": 20,
-        "repetition_penalty": 1.1,
+        "repetition_penalty": 1.21,
         "do_sample": False,
         "max_new_tokens": 12,
     }
@@ -363,8 +363,10 @@ class _FakeModel(torch.nn.Module):
         )
 
 
+@pytest.mark.parametrize("repetition_penalty", [None, 1.1, 1.21])
 def test_preprocess_and_build_request_share_prepared_state(
     monkeypatch: pytest.MonkeyPatch,
+    repetition_penalty: float | None,
 ) -> None:
     monkeypatch.setattr(
         request_builders,
@@ -390,7 +392,21 @@ def test_preprocess_and_build_request_share_prepared_state(
     )
     payload = _payload(
         {"text": "hello", "ref_audio": "reference.wav"},
-        params={"max_new_tokens": 5, "do_sample": False, "seed": 7},
+        params={
+            "max_new_tokens": 5,
+            "do_sample": False,
+            "seed": 7,
+            **(
+                {}
+                if repetition_penalty is None
+                else {"repetition_penalty": repetition_penalty}
+            ),
+        },
+        tts_params=(
+            {}
+            if repetition_penalty is None
+            else {"explicit_generation_params": ["repetition_penalty"]}
+        ),
     )
 
     prepared_payload = preprocess_cosyvoice3_payload(payload)
@@ -413,6 +429,9 @@ def test_preprocess_and_build_request_share_prepared_state(
     request_data = build_sglang_cosyvoice3_request(prepared_payload, model=model)
     assert request_data.max_new_tokens == 5
     assert request_data.temperature == 0.0
+    assert request_data.req.sampling_params.repetition_penalty == (
+        1.21 if repetition_penalty is None else repetition_penalty
+    )
     assert request_data.req.sampling_params.sampling_seed == 7
     # Stop on the full 200-id control range, not only EOS_ID.
     assert request_data.req.sampling_params.stop_token_ids == set(

--- a/tests/unit_test/model_runner/test_base_hooks.py
+++ b/tests/unit_test/model_runner/test_base_hooks.py
@@ -75,6 +75,7 @@ def _scheduler_output(*, is_prefill: bool):
         is_prefill_only=False,
         output_ids=None,
         marker="worker-batch",
+        sampling_info=SimpleNamespace(penalizer_orchestrator=None),
         prefill_input_ids_cpu=None,
         mix_running_indices=None,
     )

--- a/tests/unit_test/model_runner/test_penalty_history.py
+++ b/tests/unit_test/model_runner/test_penalty_history.py
@@ -1,0 +1,150 @@
+# SPDX-License-Identifier: Apache-2.0
+"""Retained output history survives the production forward sampling boundary."""
+
+import contextlib
+from types import SimpleNamespace
+
+import torch
+from sglang.srt.sampling.penaltylib import (
+    BatchedFrequencyPenalizer,
+    BatchedPenalizerOrchestrator,
+    BatchedPresencePenalizer,
+    BatchedRepetitionPenalizer,
+)
+from sglang.srt.sampling.sampling_batch_info import SamplingBatchInfo
+from sglang.srt.sampling.sampling_params import SamplingParams
+
+from sglang_omni.model_runner.base import ModelRunner
+
+
+class _Batch(SimpleNamespace):
+    # SimpleNamespace instances cannot be weakly referenced; the orchestrator holds a weakref to its batch.
+    pass
+
+
+def _sampling(batch):
+    n = len(batch.reqs)
+    return SamplingBatchInfo(
+        temperatures=torch.ones(n, 1),
+        top_ps=torch.ones(n),
+        top_ks=torch.ones(n, dtype=torch.int32),
+        min_ps=torch.zeros(n),
+        is_all_greedy=True,
+        is_any_greedy=True,
+        need_top_p_sampling=False,
+        need_top_k_sampling=False,
+        need_min_p_sampling=False,
+        vocab_size=8,
+        device="cpu",
+        penalizer_orchestrator=BatchedPenalizerOrchestrator(
+            vocab_size=8,
+            batch=batch,
+            penalizers={
+                BatchedRepetitionPenalizer,
+                BatchedFrequencyPenalizer,
+                BatchedPresencePenalizer,
+            },
+        ),
+    )
+
+
+def _batch(rows):
+    batch = _Batch(reqs=[], device="cpu")
+    batch.forward_mode = SimpleNamespace(is_extend=lambda: True)
+    for history, rp, freq, presence in rows:
+        batch.reqs.append(
+            SimpleNamespace(
+                output_ids=list(history),
+                sampling_params=SamplingParams(
+                    repetition_penalty=rp,
+                    frequency_penalty=freq,
+                    presence_penalty=presence,
+                ),
+            )
+        )
+    batch.sampling_info = _sampling(batch)
+    return batch
+
+
+def _forward(batch):
+    def forward_context(batch, *, isolate_sampling):
+        assert isolate_sampling
+        return contextlib.nullcontext(batch.sampling_info.copy_for_forward())
+
+    runner = object.__new__(ModelRunner)
+    runner._execution_bridge = SimpleNamespace(forward_context=forward_context)
+    with runner._execution_context(batch, isolate_sampling=True) as snapshot:
+        return snapshot
+
+
+def _logits(snapshot):
+    logits = torch.tensor([[2.6, -2, 2.6, -2, 2.6, -2, 2.6, -2]]).repeat(
+        len(snapshot), 1
+    )
+    with torch._dynamo.config.patch(disable=True):
+        snapshot.apply_logits_bias(logits)
+    return logits
+
+
+def test_mixed_restore_and_forward_snapshot_isolation():
+    batch = _batch(
+        [
+            ([2, 2, 5, -1, 8], 1.3, 0.25, -0.5),
+            ([2, 5, 5], 2.0, 0.5, 0.25),
+            ([2, 5], 1.0, 0.0, 0.0),
+            ([], 1.1, -0.25, 0.5),
+        ]
+    )
+    snapshot = _forward(batch)
+    expected = torch.tensor([[2.6, -2, 2.6, -2, 2.6, -2, 2.6, -2]]).repeat(4, 1)
+    expected[0, 2], expected[0, 5] = 2.0, -2.275
+    expected[1, 2], expected[1, 5] = 0.925, -6.5
+    # Additive first: (-2 - 0.25 + 0.5) * 1.3 = -2.275.
+    torch.testing.assert_close(_logits(snapshot), expected)
+    torch.testing.assert_close(_logits(_forward(batch)), expected)  # Idempotent.
+
+    batch.sampling_info.penalizer_orchestrator.cumulate_output_tokens(
+        torch.tensor([3, 3, 3, 3])
+    )
+    changed = expected.clone()
+    changed[:, 3] = torch.tensor([-2.275, -5.5, -2.0, -2.475])
+    torch.testing.assert_close(_logits(batch.sampling_info.copy_for_forward()), changed)
+    torch.testing.assert_close(_logits(snapshot), expected)
+
+
+def test_chunked_reprefill_rebuild_then_one_committed_decode():
+    batch = _batch([([2, 2, 5], 1.3, 0.25, -0.5)])
+    for _ in range(3):
+        previous = batch.sampling_info
+        batch.sampling_info = _sampling(batch)
+        assert (
+            batch.sampling_info.penalizer_orchestrator
+            is not previous.penalizer_orchestrator
+        )
+        torch.testing.assert_close(
+            _logits(_forward(batch))[0, [2, 5]], torch.tensor([2.0, -2.275])
+        )
+    batch.reqs[0].output_ids.append(2)
+    batch.sampling_info.penalizer_orchestrator.cumulate_output_tokens(torch.tensor([2]))
+    batch.forward_mode.is_extend = lambda: False
+    torch.testing.assert_close(
+        _logits(_forward(batch))[0, [2, 5]], torch.tensor([2.35 / 1.3, -2.275])
+    )
+
+
+def test_sampling_batch_filter_merge_preserves_row_behavior():
+    batch = _batch([([2, 2], 1.3, 0.25, -0.5), ([5], 2.0, 0.5, 0.25)])
+    other = _batch([([3, 3, 3], 1.0, 0.0, 0.0), ([5, 5], 1.3, 0.25, -0.5)])
+    _forward(batch)
+    _forward(other)
+    batch.reqs = [batch.reqs[1]]
+    batch.sampling_info.filter_batch([1], torch.tensor([1]))
+    batch.sampling_info.merge_batch(other.sampling_info)
+    batch.reqs.extend(other.reqs)
+    assert len(batch.sampling_info) == len(batch.reqs) == 3
+    # Consume directly: another restore could conceal broken filter/merge state.
+    expected = torch.tensor([[2.6, -2, 2.6, -2, 2.6, -2, 2.6, -2]]).repeat(3, 1)
+    expected[0, 5], expected[2, 5] = -5.5, -2.6
+    torch.testing.assert_close(
+        _logits(batch.sampling_info.copy_for_forward()), expected
+    )

--- a/tests/unit_test/model_runner/test_repetition_penalty_contract.py
+++ b/tests/unit_test/model_runner/test_repetition_penalty_contract.py
@@ -1,0 +1,73 @@
+# SPDX-License-Identifier: Apache-2.0
+"""Penalty ownership at the shared sampler boundary."""
+
+from types import SimpleNamespace
+
+import pytest
+import torch
+from sglang.srt.sampling.sampling_params import SamplingParams
+
+from sglang_omni.model_runner.base import ModelRunner
+
+
+def test_qwen3_omni_thinker_explicit_penalty_is_preserved():
+    from sglang_omni.models.qwen3_omni.request_builders import (
+        build_sglang_thinker_request,
+    )
+    from tests.unit_test.fixtures.qwen_fakes import FakeQwenTokenizer, make_qwen_state
+
+    data = build_sglang_thinker_request(
+        make_qwen_state(),
+        params={"repetition_penalty": 1.7},
+        tokenizer=FakeQwenTokenizer(),
+        vocab_size=32000,
+    )
+    assert isinstance(data.req.sampling_params, SamplingParams)
+    assert data.req.sampling_params.repetition_penalty == 1.7
+
+
+@pytest.mark.parametrize("with_sglang_state", [False, True])
+@pytest.mark.parametrize("dtype", [torch.float32, torch.bfloat16])
+def test_shared_sampler_receives_only_codec_shaping(with_sglang_state, dtype):
+    runner = object.__new__(ModelRunner)
+    original = torch.tensor([[4.0, -6.0, 8.0, 3.0], [-4.0, 6.0, 2.0, 1.0]], dtype=dtype)
+    expected = original.clone()
+    expected[0, 3] = -float("inf")
+    seen = []
+
+    def sample(output, forward):
+        seen.append(output.next_token_logits.clone())
+        return torch.tensor([2, 1])
+
+    runner.tp_worker = SimpleNamespace(model_runner=SimpleNamespace(sample=sample))
+    requests = [
+        SimpleNamespace(
+            data=SimpleNamespace(
+                req=SimpleNamespace(
+                    sampling_params=SimpleNamespace(
+                        repetition_penalty=p, sampling_seed=None
+                    ),
+                    output_ids=[0, 1, 0],
+                ),
+                suppress_tokens=suppress,
+                return_logprob=False,
+            )
+        )
+        for p, suppress in [(2.0, [3]), (0.5, None)]
+    ]
+    forward = SimpleNamespace(
+        sampling_info=SimpleNamespace(
+            sampling_seed=None,
+            penalizer_orchestrator=None,
+            acc_scaling_penalties=torch.ones(2, 4) if with_sglang_state else None,
+        )
+    )
+    result = runner._sample_next_token_ids(
+        SimpleNamespace(next_token_logits=original.clone()),
+        forward,
+        SimpleNamespace(),
+        requests,
+    )
+    assert result.tolist() == [2, 1]
+    assert len(seen) == 1
+    assert torch.equal(seen[0], expected)

--- a/tests/unit_test/model_runner/test_rollout_logprobs.py
+++ b/tests/unit_test/model_runner/test_rollout_logprobs.py
@@ -136,7 +136,6 @@ def test_record_rollout_logprobs_requires_return_flag() -> None:
 
 def test_sample_next_token_ids_requires_sampler_logprobs_when_requested() -> None:
     runner = object.__new__(ModelRunner)
-    runner._apply_repetition_penalty = lambda *args: None
     runner._apply_codec_suppress_tokens = lambda *args: None
     runner.tp_worker = SimpleNamespace(
         model_runner=SimpleNamespace(

--- a/tests/unit_test/pipeline/test_async_decode.py
+++ b/tests/unit_test/pipeline/test_async_decode.py
@@ -154,7 +154,9 @@ def _sched_output(n):
             )
             for i in range(n)
         ],
-        batch_data=object(),
+        batch_data=types.SimpleNamespace(
+            forward_mode=types.SimpleNamespace(is_extend=lambda: False)
+        ),
     )
 
 
@@ -224,7 +226,9 @@ def test_resolve_recomputes_finished_overrun_skip_rids():
                 data=types.SimpleNamespace(req=skip_req),
             ),
         ],
-        batch_data=object(),
+        batch_data=types.SimpleNamespace(
+            forward_mode=types.SimpleNamespace(is_extend=lambda: False)
+        ),
     )
     with _patch_event(ready=True):
         step = r.execute_launch(sched_output)
@@ -256,7 +260,9 @@ def test_resolve_skips_retracted_row():
                 data=types.SimpleNamespace(req=retracted_req),
             ),
         ],
-        batch_data=object(),
+        batch_data=types.SimpleNamespace(
+            forward_mode=types.SimpleNamespace(is_extend=lambda: False)
+        ),
     )
     with _patch_event(ready=True):
         step = r.execute_launch(sched_output)

--- a/tests/unit_test/qwen3_omni/test_logit_shaping.py
+++ b/tests/unit_test/qwen3_omni/test_logit_shaping.py
@@ -10,81 +10,6 @@ import torch
 from sglang_omni.model_runner.base import ModelRunner
 
 
-def _make_requests(output_ids_per_row, penalty: float):
-    reqs = []
-    for ids in output_ids_per_row:
-        sp = types.SimpleNamespace(repetition_penalty=penalty)
-        req = types.SimpleNamespace(sampling_params=sp, output_ids=ids)
-        data = types.SimpleNamespace(req=req)
-        reqs.append(types.SimpleNamespace(data=data))
-    return reqs
-
-
-def _scalar_reference(logits, requests, penalty):
-    out = logits.clone()
-    for row_idx, sched_req in enumerate(requests):
-        ids = sched_req.data.req.output_ids
-        if not ids:
-            continue
-        unique = list({int(t) for t in ids if 0 <= int(t) < out.shape[1]})
-        if not unique:
-            continue
-        idx = torch.tensor(unique, dtype=torch.long, device=out.device)
-        scores = out[row_idx, idx]
-        scores = torch.where(scores > 0, scores / penalty, scores * penalty)
-        out[row_idx, idx] = scores
-    return out
-
-
-@pytest.mark.parametrize("dtype", [torch.float16, torch.bfloat16, torch.float32])
-def test_apply_repetition_penalty_matches_scalar_reference(dtype):
-    device = "cuda" if torch.cuda.is_available() else "cpu"
-    vocab = 256
-    batch = 8
-    penalty = 1.2
-    torch.manual_seed(42)
-    logits_orig = (
-        torch.randn(batch, vocab, dtype=dtype, device=device) * 2.0
-    ).contiguous()
-
-    rng = torch.Generator(device="cpu").manual_seed(7)
-    output_ids = [
-        torch.randperm(vocab, generator=rng)[:32].tolist() for _ in range(batch)
-    ]
-
-    requests = _make_requests(output_ids, penalty)
-    logits_output = types.SimpleNamespace(next_token_logits=logits_orig.clone())
-
-    ModelRunner._apply_repetition_penalty(
-        types.SimpleNamespace(), logits_output, requests
-    )
-    actual = logits_output.next_token_logits
-    expected = _scalar_reference(logits_orig, requests, penalty)
-
-    tol = {torch.float16: 2.5e-3, torch.bfloat16: 1e-2, torch.float32: 1e-6}[dtype]
-    diff = (actual - expected).abs().max().item()
-    assert diff <= tol, f"max abs diff {diff:.6f} > tol {tol:.6f} for {dtype}"
-
-
-def test_repetition_penalty_incremental_matches_full_rebuild():
-    device = "cuda" if torch.cuda.is_available() else "cpu"
-    vocab = 128
-    penalty = 1.3
-    torch.manual_seed(0)
-    output_ids = [3, 7, 7, 100]
-    requests = _make_requests([output_ids], penalty)
-
-    for step_ids in ([3, 7, 7, 100, 55], [3, 7, 7, 100, 55, 3], [9], [9, 200, -1, 12]):
-        requests[0].data.req.output_ids = list(step_ids)
-        logits_orig = torch.randn(1, vocab, dtype=torch.float32, device=device)
-        logits_output = types.SimpleNamespace(next_token_logits=logits_orig.clone())
-        ModelRunner._apply_repetition_penalty(
-            types.SimpleNamespace(), logits_output, requests
-        )
-        expected = _scalar_reference(logits_orig, requests, penalty)
-        assert torch.equal(logits_output.next_token_logits, expected), step_ids
-
-
 def _make_suppress_requests(suppress_per_row):
     reqs = []
     for suppress in suppress_per_row:
@@ -128,33 +53,6 @@ def test_codec_suppress_tokens_matches_reference(share_rows):
         ModelRunner._apply_codec_suppress_tokens(runner, logits_output, requests)
         expected = _suppress_reference(logits_orig, requests)
         assert torch.equal(logits_output.next_token_logits, expected)
-
-
-def test_repetition_penalty_resets_after_empty_retract():
-    device = "cuda" if torch.cuda.is_available() else "cpu"
-    vocab = 64
-    penalty = 1.5
-    requests = _make_requests([[3, 9]], penalty)
-    runner = types.SimpleNamespace()
-
-    logits = torch.zeros(1, vocab, device=device) + 1.0
-    ModelRunner._apply_repetition_penalty(
-        runner, types.SimpleNamespace(next_token_logits=logits), requests
-    )
-
-    # Retract replaces output_ids with an empty list, then the restart
-    # generates a different same-length prefix.
-    requests[0].data.req.output_ids = []
-    ModelRunner._apply_repetition_penalty(
-        runner, types.SimpleNamespace(next_token_logits=logits.clone()), requests
-    )
-    requests[0].data.req.output_ids = [11, 12]
-    logits_orig = torch.ones(1, vocab, device=device)
-    logits_output = types.SimpleNamespace(next_token_logits=logits_orig.clone())
-    ModelRunner._apply_repetition_penalty(runner, logits_output, requests)
-
-    expected = _scalar_reference(logits_orig, requests, penalty)
-    assert torch.equal(logits_output.next_token_logits, expected)
 
 
 def test_suppress_cache_holds_one_entry_across_requests():

--- a/tests/unit_test/qwen3_omni/test_talker.py
+++ b/tests/unit_test/qwen3_omni/test_talker.py
@@ -1839,6 +1839,7 @@ class TestBuildTalkerRequestTensorStorage:
             codec_vocab_size=4096,
         )
 
+        assert data.req.sampling_params.repetition_penalty == 1.05
         assert data.prefill_input_embeds is hidden_states
         assert data.req.input_embeds is None
         assert data.req._input_embeds_are_projected is False

--- a/tests/unit_test/qwen3_tts/test_mask_logit_shaping.py
+++ b/tests/unit_test/qwen3_tts/test_mask_logit_shaping.py
@@ -34,17 +34,6 @@ def _sampling_request(repetition_penalty: float) -> types.SimpleNamespace:
     )
 
 
-def test_qwen3_tts_leaves_repetition_penalty_to_sglang() -> None:
-    runner = _runner(vocab_size=128, codec_eos_token_id=127)
-    logits = torch.randn(2, 128)
-    original = logits.clone()
-    logits_output = types.SimpleNamespace(next_token_logits=logits)
-
-    runner._apply_repetition_penalty(logits_output, [object(), object()])
-
-    assert torch.equal(logits_output.next_token_logits, original)
-
-
 def test_qwen3_tts_public_penalty_disables_async_lookahead() -> None:
     runner = _runner(vocab_size=128, codec_eos_token_id=127)
 


### PR DESCRIPTION
## Motivation

On the shared Omni sampling path both Omni's model runner and SGLang's sampler apply `repetition_penalty` to the logits, so the effective penalty is squared and regular decode and speculative verify disagree on the same prefix. 

Apply repetition penalty once through SGLang for all shared-sampler models, so that the parameter keeps its documented strength and every sampling path produces the same logits.
## Modifications

- **`model_runner/base.py`: apply the penalty only in SGLang's sampler and keep its history across retraction.**
  - Remove Omni's repetition-penalty pass and its token-history cache, leaving repetition/frequency/presence penalties to SGLang's penalizer; Omni keeps only codec suppress tokens.
  - On extend batches, re-seed the retained output history into the prepared penalizers before the forward sampling snapshot, so a request re-prefilled after retraction keeps its penalty state for every model on this path.
- **Remove per-model workarounds and set values for single application.**
  - Qwen3-TTS: drop its private restore and no-op override, now covered by the base runner.
  - Fish Audio S2-Pro: hand SGLang `repetition_penalty=1.0`, since the family penalizes in-model.
  - Fun-CosyVoice3: set the default `repetition_penalty` to 1.21, the strength the old 1.1 default was effectively served at, so default output is unchanged.
- **Tests and docs**: add tests to pin sampler ownership, penalty-history restore and the Fish Audio S2-Pro, talker and Fun-CosyVoice3 builder values; remove the obsolete Omni-penalty tests; update the Fun-CosyVoice3 cookbook with the new default.

## Related Issues

Fixes #1360. Supersedes #1817; extends #1750 (Qwen3-TTS only) to every model on the shared sampler.

## Accuracy Test

Measured on H200 with the default configuration (CUDA graphs on): main at `1b801a7c` vs main with this PR.

### Generation quality

* The generated outputs are identical between the main branch and this PR across all tested cases:
  * **Qwen3-TTS 0.6B** with 40 prompts
  * **Fish Audio S2-Pro** with 12 prompts
  * **MOSS-TTS v1.5** with 12 prompts
  * **Whisper large-v3** with 22 clips
  * **Qwen3-Omni** thinker with 6 prompts (greedy decoding); the talker was compared with CUDA graphs off (its graph-mode decode is not run-to-run deterministic even with top_k=1)


* **Fun-CosyVoice3** with 40 prompts (T0.7): 27/40 token streams identical; en WER 0.010 vs 0.010, zh CER 0.0243 vs 0.0243, 0 collapses, mean codes 121.7 (main) vs 120.6 (this PR).

### Penalty semantics

* **Qwen3-Omni thinker** with 6 prompts (greedy), explicit `repetition_penalty`: main at 1.1 and this PR at 1.21 produce identical text on 6/6, confirming main served the square.
* **Fun-CosyVoice3** with 40 prompts: omitting the sampling fields and passing them explicitly (rp 1.21, T0.7, top_p 0.8, top_k 20) give identical output on 40/40.

### Retraction

* **Qwen3-TTS 0.6B** with 40 prompts at concurrency 4, forced retraction every 16 decode steps (`SGLANG_TEST_RETRACT`): 29 requests were retracted and re-prefilled, their penalty state was restored exactly (47/47 re-prefilled rows), and with CUDA graphs off the codec tokens match the no-retraction run on 40/40.
* **Fun-CosyVoice3** with 6 prompts at concurrency 8: re-prefill restores the full penalty history (15/15 tokens; main restores none). The re-prefilled requests themselves cannot complete on main or on this PR because of a pre-existing Fun-CosyVoice3 bug (the RoPE kernel rejects the re-prefill batch), so the end-to-end retraction check is the Qwen3-TTS run above.

Behaviour change: an explicit `repetition_penalty` on the shared path now has its documented strength instead of its square.

## Benchmark & Profiling

Not applicable.

## Checklist

- [x] Format your code according with pre-commit.
- [x] Add unit tests.
- [x] Update documentation / docstrings / example tutorials as needed.
- [x] Provide throughput / latency benchmark results and accuracy evaluation results as needed.
- [ ] For reviewers: If you haven't made any contributions to this PR and are only assisting with merging the main branch, please remove yourself as a co-author when merging the PR.

## CI

CI runs on self-hosted GPU runners and requires a maintainer to add the
`run-ci` label. Once labeled, every subsequent push re-triggers CI as
long as the label remains. Use `/tag-and-rerun-ci higgs` or
`/tag-and-rerun-ci moss` or `/tag-and-rerun-ci qwen3-tts` to select a TTS CI
model, and
`/tag-and-rerun-ci fun-asr`, `/tag-and-rerun-ci qwen3-asr` or
`/tag-and-rerun-ci whisper-asr` to select an ASR CI model. One selector from
each family can be combined, for example `/tag-and-rerun-ci moss fun-asr`.
Draft PRs are skipped even if labeled.






