### PR TITLE
[MiniMax Music3] Add request-serial CUDA and MLX stage offload

### DIFF
--- a/docs/cookbook/minimax_music3.md
+++ b/docs/cookbook/minimax_music3.md
@@ -31,6 +31,40 @@ source .venv/bin/activate
 uv pip install -v -e .   # drop -e for a non-editable install
 ```
 
+### Apple Silicon (MLX)
+
+On Apple Silicon, set `SGLANG_USE_MLX=1` and serve a converted MLX artifact.
+The artifact contains the Qwen3/RVQ, Flow/DiT, DAV weights, and tokenizer, so
+the official modular PyTorch checkpoint is not loaded by this path.
+
+```bash
+SGLANG_USE_MLX=1 sgl-omni serve \
+  --model-path mlx-community/MiniMax-Music3-mxfp8 \
+  --port 8000
+```
+
+`mlx-community/MiniMax-Music3-mxfp8` is the recommended balance of memory and
+lyric fidelity. BF16, affine 8/6/4-bit, MXFP4, and NVFP4 conversions using the
+same `mlx-audio` artifact layout are also accepted. For a reproducible
+snapshot, pass revision `d00a12c3c7f80eb66379dd02dd0f30ed0ce2d96e` to both
+stages:
+
+```bash
+SGLANG_USE_MLX=1 sgl-omni serve \
+  --model-path mlx-community/MiniMax-Music3-mxfp8 \
+  --minimax_music3_ar.factory.mlx_model_revision \
+    d00a12c3c7f80eb66379dd02dd0f30ed0ce2d96e \
+  --dit_dav.factory.mlx_model_revision \
+    d00a12c3c7f80eb66379dd02dd0f30ed0ce2d96e \
+  --port 8000
+```
+
+The MLX path currently processes one song at a time. It keeps the same
+two-stage hidden-chunk contract and 32 kHz stereo response as CUDA, but does
+not use CUDA graphs, `torch.compile`, Cache-DiT, or breakable CUDA graphs.
+The implementation is native to SGLang-Omni at runtime; `mlx-audio` is an
+implementation and artifact-format reference, not a dependency.
+
 **Single GPU** (colocate both stages):
 
 ```bash

--- a/docs/cookbook/minimax_music3.md
+++ b/docs/cookbook/minimax_music3.md
@@ -81,6 +81,36 @@ Default optimizations that are on without further flags: backbone decode CUDA gr
 
 Classifier-free guidance is on in both stages and has no flag. See [Guidance](#guidance) for what it costs you, because the AR half changes how much a request occupies.
 
+### Low-memory stage offload
+
+Stage offload is opt-in and requires the single-device layout. It admits one
+song request for its complete AR-to-acoustic lifetime. On CUDA, immutable CPU
+weights remain canonical while the active stage has a GPU replica. On MLX, the
+inactive model is released and later reloaded from the local artifact snapshot.
+
+```bash
+# CUDA
+CUDA_VISIBLE_DEVICES=0 sgl-omni serve \
+  --model-path MiniMaxAI/MiniMax-Music3 \
+  --stage-offload-components ar,dit \
+  --port 8000
+
+# Apple Silicon
+SGLANG_USE_MLX=1 sgl-omni serve \
+  --model-path mlx-community/MiniMax-Music3-mxfp8 \
+  --stage-offload-components ar,dit \
+  --port 8000
+```
+
+This mode trades stage-switch latency and host/file-cache traffic for lower
+active accelerator memory. CUDA graph replay and compiled acoustic blocks are
+disabled only in this mode because parameter addresses change across
+transitions. MLX keeps tokenizer/config metadata resident, resolves the remote
+revision once per stage at startup, keeps acoustic weights loaded across all
+chunks of a request, and clears them only after terminal cleanup. Logs report
+CUDA allocated/reserved/device-free memory and MLX active/cache memory at
+transitions; allocator counters are not the same as whole-system memory use.
+
 ## Generating Music
 
 Two fields carry the request. `input` is the lyrics; `instructions` is the caption that describes style, instrumentation, tempo and mood. Both are required, and both matter: the caption is what decides genre and arrangement, and the lyrics are what gets sung.

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -34,8 +34,8 @@ dependencies = [
     # note (yexiaodong): SGLang's PyPI wheel has unconditional CUDA dependencies,
     # so Apple Silicon installs this exact tag from source with the all_mps extra.
     "sglang==0.5.18; sys_platform != 'darwin' or platform_machine != 'arm64'",
-    "mlx; sys_platform == 'darwin' and platform_machine == 'arm64'",
-    "mlx-lm; sys_platform == 'darwin' and platform_machine == 'arm64'",
+    "mlx>=0.32.1; sys_platform == 'darwin' and platform_machine == 'arm64'",
+    "mlx-lm>=0.31.3; sys_platform == 'darwin' and platform_machine == 'arm64'",
     "flashinfer_python[cu13]==0.6.17; sys_platform != 'darwin' or platform_machine != 'arm64'",  # sglang pin. Do NOT add flashinfer-cubin: PyPI has no matching cubin, and any leftover cubin wheel fails MiniMax DIT import.
     "cache-dit==1.3.0",      # MiniMax Music 3 DIT (hard import, not optional)
     "addict==2.4.0",         # sglang.multimodal_gen server_args; MiniMax DIT import
@@ -66,7 +66,8 @@ dependencies = [
     "mistral_common[audio]>=1.11.0",
     # /v1/realtime — server-side turn detection
     "silero-vad>=5.1",
-    "onnxruntime-gpu>=1.17",  # CUDAExecutionProvider for the FP32 Smart Turn model
+    "onnxruntime-gpu>=1.17; sys_platform != 'darwin' or platform_machine != 'arm64'",  # CUDAExecutionProvider for the FP32 Smart Turn model
+    "onnxruntime>=1.17; sys_platform == 'darwin' and platform_machine == 'arm64'",
     "websockets>=12.0",       # FastAPI WebSocket library + example clients
     # Testing
     "pytest>=7.0.0",

--- a/sglang_omni/cli/serve.py
+++ b/sglang_omni/cli/serve.py
@@ -251,6 +251,71 @@ def apply_tensor_parallel_engine_overrides(
     return config_cls(**data)
 
 
+def _parse_stage_offload_components(value: str | None) -> frozenset[str]:
+    if value is None:
+        return frozenset()
+    components = frozenset(
+        part.strip().lower() for part in value.split(",") if part.strip()
+    )
+    if not components:
+        raise typer.BadParameter("--stage-offload-components must not be empty")
+    return components
+
+
+def apply_stage_offload_cli_overrides(
+    pipeline_config: PipelineConfig,
+    *,
+    stage_offload_components: str | None,
+) -> PipelineConfig:
+    components = _parse_stage_offload_components(stage_offload_components)
+    if not components:
+        return pipeline_config
+
+    role_to_stage = type(pipeline_config).stage_offload_role_to_stage()
+    if not role_to_stage:
+        raise typer.BadParameter(
+            "--stage-offload-components is not supported by this pipeline"
+        )
+
+    unknown = components - role_to_stage.keys()
+    if unknown:
+        raise typer.BadParameter(
+            "--stage-offload-components does not support: "
+            f"{', '.join(sorted(unknown))}; supported: "
+            f"{', '.join(sorted(role_to_stage))}"
+        )
+    missing = role_to_stage.keys() - components
+    if missing:
+        raise typer.BadParameter(
+            "--stage-offload-components currently requires all of: "
+            f"{', '.join(sorted(role_to_stage))} (missing "
+            f"{', '.join(sorted(missing))})"
+        )
+
+    ar_stage = pipeline_config.stage_named(role_to_stage["ar"])
+    dit_stage = pipeline_config.stage_named(role_to_stage["dit"])
+    if ar_stage.gpu != dit_stage.gpu:
+        raise typer.BadParameter(
+            "--stage-offload-components ar,dit requires the "
+            f"{ar_stage.name!r} and {dit_stage.name!r} stages on the same GPU "
+            f"(currently {ar_stage.gpu!r} and {dit_stage.gpu!r}); use the "
+            "'single-gpu' config variant"
+        )
+
+    config_cls = type(pipeline_config)
+    data = pipeline_config.model_dump()
+    process = ar_stage.process or ar_stage.name
+    writes: dict[str, object] = {
+        f"stages.{ar_stage.name}.process": process,
+        f"stages.{dit_stage.name}.process": process,
+        f"stages.{ar_stage.name}.factory.enable_serial_offload": True,
+        f"stages.{dit_stage.name}.factory.enable_serial_offload": True,
+    }
+    for path_text, value in writes.items():
+        ConfigPath.parse(path_text, config_cls).write(data, value)
+    return config_cls(**data)
+
+
 def serve(
     ctx: typer.Context,
     model_path: Annotated[
@@ -325,6 +390,17 @@ def serve(
                 "A dotted per-stage flag (--<stage>.engine.mem_fraction_static) "
                 "overrides this for that stage. If omitted, SGLang chooses "
                 "the value automatically."
+            ),
+        ),
+    ] = None,
+    stage_offload_components: Annotated[
+        str | None,
+        typer.Option(
+            "--stage-offload-components",
+            "--stage_offload_components",
+            help=(
+                "Comma-separated components to run request-serially, each "
+                "offloading itself from the GPU before the next one runs."
             ),
         ),
     ] = None,
@@ -414,6 +490,10 @@ def serve(
         raise typer.BadParameter(str(exc)) from exc
     if colocate:
         _validate_colocate_config(merged_config)
+    merged_config = apply_stage_offload_cli_overrides(
+        merged_config,
+        stage_offload_components=stage_offload_components,
+    )
     merged_config = apply_tensor_parallel_engine_overrides(merged_config)
 
     if _should_print_merged_config(colocate=colocate, log_level=log_level):

--- a/sglang_omni/cli/serve.py
+++ b/sglang_omni/cli/serve.py
@@ -271,7 +271,10 @@ def apply_stage_offload_cli_overrides(
     if not components:
         return pipeline_config
 
-    role_to_stage = type(pipeline_config).stage_offload_role_to_stage()
+    role_to_stage_fn = getattr(
+        type(pipeline_config), "stage_offload_role_to_stage", None
+    )
+    role_to_stage = role_to_stage_fn() if role_to_stage_fn is not None else {}
     if not role_to_stage:
         raise typer.BadParameter(
             "--stage-offload-components is not supported by this pipeline"

--- a/sglang_omni/config/schema.py
+++ b/sglang_omni/config/schema.py
@@ -735,6 +735,11 @@ class PipelineConfig(BaseModel):
         return {}
         return {}
 
+    @classmethod
+    def stage_offload_role_to_stage(cls) -> dict[str, str]:
+        """Map serial-offload component roles to stage names."""
+        return {}
+
     def resolved_env_defaults(self) -> dict[str, str]:
         """Process-environment defaults, evaluated at launch.
 

--- a/sglang_omni/config/schema.py
+++ b/sglang_omni/config/schema.py
@@ -735,11 +735,6 @@ class PipelineConfig(BaseModel):
         return {}
         return {}
 
-    @classmethod
-    def stage_offload_role_to_stage(cls) -> dict[str, str]:
-        """Map serial-offload component roles to stage names."""
-        return {}
-
     def resolved_env_defaults(self) -> dict[str, str]:
         """Process-environment defaults, evaluated at launch.
 

--- a/sglang_omni/models/minimax_music3/README.md
+++ b/sglang_omni/models/minimax_music3/README.md
@@ -3,6 +3,14 @@
 Text-to-music: a Qwen3 backbone with an eight-codebook RVQ frame, followed by a
 flow-matching DIT and a DAC decoder. Output is 32 kHz stereo.
 
+On Apple Silicon, use the native MLX path with a converted artifact:
+
+```bash
+SGLANG_USE_MLX=1 sgl-omni serve \
+  --model-path mlx-community/MiniMax-Music3-mxfp8 \
+  --port 8000
+```
+
 ```bash
 # Single GPU
 CUDA_VISIBLE_DEVICES=0 sgl-omni serve --model-path MiniMaxAI/MiniMax-Music3 --port 8000

--- a/sglang_omni/models/minimax_music3/README.md
+++ b/sglang_omni/models/minimax_music3/README.md
@@ -32,6 +32,13 @@ in FP32. Defaults that are on without further flags: backbone decode
 CUDA graph, RVQ depth CUDA graph, compiled DIT blocks, compiled DAV decoder,
 and batched seeded sampling.
 
+For a lower-memory single-device mode, add
+`--stage-offload-components ar,dit`. This serializes the complete song request
+lifecycle. CUDA keeps canonical CPU weights and only the active stage's GPU
+replica; MLX reloads the active stage from its resolved local artifact. The
+tradeoff is stage-switch latency, and CUDA graphs/compiled acoustic blocks are
+disabled while offload is enabled.
+
 ```bash
 curl -X POST http://localhost:8000/v1/audio/speech \
   -H 'Content-Type: application/json' \

--- a/sglang_omni/models/minimax_music3/acoustic.py
+++ b/sglang_omni/models/minimax_music3/acoustic.py
@@ -36,7 +36,6 @@ from .constants import (
     SUPPORTED_ACOUSTIC_DTYPES,
 )
 from .dav import MiniMaxMusic3DAV, remove_weight_norm, select_decoder_state
-from .dit import MiniMaxMusic3DIT
 from .payload_types import MiniMaxMusic3State
 
 logger = logging.getLogger(__name__)
@@ -209,6 +208,8 @@ class MiniMaxMusic3AcousticDecoder:
         cache_dit_residual_diff_threshold: float,
         cache_dit_max_continuous_cached_steps: int,
     ) -> None:
+        from .dit import MiniMaxMusic3DIT
+
         logger.info(
             f"Loading MiniMax Music 3 PyTorch DIT from {dit_path} on device={self.device} dtype={self.dtype}"
         )
@@ -316,8 +317,8 @@ class _AcousticStreamState:
     final_state: MiniMaxMusic3State | None = None
     wave_chunks: list[Tensor] = field(default_factory=list)
     hidden_frames: int = 0
-    last_latent: Tensor | None = None
-    last_condition: Tensor | None = None
+    last_latent: Any | None = None
+    last_condition: Any | None = None
     started_at: float = field(default_factory=time.perf_counter)
     abort_event: threading.Event = field(default_factory=threading.Event)
     next_chunk_idx: int = 0
@@ -329,7 +330,7 @@ class MiniMaxMusic3AcousticScheduler(StreamingSimpleScheduler):
 
     def __init__(
         self,
-        decoder: MiniMaxMusic3AcousticDecoder,
+        decoder: Any,
     ) -> None:
         self._decoder = decoder
         self._stream_states: dict[str, _AcousticStreamState] = {}

--- a/sglang_omni/models/minimax_music3/acoustic.py
+++ b/sglang_omni/models/minimax_music3/acoustic.py
@@ -37,6 +37,7 @@ from .constants import (
 )
 from .dav import MiniMaxMusic3DAV, remove_weight_norm, select_decoder_state
 from .payload_types import MiniMaxMusic3State
+from .serial_offload import StageResidency, get_coordinator
 
 logger = logging.getLogger(__name__)
 
@@ -130,6 +131,7 @@ class MiniMaxMusic3AcousticDecoder:
         cache_dit_max_warmup_steps: int = 4,
         cache_dit_residual_diff_threshold: float = 0.08,
         cache_dit_max_continuous_cached_steps: int = 1,
+        serial_offload: bool = False,
     ) -> None:
         if not (current_platform.is_cuda() or current_platform.is_musa()):
             raise RuntimeError(
@@ -161,6 +163,30 @@ class MiniMaxMusic3AcousticDecoder:
             "breakable_cuda_graph", breakable_cuda_graph
         )
         self.breakable_cuda_graph = False
+        self._serial_offload = _boolean("serial_offload", serial_offload)
+        if self._serial_offload:
+            # Moving the module between CPU and GPU each request invalidates
+            # both torch.compile's device-bound guards and any CUDA graph's
+            # captured (now stale) memory addresses, so neither is safe here.
+            if self.compile_acoustic:
+                logger.warning(
+                    "MiniMax Music 3 serial offload disables compile_acoustic "
+                    "(torch.compile does not tolerate the repeated CPU/GPU "
+                    "moves that --stage-offload-components ar,dit performs)"
+                )
+                self.compile_acoustic = False
+            if self.breakable_cuda_graph_requested:
+                logger.warning(
+                    "MiniMax Music 3 serial offload disables breakable_cuda_graph "
+                    "(a captured CUDA graph would reference memory freed or "
+                    "relocated once the module moves off the GPU)"
+                )
+                self.breakable_cuda_graph_requested = False
+        # Serial offload parks DIT/DAV on the host between requests, so load
+        # them straight there. Staging the checkpoint through the GPU would
+        # peak with AR and DIT/DAV both fully resident, which is precisely the
+        # peak this mode exists to avoid.
+        self._load_device = torch.device("cpu") if self._serial_offload else self.device
         if self.cache_dit and self.breakable_cuda_graph_requested:
             raise ValueError(
                 "MiniMax Music 3 cache_dit and breakable_cuda_graph cannot be enabled together"
@@ -197,6 +223,28 @@ class MiniMaxMusic3AcousticDecoder:
         logger.info(
             f"MiniMax Music 3 acoustic runtime dit_steps={self.dit_steps} dit_cfg_scale={self.dit_cfg_scale:.3f} attention_backend={self.attention_backend} cache_dit={self.cache_dit} compile_acoustic={self.compile_acoustic} breakable_cuda_graph={self.breakable_cuda_graph} breakable_cuda_graph_requested={self.breakable_cuda_graph_requested}"
         )
+        self._residency: StageResidency | None = None
+        if self._serial_offload:
+            self._residency = StageResidency(
+                {"dit": self.dit, "dav": self.dav},
+                self.device,
+                resident=False,
+                label="dit/dav",
+            )
+
+    @property
+    def serial_offload(self) -> bool:
+        return self._serial_offload
+
+    def ensure_gpu_resident(self) -> None:
+        """Restore DIT/DAV to the GPU; a cheap no-op once already resident."""
+        if self._residency is not None:
+            self._residency.wake()
+
+    def offload_to_cpu(self) -> None:
+        """Drop the DIT/DAV GPU replica; a no-op once already offloaded."""
+        if self._residency is not None:
+            self._residency.sleep()
 
     def _build_dit(
         self,
@@ -211,9 +259,9 @@ class MiniMaxMusic3AcousticDecoder:
         from .dit import MiniMaxMusic3DIT
 
         logger.info(
-            f"Loading MiniMax Music 3 PyTorch DIT from {dit_path} on device={self.device} dtype={self.dtype}"
+            f"Loading MiniMax Music 3 PyTorch DIT from {dit_path} on device={self._load_device} dtype={self.dtype}"
         )
-        state = load_torch_state(dit_path, device=self.device)
+        state = load_torch_state(dit_path, device=self._load_device)
         logger.info(
             f"MiniMax Music 3 DIT checkpoint variant=FM8/ELMo condition_hidden=32768 state_keys={len(state)}"
         )
@@ -251,7 +299,7 @@ class MiniMaxMusic3AcousticDecoder:
     def _build_dav(self, dav_path: str) -> int:
         """Load the DAV decoder and return how many weight norms were folded."""
         logger.info(f"Loading MiniMax Music 3 DAV from {dav_path}")
-        state = load_torch_state(dav_path, device=self.device)
+        state = load_torch_state(dav_path, device=self._load_device)
         with torch.device("meta"):
             self.dav = MiniMaxMusic3DAV()
         self.dav.load_state_dict(select_decoder_state(state), strict=True, assign=True)
@@ -279,6 +327,7 @@ class MiniMaxMusic3AcousticDecoder:
     ) -> tuple[Tensor, Tensor, Tensor]:
         if should_abort is not None and should_abort():
             raise InterruptedError("MiniMax Music 3 acoustic generation aborted")
+        self.ensure_gpu_resident()
         hidden = hidden.unsqueeze(0).to(
             device=self.device, dtype=self.dtype, non_blocking=True
         )
@@ -466,6 +515,9 @@ class MiniMaxMusic3AcousticScheduler(StreamingSimpleScheduler):
             state.final_state = None
             state.last_latent = None
             state.last_condition = None
+        if self._decoder.serial_offload:
+            self._decoder.offload_to_cpu()
+            get_coordinator().end_dit_handoff(request_id)
 
 
 __all__ = [

--- a/sglang_omni/models/minimax_music3/acoustic.py
+++ b/sglang_omni/models/minimax_music3/acoustic.py
@@ -241,7 +241,7 @@ class MiniMaxMusic3AcousticDecoder:
         if self._residency is not None:
             self._residency.wake()
 
-    def offload_to_cpu(self) -> None:
+    def release_residency(self) -> None:
         """Drop the DIT/DAV GPU replica; a no-op once already offloaded."""
         if self._residency is not None:
             self._residency.sleep()
@@ -415,6 +415,7 @@ class MiniMaxMusic3AcousticScheduler(StreamingSimpleScheduler):
                 f"got {tuple(item.data.shape)}"
             )
         hidden = item.data[0]
+        get_coordinator().require_acoustic(request_id)
         state = self._stream_states.setdefault(request_id, _AcousticStreamState())
         metadata = item.metadata
         if not isinstance(metadata, dict):
@@ -515,9 +516,12 @@ class MiniMaxMusic3AcousticScheduler(StreamingSimpleScheduler):
             state.final_state = None
             state.last_latent = None
             state.last_condition = None
-        if self._decoder.serial_offload:
-            self._decoder.offload_to_cpu()
-            get_coordinator().end_dit_handoff(request_id)
+        if getattr(self._decoder, "serial_offload", False):
+            coordinator = get_coordinator()
+            coordinator.end_dit_handoff(
+                request_id,
+                release_acoustic=self._decoder.release_residency,
+            )
 
 
 __all__ = [

--- a/sglang_omni/models/minimax_music3/config.py
+++ b/sglang_omni/models/minimax_music3/config.py
@@ -32,6 +32,18 @@ def _visible_gpu_count() -> int:
     return torch.cuda.device_count()
 
 
+class MiniMaxMusic3ARFactoryArgs(FactoryArgs):
+    """AR constructor knobs shared by CUDA and native MLX."""
+
+    mlx_model_revision: str | None = None
+
+
+class MiniMaxMusic3ARStageConfig(EngineStageConfig):
+    factory: MiniMaxMusic3ARFactoryArgs = Field(
+        default_factory=MiniMaxMusic3ARFactoryArgs
+    )
+
+
 class DitDavFactoryArgs(FactoryArgs):
     """Acoustic DIT/DAV constructor knobs, typed like the shared ones."""
 
@@ -41,6 +53,7 @@ class DitDavFactoryArgs(FactoryArgs):
     cache_dit: bool | None = None
     compile_acoustic: bool | None = None
     breakable_cuda_graph: bool | None = None
+    mlx_model_revision: str | None = None
 
 
 class DitDavStageConfig(StageConfig):
@@ -55,11 +68,11 @@ def _stages(*, acoustic_gpu: int) -> list[StageConfig]:
             factory_path=f"{_PKG}.stages.create_preprocessing_executor",
             next="minimax_music3_ar",
         ),
-        EngineStageConfig(
+        MiniMaxMusic3ARStageConfig(
             name="minimax_music3_ar",
             process="minimax_music3_ar",
             factory_path=f"{_PKG}.stages.create_ar_executor",
-            factory=FactoryArgs(max_concurrency=16),
+            factory=MiniMaxMusic3ARFactoryArgs(max_concurrency=16),
             gpu=0,
             next="dit_dav",
             stream_to=["dit_dav"],
@@ -103,7 +116,7 @@ class MiniMaxMusic3PipelineConfig(PipelineConfig):
     requires_model_capabilities: ClassVar[bool] = True
 
     stage_config_types: ClassVar[dict[str, type[StageConfig]]] = {
-        "minimax_music3_ar": EngineStageConfig,
+        "minimax_music3_ar": MiniMaxMusic3ARStageConfig,
         "dit_dav": DitDavStageConfig,
     }
 

--- a/sglang_omni/models/minimax_music3/config.py
+++ b/sglang_omni/models/minimax_music3/config.py
@@ -36,6 +36,7 @@ class MiniMaxMusic3ARFactoryArgs(FactoryArgs):
     """AR constructor knobs shared by CUDA and native MLX."""
 
     mlx_model_revision: str | None = None
+    enable_serial_offload: bool | None = None
 
 
 class MiniMaxMusic3ARStageConfig(EngineStageConfig):
@@ -54,6 +55,7 @@ class DitDavFactoryArgs(FactoryArgs):
     compile_acoustic: bool | None = None
     breakable_cuda_graph: bool | None = None
     mlx_model_revision: str | None = None
+    enable_serial_offload: bool | None = None
 
 
 class DitDavStageConfig(StageConfig):
@@ -134,6 +136,10 @@ class MiniMaxMusic3PipelineConfig(PipelineConfig):
     @classmethod
     def process_local_edges(cls) -> frozenset[tuple[str, str]]:
         return frozenset({("preprocessing", "minimax_music3_ar")})
+
+    @classmethod
+    def stage_offload_role_to_stage(cls) -> dict[str, str]:
+        return {"ar": "minimax_music3_ar", "dit": "dit_dav"}
 
 
 class MiniMaxMusic3SingleGPUPipelineConfig(MiniMaxMusic3PipelineConfig):

--- a/sglang_omni/models/minimax_music3/engine_builder.py
+++ b/sglang_omni/models/minimax_music3/engine_builder.py
@@ -31,10 +31,13 @@ class MiniMaxMusic3EngineBuilder(TtsEngineBuilder):
     context_length = 10240
     model_arch_override = "Qwen3ForCausalLM"
 
-    def __init__(self, *, max_running_requests: int = 16) -> None:
+    def __init__(
+        self, *, max_running_requests: int = 16, enable_serial_offload: bool = False
+    ) -> None:
         self.max_running_requests = int(max_running_requests)
         if self.max_running_requests <= 0:
             raise ValueError("MiniMax Music 3 max_running_requests must be positive")
+        self._enable_serial_offload = bool(enable_serial_offload)
         self._model_runner: Any | None = None
         self._checkpoint_root: str | None = None
 
@@ -112,10 +115,15 @@ class MiniMaxMusic3EngineBuilder(TtsEngineBuilder):
     def setup_model_resources(
         self, model: Any, server_args: Any, *, generation_cuda_graph_enabled: bool
     ) -> None:
-        del generation_cuda_graph_enabled
+        del generation_cuda_graph_enabled, server_args
+        if self._enable_serial_offload:
+            logger.info(
+                "MiniMax Music 3 serial offload: skipping RVQ depth CUDA "
+                "graph capture"
+            )
+            return
         from .sglang_model import enable_rvq_depth_cuda_graph
 
-        del server_args
         enable_rvq_depth_cuda_graph(
             model, _rvq_graph_buckets(self.max_running_requests)
         )

--- a/sglang_omni/models/minimax_music3/engine_builder.py
+++ b/sglang_omni/models/minimax_music3/engine_builder.py
@@ -73,6 +73,16 @@ class MiniMaxMusic3EngineBuilder(TtsEngineBuilder):
         )
         if requested <= 0:
             raise ValueError("MiniMax Music 3 max_running_requests must be positive")
+        if self._enable_serial_offload:
+            if requested != 1:
+                logger.info(
+                    "MiniMax Music 3 serial offload limits logical AR "
+                    "concurrency from %d to 1",
+                    requested,
+                )
+            requested = 1
+            overrides["disable_cuda_graph"] = True
+            overrides["enable_torch_compile"] = False
         self.max_running_requests = requested
         rows = 2 * requested
         overrides["max_running_requests"] = rows
@@ -127,6 +137,23 @@ class MiniMaxMusic3EngineBuilder(TtsEngineBuilder):
         enable_rvq_depth_cuda_graph(
             model, _rvq_graph_buckets(self.max_running_requests)
         )
+
+    def setup_runtime_resources(self, model: Any, server_args: Any) -> None:
+        del server_args
+        if not self._enable_serial_offload:
+            return
+        import torch
+
+        from .serial_offload import get_coordinator
+
+        get_coordinator().register_ar(model, torch.device(self.device))
+
+    def cleanup_build_failure(self) -> None:
+        if not self._enable_serial_offload:
+            return
+        from .serial_offload import reset_coordinator
+
+        reset_coordinator()
 
     def make_scheduler(self, **kwargs: Any) -> Any:
         from .scheduler import MiniMaxMusic3Scheduler

--- a/sglang_omni/models/minimax_music3/mlx/__init__.py
+++ b/sglang_omni/models/minimax_music3/mlx/__init__.py
@@ -1,0 +1,6 @@
+# SPDX-License-Identifier: Apache-2.0
+"""Native MLX backend for MiniMax Music 3."""
+
+from .loader import load_mlx_acoustic_model, load_mlx_ar_model
+
+__all__ = ["load_mlx_acoustic_model", "load_mlx_ar_model"]

--- a/sglang_omni/models/minimax_music3/mlx/acoustic.py
+++ b/sglang_omni/models/minimax_music3/mlx/acoustic.py
@@ -1,0 +1,99 @@
+# SPDX-License-Identifier: Apache-2.0
+"""Stage-facing native MLX acoustic decoder for MiniMax Music 3."""
+
+from __future__ import annotations
+
+from collections.abc import Callable
+
+import mlx.core as mx
+import numpy as np
+import torch
+
+from ..acoustic import _derive_seed
+from ..chunking import overlap_mel_length
+from .euler import denoise_chunk
+from .loader import MiniMaxMusic3MlxAcousticModel, load_mlx_acoustic_model
+
+
+class MiniMaxMusic3MlxAcousticDecoder:
+    """Condition projection, Flow/DiT solve, and DAV decode on Metal."""
+
+    def __init__(
+        self,
+        model_path: str,
+        *,
+        revision: str | None = None,
+        dit_steps: int = 30,
+        dit_cfg_scale: float = 1.7,
+    ) -> None:
+        if dit_steps < 1:
+            raise ValueError("MiniMax Music 3 dit_steps must be positive")
+        if dit_cfg_scale < 0:
+            raise ValueError("MiniMax Music 3 dit_cfg_scale must be non-negative")
+        self.model: MiniMaxMusic3MlxAcousticModel = load_mlx_acoustic_model(
+            model_path,
+            revision,
+        )
+        self.device = "mps"
+        self.dtype = self.model.condition_encoder.proj.weight.dtype
+        self.dit_steps = int(dit_steps)
+        self.dit_cfg_scale = float(dit_cfg_scale)
+        self.attention_backend = "mlx_sdpa"
+        self.compile_acoustic = False
+        self.cache_dit = False
+        self.breakable_cuda_graph = False
+        self._mlx_thread_stream = mx.new_thread_local_stream(mx.gpu)
+
+    def decode_with_state(
+        self,
+        hidden: torch.Tensor,
+        *,
+        seed: int,
+        chunk_idx: int,
+        initial_latent: mx.array | None = None,
+        initial_condition: mx.array | None = None,
+        should_abort: Callable[[], bool] | None = None,
+    ) -> tuple[torch.Tensor, mx.array, mx.array]:
+        if should_abort is not None and should_abort():
+            raise InterruptedError("MiniMax Music 3 MLX acoustic generation aborted")
+        hidden_np = hidden.detach().to(device="cpu", dtype=torch.float32).numpy()
+        with mx.stream(self._mlx_thread_stream):
+            hidden_mx = mx.array(hidden_np)[None].astype(self.dtype)
+            condition = self.model.condition_encoder(hidden_mx)
+            key = mx.random.key(_derive_seed(int(seed), "dit", int(chunk_idx)))
+            noise = mx.random.normal(
+                (
+                    1,
+                    self.model.config.dit_in_channels,
+                    condition.shape[1],
+                ),
+                key=key,
+            ).astype(condition.dtype)
+            latent, condition = denoise_chunk(
+                self.model.transformer,
+                noise,
+                condition,
+                num_inference_steps=self.dit_steps,
+                guidance_scale=self.dit_cfg_scale,
+                previous_latent=initial_latent,
+                previous_condition=initial_condition,
+                should_abort=should_abort,
+            )
+            if should_abort is not None and should_abort():
+                raise InterruptedError(
+                    "MiniMax Music 3 MLX acoustic generation aborted"
+                )
+            waveform = self.model.vocoder(latent)[0].astype(mx.float32)
+            overlap = overlap_mel_length()
+            start = max(0, latent.shape[-1] - 2 * overlap)
+            end = max(start, latent.shape[-1] - overlap)
+            latent_save = latent[..., start:end]
+            condition_save = condition[:, start:end]
+            mx.eval(waveform, latent_save, condition_save)
+
+        wave_np = np.ascontiguousarray(np.asarray(waveform, dtype=np.float32))
+        wave = torch.from_numpy(wave_np).clamp(-1.0, 1.0)
+        return wave, latent_save, condition_save
+
+
+__all__ = ["MiniMaxMusic3MlxAcousticDecoder"]

--- a/sglang_omni/models/minimax_music3/mlx/acoustic.py
+++ b/sglang_omni/models/minimax_music3/mlx/acoustic.py
@@ -3,6 +3,7 @@
 
 from __future__ import annotations
 
+import logging
 from collections.abc import Callable
 
 import mlx.core as mx
@@ -11,8 +12,15 @@ import torch
 
 from ..acoustic import _derive_seed
 from ..chunking import overlap_mel_length
+from ..serial_offload import get_coordinator
 from .euler import denoise_chunk
-from .loader import MiniMaxMusic3MlxAcousticModel, load_mlx_acoustic_model
+from .loader import (
+    MiniMaxMusic3MlxAcousticModel,
+    load_mlx_acoustic_model,
+    resolve_mlx_artifact,
+)
+
+logger = logging.getLogger(__name__)
 
 
 class MiniMaxMusic3MlxAcousticDecoder:
@@ -25,17 +33,31 @@ class MiniMaxMusic3MlxAcousticDecoder:
         revision: str | None = None,
         dit_steps: int = 30,
         dit_cfg_scale: float = 1.7,
+        serial_offload: bool = False,
     ) -> None:
         if dit_steps < 1:
             raise ValueError("MiniMax Music 3 dit_steps must be positive")
         if dit_cfg_scale < 0:
             raise ValueError("MiniMax Music 3 dit_cfg_scale must be non-negative")
-        self.model: MiniMaxMusic3MlxAcousticModel = load_mlx_acoustic_model(
-            model_path,
-            revision,
-        )
+        self.serial_offload = bool(serial_offload)
+        self._artifact = resolve_mlx_artifact(model_path, revision)
+        self.model: MiniMaxMusic3MlxAcousticModel | None = None
+        if not self.serial_offload:
+            self.model = load_mlx_acoustic_model(
+                model_path,
+                revision,
+                artifact=self._artifact,
+            )
         self.device = "mps"
-        self.dtype = self.model.condition_encoder.proj.weight.dtype
+        self.dtype = (
+            self.model.condition_encoder.proj.weight.dtype
+            if self.model is not None
+            else str(
+                self._artifact[1].get("torch_dtype")
+                or self._artifact[1].get("dtype")
+                or "artifact"
+            )
+        )
         self.dit_steps = int(dit_steps)
         self.dit_cfg_scale = float(dit_cfg_scale)
         self.attention_backend = "mlx_sdpa"
@@ -43,6 +65,34 @@ class MiniMaxMusic3MlxAcousticDecoder:
         self.cache_dit = False
         self.breakable_cuda_graph = False
         self._mlx_thread_stream = mx.new_thread_local_stream(mx.gpu)
+        if self.serial_offload:
+            get_coordinator().enable()
+
+    def ensure_resident(self) -> None:
+        if self.model is not None:
+            return
+        with mx.stream(self._mlx_thread_stream):
+            self.model = load_mlx_acoustic_model(
+                str(self._artifact[0]),
+                artifact=self._artifact,
+            )
+        self.dtype = self.model.condition_encoder.proj.weight.dtype
+        logger.info(
+            "MiniMax Music 3 MLX acoustic loaded active=%.2fGiB cache=%.2fGiB",
+            mx.get_active_memory() / 1024**3,
+            mx.get_cache_memory() / 1024**3,
+        )
+
+    def release_residency(self) -> None:
+        if not self.serial_offload:
+            return
+        mx.synchronize(self._mlx_thread_stream)
+        self.model = None
+        logger.info(
+            "MiniMax Music 3 MLX acoustic released active=%.2fGiB cache=%.2fGiB",
+            mx.get_active_memory() / 1024**3,
+            mx.get_cache_memory() / 1024**3,
+        )
 
     def decode_with_state(
         self,
@@ -56,6 +106,9 @@ class MiniMaxMusic3MlxAcousticDecoder:
     ) -> tuple[torch.Tensor, mx.array, mx.array]:
         if should_abort is not None and should_abort():
             raise InterruptedError("MiniMax Music 3 MLX acoustic generation aborted")
+        self.ensure_resident()
+        if self.model is None:
+            raise RuntimeError("MiniMax Music 3 MLX acoustic model is not loaded")
         hidden_np = hidden.detach().to(device="cpu", dtype=torch.float32).numpy()
         with mx.stream(self._mlx_thread_stream):
             hidden_mx = mx.array(hidden_np)[None].astype(self.dtype)

--- a/sglang_omni/models/minimax_music3/mlx/ar.py
+++ b/sglang_omni/models/minimax_music3/mlx/ar.py
@@ -1,0 +1,206 @@
+# SPDX-License-Identifier: MIT
+# Copyright (c) 2024 Prince Canuma and contributors.
+# Adapted from Blaizzy/mlx-audio commit 921059d0074e.
+"""Hierarchical autoregressive generation for MiniMax Music 3."""
+
+from __future__ import annotations
+
+from collections.abc import Callable
+from dataclasses import dataclass
+
+import mlx.core as mx
+from mlx_lm.models.cache import make_prompt_cache
+from mlx_lm.models.qwen3 import Model as Qwen3Model
+
+from .config import AR_CFG_SCALE, AR_CFG_TOP_K, AR_SAMPLING_TOP_K, ModelConfig
+from .depth import RVQDepthDecoder
+from .fusion import fuse_frame_hiddens
+from .sampling import sample_top_k
+
+
+@dataclass
+class ARFrame:
+    semantic_code: mx.array
+    residual_codes: mx.array
+    frame_hidden: mx.array
+    last_hidden: mx.array
+    cache: list
+    ended: bool
+
+
+def qwen3_hidden(
+    language_model: Qwen3Model,
+    input_embeddings: mx.array,
+    cache=None,
+) -> tuple[mx.array, list]:
+    if cache is None:
+        cache = make_prompt_cache(language_model)
+    hidden = language_model.model(
+        mx.zeros(input_embeddings.shape[:2], dtype=mx.int32),
+        cache,
+        input_embeddings=input_embeddings,
+    )
+    return hidden, cache
+
+
+def lm_logits(language_model: Qwen3Model, hidden: mx.array) -> mx.array:
+    if language_model.args.tie_word_embeddings:
+        return language_model.model.embed_tokens.as_linear(hidden)
+    return language_model.lm_head(hidden)
+
+
+def _embed_audio_frame(
+    language_model: Qwen3Model,
+    depth: RVQDepthDecoder,
+    config: ModelConfig,
+    frame_codes: mx.array,
+) -> mx.array:
+    embeddings = language_model.model.embed_tokens(
+        frame_codes[:, :1] + config.audio_code_offset
+    )
+    offsets = mx.arange(config.residual_codebooks) * config.audio_vocab_size
+    residual = depth.audio_embeddings(frame_codes[:, 1:] + offsets[None, :]).sum(
+        axis=1, keepdims=True
+    )
+    return (embeddings + residual.astype(embeddings.dtype)) * (
+        config.num_codebooks**-0.5
+    )
+
+
+def generate_depth_codes(
+    language_model: Qwen3Model,
+    depth: RVQDepthDecoder,
+    config: ModelConfig,
+    last_hidden: mx.array,
+    semantic_code: mx.array,
+    rng_key: mx.array,
+) -> tuple[mx.array, mx.array, mx.array]:
+    sequence = [depth.projection(last_hidden)[:, None, :]]
+    code_embedding = language_model.model.embed_tokens(
+        semantic_code + config.audio_code_offset
+    )
+    sequence.append(depth.projection(code_embedding)[:, None, :])
+    codes = [semantic_code]
+    hidden_parts = []
+    key = rng_key
+    for index in range(1, config.num_codebooks):
+        hidden = depth(mx.concatenate(sequence, axis=1))[:, -1]
+        hidden_parts.append(hidden[:1])
+        logits = depth.audio_heads[index - 1](hidden)
+        conditional = logits[:1].astype(mx.float32)
+        unconditional = logits[1:2].astype(mx.float32)
+        guided = unconditional + (conditional - unconditional) * AR_CFG_SCALE
+        sampled, key = sample_top_k(guided, key, AR_SAMPLING_TOP_K)
+        code = mx.concatenate([sampled, sampled], axis=0)
+        codes.append(code)
+        if index < config.num_codebooks - 1:
+            embedding = depth.audio_embeddings(
+                code + (index - 1) * config.audio_vocab_size
+            )
+            sequence.append(depth.projection(embedding)[:, None, :])
+    return mx.stack(codes, axis=1), mx.concatenate(hidden_parts, axis=-1), key
+
+
+def ar_one_frame(
+    language_model: Qwen3Model,
+    depth: RVQDepthDecoder,
+    config: ModelConfig,
+    last_hidden: mx.array,
+    cache: list,
+    rng_key: mx.array,
+    emit_frame: bool = True,
+) -> ARFrame:
+    logits = lm_logits(language_model, last_hidden).astype(mx.float32)
+    token_ids = mx.arange(logits.shape[-1])
+    allowed = mx.logical_or(
+        mx.logical_and(
+            token_ids >= config.audio_code_offset,
+            token_ids < config.audio_code_offset + config.semantic_vocab_size,
+        ),
+        token_ids == config.audio_end_token_id,
+    )
+    logits = mx.where(allowed[None, :], logits, -1e9)
+    conditional, unconditional = logits[:1], logits[1:2]
+    guided = unconditional + (conditional - unconditional) * AR_CFG_SCALE
+    k = min(AR_CFG_TOP_K, conditional.shape[-1])
+    threshold = mx.min(mx.topk(conditional, k, axis=-1), axis=-1, keepdims=True)
+    guided = mx.where(conditional < threshold, -1e9, guided)
+    guided = mx.where(allowed[None, :], guided, -1e9)
+    sampled, key = sample_top_k(guided, rng_key, AR_SAMPLING_TOP_K)
+
+    if int(sampled.item()) == config.audio_end_token_id:
+        return ARFrame(
+            semantic_code=sampled,
+            residual_codes=mx.zeros((2, config.residual_codebooks), dtype=mx.int32),
+            frame_hidden=mx.zeros((1, config.num_codebooks * config.hidden_size)),
+            last_hidden=last_hidden,
+            cache=cache,
+            ended=True,
+        )
+
+    semantic_code = (
+        mx.concatenate([sampled, sampled], axis=0) - config.audio_code_offset
+    )
+    frame_codes, depth_hidden, key = generate_depth_codes(
+        language_model,
+        depth,
+        config,
+        last_hidden,
+        semantic_code,
+        key,
+    )
+    frame_hidden = (
+        fuse_frame_hiddens(last_hidden[:1], depth_hidden)
+        if emit_frame
+        else mx.zeros((1, config.num_codebooks * config.hidden_size))
+    )
+    feedback = _embed_audio_frame(language_model, depth, config, frame_codes)
+    hidden, cache = qwen3_hidden(language_model, feedback, cache)
+    return ARFrame(
+        semantic_code=semantic_code,
+        residual_codes=frame_codes[:, 1:],
+        frame_hidden=frame_hidden,
+        last_hidden=hidden[:, -1],
+        cache=cache,
+        ended=False,
+    )
+
+
+def generate_frame_hiddens(
+    language_model: Qwen3Model,
+    depth: RVQDepthDecoder,
+    config: ModelConfig,
+    text_ids: mx.array,
+    max_frames: int,
+    seed: int = 0,
+    should_abort: Callable[[], bool] | None = None,
+) -> mx.array:
+    mx.random.seed(seed)
+    key = mx.random.key(seed)
+    embeddings = language_model.model.embed_tokens(text_ids)
+    hidden, cache = qwen3_hidden(language_model, embeddings)
+    last_hidden = hidden[:, -1]
+    frames = []
+    for frame_index in range(max_frames + 1):
+        if should_abort is not None and should_abort():
+            raise InterruptedError("MiniMax Music 3 MLX generation aborted")
+        key, subkey = mx.random.split(key)
+        result = ar_one_frame(
+            language_model,
+            depth,
+            config,
+            last_hidden,
+            cache,
+            subkey,
+            emit_frame=frame_index > 0,
+        )
+        last_hidden, cache = result.last_hidden, result.cache
+        if result.ended:
+            break
+        if frame_index > 0:
+            frames.append(result.frame_hidden)
+            if len(frames) >= max_frames:
+                break
+    if not frames:
+        raise ValueError("MiniMax Music 3 generated zero audio frames")
+    return mx.stack(frames, axis=1)

--- a/sglang_omni/models/minimax_music3/mlx/ar_scheduler.py
+++ b/sglang_omni/models/minimax_music3/mlx/ar_scheduler.py
@@ -1,0 +1,155 @@
+# SPDX-License-Identifier: Apache-2.0
+"""Whole-request MLX AR scheduler with the CUDA pipeline's stream contract."""
+
+from __future__ import annotations
+
+import logging
+import threading
+import time
+from pathlib import Path
+
+import mlx.core as mx
+import numpy as np
+import torch
+from transformers import AutoTokenizer
+
+from sglang_omni.proto import StagePayload
+from sglang_omni.scheduling.messages import OutgoingMessage
+from sglang_omni.scheduling.pipeline_state import store_state
+from sglang_omni.scheduling.simple_scheduler import SimpleScheduler
+
+from ..chunking import chunk_windows
+from ..payload_types import MiniMaxMusic3State
+from ..prompt import validate_tokenizer_ids
+from .ar import generate_frame_hiddens
+from .loader import MiniMaxMusic3MlxARModel, load_mlx_ar_model
+
+logger = logging.getLogger(__name__)
+
+
+def _build_text_pair(
+    prompt: str,
+    model: MiniMaxMusic3MlxARModel,
+    tokenizer: object,
+) -> mx.array:
+    input_ids = tokenizer(prompt, return_tensors="np")["input_ids"]
+    if input_ids.shape[1] > 5_000:
+        raise ValueError(
+            f"MiniMax Music 3 prompt has {input_ids.shape[1]} tokens; "
+            "the maximum is 5000"
+        )
+    conditional = mx.array(input_ids.astype("int32"))
+    unconditional = conditional
+    if unconditional.shape[1] > 3:
+        middle = mx.full(
+            (1, unconditional.shape[1] - 3),
+            model.config.audio_cfg_token_id,
+            dtype=mx.int32,
+        )
+        unconditional = mx.concatenate(
+            [unconditional[:, :1], middle, unconditional[:, -2:]], axis=1
+        )
+    return mx.concatenate([conditional, unconditional], axis=0)
+
+
+class MiniMaxMusic3MlxARScheduler(SimpleScheduler):
+    """Generate MLX frame hiddens and stream transport-safe CPU chunks."""
+
+    def __init__(
+        self,
+        model_path: str,
+        *,
+        revision: str | None = None,
+    ) -> None:
+        self.model = load_mlx_ar_model(model_path, revision)
+        tokenizer_dir = Path(self.model.config.model_path) / "tokenizer"
+        if not tokenizer_dir.is_dir():
+            raise FileNotFoundError(
+                "MiniMax Music 3 MLX artifact must include its tokenizer directory"
+            )
+        self.tokenizer = AutoTokenizer.from_pretrained(
+            tokenizer_dir,
+            trust_remote_code=False,
+        )
+        validate_tokenizer_ids(self.tokenizer)
+        self._abort_events: dict[str, threading.Event] = {}
+        self._events_lock = threading.Lock()
+        self._mlx_thread_stream = mx.new_thread_local_stream(mx.gpu)
+        super().__init__(self._generate, max_concurrency=1)
+
+    def _abort_event(self, request_id: str) -> threading.Event:
+        with self._events_lock:
+            return self._abort_events.setdefault(request_id, threading.Event())
+
+    def _generate(self, payload: StagePayload) -> StagePayload:
+        state = MiniMaxMusic3State.from_dict(payload.data)
+        if state.prompt is None:
+            raise ValueError("MiniMax Music 3 preprocessing did not build a prompt")
+        abort_event = self._abort_event(payload.request_id)
+        started = time.perf_counter()
+        try:
+            with mx.stream(self._mlx_thread_stream):
+                text_ids = _build_text_pair(state.prompt, self.model, self.tokenizer)
+                hidden = generate_frame_hiddens(
+                    self.model.language_model,
+                    self.model.rvq_depth_decoder,
+                    self.model.config,
+                    text_ids,
+                    max_frames=state.max_audio_frames,
+                    seed=state.seed,
+                    should_abort=abort_event.is_set,
+                )
+                mx.eval(hidden)
+                generated_frames = int(hidden.shape[1])
+                for window in chunk_windows(generated_frames):
+                    if abort_event.is_set():
+                        raise InterruptedError("MiniMax Music 3 MLX generation aborted")
+                    chunk = hidden[:, window.start : window.end].astype(mx.float16)
+                    mx.eval(chunk)
+                    transport = torch.from_numpy(
+                        np.ascontiguousarray(np.asarray(chunk, dtype=np.float16))
+                    )
+                    self.outbox.put(
+                        OutgoingMessage(
+                            request_id=payload.request_id,
+                            type="stream",
+                            data=transport,
+                            metadata={
+                                "stream": True,
+                                "modality": "ttm_hidden",
+                                "chunk_idx": window.index,
+                                "start_frame": window.start,
+                                "end_frame": window.end,
+                                "is_final": window.is_last,
+                                "seed": state.seed,
+                            },
+                        )
+                    )
+        finally:
+            with self._events_lock:
+                self._abort_events.pop(payload.request_id, None)
+
+        state.generated_frames = generated_frames
+        state.finish_reason = (
+            "length" if generated_frames >= state.max_audio_frames else "stop"
+        )
+        state.prompt = None
+        state.caption = ""
+        state.lyrics = ""
+        logger.info(
+            "MiniMax Music 3 MLX AR done request=%s frames=%d elapsed=%.1fs",
+            payload.request_id,
+            generated_frames,
+            time.perf_counter() - started,
+        )
+        return store_state(payload, state)
+
+    def abort(self, request_id: str) -> None:
+        with self._events_lock:
+            event = self._abort_events.get(request_id)
+            if event is not None:
+                event.set()
+        super().abort(request_id)
+
+
+__all__ = ["MiniMaxMusic3MlxARScheduler", "_build_text_pair"]

--- a/sglang_omni/models/minimax_music3/mlx/ar_scheduler.py
+++ b/sglang_omni/models/minimax_music3/mlx/ar_scheduler.py
@@ -21,8 +21,13 @@ from sglang_omni.scheduling.simple_scheduler import SimpleScheduler
 from ..chunking import chunk_windows
 from ..payload_types import MiniMaxMusic3State
 from ..prompt import validate_tokenizer_ids
+from ..serial_offload import get_coordinator
 from .ar import generate_frame_hiddens
-from .loader import MiniMaxMusic3MlxARModel, load_mlx_ar_model
+from .loader import (
+    MiniMaxMusic3MlxARModel,
+    load_mlx_ar_model,
+    resolve_mlx_artifact,
+)
 
 logger = logging.getLogger(__name__)
 
@@ -60,9 +65,18 @@ class MiniMaxMusic3MlxARScheduler(SimpleScheduler):
         model_path: str,
         *,
         revision: str | None = None,
+        serial_offload: bool = False,
     ) -> None:
-        self.model = load_mlx_ar_model(model_path, revision)
-        tokenizer_dir = Path(self.model.config.model_path) / "tokenizer"
+        self._serial_offload = bool(serial_offload)
+        self._artifact = resolve_mlx_artifact(model_path, revision)
+        self.model: MiniMaxMusic3MlxARModel | None = None
+        if not self._serial_offload:
+            self.model = load_mlx_ar_model(
+                model_path,
+                revision,
+                artifact=self._artifact,
+            )
+        tokenizer_dir = Path(self._artifact[0]) / "tokenizer"
         if not tokenizer_dir.is_dir():
             raise FileNotFoundError(
                 "MiniMax Music 3 MLX artifact must include its tokenizer directory"
@@ -75,6 +89,8 @@ class MiniMaxMusic3MlxARScheduler(SimpleScheduler):
         self._abort_events: dict[str, threading.Event] = {}
         self._events_lock = threading.Lock()
         self._mlx_thread_stream = mx.new_thread_local_stream(mx.gpu)
+        if self._serial_offload:
+            get_coordinator().enable()
         super().__init__(self._generate, max_concurrency=1)
 
     def _abort_event(self, request_id: str) -> threading.Event:
@@ -87,7 +103,18 @@ class MiniMaxMusic3MlxARScheduler(SimpleScheduler):
             raise ValueError("MiniMax Music 3 preprocessing did not build a prompt")
         abort_event = self._abort_event(payload.request_id)
         started = time.perf_counter()
+        coordinator = get_coordinator()
+        handed_off = False
         try:
+            if self._serial_offload:
+                coordinator.acquire_ar(
+                    payload.request_id,
+                    should_abort=abort_event.is_set,
+                )
+                self._load_model()
+            if self.model is None:
+                raise RuntimeError("MiniMax Music 3 MLX AR model is not loaded")
+            pending: list[OutgoingMessage] = []
             with mx.stream(self._mlx_thread_stream):
                 text_ids = _build_text_pair(state.prompt, self.model, self.tokenizer)
                 hidden = generate_frame_hiddens(
@@ -106,10 +133,13 @@ class MiniMaxMusic3MlxARScheduler(SimpleScheduler):
                         raise InterruptedError("MiniMax Music 3 MLX generation aborted")
                     chunk = hidden[:, window.start : window.end].astype(mx.float16)
                     mx.eval(chunk)
-                    transport = torch.from_numpy(
-                        np.ascontiguousarray(np.asarray(chunk, dtype=np.float16))
-                    )
-                    self.outbox.put(
+                    chunk_np = np.asarray(chunk, dtype=np.float16)
+                    if self._serial_offload:
+                        chunk_np = np.array(chunk_np, copy=True, order="C")
+                    else:
+                        chunk_np = np.ascontiguousarray(chunk_np)
+                    transport = torch.from_numpy(chunk_np)
+                    pending.append(
                         OutgoingMessage(
                             request_id=payload.request_id,
                             type="stream",
@@ -125,24 +155,65 @@ class MiniMaxMusic3MlxARScheduler(SimpleScheduler):
                             },
                         )
                     )
+                    del chunk, chunk_np, transport
+                del hidden, text_ids
+
+            state.generated_frames = generated_frames
+            state.finish_reason = (
+                "length" if generated_frames >= state.max_audio_frames else "stop"
+            )
+            state.prompt = None
+            state.caption = ""
+            state.lyrics = ""
+            result = store_state(payload, state)
+            if self._serial_offload:
+                self._release_model()
+                coordinator.begin_dit_handoff(payload.request_id)
+                handed_off = True
+            for message in pending:
+                self.outbox.put(message)
+            logger.info(
+                "MiniMax Music 3 MLX AR done request=%s frames=%d elapsed=%.1fs",
+                payload.request_id,
+                generated_frames,
+                time.perf_counter() - started,
+            )
+            return result
+        except BaseException:
+            if self._serial_offload and not handed_off:
+                try:
+                    self._release_model()
+                except BaseException as cleanup_error:
+                    coordinator.fail_closed(cleanup_error)
+                    raise
+                coordinator.cancel_ar(payload.request_id)
+            raise
         finally:
             with self._events_lock:
                 self._abort_events.pop(payload.request_id, None)
 
-        state.generated_frames = generated_frames
-        state.finish_reason = (
-            "length" if generated_frames >= state.max_audio_frames else "stop"
-        )
-        state.prompt = None
-        state.caption = ""
-        state.lyrics = ""
+    def _load_model(self) -> None:
+        if self.model is not None:
+            return
+        with mx.stream(self._mlx_thread_stream):
+            self.model = load_mlx_ar_model(
+                str(self._artifact[0]),
+                artifact=self._artifact,
+            )
         logger.info(
-            "MiniMax Music 3 MLX AR done request=%s frames=%d elapsed=%.1fs",
-            payload.request_id,
-            generated_frames,
-            time.perf_counter() - started,
+            "MiniMax Music 3 MLX AR loaded active=%.2fGiB cache=%.2fGiB",
+            mx.get_active_memory() / 1024**3,
+            mx.get_cache_memory() / 1024**3,
         )
-        return store_state(payload, state)
+
+    def _release_model(self) -> None:
+        mx.synchronize(self._mlx_thread_stream)
+        self.model = None
+        logger.info(
+            "MiniMax Music 3 MLX AR released active=%.2fGiB cache=%.2fGiB",
+            mx.get_active_memory() / 1024**3,
+            mx.get_cache_memory() / 1024**3,
+        )
 
     def abort(self, request_id: str) -> None:
         with self._events_lock:

--- a/sglang_omni/models/minimax_music3/mlx/config.py
+++ b/sglang_omni/models/minimax_music3/mlx/config.py
@@ -1,0 +1,136 @@
+# SPDX-License-Identifier: MIT
+# Copyright (c) 2024 Prince Canuma and contributors.
+# Adapted from Blaizzy/mlx-audio commit 921059d0074e.
+"""Checkpoint contract and architecture sizes for MiniMax Music 3."""
+
+from __future__ import annotations
+
+from dataclasses import asdict, dataclass, field
+from typing import Any
+
+OFFICIAL_AUDIO_END_TOKEN_ID = 151670
+OFFICIAL_AUDIO_CFG_TOKEN_ID = 151654
+OFFICIAL_AUDIO_CODE_OFFSET = 151675
+OFFICIAL_SEMANTIC_VOCAB_SIZE = 16384
+
+AR_CFG_SCALE = 1.5
+AR_CFG_TOP_K = 50
+AR_SAMPLING_TOP_K = 50
+DIT_CFG_SCALE = 1.7
+
+FRAME_RATE = 25.0
+MAX_AUDIO_FRAMES = 9_000
+MAX_PROMPT_TOKENS = 5_000
+CHUNK_FRAMES = 200
+CHUNK_HOP = 100
+LATENT_HOP_LENGTH = 512
+OVERLAP_LATENT_LENGTH = 172
+CROP_LEFT_LATENT = 86
+CROP_RIGHT_LATENT = 344 - CROP_LEFT_LATENT
+SAMPLING_RATE = 44_100
+
+
+@dataclass
+class ModelConfig:
+    model_type: str = "minimax_music3"
+    model_path: str = ""
+
+    hidden_size: int = 4096
+    num_codebooks: int = 8
+    audio_vocab_size: int = 1024
+    semantic_vocab_size: int = OFFICIAL_SEMANTIC_VOCAB_SIZE
+    vocab_size: int = 200_000
+    audio_code_offset: int = OFFICIAL_AUDIO_CODE_OFFSET
+    audio_end_token_id: int = OFFICIAL_AUDIO_END_TOKEN_ID
+    audio_cfg_token_id: int = OFFICIAL_AUDIO_CFG_TOKEN_ID
+
+    num_hidden_layers: int = 36
+    intermediate_size: int = 12_288
+    num_attention_heads: int = 32
+    num_key_value_heads: int = 8
+    head_dim: int = 128
+    rms_norm_eps: float = 1e-6
+    max_position_embeddings: int = 10_240
+    rope_theta: float = 1_000_000.0
+    tie_word_embeddings: bool = False
+
+    depth_num_layers: int = 4
+    depth_num_heads: int = 16
+    depth_intermediate_size: int = 6144
+    depth_max_position_embeddings: int = 16
+
+    condition_out_dim: int = 2048
+    num_condition_layers: int = 8
+    input_sampling_rate: int = 24_000
+    input_hop_length: int = 960
+    output_sampling_rate: int = SAMPLING_RATE
+    output_hop_length: int = LATENT_HOP_LENGTH
+    dit_in_channels: int = 128
+    dit_num_layers: int = 36
+    dit_num_heads: int = 32
+    dit_head_dim: int = 64
+    dit_ff_inner_dim: int = 8192
+    dit_rotary_dim: int = 32
+    dit_fourier_dim: int = 256
+
+    vocoder_input_dim: int = 1024
+    vocoder_hidden_dim: int = 1536
+    vocoder_upsampling_ratios: tuple[int, ...] = (8, 8, 4, 2)
+    sample_rate: int = SAMPLING_RATE
+    frame_rate: float = FRAME_RATE
+    extra: dict[str, Any] = field(default_factory=dict)
+
+    def to_dict(self) -> dict[str, Any]:
+        data = asdict(self)
+        data["vocoder_upsampling_ratios"] = list(self.vocoder_upsampling_ratios)
+        return data
+
+    @classmethod
+    def from_dict(cls, data: dict[str, Any]) -> "ModelConfig":
+        known = {
+            key: value for key, value in data.items() if key in cls.__dataclass_fields__
+        }
+        if "vocoder_upsampling_ratios" in known:
+            known["vocoder_upsampling_ratios"] = tuple(
+                known["vocoder_upsampling_ratios"]
+            )
+        return cls(**known)
+
+    @classmethod
+    def tiny(cls) -> "ModelConfig":
+        return cls(
+            hidden_size=64,
+            num_codebooks=8,
+            audio_vocab_size=32,
+            semantic_vocab_size=64,
+            vocab_size=512,
+            audio_code_offset=200,
+            audio_end_token_id=199,
+            audio_cfg_token_id=198,
+            num_hidden_layers=2,
+            intermediate_size=128,
+            num_attention_heads=4,
+            num_key_value_heads=2,
+            head_dim=16,
+            max_position_embeddings=256,
+            rope_theta=10_000.0,
+            depth_num_layers=2,
+            depth_num_heads=4,
+            depth_intermediate_size=128,
+            condition_out_dim=32,
+            num_condition_layers=8,
+            dit_in_channels=16,
+            dit_num_layers=2,
+            dit_num_heads=4,
+            dit_head_dim=16,
+            dit_ff_inner_dim=64,
+            dit_rotary_dim=8,
+            dit_fourier_dim=16,
+            vocoder_input_dim=16,
+            vocoder_hidden_dim=32,
+            vocoder_upsampling_ratios=(4, 2),
+        )
+
+    @property
+    def residual_codebooks(self) -> int:
+        return self.num_codebooks - 1

--- a/sglang_omni/models/minimax_music3/mlx/depth.py
+++ b/sglang_omni/models/minimax_music3/mlx/depth.py
@@ -1,0 +1,92 @@
+# SPDX-License-Identifier: MIT
+# Copyright (c) 2024 Prince Canuma and contributors.
+# Adapted from Blaizzy/mlx-audio commit 921059d0074e.
+"""Local residual-codebook decoder for MiniMax Music 3."""
+
+from __future__ import annotations
+
+import math
+
+import mlx.core as mx
+import mlx.nn as nn
+
+from .config import ModelConfig
+
+
+class DepthAttention(nn.Module):
+    def __init__(self, dim: int, heads: int):
+        super().__init__()
+        self.heads = heads
+        self.head_dim = dim // heads
+        self.to_q = nn.Linear(dim, dim, bias=False)
+        self.to_k = nn.Linear(dim, dim, bias=False)
+        self.to_v = nn.Linear(dim, dim, bias=False)
+        self.to_out = nn.Linear(dim, dim, bias=False)
+
+    def __call__(self, x: mx.array) -> mx.array:
+        batch, length, _ = x.shape
+        q = self.to_q(x).reshape(batch, length, self.heads, self.head_dim)
+        k = self.to_k(x).reshape(batch, length, self.heads, self.head_dim)
+        v = self.to_v(x).reshape(batch, length, self.heads, self.head_dim)
+        q, k, v = (array.transpose(0, 2, 1, 3) for array in (q, k, v))
+        y = mx.fast.scaled_dot_product_attention(
+            q,
+            k,
+            v,
+            scale=1.0 / math.sqrt(self.head_dim),
+            mask="causal",
+        )
+        return self.to_out(y.transpose(0, 2, 1, 3).reshape(batch, length, -1))
+
+
+class DepthBlock(nn.Module):
+    def __init__(self, dim: int, heads: int, intermediate: int, eps: float):
+        super().__init__()
+        self.input_layernorm = nn.RMSNorm(dim, eps=eps)
+        self.attn = DepthAttention(dim, heads)
+        self.post_attention_layernorm = nn.RMSNorm(dim, eps=eps)
+        self.gate_proj = nn.Linear(dim, intermediate, bias=False)
+        self.up_proj = nn.Linear(dim, intermediate, bias=False)
+        self.down_proj = nn.Linear(intermediate, dim, bias=False)
+
+    def __call__(self, x: mx.array) -> mx.array:
+        x = x + self.attn(self.input_layernorm(x))
+        normalized = self.post_attention_layernorm(x)
+        return x + self.down_proj(
+            nn.silu(self.gate_proj(normalized)) * self.up_proj(normalized)
+        )
+
+
+class RVQDepthDecoder(nn.Module):
+    def __init__(self, config: ModelConfig):
+        super().__init__()
+        residual = config.residual_codebooks
+        self.audio_embeddings = nn.Embedding(
+            config.audio_vocab_size * residual, config.hidden_size
+        )
+        self.projection = nn.Linear(config.hidden_size, config.hidden_size, bias=False)
+        self.pos_embedding = nn.Embedding(
+            config.depth_max_position_embeddings, config.hidden_size
+        )
+        self.layers = [
+            DepthBlock(
+                config.hidden_size,
+                config.depth_num_heads,
+                config.depth_intermediate_size,
+                config.rms_norm_eps,
+            )
+            for _ in range(config.depth_num_layers)
+        ]
+        self.norm = nn.RMSNorm(config.hidden_size, eps=config.rms_norm_eps)
+        self.audio_heads = [
+            nn.Linear(config.hidden_size, config.audio_vocab_size, bias=False)
+            for _ in range(residual)
+        ]
+
+    def __call__(self, input_embeddings: mx.array) -> mx.array:
+        hidden = input_embeddings + self.pos_embedding(
+            mx.arange(input_embeddings.shape[1])
+        )
+        for layer in self.layers:
+            hidden = layer(hidden)
+        return self.norm(hidden)

--- a/sglang_omni/models/minimax_music3/mlx/dit.py
+++ b/sglang_omni/models/minimax_music3/mlx/dit.py
@@ -1,0 +1,143 @@
+# SPDX-License-Identifier: MIT
+# Copyright (c) 2024 Prince Canuma and contributors.
+# Adapted from Blaizzy/mlx-audio commit 921059d0074e.
+"""One-dimensional flow-matching transformer for MiniMax Music 3."""
+
+from __future__ import annotations
+
+import math
+
+import mlx.core as mx
+import mlx.nn as nn
+
+from .config import ModelConfig
+
+
+def _apply_partial_rotary(x: mx.array, cos: mx.array, sin: mx.array) -> mx.array:
+    rotary_dim = cos.shape[-1]
+    cos = cos[:, None, :].astype(x.dtype)
+    sin = sin[:, None, :].astype(x.dtype)
+    rotated = x[..., :rotary_dim]
+    half = rotary_dim // 2
+    rotate_half = mx.concatenate([-rotated[..., half:], rotated[..., :half]], axis=-1)
+    rotated = rotated * cos + rotate_half * sin
+    return mx.concatenate([rotated, x[..., rotary_dim:]], axis=-1)
+
+
+class FourierEmbedding(nn.Module):
+    def __init__(self, embedding_dim: int):
+        super().__init__()
+        self.weight = mx.random.normal((embedding_dim // 2, 1))
+
+    def __call__(self, timestep: mx.array) -> mx.array:
+        angles = 2.0 * math.pi * timestep.reshape(-1, 1) @ self.weight.T
+        return mx.concatenate([mx.cos(angles), mx.sin(angles)], axis=-1)
+
+
+class TimestepEmbedding(nn.Module):
+    def __init__(self, input_dim: int, output_dim: int):
+        super().__init__()
+        self.linear_1 = nn.Linear(input_dim, output_dim)
+        self.linear_2 = nn.Linear(output_dim, output_dim)
+
+    def __call__(self, x: mx.array) -> mx.array:
+        return self.linear_2(nn.silu(self.linear_1(x)))
+
+
+class DiTAttention(nn.Module):
+    def __init__(self, dim: int, heads: int, head_dim: int):
+        super().__init__()
+        self.heads = heads
+        self.head_dim = head_dim
+        inner = heads * head_dim
+        self.to_q = nn.Linear(dim, inner, bias=False)
+        self.to_k = nn.Linear(dim, inner, bias=False)
+        self.to_v = nn.Linear(dim, inner, bias=False)
+        self.to_out = [nn.Linear(inner, dim, bias=False), nn.Dropout(0.0)]
+
+    def __call__(self, x: mx.array, cos: mx.array, sin: mx.array) -> mx.array:
+        batch, length, _ = x.shape
+        q = self.to_q(x).reshape(batch, length, self.heads, self.head_dim)
+        k = self.to_k(x).reshape(batch, length, self.heads, self.head_dim)
+        v = self.to_v(x).reshape(batch, length, self.heads, self.head_dim)
+        q = _apply_partial_rotary(q, cos, sin).transpose(0, 2, 1, 3)
+        k = _apply_partial_rotary(k, cos, sin).transpose(0, 2, 1, 3)
+        v = v.transpose(0, 2, 1, 3)
+        y = mx.fast.scaled_dot_product_attention(
+            q, k, v, scale=1.0 / math.sqrt(self.head_dim)
+        )
+        y = y.transpose(0, 2, 1, 3).reshape(batch, length, -1)
+        return self.to_out[1](self.to_out[0](y))
+
+
+class DiTBlock(nn.Module):
+    def __init__(self, dim: int, heads: int, head_dim: int, ff_inner: int):
+        super().__init__()
+        self.norm1 = nn.LayerNorm(dim)
+        self.attn = DiTAttention(dim, heads, head_dim)
+        self.norm2 = nn.LayerNorm(dim)
+        self.ff_in = nn.Linear(dim, ff_inner * 2)
+        self.ff_out = nn.Linear(ff_inner, dim)
+
+    def __call__(self, x: mx.array, cos: mx.array, sin: mx.array) -> mx.array:
+        x = x + self.attn(self.norm1(x), cos, sin)
+        states, gate = mx.split(self.ff_in(self.norm2(x)), 2, axis=-1)
+        return x + self.ff_out(states * nn.silu(gate))
+
+
+class FlowMatchingTransformer(nn.Module):
+    def __init__(self, config: ModelConfig):
+        super().__init__()
+        inner = config.dit_num_heads * config.dit_head_dim
+        concat = 2 * config.dit_in_channels + config.condition_out_dim
+        self.time_proj = FourierEmbedding(config.dit_fourier_dim)
+        self.time_embed = TimestepEmbedding(config.dit_fourier_dim, inner)
+        self.preprocess_conv = nn.Conv1d(concat, concat, kernel_size=1, bias=False)
+        self.proj_in = nn.Linear(concat, inner, bias=False)
+        self.rotary_dim = config.dit_rotary_dim
+        self.transformer_blocks = [
+            DiTBlock(
+                inner,
+                config.dit_num_heads,
+                config.dit_head_dim,
+                config.dit_ff_inner_dim,
+            )
+            for _ in range(config.dit_num_layers)
+        ]
+        self.proj_out = nn.Linear(inner, config.dit_in_channels, bias=False)
+        self.postprocess_conv = nn.Conv1d(
+            config.dit_in_channels,
+            config.dit_in_channels,
+            kernel_size=1,
+            bias=False,
+        )
+
+    def _rotary(self, length: int) -> tuple[mx.array, mx.array]:
+        inv_freq = 1.0 / (
+            10_000.0
+            ** (mx.arange(0, self.rotary_dim, 2).astype(mx.float32) / self.rotary_dim)
+        )
+        frequencies = mx.outer(mx.arange(length).astype(mx.float32), inv_freq)
+        frequencies = mx.concatenate([frequencies, frequencies], axis=-1)
+        return mx.cos(frequencies), mx.sin(frequencies)
+
+    def __call__(
+        self,
+        hidden_states: mx.array,
+        timestep: mx.array,
+        encoder_hidden_states: mx.array,
+    ) -> mx.array:
+        condition = encoder_hidden_states.transpose(0, 2, 1)
+        x = mx.concatenate(
+            [hidden_states, mx.zeros_like(hidden_states), condition], axis=1
+        ).transpose(0, 2, 1)
+        x = self.preprocess_conv(x) + x
+        time_embedding = self.time_embed(self.time_proj(timestep))
+        x = self.proj_in(x)
+        x = mx.concatenate([time_embedding[:, None, :], x], axis=1)
+        cos, sin = self._rotary(x.shape[1])
+        for block in self.transformer_blocks:
+            x = block(x, cos, sin)
+        x = self.proj_out(x[:, 1:])
+        x = self.postprocess_conv(x) + x
+        return x.transpose(0, 2, 1)

--- a/sglang_omni/models/minimax_music3/mlx/euler.py
+++ b/sglang_omni/models/minimax_music3/mlx/euler.py
@@ -1,0 +1,73 @@
+# SPDX-License-Identifier: MIT
+# Copyright (c) 2024 Prince Canuma and contributors.
+# Adapted from Blaizzy/mlx-audio commit 921059d0074e.
+"""Flow-matching Euler scheduler used by MiniMax Music 3."""
+
+from __future__ import annotations
+
+from collections.abc import Callable
+
+import mlx.core as mx
+import numpy as np
+
+from .config import DIT_CFG_SCALE
+
+
+def make_sigma_schedule(num_inference_steps: int) -> np.ndarray:
+    if num_inference_steps < 1:
+        raise ValueError("num_inference_steps must be at least one")
+    raw = np.linspace(
+        1.0,
+        1.0 / num_inference_steps,
+        num_inference_steps,
+        dtype=np.float32,
+    )
+    return np.concatenate([1.0 - raw, np.array([1.0], dtype=np.float32)])
+
+
+def denoise_chunk(
+    transformer,
+    latents: mx.array,
+    condition: mx.array,
+    num_inference_steps: int = 30,
+    guidance_scale: float = DIT_CFG_SCALE,
+    previous_latent: mx.array | None = None,
+    previous_condition: mx.array | None = None,
+    should_abort: Callable[[], bool] | None = None,
+) -> tuple[mx.array, mx.array]:
+    overlap = 0
+    if previous_latent is not None and previous_condition is not None:
+        overlap = min(previous_latent.shape[-1], condition.shape[1])
+        if overlap:
+            condition = mx.concatenate(
+                [previous_condition[:, :overlap], condition[:, overlap:]], axis=1
+            )
+
+    sigmas = make_sigma_schedule(num_inference_steps)
+    x = latents
+    noise_prompt = x[..., :overlap] if overlap else None
+    zeros = mx.zeros_like(condition)
+    for index in range(num_inference_steps):
+        if should_abort is not None and should_abort():
+            raise InterruptedError("MiniMax Music 3 MLX acoustic generation aborted")
+        sigma = float(sigmas[index])
+        sigma_next = float(sigmas[index + 1])
+        if overlap:
+            blend = (
+                1.0 - (1.0 - 1e-6) * sigma
+            ) * noise_prompt + sigma * previous_latent[..., :overlap]
+            x = mx.concatenate([blend, x[..., overlap:]], axis=-1)
+        timestep = mx.full((x.shape[0],), sigma, dtype=x.dtype)
+        conditional = transformer(x, timestep, condition)
+        if guidance_scale == 1.0:
+            velocity = conditional
+        else:
+            unconditional = transformer(x, timestep, zeros)
+            velocity = unconditional + guidance_scale * (conditional - unconditional)
+        x = x + (sigma_next - sigma) * velocity
+        mx.eval(x)
+
+    if overlap:
+        x = mx.concatenate([previous_latent[..., :overlap], x[..., overlap:]], axis=-1)
+        mx.eval(x)
+    return x, condition

--- a/sglang_omni/models/minimax_music3/mlx/fusion.py
+++ b/sglang_omni/models/minimax_music3/mlx/fusion.py
@@ -1,0 +1,67 @@
+# SPDX-License-Identifier: MIT
+# Copyright (c) 2024 Prince Canuma and contributors.
+# Adapted from Blaizzy/mlx-audio commit 921059d0074e.
+"""Fuse autoregressive hidden states onto the Flow-VAE timeline."""
+
+from __future__ import annotations
+
+import mlx.core as mx
+import mlx.nn as nn
+
+from .config import ModelConfig
+
+
+def nearest_interpolate_1d(x_ncl: mx.array, size: int) -> mx.array:
+    length = x_ncl.shape[-1]
+    if size == length:
+        return x_ncl
+    indices = (mx.arange(size) * (length / size)).astype(mx.int32)
+    return x_ncl[:, :, mx.clip(indices, 0, length - 1)]
+
+
+def latent_length_from_frames(num_frames: int, config: ModelConfig) -> int:
+    return max(
+        1,
+        int(
+            num_frames
+            * config.output_sampling_rate
+            / config.input_sampling_rate
+            * config.input_hop_length
+            / config.output_hop_length
+        ),
+    )
+
+
+class ConditionEncoder(nn.Module):
+    def __init__(self, config: ModelConfig):
+        super().__init__()
+        self.config = config
+        self.layer_weight_logits = mx.zeros((config.num_condition_layers,))
+        self.layer_scale = mx.ones((1,))
+        self.proj = nn.Conv1d(
+            config.hidden_size,
+            config.condition_out_dim,
+            kernel_size=3,
+            padding=1,
+        )
+
+    def __call__(self, hidden_states: mx.array) -> mx.array:
+        batch, num_frames, _ = hidden_states.shape
+        hidden = hidden_states.reshape(
+            batch,
+            num_frames,
+            self.config.num_condition_layers,
+            self.config.hidden_size,
+        ).transpose(0, 2, 3, 1)
+        weights = mx.softmax(
+            self.layer_weight_logits.astype(mx.float32), axis=0
+        ).astype(hidden.dtype)
+        hidden = (hidden * weights.reshape(1, -1, 1, 1)).sum(axis=1)
+        hidden = self.layer_scale.astype(hidden.dtype) * hidden
+        hidden = self.proj(hidden.transpose(0, 2, 1)).transpose(0, 2, 1)
+        target = latent_length_from_frames(num_frames, self.config)
+        return nearest_interpolate_1d(hidden, target).transpose(0, 2, 1)
+
+
+def fuse_frame_hiddens(global_hidden: mx.array, depth_hiddens: mx.array) -> mx.array:
+    return mx.concatenate([global_hidden, depth_hiddens], axis=-1)

--- a/sglang_omni/models/minimax_music3/mlx/loader.py
+++ b/sglang_omni/models/minimax_music3/mlx/loader.py
@@ -1,0 +1,228 @@
+# SPDX-License-Identifier: Apache-2.0
+"""Load split MiniMax Music 3 components from an MLX artifact."""
+
+from __future__ import annotations
+
+import json
+from pathlib import Path
+from typing import Any
+
+import mlx.core as mx
+import mlx.nn as nn
+from mlx_lm.models.qwen3 import Model as Qwen3Model
+from mlx_lm.models.qwen3 import ModelArgs as Qwen3Args
+
+from .config import ModelConfig
+from .depth import RVQDepthDecoder
+from .dit import FlowMatchingTransformer
+from .fusion import ConditionEncoder
+from .vocoder import Vocoder
+
+
+def _make_qwen3(config: ModelConfig) -> Qwen3Model:
+    return Qwen3Model(
+        Qwen3Args(
+            model_type="qwen3",
+            hidden_size=config.hidden_size,
+            num_hidden_layers=config.num_hidden_layers,
+            intermediate_size=config.intermediate_size,
+            num_attention_heads=config.num_attention_heads,
+            rms_norm_eps=config.rms_norm_eps,
+            vocab_size=config.vocab_size,
+            num_key_value_heads=config.num_key_value_heads,
+            max_position_embeddings=config.max_position_embeddings,
+            rope_theta=config.rope_theta,
+            head_dim=config.head_dim,
+            tie_word_embeddings=config.tie_word_embeddings,
+        )
+    )
+
+
+class MiniMaxMusic3MlxARModel(nn.Module):
+    """Global Qwen3 generator plus the local RVQ depth decoder."""
+
+    def __init__(self, config: ModelConfig) -> None:
+        super().__init__()
+        self.config = config
+        self.language_model = _make_qwen3(config)
+        self.rvq_depth_decoder = RVQDepthDecoder(config)
+
+    @staticmethod
+    def model_quant_predicate(path: str, module: nn.Module) -> bool:
+        if not isinstance(module, nn.Linear):
+            return False
+        if path.endswith("lm_head") or ".audio_heads." in path:
+            return False
+        return path.startswith(
+            (
+                "language_model.model.layers.",
+                "rvq_depth_decoder.layers.",
+            )
+        )
+
+
+class MiniMaxMusic3MlxAcousticModel(nn.Module):
+    """Condition encoder, Flow/DiT, and stereo DAV decoder."""
+
+    def __init__(self, config: ModelConfig) -> None:
+        super().__init__()
+        self.config = config
+        self.condition_encoder = ConditionEncoder(config)
+        self.transformer = FlowMatchingTransformer(config)
+        self.vocoder = Vocoder(config)
+
+    @staticmethod
+    def model_quant_predicate(path: str, module: nn.Module) -> bool:
+        if not isinstance(module, nn.Linear):
+            return False
+        return path.startswith(
+            (
+                "transformer.proj_in",
+                "transformer.proj_out",
+                "transformer.transformer_blocks.",
+            )
+        )
+
+
+def _resolve_model_directory(model_path: str, revision: str | None) -> Path:
+    local_path = Path(model_path).expanduser()
+    if local_path.is_dir():
+        return local_path.resolve()
+    from sglang.srt.hardware_backend.mlx.remote_code_gate import (
+        ensure_remote_code_allowed,
+        resolve_model_directory,
+    )
+
+    model_dir = Path(resolve_model_directory(model_path, revision=revision))
+    ensure_remote_code_allowed(model_dir, trust_remote_code=False)
+    return model_dir
+
+
+def _read_config(model_dir: Path) -> tuple[dict[str, Any], ModelConfig]:
+    config_path = model_dir / "config.json"
+    if not config_path.is_file():
+        raise FileNotFoundError(
+            f"MiniMax Music 3 MLX artifact is missing {config_path}"
+        )
+    raw = json.loads(config_path.read_text(encoding="utf-8"))
+    architectures = set(raw.get("architectures") or ())
+    if architectures and "MiniMaxMusic3ForConditionalGeneration" not in architectures:
+        raise ValueError(
+            "MiniMax Music 3 MLX artifact has an incompatible architecture: "
+            f"{sorted(architectures)}"
+        )
+    config = ModelConfig.from_dict(raw)
+    config.model_path = str(model_dir)
+    return raw, config
+
+
+def _load_component_weights(
+    model_dir: Path,
+    prefixes: tuple[str, ...],
+) -> dict[str, mx.array]:
+    weight_files = sorted(model_dir.glob("*.safetensors"))
+    if not weight_files:
+        weight_files = sorted(model_dir.glob("*.npz"))
+    if not weight_files:
+        raise FileNotFoundError(
+            "MiniMax Music 3 native MLX requires a converted artifact with "
+            f"safetensors or npz weights: {model_dir}"
+        )
+
+    selected: dict[str, mx.array] = {}
+    for weight_file in weight_files:
+        shard = mx.load(str(weight_file))
+        for name, value in shard.items():
+            if not name.startswith(prefixes):
+                continue
+            if name in selected:
+                raise ValueError(f"duplicate MiniMax Music 3 MLX tensor {name!r}")
+            selected[name] = value
+    if not selected:
+        raise ValueError(
+            "MiniMax Music 3 MLX artifact has no weights matching "
+            + ", ".join(prefixes)
+        )
+    return selected
+
+
+def _apply_quantization(
+    model: nn.Module,
+    raw_config: dict[str, Any],
+    weights: dict[str, mx.array],
+) -> None:
+    quantization = raw_config.get("quantization") or raw_config.get(
+        "quantization_config"
+    )
+    if not isinstance(quantization, dict):
+        return
+    group_size = int(quantization.get("group_size", 64))
+    predicate = getattr(model, "model_quant_predicate", None)
+
+    def class_predicate(path: str, module: nn.Module):
+        if not hasattr(module, "to_quantized"):
+            return False
+        if hasattr(module, "weight") and module.weight.shape[-1] % group_size:
+            return False
+        if predicate is not None and not predicate(path, module):
+            return False
+        if path in quantization:
+            return quantization[path]
+        return f"{path}.scales" in weights
+
+    nn.quantize(
+        model,
+        group_size=group_size,
+        bits=int(quantization["bits"]),
+        mode=str(quantization.get("mode", "affine")),
+        class_predicate=class_predicate,
+    )
+
+
+def _load_split_model(
+    model_path: str,
+    revision: str | None,
+    model_cls: type[nn.Module],
+    prefixes: tuple[str, ...],
+) -> nn.Module:
+    model_dir = _resolve_model_directory(model_path, revision)
+    raw_config, config = _read_config(model_dir)
+    model = model_cls(config)
+    weights = _load_component_weights(model_dir, prefixes)
+    _apply_quantization(model, raw_config, weights)
+    model.load_weights(list(weights.items()), strict=True)
+    mx.eval(model.parameters())
+    model.eval()
+    return model
+
+
+def load_mlx_ar_model(
+    model_path: str,
+    revision: str | None = None,
+) -> MiniMaxMusic3MlxARModel:
+    return _load_split_model(
+        model_path,
+        revision,
+        MiniMaxMusic3MlxARModel,
+        ("language_model.", "rvq_depth_decoder."),
+    )
+
+
+def load_mlx_acoustic_model(
+    model_path: str,
+    revision: str | None = None,
+) -> MiniMaxMusic3MlxAcousticModel:
+    return _load_split_model(
+        model_path,
+        revision,
+        MiniMaxMusic3MlxAcousticModel,
+        ("condition_encoder.", "transformer.", "vocoder."),
+    )
+
+
+__all__ = [
+    "MiniMaxMusic3MlxARModel",
+    "MiniMaxMusic3MlxAcousticModel",
+    "load_mlx_acoustic_model",
+    "load_mlx_ar_model",
+]

--- a/sglang_omni/models/minimax_music3/mlx/loader.py
+++ b/sglang_omni/models/minimax_music3/mlx/loader.py
@@ -18,6 +18,8 @@ from .dit import FlowMatchingTransformer
 from .fusion import ConditionEncoder
 from .vocoder import Vocoder
 
+MlxArtifact = tuple[Path, dict[str, Any], ModelConfig]
+
 
 def _make_qwen3(config: ModelConfig) -> Qwen3Model:
     return Qwen3Model(
@@ -116,6 +118,13 @@ def _read_config(model_dir: Path) -> tuple[dict[str, Any], ModelConfig]:
     return raw, config
 
 
+def resolve_mlx_artifact(model_path: str, revision: str | None = None) -> MlxArtifact:
+    """Resolve a revision once and retain its immutable local snapshot path."""
+    model_dir = _resolve_model_directory(model_path, revision)
+    raw_config, config = _read_config(model_dir)
+    return model_dir, raw_config, config
+
+
 def _load_component_weights(
     model_dir: Path,
     prefixes: tuple[str, ...],
@@ -184,9 +193,12 @@ def _load_split_model(
     revision: str | None,
     model_cls: type[nn.Module],
     prefixes: tuple[str, ...],
+    *,
+    artifact: MlxArtifact | None = None,
 ) -> nn.Module:
-    model_dir = _resolve_model_directory(model_path, revision)
-    raw_config, config = _read_config(model_dir)
+    model_dir, raw_config, config = artifact or resolve_mlx_artifact(
+        model_path, revision
+    )
     model = model_cls(config)
     weights = _load_component_weights(model_dir, prefixes)
     _apply_quantization(model, raw_config, weights)
@@ -199,30 +211,38 @@ def _load_split_model(
 def load_mlx_ar_model(
     model_path: str,
     revision: str | None = None,
+    *,
+    artifact: MlxArtifact | None = None,
 ) -> MiniMaxMusic3MlxARModel:
     return _load_split_model(
         model_path,
         revision,
         MiniMaxMusic3MlxARModel,
         ("language_model.", "rvq_depth_decoder."),
+        artifact=artifact,
     )
 
 
 def load_mlx_acoustic_model(
     model_path: str,
     revision: str | None = None,
+    *,
+    artifact: MlxArtifact | None = None,
 ) -> MiniMaxMusic3MlxAcousticModel:
     return _load_split_model(
         model_path,
         revision,
         MiniMaxMusic3MlxAcousticModel,
         ("condition_encoder.", "transformer.", "vocoder."),
+        artifact=artifact,
     )
 
 
 __all__ = [
-    "MiniMaxMusic3MlxARModel",
     "MiniMaxMusic3MlxAcousticModel",
+    "MiniMaxMusic3MlxARModel",
+    "MlxArtifact",
     "load_mlx_acoustic_model",
     "load_mlx_ar_model",
+    "resolve_mlx_artifact",
 ]

--- a/sglang_omni/models/minimax_music3/mlx/sampling.py
+++ b/sglang_omni/models/minimax_music3/mlx/sampling.py
@@ -1,0 +1,25 @@
+# SPDX-License-Identifier: MIT
+# Copyright (c) 2024 Prince Canuma and contributors.
+# Adapted from Blaizzy/mlx-audio commit 921059d0074e.
+"""Top-k sampling used by MiniMax Music 3."""
+
+from __future__ import annotations
+
+import mlx.core as mx
+
+from .config import AR_SAMPLING_TOP_K
+
+
+def sample_top_k(
+    logits: mx.array,
+    key: mx.array,
+    top_k: int = AR_SAMPLING_TOP_K,
+) -> tuple[mx.array, mx.array]:
+    values = mx.where(
+        mx.isnan(logits), mx.array(-1e9, dtype=logits.dtype), logits
+    ).astype(mx.float32)
+    k = min(top_k, values.shape[-1])
+    threshold = mx.min(mx.topk(values, k, axis=-1), axis=-1, keepdims=True)
+    masked = mx.where(values < threshold, mx.array(-1e9, dtype=mx.float32), values)
+    next_key = mx.random.split(key)[1]
+    return mx.random.categorical(masked, axis=-1, key=key), next_key

--- a/sglang_omni/models/minimax_music3/mlx/vocoder.py
+++ b/sglang_omni/models/minimax_music3/mlx/vocoder.py
@@ -1,0 +1,98 @@
+# SPDX-License-Identifier: MIT
+# Copyright (c) 2024 Prince Canuma and contributors.
+# Adapted from Blaizzy/mlx-audio commit 921059d0074e.
+"""DAC-style Flow-VAE decoder for MiniMax Music 3."""
+
+from __future__ import annotations
+
+import math
+
+import mlx.core as mx
+import mlx.nn as nn
+
+from .config import ModelConfig
+
+
+class Snake1d(nn.Module):
+    def __init__(self, channels: int):
+        super().__init__()
+        self.alpha = mx.ones((1, channels, 1))
+
+    def __call__(self, x_ncl: mx.array) -> mx.array:
+        alpha = self.alpha.astype(x_ncl.dtype)
+        return x_ncl + mx.sin(alpha * x_ncl) ** 2 / (alpha + 1e-9)
+
+
+class ResidualUnit(nn.Module):
+    def __init__(self, dim: int, dilation: int):
+        super().__init__()
+        padding = (7 - 1) * dilation // 2
+        self.snake1 = Snake1d(dim)
+        self.conv1 = nn.Conv1d(
+            dim, dim, kernel_size=7, dilation=dilation, padding=padding
+        )
+        self.snake2 = Snake1d(dim)
+        self.conv2 = nn.Conv1d(dim, dim, kernel_size=1)
+
+    def __call__(self, x_ncl: mx.array) -> mx.array:
+        y = self.conv1(self.snake1(x_ncl).transpose(0, 2, 1))
+        y = self.conv2(self.snake2(y.transpose(0, 2, 1)).transpose(0, 2, 1))
+        return x_ncl + y.transpose(0, 2, 1)
+
+
+class VocoderBlock(nn.Module):
+    def __init__(self, input_dim: int, output_dim: int, stride: int):
+        super().__init__()
+        self.snake1 = Snake1d(input_dim)
+        self.conv_t1 = nn.ConvTranspose1d(
+            input_dim,
+            output_dim,
+            kernel_size=2 * stride,
+            stride=stride,
+            padding=math.ceil(stride / 2),
+        )
+        self.res_unit1 = ResidualUnit(output_dim, dilation=1)
+        self.res_unit2 = ResidualUnit(output_dim, dilation=3)
+        self.res_unit3 = ResidualUnit(output_dim, dilation=9)
+
+    def __call__(self, x_ncl: mx.array) -> mx.array:
+        y = self.conv_t1(self.snake1(x_ncl).transpose(0, 2, 1)).transpose(0, 2, 1)
+        return self.res_unit3(self.res_unit2(self.res_unit1(y)))
+
+
+class Vocoder(nn.Module):
+    def __init__(self, config: ModelConfig):
+        super().__init__()
+        self.config = config
+        latent_half = config.dit_in_channels // 2
+        self.dec_in_proj = nn.Conv1d(
+            latent_half, config.vocoder_input_dim, kernel_size=1
+        )
+        self.conv_in = nn.Conv1d(
+            config.vocoder_input_dim,
+            config.vocoder_hidden_dim,
+            kernel_size=7,
+            padding=3,
+        )
+        blocks = []
+        output_dim = config.vocoder_hidden_dim
+        for index, stride in enumerate(config.vocoder_upsampling_ratios):
+            input_dim = config.vocoder_hidden_dim // (2**index)
+            output_dim = config.vocoder_hidden_dim // (2 ** (index + 1))
+            blocks.append(VocoderBlock(input_dim, output_dim, stride))
+        self.blocks = blocks
+        self.snake_out = Snake1d(output_dim)
+        self.conv_out = nn.Conv1d(output_dim, 1, kernel_size=7, padding=3)
+
+    def __call__(self, latents: mx.array) -> mx.array:
+        batch, _, length = latents.shape
+        half = self.config.dit_in_channels // 2
+        hidden = latents.reshape(batch * 2, half, length)
+        hidden = self.dec_in_proj(hidden.transpose(0, 2, 1))
+        hidden = self.conv_in(hidden).transpose(0, 2, 1)
+        for block in self.blocks:
+            hidden = block(hidden)
+        wave = mx.tanh(
+            self.conv_out(self.snake_out(hidden).transpose(0, 2, 1))
+        ).transpose(0, 2, 1)
+        return wave.reshape(batch, 2, -1)

--- a/sglang_omni/models/minimax_music3/model_runner.py
+++ b/sglang_omni/models/minimax_music3/model_runner.py
@@ -18,6 +18,7 @@ from sglang_omni.sampling.seed import derive_sampling_seed
 from .chunking import ChunkWindow, chunk_windows
 from .constants import AR_CHUNK_FRAMES, AR_CHUNK_HOP_FRAMES
 from .rvq_decoder import sample_topk_seeded
+from .serial_offload import get_coordinator
 from .sglang_model import apply_cfg, depth_decode, embed_audio_frames, select_c0_logits
 
 logger = logging.getLogger(__name__)
@@ -95,6 +96,7 @@ class MiniMaxMusic3ModelRunner(ModelRunner):
             logger.warning(
                 f"MiniMax Music 3 is replaying reference code trajectories from {self._forced_codes_dir}; generated audio is the reference's, not this model's"
             )
+        self._serial_offload = get_coordinator()
 
     def requested_capture_hidden_mode_prefill(
         self, schedule_batch: Any, requests: list
@@ -198,6 +200,7 @@ class MiniMaxMusic3ModelRunner(ModelRunner):
         logger.info(
             f"MiniMax Music 3 AR done request={request_id} frames={ar_state.generated_frames} prompt_tokens={req_data.prompt_tokens} finish_reason={ar_state.finish_reason} peak_buffer_frames={ar_state.frames.peak_frames} elapsed={time.perf_counter() - ar_state.started_s:.1f}s"
         )
+        self._serial_offload.begin_dit_handoff(request_id)
 
     def reset_request(self, request_id: str) -> None:
         data = self._request_data.pop(request_id, None)
@@ -285,7 +288,8 @@ class MiniMaxMusic3ModelRunner(ModelRunner):
             ar_state.frames.append(frame_hidden[index : index + 1])
             ar_state.generated_frames += 1
             self._log_progress(cond_requests[index].request_id, ar_state)
-            self._emit_ready_window(cond_requests[index].request_id, ar_state)
+            if not self._serial_offload.enabled:
+                self._emit_ready_window(cond_requests[index].request_id, ar_state)
         result.next_token_ids = model.c0_logit_ids[sampled.repeat_interleave(2)]
 
     def _start_request(self, request_id: str, data: Any, device: torch.device) -> None:

--- a/sglang_omni/models/minimax_music3/model_runner.py
+++ b/sglang_omni/models/minimax_music3/model_runner.py
@@ -206,6 +206,7 @@ class MiniMaxMusic3ModelRunner(ModelRunner):
         data = self._request_data.pop(request_id, None)
         if data is not None:
             data.ar_state = None
+        self._serial_offload.cancel_ar(request_id)
 
     def _advance(self, result: Any, requests: list, *, emit: bool) -> None:
         """Sample one frame per row and queue whatever windows it completes."""

--- a/sglang_omni/models/minimax_music3/scheduler.py
+++ b/sglang_omni/models/minimax_music3/scheduler.py
@@ -7,6 +7,7 @@ from typing import Any
 
 from sglang_omni.scheduling.omni_scheduler import OmniScheduler
 
+from .serial_offload import get_coordinator
 from .sglang_request_builder import cfg_uncond_rid, is_cfg_uncond_rid
 
 
@@ -61,6 +62,8 @@ class MiniMaxMusic3Scheduler(OmniScheduler):
 
     def _pair_admission_limit(self, queue: list, running_batch: Any) -> int:
         """How many leading queue entries the adder may see, always whole pairs."""
+        if not get_coordinator().ar_can_admit():
+            return 0
         allocatable = int(self.get_num_allocatable_reqs(len(running_batch.reqs)))
         limit = min(len(queue), max(0, allocatable))
         limit -= limit % 2

--- a/sglang_omni/models/minimax_music3/scheduler.py
+++ b/sglang_omni/models/minimax_music3/scheduler.py
@@ -62,8 +62,6 @@ class MiniMaxMusic3Scheduler(OmniScheduler):
 
     def _pair_admission_limit(self, queue: list, running_batch: Any) -> int:
         """How many leading queue entries the adder may see, always whole pairs."""
-        if not get_coordinator().ar_can_admit():
-            return 0
         allocatable = int(self.get_num_allocatable_reqs(len(running_batch.reqs)))
         limit = min(len(queue), max(0, allocatable))
         limit -= limit % 2
@@ -74,8 +72,14 @@ class MiniMaxMusic3Scheduler(OmniScheduler):
                 queue[index + 1].origin_input_ids
             )
             if index and tokens + pair_tokens > budget:
-                return index
+                limit = index
+                break
             tokens += pair_tokens
+        coordinator = get_coordinator()
+        if coordinator.enabled:
+            if limit < 2 or not coordinator.try_acquire_ar(queue[0].rid):
+                return 0
+            return 2
         return limit
 
     def stream_output(

--- a/sglang_omni/models/minimax_music3/serial_offload.py
+++ b/sglang_omni/models/minimax_music3/serial_offload.py
@@ -1,0 +1,279 @@
+# SPDX-License-Identifier: Apache-2.0
+"""Serial GPU residency for the MiniMax Music 3 AR and DIT/DAV stages.
+
+``--stage-offload-components ar,dit`` colocates both stages in one process
+and lets only one of them hold GPU weights at a time: AR generates a whole
+request, hands off to DIT/DAV, and stays off the GPU until DIT/DAV is finished
+with that request.
+
+The handoff is keyed by request id rather than by a single boolean. AR wakes
+when nothing is outstanding, so a duplicated, out-of-order, or late terminal
+event cannot wake AR while DIT/DAV is still decoding, and an event that names
+a request nobody handed off cannot wake AR early.
+
+A handoff that never ends stops admission for good, because ``ar_can_admit``
+gates the AR scheduler's queue. That is reported rather than force-corrected:
+waking AR while DIT/DAV still holds the GPU is how this configuration runs out
+of memory, so a stuck server is preferable to a crashed one, and the log names
+the requests still outstanding.
+"""
+
+from __future__ import annotations
+
+import logging
+import threading
+import time
+from typing import Any
+
+import torch
+
+logger = logging.getLogger(__name__)
+
+STALL_REPORT_SECONDS = 900.0
+_GIB = 1024.0**3
+
+
+def _owned_tensors(
+    modules: dict[str, Any],
+) -> list[tuple[tuple[str, str], torch.Tensor]]:
+    """Every tensor owned by a stage's modules, tied tensors listed once.
+
+    ``named_parameters``/``named_buffers`` de-duplicate by default, so a tied
+    weight appears under one name per module. De-duplicate once more across the
+    group so modules that share a tensor still get one canonical host copy.
+    Residency mutates the tensor object in place, so every name that shares it
+    follows along and the tying survives the round trip.
+    """
+    owned: list[tuple[tuple[str, str], torch.Tensor]] = []
+    seen: set[int] = set()
+    for module_name, module in modules.items():
+        for tensor_name, tensor in (
+            *module.named_parameters(),
+            *module.named_buffers(),
+        ):
+            if id(tensor) in seen:
+                continue
+            seen.add(id(tensor))
+            owned.append(((module_name, tensor_name), tensor))
+    return owned
+
+
+def _gpu_memory_note(device: torch.device) -> str:
+    """Device occupancy, for attributing what a handoff actually frees.
+
+    ``torch_*`` covers only this process's caching allocator, while ``free``
+    is the whole device, so a gap between them is memory held outside torch's
+    allocator. Reporting both is what distinguishes weights coming off the GPU
+    from the pools that stay put -- notably the SGLang KV cache, which
+    ``mem_fraction_static`` reserves for the life of the process and which no
+    weight offload releases.
+    """
+    if device.type != "cuda":
+        return "cpu"
+    free, total = torch.cuda.mem_get_info(device)
+    return (
+        f"free={free / _GIB:.2f}/{total / _GIB:.2f}GiB "
+        f"torch_allocated={torch.cuda.memory_allocated(device) / _GIB:.2f}GiB "
+        f"torch_reserved={torch.cuda.memory_reserved(device) / _GIB:.2f}GiB"
+    )
+
+
+class StageResidency:
+    """GPU residency for a group of stage modules whose weights never change.
+
+    Inference never writes these weights, so the host copy is canonical: it is
+    filled once and every wake refills the GPU from it. Sleeping then only
+    drops the GPU replica -- no device-to-host copy and no fresh host
+    allocation per request, which is what ``module.to()`` in both directions
+    was paying for on every single handoff.
+
+    Reusing one host copy also stops the sleep path handing the caching
+    allocator a differently sized block each round trip. That is what lets a
+    long-running server fragment its way into an OOM after tens of requests
+    rather than failing on the first one.
+    """
+
+    def __init__(
+        self,
+        modules: dict[str, Any],
+        device: torch.device,
+        *,
+        resident: bool = True,
+        label: str = "stage",
+    ):
+        if not modules:
+            raise ValueError("StageResidency requires at least one module")
+        self._modules = dict(modules)
+        self._device = torch.device(device)
+        self._resident = bool(resident)
+        self._label = label
+        self._host: dict[tuple[str, str], torch.Tensor] = {}
+        if not self._resident:
+            # Built on the host: retain its existing storage through a distinct
+            # tensor handle. Keeping the Parameter itself here would alias the
+            # object whose ``.data`` wake replaces, moving the supposed host
+            # copy onto the GPU along with the module.
+            self._host = {
+                name: tensor.detach() for name, tensor in _owned_tensors(self._modules)
+            }
+        weight_bytes = sum(
+            tensor.numel() * tensor.element_size()
+            for _, tensor in _owned_tensors(self._modules)
+        )
+        logger.info(
+            f"MiniMax Music 3 residency {label}: {weight_bytes / _GIB:.2f}GiB of "
+            f"weights, starts {'resident' if self._resident else 'offloaded'} "
+            f"({_gpu_memory_note(self._device)})"
+        )
+
+    @property
+    def resident(self) -> bool:
+        return self._resident
+
+    def sleep(self) -> None:
+        """Drop the GPU replica; a cheap no-op once already asleep."""
+        if not self._resident:
+            return
+        owned = _owned_tensors(self._modules)
+        if not self._host:
+            self._host = {
+                name: tensor.detach().to("cpu", copy=True) for name, tensor in owned
+            }
+        for name, tensor in owned:
+            tensor.data = self._host[name]
+        self._resident = False
+        logger.info(
+            f"MiniMax Music 3 residency {self._label} -> host "
+            f"({_gpu_memory_note(self._device)})"
+        )
+
+    def wake(self) -> None:
+        """Refill the GPU replica from the host copy; no-op once resident."""
+        if self._resident:
+            return
+        for name, tensor in _owned_tensors(self._modules):
+            tensor.data = self._host[name].to(
+                self._device, copy=True, non_blocking=True
+            )
+        if self._device.type == "cuda":
+            torch.cuda.synchronize(self._device)
+        self._resident = True
+        logger.info(
+            f"MiniMax Music 3 residency {self._label} -> gpu "
+            f"({_gpu_memory_note(self._device)})"
+        )
+
+
+class SerialOffloadCoordinator:
+    """Process-wide GPU residency coordinator (see module docstring)."""
+
+    def __init__(self) -> None:
+        self._lock = threading.Lock()
+        self._enabled = False
+        self._ar_active = True
+        self._ar: StageResidency | None = None
+        self._outstanding: set[str] = set()
+        self._paused_at: float | None = None
+        self._stall_reported = False
+
+    @property
+    def enabled(self) -> bool:
+        return self._enabled
+
+    def register_ar(self, model: Any, device: torch.device) -> None:
+        with self._lock:
+            self._ar = StageResidency({"ar": model}, device, label="ar")
+            self._enabled = True
+            self._ar_active = True
+        logger.info(
+            f"MiniMax Music 3 serial offload enabled device={device}; AR "
+            "starts GPU-resident, DIT/DAV starts offloaded"
+        )
+
+    def ar_can_admit(self) -> bool:
+        """Whether AR may admit a new request onto the GPU right now."""
+        if not self._enabled:
+            return True
+        with self._lock:
+            if self._ar_active:
+                return True
+            self._report_stall_locked()
+            return False
+
+    def begin_dit_handoff(self, request_id: str) -> None:
+        """Hand the GPU to DIT/DAV for *request_id* and take AR off it."""
+        if not self._enabled:
+            return
+        with self._lock:
+            self._require_ar_locked()
+            self._outstanding.add(request_id)
+            if not self._ar_active:
+                return
+            self._ar.sleep()
+            self._ar_active = False
+            self._paused_at = time.monotonic()
+            self._stall_reported = False
+        logger.info(
+            f"MiniMax Music 3 serial offload: AR -> CPU (DIT/DAV's turn, "
+            f"request={request_id})"
+        )
+
+    def end_dit_handoff(self, request_id: str) -> None:
+        """Retire *request_id*; give the GPU back once nothing is outstanding.
+
+        Safe to call for a request that never handed off, and safe to call
+        more than once: both leave the outstanding set unchanged.
+        """
+        if not self._enabled:
+            return
+        with self._lock:
+            self._require_ar_locked()
+            self._outstanding.discard(request_id)
+            if self._ar_active or self._outstanding:
+                return
+            self._ar.wake()
+            self._ar_active = True
+            self._paused_at = None
+            self._stall_reported = False
+        logger.info(
+            f"MiniMax Music 3 serial offload: AR -> GPU (AR's turn, "
+            f"request={request_id})"
+        )
+
+    def _require_ar_locked(self) -> None:
+        if self._ar is None:
+            raise RuntimeError(
+                "MiniMax Music 3 serial offload is enabled but the AR "
+                "backbone was never registered"
+            )
+
+    def _report_stall_locked(self) -> None:
+        """Name the outstanding requests once AR has been parked too long."""
+        if self._paused_at is None or self._stall_reported:
+            return
+        elapsed = time.monotonic() - self._paused_at
+        if elapsed < STALL_REPORT_SECONDS:
+            return
+        self._stall_reported = True
+        logger.error(
+            f"MiniMax Music 3 serial offload: AR has been off the GPU for "
+            f"{elapsed:.0f}s and is still waiting on "
+            f"{sorted(self._outstanding)}; AR admits nothing until DIT/DAV "
+            "retires them, so this server needs a restart if the requests "
+            "are gone"
+        )
+
+
+_COORDINATOR = SerialOffloadCoordinator()
+
+
+def get_coordinator() -> SerialOffloadCoordinator:
+    return _COORDINATOR
+
+
+__all__ = [
+    "STALL_REPORT_SECONDS",
+    "StageResidency",
+    "SerialOffloadCoordinator",
+    "get_coordinator",
+]

--- a/sglang_omni/models/minimax_music3/serial_offload.py
+++ b/sglang_omni/models/minimax_music3/serial_offload.py
@@ -6,13 +6,11 @@ and lets only one of them hold GPU weights at a time: AR generates a whole
 request, hands off to DIT/DAV, and stays off the GPU until DIT/DAV is finished
 with that request.
 
-The handoff is keyed by request id rather than by a single boolean. AR wakes
-when nothing is outstanding, so a duplicated, out-of-order, or late terminal
-event cannot wake AR while DIT/DAV is still decoding, and an event that names
-a request nobody handed off cannot wake AR early.
+The handoff has one request owner. A duplicated, out-of-order, or late terminal
+event cannot wake AR while DIT/DAV is decoding another request.
 
-A handoff that never ends stops admission for good, because ``ar_can_admit``
-gates the AR scheduler's queue. That is reported rather than force-corrected:
+A handoff that never ends stops admission for good. That is reported rather
+than force-corrected:
 waking AR while DIT/DAV still holds the GPU is how this configuration runs out
 of memory, so a stuck server is preferable to a crashed one, and the log names
 the requests still outstanding.
@@ -23,6 +21,7 @@ from __future__ import annotations
 import logging
 import threading
 import time
+from collections.abc import Callable
 from typing import Any
 
 import torch
@@ -134,6 +133,8 @@ class StageResidency:
         """Drop the GPU replica; a cheap no-op once already asleep."""
         if not self._resident:
             return
+        if self._device.type == "cuda":
+            torch.cuda.synchronize(self._device)
         owned = _owned_tensors(self._modules)
         if not self._host:
             self._host = {
@@ -165,14 +166,15 @@ class StageResidency:
 
 
 class SerialOffloadCoordinator:
-    """Process-wide GPU residency coordinator (see module docstring)."""
+    """Process-wide ownership and optional CUDA residency coordinator."""
 
     def __init__(self) -> None:
-        self._lock = threading.Lock()
+        self._condition = threading.Condition()
         self._enabled = False
-        self._ar_active = True
         self._ar: StageResidency | None = None
-        self._outstanding: set[str] = set()
+        self._owner: str | None = None
+        self._phase = "disabled"
+        self._failure: BaseException | None = None
         self._paused_at: float | None = None
         self._stall_reported = False
 
@@ -180,75 +182,180 @@ class SerialOffloadCoordinator:
     def enabled(self) -> bool:
         return self._enabled
 
-    def register_ar(self, model: Any, device: torch.device) -> None:
-        with self._lock:
-            self._ar = StageResidency({"ar": model}, device, label="ar")
+    def enable(self) -> None:
+        """Enable request ownership for a backend without CUDA residency."""
+        with self._condition:
+            if self._enabled:
+                return
             self._enabled = True
-            self._ar_active = True
+            self._phase = "idle"
+
+    def register_ar(self, model: Any, device: torch.device) -> None:
+        residency = StageResidency({"ar": model}, device, label="ar")
+        with self._condition:
+            if self._enabled:
+                raise RuntimeError("MiniMax Music 3 serial offload is already enabled")
+            self._failure = None
+            self._owner = None
+            self._ar = residency
+            self._enabled = True
+            self._phase = "idle"
         logger.info(
             f"MiniMax Music 3 serial offload enabled device={device}; AR "
             "starts GPU-resident, DIT/DAV starts offloaded"
         )
 
-    def ar_can_admit(self) -> bool:
-        """Whether AR may admit a new request onto the GPU right now."""
+    def try_acquire_ar(self, request_id: str) -> bool:
+        """Atomically claim the complete AR-to-acoustic request lifecycle."""
         if not self._enabled:
             return True
-        with self._lock:
-            if self._ar_active:
+        with self._condition:
+            self._raise_if_failed_locked()
+            if self._owner == request_id and self._phase == "ar":
+                return True
+            if self._owner is None and self._phase == "idle":
+                self._owner = request_id
+                self._phase = "ar"
                 return True
             self._report_stall_locked()
             return False
+
+    def acquire_ar(
+        self,
+        request_id: str,
+        *,
+        should_abort: Callable[[], bool] | None = None,
+    ) -> None:
+        """Wait for and claim AR ownership without holding the lock during work."""
+        if not self._enabled:
+            return
+        with self._condition:
+            while not self.try_acquire_ar(request_id):
+                if should_abort is not None and should_abort():
+                    raise InterruptedError(
+                        "MiniMax Music 3 serial offload admission aborted"
+                    )
+                self._condition.wait(timeout=0.1)
 
     def begin_dit_handoff(self, request_id: str) -> None:
         """Hand the GPU to DIT/DAV for *request_id* and take AR off it."""
         if not self._enabled:
             return
-        with self._lock:
-            self._require_ar_locked()
-            self._outstanding.add(request_id)
-            if not self._ar_active:
+        with self._condition:
+            self._raise_if_failed_locked()
+            if self._owner != request_id:
+                raise RuntimeError(
+                    "MiniMax Music 3 serial offload handoff does not own request "
+                    f"{request_id!r} (owner={self._owner!r})"
+                )
+            if self._phase == "acoustic":
                 return
-            self._ar.sleep()
-            self._ar_active = False
+            if self._phase != "ar":
+                raise RuntimeError(
+                    f"MiniMax Music 3 cannot hand off from phase {self._phase!r}"
+                )
+            self._phase = "ar_unloading"
+
+        try:
+            if self._ar is not None:
+                self._ar.sleep()
+        except BaseException as exc:
+            self._fail_closed(exc)
+            raise
+
+        with self._condition:
+            self._phase = "acoustic"
             self._paused_at = time.monotonic()
             self._stall_reported = False
+            self._condition.notify_all()
         logger.info(
             f"MiniMax Music 3 serial offload: AR -> CPU (DIT/DAV's turn, "
             f"request={request_id})"
         )
 
-    def end_dit_handoff(self, request_id: str) -> None:
-        """Retire *request_id*; give the GPU back once nothing is outstanding.
+    def require_acoustic(self, request_id: str) -> None:
+        """Reject compute that is not owned by the active acoustic request."""
+        if not self._enabled:
+            return
+        with self._condition:
+            self._raise_if_failed_locked()
+            if self._owner != request_id or self._phase != "acoustic":
+                raise RuntimeError(
+                    "MiniMax Music 3 acoustic request does not own residency: "
+                    f"request={request_id!r} owner={self._owner!r} "
+                    f"phase={self._phase!r}"
+                )
 
-        Safe to call for a request that never handed off, and safe to call
-        more than once: both leave the outstanding set unchanged.
+    def end_dit_handoff(
+        self,
+        request_id: str,
+        *,
+        release_acoustic: Callable[[], None] | None = None,
+    ) -> None:
+        """Retire *request_id* and return residency to AR.
+
+        Unknown and duplicate terminal events are no-ops. Acoustic release and
+        AR wake run without the ownership mutex held.
         """
         if not self._enabled:
             return
-        with self._lock:
-            self._require_ar_locked()
-            self._outstanding.discard(request_id)
-            if self._ar_active or self._outstanding:
+        with self._condition:
+            self._raise_if_failed_locked()
+            if self._owner != request_id or self._phase != "acoustic":
                 return
-            self._ar.wake()
-            self._ar_active = True
+            self._phase = "acoustic_unloading"
+
+        try:
+            if release_acoustic is not None:
+                release_acoustic()
+            if self._ar is not None:
+                self._ar.wake()
+        except BaseException as exc:
+            self._fail_closed(exc)
+            raise
+
+        with self._condition:
+            self._owner = None
+            self._phase = "idle"
             self._paused_at = None
             self._stall_reported = False
+            self._condition.notify_all()
         logger.info(
             f"MiniMax Music 3 serial offload: AR -> GPU (AR's turn, "
             f"request={request_id})"
         )
 
-    def _require_ar_locked(self) -> None:
-        if self._ar is None:
+    def cancel_ar(self, request_id: str) -> None:
+        """Release an AR owner after its compute has stopped, before handoff."""
+        if not self._enabled:
+            return
+        with self._condition:
+            if self._owner != request_id or self._phase != "ar":
+                return
+            self._owner = None
+            self._phase = "idle"
+            self._condition.notify_all()
+
+    def _fail_closed(self, exc: BaseException) -> None:
+        with self._condition:
+            self._failure = exc
+            self._phase = "failed"
+            self._condition.notify_all()
+
+    def fail_closed(self, exc: BaseException) -> None:
+        """Prevent later admission after an unsafe backend cleanup failure."""
+        if self._enabled:
+            self._fail_closed(exc)
+
+    def _raise_if_failed_locked(self) -> None:
+        if self._failure is not None:
             raise RuntimeError(
-                "MiniMax Music 3 serial offload is enabled but the AR "
-                "backbone was never registered"
-            )
+                "MiniMax Music 3 serial offload is unavailable after a residency "
+                "transition failed"
+            ) from self._failure
 
     def _report_stall_locked(self) -> None:
-        """Name the outstanding requests once AR has been parked too long."""
+        """Name the owner once AR has been parked too long."""
         if self._paused_at is None or self._stall_reported:
             return
         elapsed = time.monotonic() - self._paused_at
@@ -258,7 +365,7 @@ class SerialOffloadCoordinator:
         logger.error(
             f"MiniMax Music 3 serial offload: AR has been off the GPU for "
             f"{elapsed:.0f}s and is still waiting on "
-            f"{sorted(self._outstanding)}; AR admits nothing until DIT/DAV "
+            f"{self._owner!r}; AR admits nothing until DIT/DAV "
             "retires them, so this server needs a restart if the requests "
             "are gone"
         )
@@ -271,9 +378,16 @@ def get_coordinator() -> SerialOffloadCoordinator:
     return _COORDINATOR
 
 
+def reset_coordinator() -> None:
+    """Reset process-local state after a failed build or during test teardown."""
+    global _COORDINATOR
+    _COORDINATOR = SerialOffloadCoordinator()
+
+
 __all__ = [
     "STALL_REPORT_SECONDS",
-    "StageResidency",
     "SerialOffloadCoordinator",
+    "StageResidency",
     "get_coordinator",
+    "reset_coordinator",
 ]

--- a/sglang_omni/models/minimax_music3/stages.py
+++ b/sglang_omni/models/minimax_music3/stages.py
@@ -23,6 +23,12 @@ logger = logging.getLogger(__name__)
 _DEFAULT_AR_CONCURRENCY = int(os.environ.get("MINIMAX_MUSIC3_AR_CONCURRENCY", "16"))
 
 
+def _use_mlx_backend() -> bool:
+    from sglang.srt.utils.tensor_bridge import use_mlx
+
+    return bool(use_mlx())
+
+
 def create_preprocessing_executor(model_path: str) -> SimpleScheduler:
     del model_path
 
@@ -43,7 +49,19 @@ def create_ar_executor(
     device: str | None = None,
     max_concurrency: int = _DEFAULT_AR_CONCURRENCY,
     server_args_overrides: dict[str, Any] | None = None,
+    mlx_model_revision: str | None = None,
 ):
+    if _use_mlx_backend():
+        if not current_platform.is_mps():
+            raise RuntimeError("SGLANG_USE_MLX=1 requires the Apple Metal platform")
+        from .mlx.ar_scheduler import MiniMaxMusic3MlxARScheduler
+
+        scheduler = MiniMaxMusic3MlxARScheduler(
+            model_path,
+            revision=mlx_model_revision,
+        )
+        logger.info("MiniMax Music 3 AR executor ready backend=mlx max_concurrency=1")
+        return scheduler
     if device is None:
         if gpu_id is None or not (
             current_platform.is_cuda() or current_platform.is_musa()
@@ -93,7 +111,34 @@ def create_dit_dav_executor(
     cache_dit_max_warmup_steps: int = 4,
     cache_dit_residual_diff_threshold: float = 0.08,
     cache_dit_max_continuous_cached_steps: int = 1,
+    mlx_model_revision: str | None = None,
 ) -> MiniMaxMusic3AcousticScheduler:
+    if _use_mlx_backend():
+        if not current_platform.is_mps():
+            raise RuntimeError("SGLANG_USE_MLX=1 requires the Apple Metal platform")
+        if cache_dit:
+            raise ValueError("MiniMax Music 3 cache_dit is unavailable with MLX")
+        if breakable_cuda_graph:
+            raise ValueError(
+                "MiniMax Music 3 breakable_cuda_graph is unavailable with MLX"
+            )
+        from .mlx.acoustic import MiniMaxMusic3MlxAcousticDecoder
+
+        decoder = MiniMaxMusic3MlxAcousticDecoder(
+            model_path,
+            revision=mlx_model_revision,
+            dit_steps=dit_steps,
+            dit_cfg_scale=dit_cfg_scale,
+        )
+        logger.info(
+            "MiniMax Music 3 acoustic executor ready backend=mlx dtype=%s "
+            "dit_steps=%d dit_cfg_scale=%.3f sample_rate=%d",
+            decoder.dtype,
+            decoder.dit_steps,
+            decoder.dit_cfg_scale,
+            OUTPUT_SAMPLE_RATE,
+        )
+        return MiniMaxMusic3AcousticScheduler(decoder)
     if device is None:
         if gpu_id is None or not (
             current_platform.is_cuda() or current_platform.is_musa()

--- a/sglang_omni/models/minimax_music3/stages.py
+++ b/sglang_omni/models/minimax_music3/stages.py
@@ -60,6 +60,7 @@ def create_ar_executor(
         scheduler = MiniMaxMusic3MlxARScheduler(
             model_path,
             revision=mlx_model_revision,
+            serial_offload=enable_serial_offload,
         )
         logger.info("MiniMax Music 3 AR executor ready backend=mlx max_concurrency=1")
         return scheduler
@@ -69,6 +70,8 @@ def create_ar_executor(
         ):
             raise RuntimeError("MiniMax Music 3 requires CUDA/MUSA backend")
         device = f"cuda:{gpu_id}"
+    if enable_serial_offload and torch.device(device).type != "cuda":
+        raise RuntimeError("MiniMax Music 3 serial offload requires CUDA or MLX")
     torch.backends.cudnn.enabled = False
     torch.backends.cuda.enable_cudnn_sdp(False)
 
@@ -79,7 +82,8 @@ def create_ar_executor(
     if requested is not None:
         max_concurrency = int(requested)
     builder = MiniMaxMusic3EngineBuilder(
-        max_running_requests=max(int(max_concurrency), 1)
+        max_running_requests=max(int(max_concurrency), 1),
+        enable_serial_offload=enable_serial_offload,
     )
     scheduler = builder.build(
         model_path,
@@ -131,6 +135,7 @@ def create_dit_dav_executor(
             revision=mlx_model_revision,
             dit_steps=dit_steps,
             dit_cfg_scale=dit_cfg_scale,
+            serial_offload=enable_serial_offload,
         )
         logger.info(
             "MiniMax Music 3 acoustic executor ready backend=mlx dtype=%s "
@@ -149,6 +154,8 @@ def create_dit_dav_executor(
                 "MiniMax Music 3 acoustic inference requires CUDA/MUSA backend"
             )
         device = f"cuda:{gpu_id}"
+    if enable_serial_offload and torch.device(device).type != "cuda":
+        raise RuntimeError("MiniMax Music 3 serial offload requires CUDA or MLX")
     decoder = MiniMaxMusic3AcousticDecoder(
         model_path,
         device=device,
@@ -165,6 +172,7 @@ def create_dit_dav_executor(
         cache_dit_max_warmup_steps=cache_dit_max_warmup_steps,
         cache_dit_residual_diff_threshold=cache_dit_residual_diff_threshold,
         cache_dit_max_continuous_cached_steps=cache_dit_max_continuous_cached_steps,
+        serial_offload=enable_serial_offload,
     )
     logger.info(
         f"MiniMax Music 3 acoustic executor ready device={decoder.device} dtype={decoder.dtype} dit_steps={decoder.dit_steps} dit_cfg_scale={decoder.dit_cfg_scale:.3f} attention_backend={decoder.attention_backend} compile_acoustic={decoder.compile_acoustic} sample_rate={OUTPUT_SAMPLE_RATE}"

--- a/sglang_omni/models/minimax_music3/stages.py
+++ b/sglang_omni/models/minimax_music3/stages.py
@@ -50,6 +50,7 @@ def create_ar_executor(
     max_concurrency: int = _DEFAULT_AR_CONCURRENCY,
     server_args_overrides: dict[str, Any] | None = None,
     mlx_model_revision: str | None = None,
+    enable_serial_offload: bool = False,
 ):
     if _use_mlx_backend():
         if not current_platform.is_mps():
@@ -112,6 +113,7 @@ def create_dit_dav_executor(
     cache_dit_residual_diff_threshold: float = 0.08,
     cache_dit_max_continuous_cached_steps: int = 1,
     mlx_model_revision: str | None = None,
+    enable_serial_offload: bool = False,
 ) -> MiniMaxMusic3AcousticScheduler:
     if _use_mlx_backend():
         if not current_platform.is_mps():

--- a/tests/unit_test/minimax_music3/test_core.py
+++ b/tests/unit_test/minimax_music3/test_core.py
@@ -345,6 +345,7 @@ def test_rvq_cuda_graph_replays_per_bucket_and_clones_outputs() -> None:
 
 
 @pytest.mark.accelerator
+@pytest.mark.skipif(not torch.cuda.is_available(), reason="CUDA is required")
 def test_rvq_cuda_graph_declines_a_batch_larger_than_every_bucket() -> None:
     def depth_forward(hidden, c0, seeds, positions, forced, replay):
         del c0, seeds, positions, replay

--- a/tests/unit_test/minimax_music3/test_mlx_backend.py
+++ b/tests/unit_test/minimax_music3/test_mlx_backend.py
@@ -1,0 +1,168 @@
+# SPDX-License-Identifier: Apache-2.0
+"""Contracts for the native MiniMax Music 3 MLX backend."""
+
+from __future__ import annotations
+
+import json
+from pathlib import Path
+
+import numpy as np
+import pytest
+
+mx = pytest.importorskip("mlx.core")
+nn = pytest.importorskip("mlx.nn")
+
+
+def test_tiny_ar_and_acoustic_pipeline_is_finite() -> None:
+    from sglang_omni.models.minimax_music3.mlx.ar import generate_frame_hiddens
+    from sglang_omni.models.minimax_music3.mlx.config import ModelConfig
+    from sglang_omni.models.minimax_music3.mlx.euler import denoise_chunk
+    from sglang_omni.models.minimax_music3.mlx.loader import (
+        MiniMaxMusic3MlxAcousticModel,
+        MiniMaxMusic3MlxARModel,
+    )
+
+    config = ModelConfig.tiny()
+    ar_model = MiniMaxMusic3MlxARModel(config)
+    acoustic_model = MiniMaxMusic3MlxAcousticModel(config)
+    mx.eval(ar_model.parameters(), acoustic_model.parameters())
+    text_ids = mx.array(
+        [[1, 2, 3], [1, config.audio_cfg_token_id, 3]],
+        dtype=mx.int32,
+    )
+
+    hidden = generate_frame_hiddens(
+        ar_model.language_model,
+        ar_model.rvq_depth_decoder,
+        config,
+        text_ids,
+        max_frames=2,
+        seed=7,
+    )
+    condition = acoustic_model.condition_encoder(hidden)
+    noise = mx.random.normal((1, config.dit_in_channels, condition.shape[1])).astype(
+        condition.dtype
+    )
+    latent, _ = denoise_chunk(
+        acoustic_model.transformer,
+        noise,
+        condition,
+        num_inference_steps=1,
+    )
+    waveform = acoustic_model.vocoder(latent)
+    mx.eval(waveform)
+
+    assert hidden.shape == (1, 2, config.num_codebooks * config.hidden_size)
+    assert waveform.shape[0:2] == (1, 2)
+    assert np.isfinite(np.asarray(waveform)).all()
+
+
+def test_split_loader_reads_one_converted_artifact(tmp_path: Path) -> None:
+    from mlx.utils import tree_flatten
+
+    from sglang_omni.models.minimax_music3.mlx.config import ModelConfig
+    from sglang_omni.models.minimax_music3.mlx.loader import (
+        MiniMaxMusic3MlxAcousticModel,
+        MiniMaxMusic3MlxARModel,
+        load_mlx_acoustic_model,
+        load_mlx_ar_model,
+    )
+
+    config = ModelConfig.tiny()
+    ar_model = MiniMaxMusic3MlxARModel(config)
+    acoustic_model = MiniMaxMusic3MlxAcousticModel(config)
+    for model in (ar_model, acoustic_model):
+        nn.quantize(
+            model,
+            group_size=32,
+            bits=8,
+            mode="mxfp8",
+            class_predicate=model.model_quant_predicate,
+        )
+    mx.eval(ar_model.parameters(), acoustic_model.parameters())
+    raw_config = config.to_dict()
+    raw_config["architectures"] = ["MiniMaxMusic3ForConditionalGeneration"]
+    raw_config["quantization"] = {
+        "group_size": 32,
+        "bits": 8,
+        "mode": "mxfp8",
+    }
+    (tmp_path / "config.json").write_text(json.dumps(raw_config))
+    weights = dict(
+        tree_flatten(ar_model.parameters()) + tree_flatten(acoustic_model.parameters())
+    )
+    mx.save_safetensors(str(tmp_path / "model.safetensors"), weights)
+
+    loaded_ar = load_mlx_ar_model(str(tmp_path))
+    loaded_acoustic = load_mlx_acoustic_model(str(tmp_path))
+
+    assert loaded_ar.config.hidden_size == config.hidden_size
+    assert loaded_acoustic.config.dit_num_layers == config.dit_num_layers
+    assert isinstance(
+        loaded_ar.language_model.model.layers[0].self_attn.q_proj,
+        nn.QuantizedLinear,
+    )
+    assert isinstance(
+        loaded_acoustic.transformer.transformer_blocks[0].ff_in,
+        nn.QuantizedLinear,
+    )
+
+
+@pytest.mark.parametrize(
+    ("model_cls", "selected_path", "untouched_path"),
+    [
+        (
+            "ar",
+            "language_model.model.layers.0.self_attn.q_proj",
+            "language_model.lm_head",
+        ),
+        (
+            "acoustic",
+            "transformer.transformer_blocks.0.ff_in",
+            "vocoder.conv_in",
+        ),
+    ],
+)
+def test_quantization_policy_keeps_heads_and_vocoder_dense(
+    model_cls: str,
+    selected_path: str,
+    untouched_path: str,
+) -> None:
+    from sglang_omni.models.minimax_music3.mlx.config import ModelConfig
+    from sglang_omni.models.minimax_music3.mlx.loader import (
+        MiniMaxMusic3MlxAcousticModel,
+        MiniMaxMusic3MlxARModel,
+    )
+
+    cls = (
+        MiniMaxMusic3MlxARModel if model_cls == "ar" else MiniMaxMusic3MlxAcousticModel
+    )
+    model = cls(ModelConfig.tiny())
+    modules = dict(model.named_modules())
+
+    assert model.model_quant_predicate(selected_path, modules[selected_path])
+    assert not model.model_quant_predicate(untouched_path, modules[untouched_path])
+
+
+def test_euler_abort_is_observed_between_steps() -> None:
+    from sglang_omni.models.minimax_music3.mlx.euler import denoise_chunk
+
+    calls = 0
+
+    class Transformer:
+        def __call__(self, hidden, timestep, condition):
+            nonlocal calls
+            del timestep, condition
+            calls += 1
+            return mx.zeros_like(hidden)
+
+    with pytest.raises(InterruptedError, match="aborted"):
+        denoise_chunk(
+            Transformer(),
+            mx.zeros((1, 2, 3)),
+            mx.zeros((1, 3, 4)),
+            num_inference_steps=3,
+            should_abort=lambda: calls >= 1,
+        )
+
+    assert calls == 2

--- a/tests/unit_test/minimax_music3/test_mlx_backend.py
+++ b/tests/unit_test/minimax_music3/test_mlx_backend.py
@@ -13,6 +13,44 @@ mx = pytest.importorskip("mlx.core")
 nn = pytest.importorskip("mlx.nn")
 
 
+def _write_tiny_artifact(tmp_path: Path):
+    from mlx.utils import tree_flatten
+
+    from sglang_omni.models.minimax_music3.mlx.config import ModelConfig
+    from sglang_omni.models.minimax_music3.mlx.loader import (
+        MiniMaxMusic3MlxAcousticModel,
+        MiniMaxMusic3MlxARModel,
+    )
+
+    config = ModelConfig.tiny()
+    ar_model = MiniMaxMusic3MlxARModel(config)
+    acoustic_model = MiniMaxMusic3MlxAcousticModel(config)
+    for model in (ar_model, acoustic_model):
+        nn.quantize(
+            model,
+            group_size=32,
+            bits=8,
+            mode="mxfp8",
+            class_predicate=model.model_quant_predicate,
+        )
+    mx.eval(ar_model.parameters(), acoustic_model.parameters())
+    raw_config = config.to_dict()
+    raw_config["architectures"] = ["MiniMaxMusic3ForConditionalGeneration"]
+    raw_config["quantization"] = {
+        "group_size": 32,
+        "bits": 8,
+        "mode": "mxfp8",
+    }
+    (tmp_path / "config.json").write_text(json.dumps(raw_config))
+    weights = dict(
+        tree_flatten(ar_model.parameters()) + tree_flatten(acoustic_model.parameters())
+    )
+    mx.save_safetensors(str(tmp_path / "model.safetensors"), weights)
+    del ar_model, acoustic_model, weights
+    mx.clear_cache()
+    return config
+
+
 def test_tiny_ar_and_acoustic_pipeline_is_finite() -> None:
     from sglang_omni.models.minimax_music3.mlx.ar import generate_frame_hiddens
     from sglang_omni.models.minimax_music3.mlx.config import ModelConfig
@@ -58,40 +96,12 @@ def test_tiny_ar_and_acoustic_pipeline_is_finite() -> None:
 
 
 def test_split_loader_reads_one_converted_artifact(tmp_path: Path) -> None:
-    from mlx.utils import tree_flatten
-
-    from sglang_omni.models.minimax_music3.mlx.config import ModelConfig
     from sglang_omni.models.minimax_music3.mlx.loader import (
-        MiniMaxMusic3MlxAcousticModel,
-        MiniMaxMusic3MlxARModel,
         load_mlx_acoustic_model,
         load_mlx_ar_model,
     )
 
-    config = ModelConfig.tiny()
-    ar_model = MiniMaxMusic3MlxARModel(config)
-    acoustic_model = MiniMaxMusic3MlxAcousticModel(config)
-    for model in (ar_model, acoustic_model):
-        nn.quantize(
-            model,
-            group_size=32,
-            bits=8,
-            mode="mxfp8",
-            class_predicate=model.model_quant_predicate,
-        )
-    mx.eval(ar_model.parameters(), acoustic_model.parameters())
-    raw_config = config.to_dict()
-    raw_config["architectures"] = ["MiniMaxMusic3ForConditionalGeneration"]
-    raw_config["quantization"] = {
-        "group_size": 32,
-        "bits": 8,
-        "mode": "mxfp8",
-    }
-    (tmp_path / "config.json").write_text(json.dumps(raw_config))
-    weights = dict(
-        tree_flatten(ar_model.parameters()) + tree_flatten(acoustic_model.parameters())
-    )
-    mx.save_safetensors(str(tmp_path / "model.safetensors"), weights)
+    config = _write_tiny_artifact(tmp_path)
 
     loaded_ar = load_mlx_ar_model(str(tmp_path))
     loaded_acoustic = load_mlx_acoustic_model(str(tmp_path))
@@ -106,6 +116,59 @@ def test_split_loader_reads_one_converted_artifact(tmp_path: Path) -> None:
         loaded_acoustic.transformer.transformer_blocks[0].ff_in,
         nn.QuantizedLinear,
     )
+
+
+def test_ar_same_seed_is_stable_across_reload(tmp_path: Path) -> None:
+    from sglang_omni.models.minimax_music3.mlx.ar import generate_frame_hiddens
+    from sglang_omni.models.minimax_music3.mlx.loader import load_mlx_ar_model
+
+    config = _write_tiny_artifact(tmp_path)
+    text_ids = mx.array([[1, 2, 3], [1, 2, 3]], dtype=mx.int32)
+
+    first_model = load_mlx_ar_model(str(tmp_path))
+    first = generate_frame_hiddens(
+        first_model.language_model,
+        first_model.rvq_depth_decoder,
+        config,
+        text_ids,
+        max_frames=2,
+        seed=17,
+    )
+    mx.eval(first)
+    first_np = np.array(first, copy=True)
+    del first, first_model
+    mx.clear_cache()
+
+    second_model = load_mlx_ar_model(str(tmp_path))
+    second = generate_frame_hiddens(
+        second_model.language_model,
+        second_model.rvq_depth_decoder,
+        config,
+        text_ids,
+        max_frames=2,
+        seed=17,
+    )
+    mx.eval(second)
+
+    np.testing.assert_array_equal(np.asarray(second), first_np)
+
+
+def test_acoustic_release_reduces_active_mlx_allocation(tmp_path: Path) -> None:
+    from sglang_omni.models.minimax_music3.mlx.acoustic import (
+        MiniMaxMusic3MlxAcousticDecoder,
+    )
+
+    _write_tiny_artifact(tmp_path)
+    decoder = MiniMaxMusic3MlxAcousticDecoder(str(tmp_path), serial_offload=True)
+    before = mx.get_active_memory()
+
+    decoder.ensure_resident()
+    loaded = mx.get_active_memory()
+    decoder.release_residency()
+    released = mx.get_active_memory()
+
+    assert loaded > before
+    assert released < loaded
 
 
 @pytest.mark.parametrize(

--- a/tests/unit_test/minimax_music3/test_mlx_offload.py
+++ b/tests/unit_test/minimax_music3/test_mlx_offload.py
@@ -1,0 +1,301 @@
+# SPDX-License-Identifier: Apache-2.0
+"""MLX offload lifecycle tests runnable without Apple hardware."""
+
+from __future__ import annotations
+
+import importlib
+import sys
+from contextlib import nullcontext
+from pathlib import Path
+from types import ModuleType, SimpleNamespace
+
+import numpy as np
+import pytest
+
+
+class _Coordinator:
+    def __init__(self, events: list[str]) -> None:
+        self.events = events
+
+    def enable(self) -> None:
+        self.events.append("enable")
+
+    def acquire_ar(self, request_id: str, *, should_abort) -> None:
+        assert not should_abort()
+        self.events.append(f"acquire:{request_id}")
+
+    def begin_dit_handoff(self, request_id: str) -> None:
+        self.events.append(f"handoff:{request_id}")
+
+    def cancel_ar(self, request_id: str) -> None:
+        self.events.append(f"cancel:{request_id}")
+
+    def fail_closed(self, exc: BaseException) -> None:
+        self.events.append(f"failed:{type(exc).__name__}")
+
+
+def _fake_mlx(monkeypatch: pytest.MonkeyPatch, events: list[str]) -> ModuleType:
+    mlx = ModuleType("mlx")
+    core = ModuleType("mlx.core")
+    core.gpu = object()
+    core.float16 = np.float16
+    core.new_thread_local_stream = lambda device: "stream"
+    core.stream = lambda stream: nullcontext()
+    core.eval = lambda *values: None
+    core.synchronize = lambda stream: events.append("synchronize")
+    core.get_active_memory = lambda: 0
+    core.get_cache_memory = lambda: 0
+    mlx.core = core
+    monkeypatch.setitem(sys.modules, "mlx", mlx)
+    monkeypatch.setitem(sys.modules, "mlx.core", core)
+    return core
+
+
+def _import_ar_scheduler(
+    monkeypatch: pytest.MonkeyPatch,
+    tmp_path: Path,
+    events: list[str],
+):
+    _fake_mlx(monkeypatch, events)
+    transformers = ModuleType("transformers")
+    transformers.AutoTokenizer = SimpleNamespace(from_pretrained=lambda *args: None)
+    monkeypatch.setitem(sys.modules, "transformers", transformers)
+    package_name = "sglang_omni.models.minimax_music3.mlx"
+    package = ModuleType(package_name)
+    package.__path__ = [
+        str(Path(__file__).parents[3] / "sglang_omni/models/minimax_music3/mlx")
+    ]
+    monkeypatch.setitem(sys.modules, package_name, package)
+    monkeypatch.delitem(sys.modules, f"{package_name}.ar_scheduler", raising=False)
+
+    model_config = SimpleNamespace(model_path=str(tmp_path), audio_cfg_token_id=7)
+
+    class Model:
+        def __init__(self) -> None:
+            self.config = model_config
+            self.language_model = object()
+            self.rvq_depth_decoder = object()
+
+    loader = ModuleType(f"{package_name}.loader")
+    loader.MiniMaxMusic3MlxARModel = Model
+    loader.resolve_mlx_artifact = lambda path, revision: (
+        tmp_path,
+        {},
+        model_config,
+    )
+
+    def load_model(path, revision=None, *, artifact=None):
+        del path, revision, artifact
+        events.append("load")
+        return Model()
+
+    loader.load_mlx_ar_model = load_model
+    monkeypatch.setitem(sys.modules, loader.__name__, loader)
+    ar = ModuleType(f"{package_name}.ar")
+    ar.generate_frame_hiddens = lambda *args, **kwargs: np.zeros(
+        (1, 2, 4), dtype=np.float32
+    )
+    monkeypatch.setitem(sys.modules, ar.__name__, ar)
+
+    module = importlib.import_module(f"{package_name}.ar_scheduler")
+    monkeypatch.setattr(
+        module.AutoTokenizer,
+        "from_pretrained",
+        lambda *args, **kwargs: object(),
+    )
+    monkeypatch.setattr(module, "validate_tokenizer_ids", lambda tokenizer: None)
+    coordinator = _Coordinator(events)
+    monkeypatch.setattr(module, "get_coordinator", lambda: coordinator)
+    (tmp_path / "tokenizer").mkdir()
+    return module, coordinator
+
+
+def _import_acoustic_decoder(
+    monkeypatch: pytest.MonkeyPatch,
+    tmp_path: Path,
+    events: list[str],
+):
+    importlib.import_module("sglang_omni.models.minimax_music3.acoustic")
+    _fake_mlx(monkeypatch, events)
+    package_name = "sglang_omni.models.minimax_music3.mlx"
+    package = ModuleType(package_name)
+    package.__path__ = [
+        str(Path(__file__).parents[3] / "sglang_omni/models/minimax_music3/mlx")
+    ]
+    monkeypatch.setitem(sys.modules, package_name, package)
+    monkeypatch.delitem(sys.modules, f"{package_name}.acoustic", raising=False)
+
+    config = SimpleNamespace(dit_in_channels=4)
+
+    class Model:
+        def __init__(self) -> None:
+            weight = SimpleNamespace(dtype="float16")
+            self.condition_encoder = SimpleNamespace(
+                proj=SimpleNamespace(weight=weight)
+            )
+
+    loader = ModuleType(f"{package_name}.loader")
+    loader.MiniMaxMusic3MlxAcousticModel = Model
+    loader.resolve_mlx_artifact = lambda path, revision: (
+        tmp_path,
+        {"dtype": "float16"},
+        config,
+    )
+
+    def load_model(path, revision=None, *, artifact=None):
+        del path, revision, artifact
+        events.append("load")
+        return Model()
+
+    loader.load_mlx_acoustic_model = load_model
+    monkeypatch.setitem(sys.modules, loader.__name__, loader)
+    euler = ModuleType(f"{package_name}.euler")
+    euler.denoise_chunk = lambda *args, **kwargs: None
+    monkeypatch.setitem(sys.modules, euler.__name__, euler)
+    module = importlib.import_module(f"{package_name}.acoustic")
+    coordinator = _Coordinator(events)
+    monkeypatch.setattr(module, "get_coordinator", lambda: coordinator)
+    return module
+
+
+def test_ar_offload_loads_after_ownership_and_hands_off_before_publish(
+    monkeypatch: pytest.MonkeyPatch,
+    tmp_path: Path,
+) -> None:
+    events: list[str] = []
+    module, _ = _import_ar_scheduler(monkeypatch, tmp_path, events)
+    monkeypatch.setattr(
+        module.MiniMaxMusic3State,
+        "from_dict",
+        lambda data: SimpleNamespace(
+            prompt="song",
+            max_audio_frames=301,
+            seed=7,
+            generated_frames=0,
+            finish_reason=None,
+            caption="caption",
+            lyrics="lyrics",
+        ),
+    )
+    monkeypatch.setattr(module, "_build_text_pair", lambda *args: object())
+    monkeypatch.setattr(module, "store_state", lambda payload, state: state)
+    source_hidden = np.zeros((1, 301, 4), dtype=np.float16)
+
+    class SharedArray:
+        def __init__(self, array):
+            self.array = array
+
+        @property
+        def shape(self):
+            return self.array.shape
+
+        def __getitem__(self, key):
+            return SharedArray(self.array[key])
+
+        def astype(self, dtype):
+            assert dtype == np.float16
+            return self
+
+        def __array__(self, dtype=None, copy=None):
+            del copy
+            return np.asarray(self.array, dtype=dtype)
+
+    monkeypatch.setattr(
+        module,
+        "generate_frame_hiddens",
+        lambda *args, **kwargs: SharedArray(source_hidden),
+    )
+    scheduler = module.MiniMaxMusic3MlxARScheduler(str(tmp_path), serial_offload=True)
+    assert "load" not in events
+
+    scheduler._generate(SimpleNamespace(request_id="req-1", data={}))
+
+    assert scheduler.model is None
+    assert scheduler.outbox.qsize() == 3
+    assert events == [
+        "enable",
+        "acquire:req-1",
+        "load",
+        "synchronize",
+        "handoff:req-1",
+    ]
+    message = scheduler.outbox.get_nowait()
+    source_hidden.fill(1)
+    assert message.data.device.type == "cpu"
+    assert not message.data.bool().any()
+
+
+def test_ar_load_failure_releases_owner_after_synchronizing(
+    monkeypatch: pytest.MonkeyPatch,
+    tmp_path: Path,
+) -> None:
+    events: list[str] = []
+    module, _ = _import_ar_scheduler(monkeypatch, tmp_path, events)
+    monkeypatch.setattr(
+        module.MiniMaxMusic3State,
+        "from_dict",
+        lambda data: SimpleNamespace(prompt="song"),
+    )
+
+    def fail_load(*args, **kwargs):
+        raise OSError("load failed")
+
+    monkeypatch.setattr(module, "load_mlx_ar_model", fail_load)
+    scheduler = module.MiniMaxMusic3MlxARScheduler(str(tmp_path), serial_offload=True)
+
+    with pytest.raises(OSError, match="load failed"):
+        scheduler._generate(SimpleNamespace(request_id="req-1", data={}))
+
+    assert events[-2:] == ["synchronize", "cancel:req-1"]
+
+
+def test_ar_resident_mode_loads_during_construction(
+    monkeypatch: pytest.MonkeyPatch,
+    tmp_path: Path,
+) -> None:
+    events: list[str] = []
+    module, _ = _import_ar_scheduler(monkeypatch, tmp_path, events)
+
+    scheduler = module.MiniMaxMusic3MlxARScheduler(str(tmp_path), serial_offload=False)
+
+    assert scheduler.model is not None
+    assert events == ["load"]
+
+
+def test_acoustic_offload_loads_once_for_chunks_then_releases(
+    monkeypatch: pytest.MonkeyPatch,
+    tmp_path: Path,
+) -> None:
+    events: list[str] = []
+    module = _import_acoustic_decoder(monkeypatch, tmp_path, events)
+    decoder = module.MiniMaxMusic3MlxAcousticDecoder(str(tmp_path), serial_offload=True)
+    assert decoder.model is None
+    assert events == ["enable"]
+
+    decoder.ensure_resident()
+    first_model = decoder.model
+    decoder.ensure_resident()
+
+    assert decoder.model is first_model
+    assert events == ["enable", "load"]
+    decoder.release_residency()
+    assert decoder.model is None
+    assert events == ["enable", "load", "synchronize"]
+
+
+def test_acoustic_offload_is_stable_across_20_reload_cycles(
+    monkeypatch: pytest.MonkeyPatch,
+    tmp_path: Path,
+) -> None:
+    events: list[str] = []
+    module = _import_acoustic_decoder(monkeypatch, tmp_path, events)
+    decoder = module.MiniMaxMusic3MlxAcousticDecoder(str(tmp_path), serial_offload=True)
+
+    for _ in range(20):
+        decoder.ensure_resident()
+        decoder.ensure_resident()
+        decoder.release_residency()
+
+    assert decoder.model is None
+    assert events.count("load") == 20
+    assert events.count("synchronize") == 20

--- a/tests/unit_test/minimax_music3/test_mlx_stage_selection.py
+++ b/tests/unit_test/minimax_music3/test_mlx_stage_selection.py
@@ -1,0 +1,101 @@
+# SPDX-License-Identifier: Apache-2.0
+"""Backend-selection contracts for MiniMax Music 3 MLX stages."""
+
+from __future__ import annotations
+
+import sys
+from types import SimpleNamespace
+
+import pytest
+
+from sglang_omni.models.minimax_music3 import stages
+
+
+def _select_mlx(monkeypatch: pytest.MonkeyPatch) -> None:
+    monkeypatch.setattr(stages, "_use_mlx_backend", lambda: True)
+    monkeypatch.setattr(stages.current_platform, "is_mps", lambda: True)
+
+
+def test_create_ar_executor_selects_native_mlx(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    _select_mlx(monkeypatch)
+    observed = {}
+
+    class Scheduler:
+        def __init__(self, model_path, *, revision):
+            observed.update(model_path=model_path, revision=revision)
+
+    monkeypatch.setitem(
+        sys.modules,
+        "sglang_omni.models.minimax_music3.mlx.ar_scheduler",
+        SimpleNamespace(MiniMaxMusic3MlxARScheduler=Scheduler),
+    )
+
+    scheduler = stages.create_ar_executor(
+        "mlx-community/MiniMax-Music3-mxfp8",
+        mlx_model_revision="revision-a",
+    )
+
+    assert isinstance(scheduler, Scheduler)
+    assert observed == {
+        "model_path": "mlx-community/MiniMax-Music3-mxfp8",
+        "revision": "revision-a",
+    }
+
+
+def test_create_acoustic_executor_selects_native_mlx(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    _select_mlx(monkeypatch)
+    observed = {}
+
+    class Decoder:
+        dtype = "bfloat16"
+        dit_steps = 4
+        dit_cfg_scale = 1.25
+
+        def __init__(self, model_path, *, revision, dit_steps, dit_cfg_scale):
+            self.dit_steps = dit_steps
+            self.dit_cfg_scale = dit_cfg_scale
+            observed.update(
+                model_path=model_path,
+                revision=revision,
+                dit_steps=dit_steps,
+                dit_cfg_scale=dit_cfg_scale,
+            )
+
+    monkeypatch.setitem(
+        sys.modules,
+        "sglang_omni.models.minimax_music3.mlx.acoustic",
+        SimpleNamespace(MiniMaxMusic3MlxAcousticDecoder=Decoder),
+    )
+
+    scheduler = stages.create_dit_dav_executor(
+        "mlx-community/MiniMax-Music3-mxfp8",
+        dit_steps=4,
+        dit_cfg_scale=1.25,
+        mlx_model_revision="revision-b",
+    )
+
+    assert scheduler._decoder.__class__ is Decoder
+    assert observed == {
+        "model_path": "mlx-community/MiniMax-Music3-mxfp8",
+        "revision": "revision-b",
+        "dit_steps": 4,
+        "dit_cfg_scale": 1.25,
+    }
+
+
+@pytest.mark.parametrize("option", ["cache_dit", "breakable_cuda_graph"])
+def test_mlx_acoustic_rejects_cuda_only_options(
+    monkeypatch: pytest.MonkeyPatch,
+    option: str,
+) -> None:
+    _select_mlx(monkeypatch)
+
+    with pytest.raises(ValueError, match="unavailable with MLX"):
+        stages.create_dit_dav_executor(
+            "mlx-community/MiniMax-Music3-mxfp8",
+            **{option: True},
+        )

--- a/tests/unit_test/minimax_music3/test_mlx_stage_selection.py
+++ b/tests/unit_test/minimax_music3/test_mlx_stage_selection.py
@@ -23,8 +23,12 @@ def test_create_ar_executor_selects_native_mlx(
     observed = {}
 
     class Scheduler:
-        def __init__(self, model_path, *, revision):
-            observed.update(model_path=model_path, revision=revision)
+        def __init__(self, model_path, *, revision, serial_offload):
+            observed.update(
+                model_path=model_path,
+                revision=revision,
+                serial_offload=serial_offload,
+            )
 
     monkeypatch.setitem(
         sys.modules,
@@ -41,7 +45,33 @@ def test_create_ar_executor_selects_native_mlx(
     assert observed == {
         "model_path": "mlx-community/MiniMax-Music3-mxfp8",
         "revision": "revision-a",
+        "serial_offload": False,
     }
+
+
+def test_create_ar_executor_forwards_serial_offload_to_mlx(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    _select_mlx(monkeypatch)
+    observed = {}
+
+    class Scheduler:
+        def __init__(self, model_path, *, revision, serial_offload):
+            observed.update(
+                model_path=model_path,
+                revision=revision,
+                serial_offload=serial_offload,
+            )
+
+    monkeypatch.setitem(
+        sys.modules,
+        "sglang_omni.models.minimax_music3.mlx.ar_scheduler",
+        SimpleNamespace(MiniMaxMusic3MlxARScheduler=Scheduler),
+    )
+
+    stages.create_ar_executor("artifact", enable_serial_offload=True)
+
+    assert observed["serial_offload"] is True
 
 
 def test_create_acoustic_executor_selects_native_mlx(
@@ -55,7 +85,9 @@ def test_create_acoustic_executor_selects_native_mlx(
         dit_steps = 4
         dit_cfg_scale = 1.25
 
-        def __init__(self, model_path, *, revision, dit_steps, dit_cfg_scale):
+        def __init__(
+            self, model_path, *, revision, dit_steps, dit_cfg_scale, serial_offload
+        ):
             self.dit_steps = dit_steps
             self.dit_cfg_scale = dit_cfg_scale
             observed.update(
@@ -63,6 +95,7 @@ def test_create_acoustic_executor_selects_native_mlx(
                 revision=revision,
                 dit_steps=dit_steps,
                 dit_cfg_scale=dit_cfg_scale,
+                serial_offload=serial_offload,
             )
 
     monkeypatch.setitem(
@@ -84,7 +117,34 @@ def test_create_acoustic_executor_selects_native_mlx(
         "revision": "revision-b",
         "dit_steps": 4,
         "dit_cfg_scale": 1.25,
+        "serial_offload": False,
     }
+
+
+def test_create_acoustic_executor_forwards_serial_offload_to_mlx(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    _select_mlx(monkeypatch)
+    observed = {}
+
+    class Decoder:
+        dtype = "bfloat16"
+        dit_steps = 4
+        dit_cfg_scale = 1.25
+
+        def __init__(self, model_path, **kwargs):
+            del model_path
+            observed.update(kwargs)
+
+    monkeypatch.setitem(
+        sys.modules,
+        "sglang_omni.models.minimax_music3.mlx.acoustic",
+        SimpleNamespace(MiniMaxMusic3MlxAcousticDecoder=Decoder),
+    )
+
+    stages.create_dit_dav_executor("artifact", enable_serial_offload=True)
+
+    assert observed["serial_offload"] is True
 
 
 @pytest.mark.parametrize("option", ["cache_dit", "breakable_cuda_graph"])

--- a/tests/unit_test/minimax_music3/test_serial_offload.py
+++ b/tests/unit_test/minimax_music3/test_serial_offload.py
@@ -1,0 +1,250 @@
+# SPDX-License-Identifier: Apache-2.0
+"""Serial offload coordinator behind --stage-offload-components ar,dit."""
+
+from __future__ import annotations
+
+import pytest
+import torch
+
+from sglang_omni.models.minimax_music3.serial_offload import (
+    STALL_REPORT_SECONDS,
+    SerialOffloadCoordinator,
+    StageResidency,
+    get_coordinator,
+)
+
+
+def _registered() -> SerialOffloadCoordinator:
+    coordinator = SerialOffloadCoordinator()
+    coordinator.register_ar(torch.nn.Linear(2, 2), torch.device("cpu"))
+    return coordinator
+
+
+def test_get_coordinator_returns_a_process_wide_singleton() -> None:
+    assert get_coordinator() is get_coordinator()
+
+
+def test_disabled_coordinator_never_blocks_admission_and_handoffs_are_noops() -> None:
+    coordinator = SerialOffloadCoordinator()
+
+    assert coordinator.enabled is False
+    assert coordinator.ar_can_admit() is True
+    coordinator.begin_dit_handoff("req-1")
+    coordinator.end_dit_handoff("req-1")
+    assert coordinator.ar_can_admit() is True
+
+
+def test_register_ar_enables_the_coordinator_and_starts_ar_active() -> None:
+    coordinator = _registered()
+
+    assert coordinator.enabled is True
+    assert coordinator.ar_can_admit() is True
+
+
+def test_begin_dit_handoff_moves_ar_off_the_gpu_and_blocks_admission() -> None:
+    coordinator = _registered()
+
+    coordinator.begin_dit_handoff("req-1")
+
+    assert coordinator.ar_can_admit() is False
+
+
+def test_end_dit_handoff_restores_ar_and_reopens_admission() -> None:
+    coordinator = _registered()
+    coordinator.begin_dit_handoff("req-1")
+
+    coordinator.end_dit_handoff("req-1")
+
+    assert coordinator.ar_can_admit() is True
+
+
+def test_handoff_calls_are_idempotent() -> None:
+    coordinator = _registered()
+
+    coordinator.begin_dit_handoff("req-1")
+    coordinator.begin_dit_handoff("req-1")
+    assert coordinator.ar_can_admit() is False
+
+    coordinator.end_dit_handoff("req-1")
+    coordinator.end_dit_handoff("req-1")
+    assert coordinator.ar_can_admit() is True
+
+
+def test_ar_stays_parked_until_every_outstanding_request_retires() -> None:
+    """The wake is driven by the outstanding set, not by the last event."""
+    coordinator = _registered()
+    coordinator.begin_dit_handoff("req-1")
+    coordinator.begin_dit_handoff("req-2")
+
+    coordinator.end_dit_handoff("req-1")
+    assert coordinator.ar_can_admit() is False
+
+    coordinator.end_dit_handoff("req-2")
+    assert coordinator.ar_can_admit() is True
+
+
+def test_end_for_a_request_that_never_handed_off_does_not_wake_ar() -> None:
+    coordinator = _registered()
+    coordinator.begin_dit_handoff("req-1")
+
+    coordinator.end_dit_handoff("req-unknown")
+
+    assert coordinator.ar_can_admit() is False
+
+
+def test_a_stalled_handoff_is_reported_once_and_never_force_woken(
+    caplog: pytest.LogCaptureFixture,
+) -> None:
+    coordinator = _registered()
+    coordinator.begin_dit_handoff("req-1")
+    # Backdate the pause past the reporting threshold.
+    coordinator._paused_at -= STALL_REPORT_SECONDS + 1.0
+
+    with caplog.at_level("ERROR"):
+        assert coordinator.ar_can_admit() is False
+        assert coordinator.ar_can_admit() is False
+
+    stall_records = [r for r in caplog.records if "off the GPU for" in r.message]
+    assert len(stall_records) == 1
+    assert "req-1" in stall_records[0].message
+
+
+def test_handoff_without_registration_raises_if_force_enabled() -> None:
+    """Defensive guard for a caller that enables without registering."""
+    coordinator = SerialOffloadCoordinator()
+    coordinator._enabled = True
+
+    with pytest.raises(RuntimeError, match="never registered"):
+        coordinator.begin_dit_handoff("req-1")
+    with pytest.raises(RuntimeError, match="never registered"):
+        coordinator.end_dit_handoff("req-1")
+
+
+def test_residency_sleep_and_wake_preserve_weights_and_state() -> None:
+    module = torch.nn.Linear(2, 2)
+    expected = module.weight.detach().clone()
+    residency = StageResidency({"module": module}, torch.device("cpu"))
+
+    residency.sleep()
+    assert residency.resident is False
+    residency.wake()
+
+    assert residency.resident is True
+    assert torch.equal(module.weight, expected)
+
+
+def test_residency_reuses_one_host_copy_instead_of_recopying_each_sleep() -> None:
+    """The weights are immutable, so only the first sleep may snapshot them."""
+    module = torch.nn.Linear(2, 2)
+    residency = StageResidency({"module": module}, torch.device("cpu"))
+
+    residency.sleep()
+    snapshot = residency._host[("module", "weight")]
+    residency.wake()
+    residency.sleep()
+
+    assert residency._host[("module", "weight")] is snapshot
+
+
+def test_a_host_built_module_is_asleep_and_never_snapshots_from_the_gpu() -> None:
+    module = torch.nn.Linear(2, 2)
+    residency = StageResidency({"module": module}, torch.device("cpu"), resident=False)
+
+    assert residency.resident is False
+    assert residency._host[("module", "weight")] is not module.weight
+    assert residency._host[("module", "weight")].data_ptr() == module.weight.data_ptr()
+
+    residency.wake()
+    assert residency.resident is True
+
+
+def test_residency_keeps_tied_weights_tied_across_a_round_trip() -> None:
+    module = torch.nn.Linear(4, 4)
+    tied = torch.nn.Linear(4, 4)
+    tied.weight = module.weight
+    parent = torch.nn.Sequential(module, tied)
+    residency = StageResidency({"module": parent}, torch.device("cpu"))
+
+    residency.sleep()
+    residency.wake()
+
+    assert module.weight is tied.weight
+    assert module.weight.data_ptr() == tied.weight.data_ptr()
+
+
+@pytest.mark.gpu
+@pytest.mark.skipif(not torch.cuda.is_available(), reason="CUDA is required")
+def test_serial_offload_round_trip_moves_weights_between_devices() -> None:
+    coordinator = SerialOffloadCoordinator()
+    device = torch.device("cuda:0")
+    model = torch.nn.Linear(4, 4).to(device)
+    coordinator.register_ar(model, device)
+
+    coordinator.begin_dit_handoff("req-1")
+    assert next(model.parameters()).device.type == "cpu"
+
+    coordinator.end_dit_handoff("req-1")
+    assert next(model.parameters()).device == device
+
+
+@pytest.mark.gpu
+@pytest.mark.skipif(not torch.cuda.is_available(), reason="CUDA is required")
+def test_host_built_residency_keeps_canonical_copy_on_cpu() -> None:
+    device = torch.device("cuda:0")
+    model = torch.nn.Linear(4, 4)
+    expected = model.weight.detach().clone()
+    residency = StageResidency({"module": model}, device, resident=False)
+    host_weight = residency._host[("module", "weight")]
+
+    residency.wake()
+    assert model.weight.device == device
+    assert host_weight.device.type == "cpu"
+
+    residency.sleep()
+    assert model.weight.device.type == "cpu"
+    assert model.weight.data_ptr() == host_weight.data_ptr()
+    assert torch.equal(model.weight, expected)
+
+    residency.wake()
+    assert model.weight.device == device
+    assert host_weight.device.type == "cpu"
+    assert torch.equal(model.weight.cpu(), expected)
+
+
+@pytest.mark.gpu
+@pytest.mark.skipif(not torch.cuda.is_available(), reason="CUDA is required")
+def test_stage_group_wakes_once_and_keeps_allocator_blocks_cached(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    device = torch.device("cuda:0")
+    dit = torch.nn.Linear(4, 4)
+    dav = torch.nn.Linear(4, 4)
+    residency = StageResidency(
+        {"dit": dit, "dav": dav}, device, resident=False, label="dit/dav"
+    )
+    synchronize_calls: list[torch.device] = []
+    empty_cache_calls = 0
+    synchronize = torch.cuda.synchronize
+    empty_cache = torch.cuda.empty_cache
+
+    def tracked_synchronize(target: torch.device) -> None:
+        synchronize_calls.append(target)
+        synchronize(target)
+
+    def tracked_empty_cache() -> None:
+        nonlocal empty_cache_calls
+        empty_cache_calls += 1
+        empty_cache()
+
+    monkeypatch.setattr(torch.cuda, "synchronize", tracked_synchronize)
+    monkeypatch.setattr(torch.cuda, "empty_cache", tracked_empty_cache)
+
+    residency.wake()
+    assert next(dit.parameters()).device == device
+    assert next(dav.parameters()).device == device
+    assert synchronize_calls == [device]
+
+    residency.sleep()
+    assert next(dit.parameters()).device.type == "cpu"
+    assert next(dav.parameters()).device.type == "cpu"
+    assert empty_cache_calls == 0

--- a/tests/unit_test/minimax_music3/test_serial_offload.py
+++ b/tests/unit_test/minimax_music3/test_serial_offload.py
@@ -3,6 +3,8 @@
 
 from __future__ import annotations
 
+from types import SimpleNamespace
+
 import pytest
 import torch
 
@@ -28,96 +30,317 @@ def test_disabled_coordinator_never_blocks_admission_and_handoffs_are_noops() ->
     coordinator = SerialOffloadCoordinator()
 
     assert coordinator.enabled is False
-    assert coordinator.ar_can_admit() is True
+    assert coordinator.try_acquire_ar("req-1") is True
     coordinator.begin_dit_handoff("req-1")
     coordinator.end_dit_handoff("req-1")
-    assert coordinator.ar_can_admit() is True
+    assert coordinator.try_acquire_ar("req-2") is True
 
 
 def test_register_ar_enables_the_coordinator_and_starts_ar_active() -> None:
     coordinator = _registered()
 
     assert coordinator.enabled is True
-    assert coordinator.ar_can_admit() is True
+    assert coordinator.try_acquire_ar("req-1") is True
 
 
 def test_begin_dit_handoff_moves_ar_off_the_gpu_and_blocks_admission() -> None:
     coordinator = _registered()
+    assert coordinator.try_acquire_ar("req-1")
 
     coordinator.begin_dit_handoff("req-1")
 
-    assert coordinator.ar_can_admit() is False
+    assert coordinator.try_acquire_ar("req-2") is False
 
 
 def test_end_dit_handoff_restores_ar_and_reopens_admission() -> None:
     coordinator = _registered()
+    assert coordinator.try_acquire_ar("req-1")
     coordinator.begin_dit_handoff("req-1")
 
     coordinator.end_dit_handoff("req-1")
 
-    assert coordinator.ar_can_admit() is True
+    assert coordinator.try_acquire_ar("req-2") is True
 
 
 def test_handoff_calls_are_idempotent() -> None:
     coordinator = _registered()
+    assert coordinator.try_acquire_ar("req-1")
 
     coordinator.begin_dit_handoff("req-1")
     coordinator.begin_dit_handoff("req-1")
-    assert coordinator.ar_can_admit() is False
+    assert coordinator.try_acquire_ar("req-2") is False
 
     coordinator.end_dit_handoff("req-1")
     coordinator.end_dit_handoff("req-1")
-    assert coordinator.ar_can_admit() is True
+    assert coordinator.try_acquire_ar("req-2") is True
 
 
-def test_ar_stays_parked_until_every_outstanding_request_retires() -> None:
-    """The wake is driven by the outstanding set, not by the last event."""
+def test_second_request_cannot_enter_the_first_request_lifecycle() -> None:
     coordinator = _registered()
+    assert coordinator.try_acquire_ar("req-1")
+    assert coordinator.try_acquire_ar("req-2") is False
     coordinator.begin_dit_handoff("req-1")
-    coordinator.begin_dit_handoff("req-2")
 
-    coordinator.end_dit_handoff("req-1")
-    assert coordinator.ar_can_admit() is False
-
-    coordinator.end_dit_handoff("req-2")
-    assert coordinator.ar_can_admit() is True
+    with pytest.raises(RuntimeError, match="does not own"):
+        coordinator.begin_dit_handoff("req-2")
 
 
 def test_end_for_a_request_that_never_handed_off_does_not_wake_ar() -> None:
     coordinator = _registered()
+    assert coordinator.try_acquire_ar("req-1")
     coordinator.begin_dit_handoff("req-1")
 
     coordinator.end_dit_handoff("req-unknown")
 
-    assert coordinator.ar_can_admit() is False
+    assert coordinator.try_acquire_ar("req-2") is False
+
+
+def test_late_terminal_for_old_request_does_not_release_new_owner() -> None:
+    coordinator = _registered()
+    assert coordinator.try_acquire_ar("req-old")
+    coordinator.begin_dit_handoff("req-old")
+    coordinator.end_dit_handoff("req-old")
+    assert coordinator.try_acquire_ar("req-new")
+    coordinator.begin_dit_handoff("req-new")
+    released: list[str] = []
+
+    coordinator.end_dit_handoff(
+        "req-old", release_acoustic=lambda: released.append("old")
+    )
+
+    assert released == []
+    assert coordinator.try_acquire_ar("req-other") is False
+
+
+def test_acoustic_release_failure_fails_closed() -> None:
+    coordinator = _registered()
+    assert coordinator.try_acquire_ar("req-1")
+    coordinator.begin_dit_handoff("req-1")
+
+    def fail_release() -> None:
+        raise OSError("release failed")
+
+    with pytest.raises(OSError, match="release failed"):
+        coordinator.end_dit_handoff("req-1", release_acoustic=fail_release)
+    with pytest.raises(RuntimeError, match="transition failed"):
+        coordinator.try_acquire_ar("req-2")
+
+
+def test_cancel_before_handoff_releases_owner() -> None:
+    coordinator = _registered()
+    assert coordinator.try_acquire_ar("req-1")
+
+    coordinator.cancel_ar("req-1")
+
+    assert coordinator.try_acquire_ar("req-2") is True
 
 
 def test_a_stalled_handoff_is_reported_once_and_never_force_woken(
     caplog: pytest.LogCaptureFixture,
 ) -> None:
     coordinator = _registered()
+    assert coordinator.try_acquire_ar("req-1")
     coordinator.begin_dit_handoff("req-1")
     # Backdate the pause past the reporting threshold.
     coordinator._paused_at -= STALL_REPORT_SECONDS + 1.0
 
     with caplog.at_level("ERROR"):
-        assert coordinator.ar_can_admit() is False
-        assert coordinator.ar_can_admit() is False
+        assert coordinator.try_acquire_ar("req-2") is False
+        assert coordinator.try_acquire_ar("req-2") is False
 
     stall_records = [r for r in caplog.records if "off the GPU for" in r.message]
     assert len(stall_records) == 1
     assert "req-1" in stall_records[0].message
 
 
-def test_handoff_without_registration_raises_if_force_enabled() -> None:
-    """Defensive guard for a caller that enables without registering."""
+def test_ownership_without_cuda_residency_supports_mlx() -> None:
     coordinator = SerialOffloadCoordinator()
-    coordinator._enabled = True
+    coordinator.enable()
 
-    with pytest.raises(RuntimeError, match="never registered"):
+    assert coordinator.try_acquire_ar("req-1")
+    coordinator.begin_dit_handoff("req-1")
+    coordinator.end_dit_handoff("req-1")
+    assert coordinator.try_acquire_ar("req-2")
+
+
+def test_transition_failure_fails_closed() -> None:
+    coordinator = _registered()
+    assert coordinator.try_acquire_ar("req-1")
+    assert coordinator._ar is not None
+
+    def fail_sleep() -> None:
+        raise OSError("copy failed")
+
+    coordinator._ar.sleep = fail_sleep
+    with pytest.raises(OSError, match="copy failed"):
         coordinator.begin_dit_handoff("req-1")
-    with pytest.raises(RuntimeError, match="never registered"):
-        coordinator.end_dit_handoff("req-1")
+    with pytest.raises(RuntimeError, match="transition failed"):
+        coordinator.try_acquire_ar("req-2")
+
+
+def test_builder_serial_mode_uses_one_cfg_pair_and_disables_graphs() -> None:
+    from sglang_omni.models.minimax_music3.engine_builder import (
+        MiniMaxMusic3EngineBuilder,
+    )
+
+    builder = MiniMaxMusic3EngineBuilder(
+        max_running_requests=8,
+        enable_serial_offload=True,
+    )
+    overrides = builder.generation_defaults(dtype="bfloat16")
+
+    builder.adjust_overrides(overrides)
+
+    assert builder.max_running_requests == 1
+    assert overrides["max_running_requests"] == 2
+    assert overrides["disable_cuda_graph"] is True
+    assert overrides["enable_torch_compile"] is False
+
+
+def test_builder_default_mode_preserves_requested_concurrency() -> None:
+    from sglang_omni.models.minimax_music3.engine_builder import (
+        MiniMaxMusic3EngineBuilder,
+    )
+
+    builder = MiniMaxMusic3EngineBuilder(max_running_requests=8)
+    overrides = builder.generation_defaults(dtype="bfloat16")
+
+    builder.adjust_overrides(overrides)
+
+    assert builder.max_running_requests == 8
+    assert overrides["max_running_requests"] == 16
+    assert overrides["disable_cuda_graph"] is False
+
+
+def test_builder_registers_complete_ar_model_with_coordinator(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    from sglang_omni.models.minimax_music3 import serial_offload
+    from sglang_omni.models.minimax_music3.engine_builder import (
+        MiniMaxMusic3EngineBuilder,
+    )
+
+    coordinator = SerialOffloadCoordinator()
+    monkeypatch.setattr(serial_offload, "_COORDINATOR", coordinator)
+    model = torch.nn.Module()
+    model.backbone = torch.nn.Linear(2, 2)
+    model.audio_decoder = torch.nn.Linear(2, 2)
+    builder = MiniMaxMusic3EngineBuilder(enable_serial_offload=True)
+    builder.device = "cpu"
+
+    builder.setup_runtime_resources(model, SimpleNamespace())
+
+    assert coordinator.enabled
+    assert coordinator._ar is not None
+    assert coordinator._ar._modules == {"ar": model}
+    assert coordinator.try_acquire_ar("request")
+
+
+def test_cuda_factory_forwards_serial_offload_to_builder(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    from sglang_omni.models.minimax_music3 import engine_builder, stages
+
+    observed = {}
+
+    class Builder:
+        max_running_requests = 1
+
+        def __init__(self, **kwargs):
+            observed.update(init=kwargs)
+
+        def build(self, model_path, **kwargs):
+            observed.update(model_path=model_path, build=kwargs)
+            return "scheduler"
+
+    monkeypatch.setattr(stages, "_use_mlx_backend", lambda: False)
+    monkeypatch.setattr(engine_builder, "MiniMaxMusic3EngineBuilder", Builder)
+
+    result = stages.create_ar_executor(
+        "checkpoint",
+        device="cuda:0",
+        enable_serial_offload=True,
+    )
+
+    assert result == "scheduler"
+    assert observed["init"]["enable_serial_offload"] is True
+
+
+def test_scheduler_admission_claims_only_one_logical_request(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    from sglang_omni.models.minimax_music3 import scheduler as scheduler_module
+    from sglang_omni.models.minimax_music3.scheduler import MiniMaxMusic3Scheduler
+
+    coordinator = SerialOffloadCoordinator()
+    coordinator.enable()
+    monkeypatch.setattr(scheduler_module, "get_coordinator", lambda: coordinator)
+    scheduler = SimpleNamespace(
+        max_prefill_tokens=100,
+        get_num_allocatable_reqs=lambda running: 4 - running,
+    )
+    queue = [
+        SimpleNamespace(rid="req-1", origin_input_ids=[1]),
+        SimpleNamespace(rid="req-1-cfg", origin_input_ids=[1]),
+        SimpleNamespace(rid="req-2", origin_input_ids=[1]),
+        SimpleNamespace(rid="req-2-cfg", origin_input_ids=[1]),
+    ]
+
+    limit = MiniMaxMusic3Scheduler._pair_admission_limit(
+        scheduler, queue, SimpleNamespace(reqs=[])
+    )
+
+    assert limit == 2
+    assert coordinator.try_acquire_ar("req-2") is False
+
+
+def test_ar_reset_releases_owner_before_handoff() -> None:
+    from sglang_omni.models.minimax_music3.model_runner import (
+        MiniMaxMusic3ModelRunner,
+    )
+
+    coordinator = SerialOffloadCoordinator()
+    coordinator.enable()
+    assert coordinator.try_acquire_ar("req-1")
+    runner = object.__new__(MiniMaxMusic3ModelRunner)
+    runner._request_data = {"req-1": SimpleNamespace(ar_state=object())}
+    runner._serial_offload = coordinator
+
+    runner.reset_request("req-1")
+
+    assert coordinator.try_acquire_ar("req-2")
+
+
+def test_acoustic_scheduler_releases_only_the_current_owner(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    from sglang_omni.models.minimax_music3 import acoustic
+
+    coordinator = SerialOffloadCoordinator()
+    coordinator.enable()
+    assert coordinator.try_acquire_ar("req-current")
+    coordinator.begin_dit_handoff("req-current")
+    monkeypatch.setattr(acoustic, "get_coordinator", lambda: coordinator)
+
+    class Decoder:
+        serial_offload = True
+
+        def __init__(self) -> None:
+            self.release_calls = 0
+
+        def release_residency(self) -> None:
+            self.release_calls += 1
+
+    decoder = Decoder()
+    scheduler = acoustic.MiniMaxMusic3AcousticScheduler(decoder)
+
+    scheduler.clear_stream_state("req-old")
+    assert decoder.release_calls == 0
+    assert coordinator.try_acquire_ar("req-next") is False
+
+    scheduler.abort("req-current")
+    assert decoder.release_calls == 1
+    assert coordinator.try_acquire_ar("req-next")
 
 
 def test_residency_sleep_and_wake_preserve_weights_and_state() -> None:
@@ -172,13 +395,14 @@ def test_residency_keeps_tied_weights_tied_across_a_round_trip() -> None:
     assert module.weight.data_ptr() == tied.weight.data_ptr()
 
 
-@pytest.mark.gpu
+@pytest.mark.accelerator
 @pytest.mark.skipif(not torch.cuda.is_available(), reason="CUDA is required")
 def test_serial_offload_round_trip_moves_weights_between_devices() -> None:
     coordinator = SerialOffloadCoordinator()
     device = torch.device("cuda:0")
     model = torch.nn.Linear(4, 4).to(device)
     coordinator.register_ar(model, device)
+    assert coordinator.try_acquire_ar("req-1")
 
     coordinator.begin_dit_handoff("req-1")
     assert next(model.parameters()).device.type == "cpu"
@@ -187,7 +411,7 @@ def test_serial_offload_round_trip_moves_weights_between_devices() -> None:
     assert next(model.parameters()).device == device
 
 
-@pytest.mark.gpu
+@pytest.mark.accelerator
 @pytest.mark.skipif(not torch.cuda.is_available(), reason="CUDA is required")
 def test_host_built_residency_keeps_canonical_copy_on_cpu() -> None:
     device = torch.device("cuda:0")
@@ -211,7 +435,7 @@ def test_host_built_residency_keeps_canonical_copy_on_cpu() -> None:
     assert torch.equal(model.weight.cpu(), expected)
 
 
-@pytest.mark.gpu
+@pytest.mark.accelerator
 @pytest.mark.skipif(not torch.cuda.is_available(), reason="CUDA is required")
 def test_stage_group_wakes_once_and_keeps_allocator_blocks_cached(
     monkeypatch: pytest.MonkeyPatch,
@@ -247,4 +471,5 @@ def test_stage_group_wakes_once_and_keeps_allocator_blocks_cached(
     residency.sleep()
     assert next(dit.parameters()).device.type == "cpu"
     assert next(dav.parameters()).device.type == "cpu"
+    assert synchronize_calls == [device, device]
     assert empty_cache_calls == 0

--- a/tests/unit_test/serve/test_stage_offload_cli_overrides.py
+++ b/tests/unit_test/serve/test_stage_offload_cli_overrides.py
@@ -1,0 +1,94 @@
+# SPDX-License-Identifier: Apache-2.0
+"""--stage-offload-components ar,dit CLI wiring."""
+
+from __future__ import annotations
+
+import pytest
+import typer
+
+from sglang_omni.cli.serve import apply_stage_offload_cli_overrides
+from sglang_omni.config import PipelineConfig, StageConfig
+from sglang_omni.models.higgs_tts.config import HiggsTtsPipelineConfig
+from sglang_omni.models.minimax_music3.config import (
+    MiniMaxMusic3DualGPUPipelineConfig,
+    MiniMaxMusic3SingleGPUPipelineConfig,
+)
+
+
+def _stage(config: PipelineConfig, name: str) -> StageConfig:
+    return next(stage for stage in config.stages if stage.name == name)
+
+
+def test_absent_flag_is_a_no_op() -> None:
+    config = MiniMaxMusic3SingleGPUPipelineConfig(model_path="/models/minimax")
+
+    result = apply_stage_offload_cli_overrides(config, stage_offload_components=None)
+
+    assert result is config
+    assert _stage(result, "minimax_music3_ar").factory.enable_serial_offload is None
+
+
+def test_ar_and_dit_colocates_both_stages_and_flags_their_factory_args() -> None:
+    config = MiniMaxMusic3SingleGPUPipelineConfig(model_path="/models/minimax")
+
+    result = apply_stage_offload_cli_overrides(
+        config, stage_offload_components="ar,dit"
+    )
+
+    ar_stage = _stage(result, "minimax_music3_ar")
+    dit_stage = _stage(result, "dit_dav")
+    assert ar_stage.process == dit_stage.process
+    assert ar_stage.factory.enable_serial_offload is True
+    assert dit_stage.factory.enable_serial_offload is True
+    # The override deep-copies, matching every other apply_*_cli_overrides.
+    assert _stage(config, "minimax_music3_ar").factory.enable_serial_offload is None
+
+
+def test_whitespace_and_case_are_normalized() -> None:
+    config = MiniMaxMusic3SingleGPUPipelineConfig(model_path="/models/minimax")
+
+    result = apply_stage_offload_cli_overrides(
+        config, stage_offload_components=" AR , Dit "
+    )
+
+    assert (
+        _stage(result, "dit_dav").process == _stage(result, "minimax_music3_ar").process
+    )
+
+
+def test_partial_component_list_is_rejected() -> None:
+    config = MiniMaxMusic3SingleGPUPipelineConfig(model_path="/models/minimax")
+
+    with pytest.raises(typer.BadParameter, match="requires all of"):
+        apply_stage_offload_cli_overrides(config, stage_offload_components="ar")
+
+
+def test_unknown_component_is_rejected() -> None:
+    config = MiniMaxMusic3SingleGPUPipelineConfig(model_path="/models/minimax")
+
+    with pytest.raises(typer.BadParameter, match="does not support"):
+        apply_stage_offload_cli_overrides(
+            config, stage_offload_components="ar,dit,talker"
+        )
+
+
+def test_empty_flag_value_is_rejected() -> None:
+    config = MiniMaxMusic3SingleGPUPipelineConfig(model_path="/models/minimax")
+
+    with pytest.raises(typer.BadParameter, match="must not be empty"):
+        apply_stage_offload_cli_overrides(config, stage_offload_components=" , ")
+
+
+def test_unsupported_pipeline_is_rejected() -> None:
+    config = HiggsTtsPipelineConfig(model_path="dummy")
+
+    with pytest.raises(typer.BadParameter, match="not supported"):
+        apply_stage_offload_cli_overrides(config, stage_offload_components="ar,dit")
+
+
+def test_mismatched_gpu_placement_is_rejected() -> None:
+    config = MiniMaxMusic3DualGPUPipelineConfig(model_path="/models/minimax")
+    assert _stage(config, "minimax_music3_ar").gpu != _stage(config, "dit_dav").gpu
+
+    with pytest.raises(typer.BadParameter, match="same GPU"):
+        apply_stage_offload_cli_overrides(config, stage_offload_components="ar,dit")


### PR DESCRIPTION
## Summary

This draft combines the current native MLX Music3 work from #1990 with the
request-serial CUDA offload work from #1619, then extends the same stage-wise
behavior to MLX without introducing a shared backend framework.

- One logical song owns AR -> acoustic until terminal cleanup; CUDA still has
  two internal CFG slots.
- CUDA keeps canonical CPU weights and gives only the active stage a GPU
  replica. Generation/RVQ CUDA graphs and acoustic compile are disabled only
  in offload mode.
- MLX resolves an immutable local artifact at startup, loads only after request
  ownership, makes the hidden handoff transport-owning, keeps the full acoustic
  stage resident across chunks, and drops model references after terminal
  cleanup.
- Finish, abort, load failure, duplicate terminal, and late terminal paths are
  owner checked. Unsafe transition failures fail closed.
- Offload remains opt-in; resident defaults are unchanged.

This is intentionally limited to one device and one logical request. It does
not add layer offload, prefetch, a memory planner, another request queue, or a
generic backend residency abstraction.

## Provenance

- base: `d80b95799f77e40295c669d965f0ada25322e215`
- head: `de6236a3326198c3dc779c368874aa68ad93d8e1`
- #1619 head rechecked: `14dbfc89bd49f88f38e7e5db8640610f29e762a9`
- #1990 head rechecked: `27ea43d9dab1e57f388a08cc944fa6da25a2442f`

Commits are kept reviewable as upstream MLX, upstream serial residency, CUDA
wiring/ownership fixes, MLX lifecycle/tests, and documentation.

## Main files

- `sglang_omni/models/minimax_music3/serial_offload.py`: request ownership and
  CUDA canonical-host residency
- `engine_builder.py`, `model_runner.py`, `scheduler.py`, `acoustic.py`,
  `stages.py`: production wiring, CFG capacity, handoff, terminal cleanup
- `mlx/loader.py`, `mlx/ar_scheduler.py`, `mlx/acoustic.py`: fixed artifact,
  lazy load, synchronization, owning hidden transport, stage release
- `tests/unit_test/minimax_music3/`: factory, ownership, failure, alias,
  residency, reload, and MLX allocation coverage
- `docs/cookbook/minimax_music3.md` and model README: enablement and costs

## Enablement

```bash
# CUDA
CUDA_VISIBLE_DEVICES=0 sgl-omni serve \
  --model-path MiniMaxAI/MiniMax-Music3 \
  --stage-offload-components ar,dit

# Apple Silicon
SGLANG_USE_MLX=1 sgl-omni serve \
  --model-path mlx-community/MiniMax-Music3-mxfp8 \
  --stage-offload-components ar,dit
```

## Verification

Host: Linux x86_64, Intel Xeon Platinum 8480C, 2 TiB RAM, PyTorch
`2.13.0+cu130`, driver `595.71.05`, 8x NVIDIA H200 143771 MiB. Synthetic CUDA
measurements used otherwise-idle GPU 2. There is no Apple Silicon/MLX runtime
and no MiniMax checkpoint in this environment.

```bash
uvx ruff format --check \
  sglang_omni/models/minimax_music3/mlx/loader.py \
  sglang_omni/models/minimax_music3/mlx/ar_scheduler.py \
  sglang_omni/models/minimax_music3/mlx/acoustic.py \
  tests/unit_test/minimax_music3/test_mlx_offload.py \
  tests/unit_test/minimax_music3/test_mlx_backend.py \
  tests/unit_test/minimax_music3/test_mlx_stage_selection.py

uvx ruff check --select F,I \
  sglang_omni/models/minimax_music3/mlx/loader.py \
  sglang_omni/models/minimax_music3/mlx/ar_scheduler.py \
  sglang_omni/models/minimax_music3/mlx/acoustic.py \
  tests/unit_test/minimax_music3/test_mlx_offload.py \
  tests/unit_test/minimax_music3/test_mlx_backend.py \
  tests/unit_test/minimax_music3/test_mlx_stage_selection.py

pytest -q tests/unit_test/minimax_music3 \
  tests/unit_test/serve/test_stage_offload_cli_overrides.py \
  tests/test_ci/test_omni_missing_dependencies.py
```

Result: `102 passed, 1 skipped`; formatting and selected `F,I` lint passed.
The skip is native MLX on Linux. No tests failed.

## A/B/C/D synthetic mechanism measurement

Each synthetic stage is one 256 MiB fp32 parameter. Three independent
processes per variant were run; each process ran 10 request/round-trip trials.
Times are mean of the three per-process means, with between-process standard
deviation. This measures `StageResidency`, not Music3 inference.

| Variant | allocated / reserved | device free | RSS | repeated operation |
| --- | ---: | ---: | ---: | ---: |
| A: both resident | 0.50 / 0.50 GiB | 138.698 GiB | 0.602 GiB | 0.006 ms |
| B: ownership, both resident | 0.50 / 0.50 GiB | 138.698 GiB | 0.597 GiB | 0.015 +/- 0.001 ms |
| C: final offload | 0.25 / 0.25 GiB | 138.948 GiB | 1.109 GiB | 108.173 +/- 15.629 ms |
| D: C without canonical host reuse | 0.25 / 0.25 GiB | 138.948 GiB | 0.861 GiB | 232.040 +/- 11.977 ms |

C first round trip: `145.364 +/- 6.168 ms`. D first round trip:
`218.028 +/- 10.330 ms`. C intentionally pays about 0.25 GiB more host RSS to
reuse an immutable canonical copy; deleting it made repeated transfer about
2.15x slower. CUDA allocated is the relevant same-process result. Device-free
is reported separately and was stable in the isolated rerun; it is not added
to allocator values.

Reproduction (run the committed test suite first, then run the temporary
mechanism harness at this PR's head):

```bash
git checkout de6236a3326198c3dc779c368874aa68ad93d8e1
VARIANT=A CUDA_VISIBLE_DEVICES=2 PYTHONPATH=. python /tmp/minimax_offload_bench.py
VARIANT=B CUDA_VISIBLE_DEVICES=2 PYTHONPATH=. python /tmp/minimax_offload_bench.py
VARIANT=C CUDA_VISIBLE_DEVICES=2 PYTHONPATH=. python /tmp/minimax_offload_bench.py
VARIANT=D CUDA_VISIBLE_DEVICES=2 PYTHONPATH=. python /tmp/minimax_offload_bench.py
```

Create `/tmp/minimax_offload_bench.py` with this harness; repeat the four
commands above three times:

<details>
<summary>Synthetic benchmark harness</summary>

```python
import json, os, statistics, time
import psutil
import torch
from sglang_omni.models.minimax_music3.serial_offload import (
    SerialOffloadCoordinator,
    StageResidency,
)

DEVICE = torch.device("cuda:0")
N, TRIALS, GIB = 64 * 1024 * 1024, 10, 1024**3
PROCESS = psutil.Process(os.getpid())

class Stage(torch.nn.Module):
    def __init__(self, device):
        super().__init__()
        self.weight = torch.nn.Parameter(
            torch.ones(N, dtype=torch.float32, device=device),
            requires_grad=False,
        )

def sample():
    free, _ = torch.cuda.mem_get_info(DEVICE)
    return {
        "allocated_gib": torch.cuda.memory_allocated(DEVICE) / GIB,
        "reserved_gib": torch.cuda.memory_reserved(DEVICE) / GIB,
        "device_free_gib": free / GIB,
        "rss_gib": PROCESS.memory_info().rss / GIB,
    }

def stats(values):
    return {
        "mean": statistics.mean(values),
        "stdev": statistics.stdev(values),
        "min": min(values),
        "max": max(values),
    }

torch.cuda.init()
torch.cuda.empty_cache()
torch.cuda.synchronize(DEVICE)
baseline = sample()
variant = os.environ["VARIANT"]
started = time.perf_counter()

if variant in {"A", "B"}:
    ar, acoustic = Stage(DEVICE), Stage(DEVICE)
    coordinator = None
    if variant == "B":
        coordinator = SerialOffloadCoordinator()
        coordinator.enable()
    torch.cuda.synchronize(DEVICE)
    startup_ms = (time.perf_counter() - started) * 1000
    times = []
    for i in range(TRIALS):
        tick = time.perf_counter()
        if coordinator:
            request_id = f"request-{i}"
            coordinator.acquire_ar(request_id)
            coordinator.begin_dit_handoff(request_id)
            coordinator.require_acoustic(request_id)
            coordinator.end_dit_handoff(request_id)
        else:
            torch.cuda.synchronize(DEVICE)
        times.append((time.perf_counter() - tick) * 1000)
    result = {
        "startup_ms": startup_ms,
        "steady": sample(),
        "request_ms": stats(times),
    }
elif variant == "C":
    ar, acoustic = Stage(DEVICE), Stage("cpu")
    ar_res = StageResidency({"ar": ar}, DEVICE, resident=True)
    ac_res = StageResidency({"acoustic": acoustic}, DEVICE, resident=False)
    torch.cuda.synchronize(DEVICE)
    startup_ms = (time.perf_counter() - started) * 1000
    tick = time.perf_counter()
    ar_res.sleep(); ac_res.wake(); ac_res.sleep(); ar_res.wake()
    first_ms = (time.perf_counter() - tick) * 1000
    samples, times = [sample()], []
    for _ in range(TRIALS):
        tick = time.perf_counter()
        ar_res.sleep(); ac_res.wake(); samples.append(sample())
        ac_res.sleep(); ar_res.wake(); samples.append(sample())
        times.append((time.perf_counter() - tick) * 1000)
    result = {
        "startup_ms": startup_ms,
        "first_ms": first_ms,
        "steady": sample(),
        "max_allocated_gib": max(x["allocated_gib"] for x in samples),
        "request_ms": stats(times),
    }
elif variant == "D":
    ar, acoustic = Stage(DEVICE), Stage("cpu")
    torch.cuda.synchronize(DEVICE)
    startup_ms = (time.perf_counter() - started) * 1000
    tick = time.perf_counter()
    ar.to("cpu"); acoustic.to(DEVICE); torch.cuda.synchronize(DEVICE)
    acoustic.to("cpu"); ar.to(DEVICE); torch.cuda.synchronize(DEVICE)
    first_ms = (time.perf_counter() - tick) * 1000
    samples, times = [sample()], []
    for _ in range(TRIALS):
        tick = time.perf_counter()
        ar.to("cpu"); acoustic.to(DEVICE); torch.cuda.synchronize(DEVICE)
        samples.append(sample())
        acoustic.to("cpu"); ar.to(DEVICE); torch.cuda.synchronize(DEVICE)
        samples.append(sample())
        times.append((time.perf_counter() - tick) * 1000)
    result = {
        "startup_ms": startup_ms,
        "first_ms": first_ms,
        "steady": sample(),
        "max_allocated_gib": max(x["allocated_gib"] for x in samples),
        "request_ms": stats(times),
    }
else:
    raise ValueError(variant)

result.update(baseline=baseline, variant=variant)
print(json.dumps(result, sort_keys=True))
```

</details>

## Subtraction / ablation record

| Candidate | Removal or replacement | Evidence | Conclusion |
| --- | --- | --- | --- |
| generic manager/registry and second queue | reused model-local coordinator and existing scheduler queues | factory and two-request lifecycle tests pass | deleted/not introduced |
| outstanding request set and redundant state | single owner + phase | late old terminal without owner validation released a newer owner in the directed counter-test | retain only owner/phase and validation |
| CUDA boundary synchronization | removed under a safe mocked test | stage boundary synchronization test failed | retained |
| owning MLX hidden copy | replaced with `ascontiguousarray` in directed alias test | source mutation changed the published Torch tensor | retained in offload mode |
| per-release `mx.clear_cache()` | removed; release now synchronizes and drops the real model reference | post-removal MLX lifecycle suite: 11 passed; no Apple memory benefit evidence available | deleted |
| reusable CUDA canonical host copy | D replaced it with repeated `.to()` movement | same allocated reduction, but 232.040 ms vs 108.173 ms repeated round trip | retained |
| `gc.collect()`, extra host cache, generic config hook | omitted or removed | no required responsibility or measured benefit | deleted/not introduced |

## mac result
### Test Environment

* **Device:** MacBook Air (13-inch, M5)
* **Chip:** Apple M5
* **Unified Memory:** 24 GB
* **OS:** macOS 26.6.2 (Build 25G83)

---

### Result

`sgl-omni serve --model-path mlx-community/MiniMax-Music3-mxfp8 --stage-offload-components ar,dit` → **HTTP 200**, 1.28 MB WAV, 32 kHz stereo, 10.00s, `finish_reason=length`.

| Metric / Stage | Measurement |
| :--- | :--- |
| **Port open** | ~15s (weights load on first request, as designed) |
| **AR stage** | 43.0s / 250 frames |
| **Acoustic stage** | 47.0s (2 chunks) |
| **Total request** | 90s for 10s audio (~9× slower than realtime) |

The offload lifecycle ran exactly as specified:
* **AR active:** 10.41 GiB → released 0.00 GiB → AR → CPU (DiT/DAV's turn)
* **Acoustic active:** 2.49 GiB → released → AR → GPU
* **VRAM usage:** Peak single-stage 10.41 GiB vs. 12.91 GiB both-resident (on 24 GiB pool).


## Not run / acceptance gaps

- Resident/offload output parity, fixed-seed audio, single/cross-chunk, 250/750
  frame requests, full HTTP latency, first-audio latency: **NOT RUN**.
- 20-50 real repeated requests and overlapping HTTP submissions: **NOT RUN**.
- 24 GiB discrete GPU peak/RSS and low-memory usability: **NOT RUN**.
- Apple Silicon MLX active/cache/peak, process pressure/swap, reload stability,
  parity, and low-memory usability: **NOT RUN**.

Accordingly, this draft does not claim either backend has completed hardware
acceptance. The tests establish wiring, ownership, cleanup, default-path
behavior, and synthetic residency mechanics; checkpoint and target-hardware
validation remains required before marking ready.
