### PR TITLE
[Qwen3-Omni Perf]: add optional exact EOS graphs for Code2Wav

### DIFF
--- a/sglang_omni/models/qwen3_omni/components/code2wav_cuda_graph.py
+++ b/sglang_omni/models/qwen3_omni/components/code2wav_cuda_graph.py
@@ -255,6 +255,7 @@ class Code2WavCudaGraphRunner:
         total_gpu_memory_fraction: float | None,
         graph_keys: tuple[GraphKey, ...],
         device_api: Any | None = None,
+        graph_memory_budget_bytes: int | None = None,
     ) -> Code2WavCudaGraphRunner:
         """Build the configured serving-reachable serial graphs."""
 
@@ -265,10 +266,18 @@ class Code2WavCudaGraphRunner:
             graph_keys=graph_keys,
             device_api=_TorchDeviceApi() if device_api is None else device_api,
         )
-        runner._build(total_gpu_memory_fraction)
+        runner._build(total_gpu_memory_fraction, graph_memory_budget_bytes)
         return runner
 
-    def _build(self, total_gpu_memory_fraction: float | None) -> None:
+    def _build(
+        self,
+        total_gpu_memory_fraction: float | None,
+        graph_memory_budget_bytes: int | None = None,
+    ) -> None:
+        if graph_memory_budget_bytes is not None and (
+            type(graph_memory_budget_bytes) is not int or graph_memory_budget_bytes < 0
+        ):
+            raise ValueError("graph_memory_budget_bytes must be a nonnegative integer")
         fraction = self._valid_fraction(total_gpu_memory_fraction)
         if fraction is None:
             self._disable_reason = "invalid_total_gpu_memory_fraction"
@@ -299,6 +308,11 @@ class Code2WavCudaGraphRunner:
         stage_budget = int(before["total_bytes"] * fraction)
         loaded_model_footprint = before["allocated_bytes"]
         graph_budget = max(0, stage_budget - loaded_model_footprint)
+        if graph_memory_budget_bytes is not None:
+            graph_budget = min(graph_budget, graph_memory_budget_bytes)
+            self._memory_stats["graph_memory_budget_cap_bytes"] = (
+                graph_memory_budget_bytes
+            )
         self._memory_stats.update(
             {
                 "stage_budget_bytes": stage_budget,

--- a/sglang_omni/models/qwen3_omni/components/code2wav_scheduler.py
+++ b/sglang_omni/models/qwen3_omni/components/code2wav_scheduler.py
@@ -149,8 +149,12 @@ class Code2WavScheduler(StreamingVocoderBase[Code2WavStreamState, "list[int]"]):
         batch_ceiling: int = 8,
         enable_output_overlap: bool = True,
         enable_cuda_graph: bool = False,
+        enable_eos_cuda_graph: bool = False,
         _cuda_graph_runner: Code2WavCudaGraphRunner | None = None,
+        _eos_cuda_graph_runner: Code2WavCudaGraphRunner | None = None,
     ):
+        if enable_eos_cuda_graph and not enable_cuda_graph:
+            raise ValueError("EOS CUDA graph replay requires enable_cuda_graph")
         self._model = model
         self._device = torch.device(device)
         self._stream_chunk_size = max(int(stream_chunk_size), 1)
@@ -159,6 +163,10 @@ class Code2WavScheduler(StreamingVocoderBase[Code2WavStreamState, "list[int]"]):
         self._total_upsample = int(model.total_upsample)
         self._cuda_graph_runner = (
             _cuda_graph_runner if bool(enable_cuda_graph) else None
+        )
+        self._enable_eos_cuda_graph = bool(enable_eos_cuda_graph)
+        self._eos_cuda_graph_runner = (
+            _eos_cuda_graph_runner if self._enable_eos_cuda_graph else None
         )
         super().__init__(
             None,
@@ -328,7 +336,8 @@ class Code2WavScheduler(StreamingVocoderBase[Code2WavStreamState, "list[int]"]):
         codes = window.transpose(0, 1).unsqueeze(0)
         wav, execution_metadata = self._forward_codes(
             codes,
-            graph_eligible=not is_final,
+            graph_eligible=not is_final or self._enable_eos_cuda_graph,
+            is_final=is_final,
         )
         wav = wav[..., -(end - start) * self._total_upsample :]
         samples = int(wav.numel())
@@ -559,11 +568,24 @@ class Code2WavScheduler(StreamingVocoderBase[Code2WavStreamState, "list[int]"]):
         codes: torch.Tensor,
         *,
         graph_eligible: bool = False,
+        is_final: bool = False,
     ) -> tuple[torch.Tensor, dict[str, Any]]:
+        runner = self._cuda_graph_runner
+        if (
+            is_final
+            and self._enable_eos_cuda_graph
+            and self._eos_cuda_graph_runner is not None
+            and int(codes.shape[0]) == 1
+            and runner is not None
+            and 1 not in runner.available_batch_sizes(int(codes.shape[-1]))
+            and 1
+            in self._eos_cuda_graph_runner.available_batch_sizes(int(codes.shape[-1]))
+        ):
+            runner = self._eos_cuda_graph_runner
         with torch.no_grad():
             if self._device.type != "cpu":
                 torch.get_device_module(self._device).set_device(self._device)
-            if self._cuda_graph_runner is None:
+            if runner is None:
                 result = Code2WavRunResult(
                     output=self._model(codes),
                     execution_mode="eager",
@@ -571,7 +593,7 @@ class Code2WavScheduler(StreamingVocoderBase[Code2WavStreamState, "list[int]"]):
                     fallback_reason=None,
                 )
             else:
-                result = self._cuda_graph_runner.run(
+                result = runner.run(
                     codes,
                     eligible=graph_eligible,
                 )
@@ -954,6 +976,74 @@ class Code2WavScheduler(StreamingVocoderBase[Code2WavStreamState, "list[int]"]):
         return audio_samples, execution_metadata
 
 
+def _build_eos_cuda_graph_runner(
+    model: Any,
+    *,
+    baseline: Code2WavCudaGraphRunner,
+    device: torch.device,
+    total_gpu_memory_fraction: float | None,
+    max_frames: int,
+) -> Code2WavCudaGraphRunner | None:
+    baseline_stats = baseline.stats()
+    report: dict[str, Any] = {
+        "max_frames": max_frames,
+        "baseline_published_graph_count": baseline_stats["build"][
+            "published_graph_count"
+        ],
+        "optional_requested_keys": [],
+        "optional_published_keys": [],
+    }
+    runner = None
+    if not baseline_stats["enabled"]:
+        report["skip_reason"] = "baseline_disabled"
+    elif max_frames == 0:
+        report["skip_reason"] = "existing_keys_only"
+    else:
+        keys = tuple(
+            GraphKey(batch_size=1, frames=frames)
+            for frames in range(1, max_frames + 1)
+            if 1 not in baseline.available_batch_sizes(frames)
+        )
+        memory = baseline_stats["memory"]
+        remaining = max(
+            0,
+            memory["stage_budget_bytes"]
+            - memory["loaded_model_footprint_bytes"]
+            - memory["graph_footprint_bytes"],
+        )
+        report.update(
+            baseline_graph_footprint_bytes=memory["graph_footprint_bytes"],
+            remaining_graph_budget_bytes=remaining,
+            optional_requested_keys=[
+                {"batch_size": key.batch_size, "frames": key.frames} for key in keys
+            ],
+        )
+        if not keys:
+            report["skip_reason"] = "no_missing_keys"
+        elif remaining == 0:
+            report["skip_reason"] = "no_remaining_graph_budget"
+        else:
+            runner = Code2WavCudaGraphRunner.build(
+                model,
+                device=device,
+                num_quantizers=int(model.config.num_quantizers),
+                total_gpu_memory_fraction=total_gpu_memory_fraction,
+                graph_keys=keys,
+                graph_memory_budget_bytes=remaining,
+            )
+            report["optional_runner"] = runner.stats()
+            report["optional_published_keys"] = [
+                {"batch_size": key.batch_size, "frames": key.frames}
+                for key in keys
+                if 1 in runner.available_batch_sizes(key.frames)
+            ]
+    logger.info(
+        "Code2Wav optional EOS graph startup stats=%s",
+        json.dumps(report, sort_keys=True, separators=(",", ":")),
+    )
+    return runner
+
+
 def create_code2wav_scheduler(
     model_path: str,
     *,
@@ -969,9 +1059,18 @@ def create_code2wav_scheduler(
     batch_ceiling: int = 8,
     enable_output_overlap: bool = True,
     enable_cuda_graph: bool = False,
+    enable_eos_cuda_graph: bool = False,
+    eos_cuda_graph_max_frames: int = 35,
     total_gpu_memory_fraction: float | None = None,
 ):
     """Factory: returns Code2WavScheduler."""
+    if enable_eos_cuda_graph and not enable_cuda_graph:
+        raise ValueError("EOS CUDA graph replay requires enable_cuda_graph")
+    if (
+        type(eos_cuda_graph_max_frames) is not int
+        or not 0 <= eos_cuda_graph_max_frames <= 48
+    ):
+        raise ValueError("eos_cuda_graph_max_frames must be an integer from 0 to 48")
     if enable_cuda_graph and total_gpu_memory_fraction is None:
         raise ValueError(
             "Code2Wav device graph requires gpu_memory_fraction "
@@ -987,6 +1086,7 @@ def create_code2wav_scheduler(
     left_context_size = max(int(left_context_size), 0)
     model = load_code2wav_model(model_path, device=device, dtype=dtype)
     cuda_graph_runner = None
+    eos_cuda_graph_runner = None
     if enable_cuda_graph:
         if enable_batching:
             graph_keys = _batched_graph_keys(
@@ -1025,6 +1125,14 @@ def create_code2wav_scheduler(
                 separators=(",", ":"),
             ),
         )
+        if enable_eos_cuda_graph:
+            eos_cuda_graph_runner = _build_eos_cuda_graph_runner(
+                model,
+                baseline=cuda_graph_runner,
+                device=concrete_device,
+                total_gpu_memory_fraction=total_gpu_memory_fraction,
+                max_frames=eos_cuda_graph_max_frames,
+            )
     return Code2WavScheduler(
         model,
         device=device,
@@ -1037,5 +1145,7 @@ def create_code2wav_scheduler(
         batch_ceiling=batch_ceiling,
         enable_output_overlap=enable_output_overlap,
         enable_cuda_graph=enable_cuda_graph,
+        enable_eos_cuda_graph=enable_eos_cuda_graph,
         _cuda_graph_runner=cuda_graph_runner,
+        _eos_cuda_graph_runner=eos_cuda_graph_runner,
     )

--- a/tests/unit_test/qwen3_omni/test_code2wav_eos48_graph.py
+++ b/tests/unit_test/qwen3_omni/test_code2wav_eos48_graph.py
@@ -1,0 +1,191 @@
+# SPDX-License-Identifier: Apache-2.0
+
+from types import SimpleNamespace
+
+import numpy as np
+import pytest
+import torch
+
+from sglang_omni.models.qwen3_omni.components import code2wav_scheduler as mod
+from sglang_omni.models.qwen3_omni.components.code2wav_cuda_graph import GraphKey
+from tests.unit_test.qwen3_omni.test_code2wav_cuda_graph import _codes
+from tests.unit_test.qwen3_omni.test_code2wav_eos_graph import (
+    BASE_KEYS,
+    _baseline,
+    _BorrowedRunner,
+    _MemoryBackend,
+    _optional,
+    _RecordingModel,
+    _state,
+)
+
+EXTRA48 = tuple(
+    GraphKey(1, frames)
+    for frames in range(1, 49)
+    if GraphKey(1, frames) not in BASE_KEYS
+)
+
+
+def test_wider_single_optional_pool_covers_contiguous_range_with_same_budget(
+    monkeypatch,
+):
+    model, baseline_backend, baseline = _baseline()
+    before = baseline.stats()
+    baseline_graphs = dict(baseline._graphs)
+    backend = _MemoryBackend(before=(140, 400), after=(180, 501))
+    optional, calls = _optional(monkeypatch, model, baseline, backend, max_frames=48)
+    assert len(calls) == 1
+    assert calls[0]["graph_keys"] == EXTRA48
+    assert len(EXTRA48) == 44
+    assert calls[0]["graph_memory_budget_bytes"] == 120
+    assert optional.stats()["build"]["published_graph_count"] == 44
+    assert optional.stats()["memory"]["graph_budget_bytes"] == 120
+    assert backend.capture_calls == 44
+    assert backend.warmup_iterations == [3] * 44
+    assert baseline.stats() == before
+    assert baseline._graphs == baseline_graphs
+    assert optional._pool is not baseline._pool
+    assert optional._capture_stream is not baseline._capture_stream
+    assert {
+        frames
+        for frames in range(1, 50)
+        if baseline.available_batch_sizes(frames)
+        or optional.available_batch_sizes(frames)
+    } == set(range(1, 49))
+    for offset in (1, 19, 1):
+        for key in (*BASE_KEYS, *EXTRA48):
+            target = baseline if key in BASE_KEYS else optional
+            target_backend = baseline_backend if key in BASE_KEYS else backend
+            codes = _codes(target_backend, key.batch_size, key.frames)
+            codes.add_(offset)
+            expected = model(codes).clone()
+            replay = target.run(codes)
+            assert replay.execution_mode == "cuda_graph"
+            assert torch.equal(replay.output, expected)
+
+
+@pytest.mark.parametrize("failure", ["oom", "equivalence", "replay", "budget"])
+def test_failure_at_expanded_tier_does_not_publish_partial_optional_coverage(
+    monkeypatch, failure
+):
+    model, baseline_backend, baseline = _baseline()
+    before = baseline.stats()
+    graphs = dict(baseline._graphs)
+    last_key = len(EXTRA48) - 1
+    backend = _MemoryBackend(
+        before=(140, 400),
+        after=(180, 540) if failure == "budget" else (180, 501),
+        capture_error_at=last_key if failure == "oom" else None,
+        corrupt_at=last_key if failure == "equivalence" else None,
+        replay_error_at=last_key if failure == "replay" else None,
+    )
+    optional, calls = _optional(monkeypatch, model, baseline, backend, max_frames=48)
+    assert calls[0]["graph_keys"] == EXTRA48
+    assert optional.stats()["enabled"] is False
+    assert optional.stats()["build"]["published_graph_count"] == 0
+    assert all(optional.available_batch_sizes(frames) == () for frames in range(1, 49))
+    assert baseline.stats() == before
+    assert baseline._graphs == graphs
+    assert baseline.available_batch_sizes(35) == (8, 4, 2, 1)
+    assert baseline.run(_codes(baseline_backend, 8, 35)).execution_mode == "cuda_graph"
+
+
+def _factory(monkeypatch, *, enabled=True, cap=48):
+    model = _RecordingModel()
+    model.config = SimpleNamespace(num_quantizers=2)
+    monkeypatch.setattr(mod, "load_code2wav_model", lambda *a, **k: model)
+    builds = []
+    runners = []
+
+    class _Builder:
+        @classmethod
+        def build(cls, model, **kwargs):
+            builds.append(kwargs)
+            runner = _BorrowedRunner(model, kwargs["graph_keys"])
+            stats = runner.stats()
+            stats.update(
+                build={"published_graph_count": len(runner._keys)},
+                memory={
+                    "stage_budget_bytes": 500,
+                    "loaded_model_footprint_bytes": 100,
+                    "graph_footprint_bytes": 280,
+                },
+            )
+            runner.stats = lambda: stats
+            runners.append(runner)
+            return runner
+
+    monkeypatch.setattr(mod, "Code2WavCudaGraphRunner", _Builder)
+    scheduler = mod.create_code2wav_scheduler(
+        "fake",
+        device="cpu",
+        stream_chunk_size=10,
+        left_context_size=25,
+        enable_batching=True,
+        batch_ceiling=8,
+        enable_cuda_graph=True,
+        enable_eos_cuda_graph=enabled,
+        eos_cuda_graph_max_frames=cap,
+        total_gpu_memory_fraction=0.5,
+    )
+    return scheduler, model, builds, runners
+
+
+@pytest.mark.parametrize("cap", [36, 48])
+def test_factory_accepts_expanded_cap_and_keeps_baseline_matrix(monkeypatch, cap):
+    scheduler, _, builds, _ = _factory(monkeypatch, cap=cap)
+    assert builds[0]["graph_keys"] == BASE_KEYS
+    assert "graph_memory_budget_bytes" not in builds[0]
+    assert len(builds) == 2
+    assert builds[1]["graph_keys"] == tuple(key for key in EXTRA48 if key.frames <= cap)
+    assert builds[1]["graph_memory_budget_bytes"] == 120
+    assert scheduler._enable_eos_cuda_graph is True
+    assert scheduler._chunk_aligned_dispatch is True
+
+
+@pytest.mark.parametrize("frames", range(36, 50))
+def test_expanded_final_windows_preserve_exact_inputs_samples_and_owned_output(
+    monkeypatch, frames
+):
+    snapshots = []
+    for enabled in (False, True):
+        scheduler, model, _, runners = _factory(monkeypatch, enabled=enabled)
+        state = _state(frames)
+        start = state.emitted
+        original_parts = len(state.audio_parts)
+        expected_codes = torch.stack(
+            state.chunks[start - min(start, 25) :]
+        ).T.unsqueeze(0)
+        waveform = scheduler.decode_delta("a", state, is_final=True)
+        saved = waveform.clone()
+        stored = state.audio_parts[-1].copy()
+        assert torch.equal(model.inputs[-1], expected_codes)
+        assert state.emitted == len(state.chunks)
+        assert len(state.audio_parts) == original_parts + 1
+        assert len(waveform) == min(frames * 4 - 1, (len(state.chunks) - start) * 4)
+        assert scheduler.decode_delta("a", state, is_final=True) is None
+        if enabled and frames <= 48:
+            assert runners[1].calls[-1] == ((1, 2, frames), True, "cuda_graph")
+            assert runners[0].calls == []
+        else:
+            assert runners[0].calls[-1][2] == "eager"
+            assert len(runners) == 1 or runners[1].calls == []
+        scheduler.decode_delta("b", _state(frames, offset=19), is_final=True)
+        assert torch.equal(waveform, saved)
+        np.testing.assert_array_equal(state.audio_parts[-1], stored)
+        snapshots.append((saved, model.inputs[0]))
+    assert torch.equal(snapshots[0][0], snapshots[1][0])
+    assert torch.equal(snapshots[0][1], snapshots[1][1])
+
+
+def test_expansion_still_excludes_nonfinal_and_batched_requests(monkeypatch):
+    scheduler, _, _, runners = _factory(monkeypatch)
+    scheduler.decode_delta("a", _state(48), is_final=False)
+    assert runners[1].calls == []
+    assert runners[0].calls[-1] == ((1, 2, 48), True, "eager")
+    batched = torch.arange(2 * 2 * 48).reshape(2, 2, 48)
+    _, execution = scheduler._forward_codes(batched, graph_eligible=True, is_final=True)
+    assert execution["execution_mode"] == "eager"
+    assert execution["fallback_reason"] == "key_miss"
+    assert runners[1].calls == []
+    assert runners[0].calls[-1] == ((2, 2, 48), True, "eager")

--- a/tests/unit_test/qwen3_omni/test_code2wav_eos_graph.py
+++ b/tests/unit_test/qwen3_omni/test_code2wav_eos_graph.py
@@ -1,0 +1,394 @@
+# SPDX-License-Identifier: Apache-2.0
+
+import json
+from types import SimpleNamespace
+
+import numpy as np
+import pytest
+import torch
+
+from sglang_omni.models.qwen3_omni.components import code2wav_scheduler as mod
+from sglang_omni.models.qwen3_omni.components.code2wav_cuda_graph import (
+    Code2WavCudaGraphRunner,
+    Code2WavRunResult,
+    GraphKey,
+)
+from tests.unit_test.fixtures.qwen_fakes import FakeCode2WavModel, make_qwen_payload
+from tests.unit_test.qwen3_omni.test_code2wav_batching import _FakeGraphRunner
+from tests.unit_test.qwen3_omni.test_code2wav_cuda_graph import (
+    _codes,
+    _FakeCudaBackend,
+    _FakeModel,
+)
+
+BASE_KEYS = mod._batched_graph_keys(10, 25, 8)
+EXTRA_KEYS = tuple(
+    GraphKey(1, n) for n in range(1, 36) if GraphKey(1, n) not in BASE_KEYS
+)
+
+
+class _MemoryBackend(_FakeCudaBackend):
+    def __init__(self, *, before=(100, 120), after=(140, 400), **kwargs):
+        super().__init__(**kwargs)
+        self.before = before
+        self.after = after
+        self.snapshots = 0
+
+    def memory_stats(self, device):
+        del device
+        allocated, reserved = self.before if self.snapshots == 0 else self.after
+        self.snapshots += 1
+        return dict(
+            allocated_bytes=allocated,
+            reserved_bytes=reserved,
+            max_reserved_bytes=reserved,
+            free_bytes=1000 - reserved,
+            total_bytes=1000,
+        )
+
+
+def _baseline():
+    model = _FakeModel()
+    model.config = SimpleNamespace(num_quantizers=16)
+    backend = _MemoryBackend()
+    runner = Code2WavCudaGraphRunner.build(
+        model,
+        device="cuda:0",
+        num_quantizers=16,
+        total_gpu_memory_fraction=0.5,
+        graph_keys=BASE_KEYS,
+        device_api=backend,
+    )
+    assert runner.stats()["build"]["published_graph_count"] == 16
+    return model, backend, runner
+
+
+def _optional(monkeypatch, model, baseline, backend, *, max_frames=35):
+    captured = []
+
+    class _Builder:
+        @classmethod
+        def build(cls, model, **kwargs):
+            captured.append(kwargs)
+            return Code2WavCudaGraphRunner.build(model, device_api=backend, **kwargs)
+
+    monkeypatch.setattr(mod, "Code2WavCudaGraphRunner", _Builder)
+    optional = mod._build_eos_cuda_graph_runner(
+        model,
+        baseline=baseline,
+        device=torch.device("cuda:0"),
+        total_gpu_memory_fraction=0.5,
+        max_frames=max_frames,
+    )
+    return optional, captured
+
+
+def test_optional_pool_captures_only_missing_keys_and_charges_reserved_baseline(
+    monkeypatch,
+):
+    model, baseline_backend, baseline = _baseline()
+    before = baseline.stats()
+    graph_objects = dict(baseline._graphs)
+    backend = _MemoryBackend(before=(140, 400), after=(180, 501))
+    optional, calls = _optional(monkeypatch, model, baseline, backend)
+    assert len(calls) == 1
+    assert calls[0]["graph_keys"] == EXTRA_KEYS
+    assert len(EXTRA_KEYS) == 31
+    assert calls[0]["graph_memory_budget_bytes"] == 120
+    assert optional.stats()["memory"]["graph_budget_bytes"] == 120
+    assert optional.stats()["build"]["published_graph_count"] == 31
+    assert baseline.stats() == before
+    assert baseline._graphs == graph_objects
+    assert baseline._pool is not optional._pool
+    assert baseline._capture_stream is not optional._capture_stream
+    assert backend.capture_calls == 31
+    assert backend.warmup_iterations == [3] * 31
+    for generation in (1, 2):
+        for key in (*BASE_KEYS, *EXTRA_KEYS):
+            target = baseline if key in BASE_KEYS else optional
+            target_backend = baseline_backend if key in BASE_KEYS else backend
+            codes = _codes(target_backend, key.batch_size, key.frames)
+            codes.add_(generation)
+            expected = model(codes).clone()
+            replay = target.run(codes)
+            assert replay.execution_mode == "cuda_graph"
+            assert torch.equal(replay.output, expected)
+
+
+@pytest.mark.parametrize("failure", ["oom", "equivalence", "replay", "budget"])
+def test_optional_startup_failure_preserves_baseline_graphs_and_batching(
+    monkeypatch, failure
+):
+    model, baseline_backend, baseline = _baseline()
+    before = baseline.stats()
+    graphs = dict(baseline._graphs)
+    backend = _MemoryBackend(
+        before=(140, 400),
+        after=(180, 540) if failure == "budget" else (180, 501),
+        capture_error_at=0 if failure == "oom" else None,
+        corrupt_at=0 if failure == "equivalence" else None,
+        replay_error_at=0 if failure == "replay" else None,
+    )
+    optional, _ = _optional(monkeypatch, model, baseline, backend)
+    assert optional.stats()["enabled"] is False
+    assert optional.stats()["build"]["published_graph_count"] == 0
+    assert baseline.stats() == before
+    assert baseline._graphs == graphs
+    assert baseline.available_batch_sizes(35) == (8, 4, 2, 1)
+    assert baseline.run(_codes(baseline_backend, 8, 35)).execution_mode == "cuda_graph"
+    assert baseline.run(_codes(baseline_backend, 1, 30)).execution_mode == "cuda_graph"
+    assert optional.available_batch_sizes(34) == ()
+
+
+def test_existing_keys_only_does_not_build_optional_pool(monkeypatch):
+    model, _, baseline = _baseline()
+    optional, calls = _optional(
+        monkeypatch, model, baseline, _MemoryBackend(), max_frames=0
+    )
+    assert optional is None
+    assert calls == []
+
+
+@pytest.mark.parametrize("reason", ["baseline_disabled", "no_remaining_graph_budget"])
+def test_unavailable_baseline_or_budget_never_captures_optional(monkeypatch, reason):
+    model, _, baseline = _baseline()
+    stats = baseline.stats()
+    if reason == "baseline_disabled":
+        stats["enabled"] = False
+    else:
+        stats["memory"]["graph_footprint_bytes"] = 400
+    monkeypatch.setattr(baseline, "stats", lambda: stats)
+    optional, calls = _optional(monkeypatch, model, baseline, _MemoryBackend())
+    assert optional is None
+    assert calls == []
+
+
+@pytest.mark.parametrize("cap", [-1, True, 1.5])
+def test_runner_rejects_invalid_memory_cap_before_capture(cap):
+    backend = _MemoryBackend()
+    with pytest.raises(ValueError, match="nonnegative integer"):
+        Code2WavCudaGraphRunner.build(
+            _FakeModel(),
+            device="cuda:0",
+            num_quantizers=16,
+            total_gpu_memory_fraction=0.5,
+            graph_keys=EXTRA_KEYS,
+            graph_memory_budget_bytes=cap,
+            device_api=backend,
+        )
+    assert backend.capture_calls == 0
+
+
+class _RecordingModel(FakeCode2WavModel):
+    def __init__(self):
+        super().__init__(total_upsample=4, output_deficit=1)
+        self.inputs = []
+
+    def __call__(self, codes):
+        self.inputs.append(codes.clone())
+        return super().__call__(codes)
+
+
+class _BorrowedRunner(_FakeGraphRunner):
+    def __init__(self, model, keys):
+        super().__init__(model, keys)
+        self.buffers = {}
+
+    def run(self, codes, *, eligible):
+        result = super().run(codes, eligible=eligible)
+        if result.execution_mode != "cuda_graph":
+            return result
+        buffer = self.buffers.setdefault(result.key, torch.empty_like(result.output))
+        buffer.copy_(result.output)
+        return Code2WavRunResult(
+            buffer, result.execution_mode, result.key, result.fallback_reason
+        )
+
+
+def _scheduler(*, enabled=True, optional=True):
+    model = _RecordingModel()
+    baseline = _BorrowedRunner(model, BASE_KEYS)
+    extra = _BorrowedRunner(model, EXTRA_KEYS if optional else ())
+    scheduler = mod.Code2WavScheduler(
+        model,
+        device="cpu",
+        stream_chunk_size=10,
+        left_context_size=25,
+        enable_batching=True,
+        batch_ceiling=8,
+        enable_cuda_graph=True,
+        enable_eos_cuda_graph=enabled,
+        _cuda_graph_runner=baseline,
+        _eos_cuda_graph_runner=extra,
+    )
+    return scheduler, model, baseline, extra
+
+
+def _state(window_frames, *, offset=0):
+    start = 52 if window_frames > 25 else 0
+    context = min(start, 25)
+    end = start + window_frames - context
+    return mod.Code2WavStreamState(
+        chunks=[
+            torch.tensor([(i + offset) % 2048, (3 * i + offset) % 2048])
+            for i in range(end)
+        ],
+        emitted=start,
+        checked=end,
+        stream_enabled=True,
+        audio_parts=[np.arange(3, dtype=np.float32)] if start else [],
+    )
+
+
+@pytest.mark.parametrize("window_frames", range(1, 48))
+def test_final_replay_preserves_exact_context_tail_samples_and_saved_output(
+    window_frames,
+):
+    snapshots = []
+    for enabled in (False, True):
+        scheduler, model, baseline, optional = _scheduler(enabled=enabled)
+        state = _state(window_frames)
+        start = state.emitted
+        original_parts = len(state.audio_parts)
+        expected_codes = torch.stack(
+            state.chunks[start - min(start, 25) :]
+        ).T.unsqueeze(0)
+        waveform = scheduler.decode_delta("a", state, is_final=True)
+        saved = waveform.clone()
+        stored = state.audio_parts[-1].copy()
+        assert torch.equal(model.inputs[-1], expected_codes)
+        assert state.emitted == len(state.chunks)
+        assert len(state.audio_parts) == original_parts + 1
+        assert len(waveform) == min(
+            window_frames * 4 - 1, (len(state.chunks) - start) * 4
+        )
+        assert scheduler.decode_delta("a", state, is_final=True) is None
+        if enabled and GraphKey(1, window_frames) in EXTRA_KEYS:
+            assert optional.calls[-1] == ((1, 2, window_frames), True, "cuda_graph")
+            assert baseline.calls == []
+        else:
+            expected_mode = (
+                "cuda_graph"
+                if enabled and GraphKey(1, window_frames) in BASE_KEYS
+                else "eager"
+            )
+            assert baseline.calls[-1][2] == expected_mode
+            assert optional.calls == []
+        scheduler.decode_delta("b", _state(window_frames, offset=19), is_final=True)
+        assert torch.equal(waveform, saved)
+        np.testing.assert_array_equal(state.audio_parts[-1], stored)
+        snapshots.append((saved, model.inputs[0]))
+    assert torch.equal(snapshots[0][0], snapshots[1][0])
+    assert torch.equal(snapshots[0][1], snapshots[1][1])
+
+
+def test_nonfinal_never_routes_optional_and_disabled_optional_preserves_fallback():
+    scheduler, _, baseline, optional = _scheduler()
+    scheduler.decode_delta("a", _state(34), is_final=False)
+    assert optional.calls == []
+    assert baseline.calls[-1] == ((1, 2, 34), True, "eager")
+    scheduler, _, baseline, optional = _scheduler(optional=False)
+    for frames in (30, 34, 35, 36):
+        scheduler.decode_delta(str(frames), _state(frames), is_final=True)
+    assert optional.calls == []
+    assert [call[2] for call in baseline.calls] == [
+        "cuda_graph",
+        "eager",
+        "cuda_graph",
+        "eager",
+    ]
+
+
+def test_stream_done_emits_owned_tail_before_terminal_result():
+    scheduler, _, _, optional = _scheduler()
+    state = _state(34)
+    scheduler._stream_states["a"] = state
+    scheduler._stream_payloads["a"] = make_qwen_payload(request_id="a")
+    messages = scheduler.on_stream_done("a")
+    assert [message.type for message in messages] == ["stream", "result"]
+    assert len(optional.calls) == 1
+    assert state.emitted == len(state.chunks)
+    assert scheduler.decode_delta("a", state, is_final=True) is None
+
+
+@pytest.mark.parametrize("enabled", [False, True])
+def test_factory_leaves_baseline_matrix_unchanged_and_plumbs_eos_flag(
+    monkeypatch, enabled, caplog
+):
+    caplog.set_level("INFO", logger=mod.__name__)
+    model = _RecordingModel()
+    model.config = SimpleNamespace(num_quantizers=2)
+    monkeypatch.setattr(mod, "load_code2wav_model", lambda *a, **k: model)
+    builds = []
+
+    class _Builder:
+        @classmethod
+        def build(cls, model, **kwargs):
+            builds.append(kwargs)
+            runner = _FakeGraphRunner(model, kwargs["graph_keys"])
+            stats = runner.stats()
+            stats.update(
+                build={"published_graph_count": len(runner._keys)},
+                memory={
+                    "stage_budget_bytes": 500,
+                    "loaded_model_footprint_bytes": 100,
+                    "graph_footprint_bytes": 280,
+                },
+            )
+            runner.stats = lambda: stats
+            return runner
+
+    monkeypatch.setattr(mod, "Code2WavCudaGraphRunner", _Builder)
+    scheduler = mod.create_code2wav_scheduler(
+        "fake",
+        device="cpu",
+        stream_chunk_size=10,
+        left_context_size=25,
+        enable_batching=True,
+        batch_ceiling=8,
+        enable_cuda_graph=True,
+        enable_eos_cuda_graph=enabled,
+        total_gpu_memory_fraction=0.5,
+    )
+    assert builds[0]["graph_keys"] == BASE_KEYS
+    assert "graph_memory_budget_bytes" not in builds[0]
+    assert len(builds) == (2 if enabled else 1)
+    assert scheduler._enable_eos_cuda_graph is enabled
+    assert scheduler._chunk_aligned_dispatch is True
+    if enabled:
+        assert builds[1]["graph_keys"] == EXTRA_KEYS
+        assert builds[1]["graph_memory_budget_bytes"] == 120
+    baseline_messages = [
+        m
+        for m in caplog.messages
+        if m.startswith("Code2Wav device graph startup stats=")
+    ]
+    optional_messages = [
+        m
+        for m in caplog.messages
+        if m.startswith("Code2Wav optional EOS graph startup stats=")
+    ]
+    assert len(baseline_messages) == 1
+    assert len(optional_messages) == int(enabled)
+    if enabled:
+        report = json.loads(optional_messages[0].split("stats=", 1)[1])
+        assert report["baseline_published_graph_count"] == 16
+        assert report["optional_published_keys"] == report["optional_requested_keys"]
+        assert len(report["optional_published_keys"]) == 31
+
+
+@pytest.mark.parametrize(
+    "kwargs",
+    [
+        {"enable_eos_cuda_graph": True},
+        {"eos_cuda_graph_max_frames": -1},
+        {"eos_cuda_graph_max_frames": 49},
+        {"eos_cuda_graph_max_frames": True},
+    ],
+)
+def test_factory_rejects_invalid_opt_in_before_loading(monkeypatch, kwargs):
+    monkeypatch.setattr(
+        mod, "load_code2wav_model", lambda *a, **k: pytest.fail("loaded model")
+    )
+    with pytest.raises(ValueError):
+        mod.create_code2wav_scheduler("fake", device="cpu", **kwargs)


### PR DESCRIPTION
<!-- Thank you for your contribution! We appreciate it. The following guidelines will help improve your pull request and facilitate feedback. If anything is unclear, don't hesitate to submit your pull request and ask the maintainers for assistance. -->

## Motivation

<!-- Explain the purpose of this PR and the goals it aims to achieve. -->

Code2Wav runs final audio windows eagerly, including shapes already covered by its CUDA graphs. Add an opt-in path for exact final-window replay while preserving audio context, tail length, and output ownership.

## Modifications

<!-- Describe the changes made in this PR. -->

- Keep EOS graph replay disabled by default. When enabled, reuse baseline keys and optionally capture missing batch-1 widths through `eos_cuda_graph_max_frames` (default 35; supported range 0–48).
- Charge the optional pool against the stage memory budget remaining after the baseline footprint. Optional capture failure preserves baseline graphs and eager fallback. Runtime replay exceptions retain the existing disable-and-propagate behavior; the failing request is not retried eagerly.
- Preserve main's graph matrix and batching policy. Final audio is copied before later replay can overwrite graph output. Add tests for routing, ownership, budget limits, and failure isolation.

## Related Issues

<!-- Link to any related issues here. e.g. "Fixes #123" or "Closes #456" -->

None linked.

## Accuracy Test

<!-- If this PR affects model-side code (e.g., kernels, model architecture), please provide accuracy test results. Ref: https://docs.sglang.io/docs/developer_guide/evaluating_new_models -->

**CPU: 167 passed, 3 accelerator tests deselected.**

```bash
python -B -m pytest \
  tests/unit_test/qwen3_omni/test_code2wav_eos_graph.py \
  tests/unit_test/qwen3_omni/test_code2wav_eos48_graph.py \
  tests/unit_test/qwen3_omni/test_code2wav_cuda_graph.py \
  tests/unit_test/qwen3_omni/test_code2wav_batching.py \
  -m 'not accelerator' -q --disable-warnings --tb=short
```

The graph tests use a fake CUDA backend. **This main-based commit has not been tested with a real checkpoint on GPU.** GPU numerical parity, natural-EOS behavior, and audio quality remain unmeasured.

Targeted Black 24.10.0 and isort 5.13.2 checks passed on the four changed files using existing cached environments; `git diff --check` passed. The full local pre-commit suite was not run. GitHub lint, docs, test-layout, playback-test, and XPU change detection passed on `e5131815`. Omni/XPU admission gates block this Draft PR, so model/device jobs were skipped; main-based GPU validation remains unmeasured.

## Benchmark & Profiling

<!-- If this PR is expected to impact performance, please provide benchmark and profiling results. Ref: https://docs.sglang.io/docs/developer_guide/benchmark_and_profiling -->

**No main-based GPU benchmark or profiling result is available; no main performance gain is claimed.** Earlier component, serving, and quality results on the separate cumulative L5 branch do not qualify this commit.

With batching enabled, ceiling 8, 10-frame chunks, 25-frame context, and full baseline publication, cap 48 requests 16 baseline + 44 optional keys. Factory-default serial mode requests 4 + 44. Actual startup stats determine available keys. Capture cost, retained memory, graph activation, and matched serving latency/throughput still require measurement on this commit.

## Checklist

- [ ] Format your code according with pre-commit.
- [x] Add unit tests.
- [ ] Update documentation / docstrings / example tutorials as needed.
- [ ] Provide throughput / latency benchmark results and accuracy evaluation results as needed.
- [ ] For reviewers: If you haven't made any contributions to this PR and are only assisting with merging the main branch, please remove yourself as a co-author when merging the PR.

## CI

CI runs on self-hosted GPU runners and requires a maintainer to add the
`run-ci` label. Once labeled, every subsequent push re-triggers CI as
long as the label remains. Use `/tag-and-rerun-ci higgs` or
`/tag-and-rerun-ci moss` or `/tag-and-rerun-ci qwen3-tts` to select a TTS CI
model, and
`/tag-and-rerun-ci fun-asr`, `/tag-and-rerun-ci qwen3-asr` or
`/tag-and-rerun-ci whisper-asr` to select an ASR CI model. One selector from
each family can be combined, for example `/tag-and-rerun-ci moss fun-asr`.
Draft PRs are skipped even if labeled.
