### PR TITLE
Support Qwen-omni AutoRound MXFP loading

### DIFF
--- a/sglang_omni/model_runner/model_worker.py
+++ b/sglang_omni/model_runner/model_worker.py
@@ -8,9 +8,13 @@ from types import SimpleNamespace
 from typing import TYPE_CHECKING, Any
 
 from sglang_omni.quantization import (
+    disable_quantization_for_full_precision_stage,
     needs_quant_config_normalization,
     normalize_quant_config,
+    requires_fp8_gemm_initialization,
     resolve_quant_config,
+    resolve_stage_local_mxfp_profile,
+    validate_stage_local_mxfp_config,
 )
 from sglang_omni.vendor.sglang.server_args import override_server_args
 
@@ -103,6 +107,9 @@ class ModelWorker:
     @staticmethod
     def _apply_arch_override(model_config: ModelConfig, arch: str) -> None:
         """Override model config for a sub-model architecture."""
+        # ModelConfig detects root quantization before the stage override.
+        # Clear inherited metadata for stages declared full precision.
+        disable_quantization_for_full_precision_stage(model_config, arch)
         model_config.hf_config.architectures = [arch]
         if arch == "WhisperForConditionalGeneration":
             cfg = model_config.hf_config
@@ -462,6 +469,9 @@ def _apply_model_worker_backend_policy(
         )
     has_moe = _model_config_has_moe(model_config)
     has_native_fp8_block_quant = _model_config_has_native_fp8_block_quant(model_config)
+    stage_local_mxfp = resolve_stage_local_mxfp_profile(
+        model_config, model_arch_override
+    )
 
     if (
         model_arch_override == "Qwen3OmniTalker"
@@ -514,6 +524,26 @@ def _apply_model_worker_backend_policy(
             "moe_runner_backend='flashinfer_cutlass'. Leave the backend as "
             "'auto' so Omni selects a native-FP8-compatible MoE runner."
         )
+
+    if stage_local_mxfp is not None and has_moe:
+        required_backend = stage_local_mxfp.preferred_cuda_moe_backend
+        if not _is_stage_local_mxfp_supported():
+            raise ValueError(
+                "Stage-local AutoRound MXFP8 requires SM100 CUDA kernels."
+            )
+        if moe_runner_backend == "auto":
+            override_server_args(
+                server_args,
+                "sglang-omni-stage-local-mxfp-policy",
+                moe_runner_backend=required_backend,
+            )
+            moe_runner_backend = server_args.moe_runner_backend
+        elif moe_runner_backend != required_backend:
+            raise ValueError(
+                "Stage-local AutoRound MXFP requires "
+                f"moe_runner_backend={required_backend!r}, got "
+                f"{moe_runner_backend!r}."
+            )
 
     fp8_gemm_backend = _normalize_quantization(server_args.fp8_gemm_runner_backend)
     if (
@@ -591,6 +621,13 @@ def _is_fp8_cutlass_moe_supported() -> bool:
     )
 
 
+def _is_stage_local_mxfp_supported() -> bool:
+    """Stage-local MXFP8 dense kernels currently require SM100."""
+    from sglang.srt.utils import is_sm100_supported
+
+    return bool(is_sm100_supported())
+
+
 def _apply_omni_quantization_adapters(model_config: ModelConfig) -> None:
     """Apply Omni-specific quantization adapters before SGLang builds its config.
 
@@ -600,6 +637,7 @@ def _apply_omni_quantization_adapters(model_config: ModelConfig) -> None:
     against runtime module names, currently AutoRound.
     """
     quant_dict = resolve_quant_config(model_config.hf_config)
+    validate_stage_local_mxfp_config(model_config)
     if quant_dict is None:
         return
 
@@ -619,7 +657,9 @@ def _initialize_model_worker_backend_globals(
 
         initialize_moe_config(server_args)
 
-    if effective_quantization == "fp8":
+    if requires_fp8_gemm_initialization(
+        effective_quantization, model_config.hf_config
+    ):
         from sglang.srt.layers.quantization.fp8_utils import initialize_fp8_gemm_config
 
         initialize_fp8_gemm_config(server_args)

--- a/sglang_omni/models/qwen3_omni/components/sglang_thinker.py
+++ b/sglang_omni/models/qwen3_omni/components/sglang_thinker.py
@@ -24,6 +24,38 @@ from sglang.srt.utils import add_prefix, logger
 from sglang_omni.quantization import get_weight_preprocessor
 
 
+def _load_expert_parameter(
+    param: torch.nn.Parameter,
+    loaded_weight: torch.Tensor,
+    mapped_name: str,
+    shard_id: str,
+    expert_id: int,
+) -> None:
+    """Load a checkpoint tensor into one fused expert and shard."""
+    weight_loader = getattr(param, "weight_loader", default_weight_loader)
+    weight_loader(param, loaded_weight, mapped_name, shard_id, expert_id)
+
+
+def _expert_parameter_mapping(
+    name: str,
+    mappings: Iterable[tuple[str, str, int, str]],
+) -> tuple[str, str, int] | None:
+    """Map an expert weight or group scale to its fused runtime parameter."""
+    is_weight_scale = name.endswith(".weight_scale")
+    lookup_name = (
+        name[: -len(".weight_scale")] + ".weight" if is_weight_scale else name
+    )
+    parameter_suffix = "_scale" if is_weight_scale else ""
+    for param_name, weight_name, expert_id, shard_id in mappings:
+        if weight_name in lookup_name:
+            return (
+                lookup_name.replace(weight_name, param_name) + parameter_suffix,
+                shard_id,
+                expert_id,
+            )
+    return None
+
+
 class Qwen3OmniThinkerForCausalLM(nn.Module):
     """Qwen3-Omni thinker text model without duplicated audio/vision towers."""
 
@@ -161,13 +193,11 @@ class Qwen3OmniThinkerForCausalLM(nn.Module):
                 weight_loader(param, loaded_weight, shard_id)
                 break
             else:
-                is_expert_weight = False
-                for mapping in expert_params_mapping:
-                    param_name, weight_name, expert_id, shard_id = mapping
-                    if weight_name not in name:
-                        continue
-                    is_expert_weight = True
-                    mapped = name.replace(weight_name, param_name)
+                expert_mapping = _expert_parameter_mapping(
+                    name, expert_params_mapping
+                )
+                if expert_mapping is not None:
+                    mapped, shard_id, expert_id = expert_mapping
                     if is_fused_expert:
                         loaded = loaded_weight.transpose(-1, -2)
                         if "experts.gate_up_proj" in name:
@@ -196,20 +226,14 @@ class Qwen3OmniThinkerForCausalLM(nn.Module):
                         if param is None:
                             continue
                         loaded_weight = preprocess_weight(mapped, loaded_weight)
-                        weight_loader = getattr(
-                            param, "weight_loader", default_weight_loader
-                        )
-                        weight_loader(
+                        _load_expert_parameter(
                             param,
                             loaded_weight,
                             mapped,
-                            shard_id=shard_id,
-                            expert_id=expert_id,
+                            shard_id,
+                            expert_id,
                         )
-                    break
                 else:
-                    if is_expert_weight:
-                        continue
                     if name.endswith(ignore_suffixes) and name not in params_dict:
                         continue
                     param = params_dict.get(name)

--- a/sglang_omni/models/qwen3_omni/components/thinker_model.py
+++ b/sglang_omni/models/qwen3_omni/components/thinker_model.py
@@ -418,6 +418,9 @@ class Qwen3OmniMoeThinkerTextSparseMoeBlock(nn.Module):
             quant_config=quant_config,
             prefix=add_prefix("experts", prefix),
             routing_method_type=RoutingMethodType.Renormalize,
+            # The checkpoint exposes gate_proj and up_proj separately, and
+            # FusedMoE loads them into contiguous [gate; up] halves.
+            gate_up_interleaved=False,
         )
 
         self.gate = ReplicatedLinear(

--- a/sglang_omni/quantization.py
+++ b/sglang_omni/quantization.py
@@ -3,13 +3,15 @@
 
 SGLang owns quantization end-to-end: it parses `quantization_config`,
 constructs quantized layers, and executes post-load hooks. This module only
-provides the Qwen3-Omni-specific compatibility SGLang cannot infer by itself:
-stage-local AutoRound config normalization and FP8 scale preprocessing for
-custom weight loaders.
+provides the multi-stage compatibility SGLang cannot infer by itself:
+stage-local AutoRound config normalization and scale preprocessing for custom
+weight loaders.
 """
 
 from __future__ import annotations
 
+import re
+from dataclasses import dataclass
 from typing import TYPE_CHECKING, Any, Callable
 
 if TYPE_CHECKING:
@@ -38,8 +40,82 @@ __all__ = [
     "convert_fp8_weight_scale_inv",
     "get_weight_preprocessor",
     "needs_quant_config_normalization",
+    "get_stage_local_mxfp_policy",
+    "resolve_stage_local_mxfp_profile",
+    "requires_fp8_gemm_initialization",
+    "validate_stage_local_mxfp_config",
     "normalize_quant_config",
+    "disable_quantization_for_full_precision_stage",
 ]
+
+_MXFP_NAMES = {"mx", "mx_fp", "mxfp"}
+
+
+@dataclass(frozen=True)
+class StageLocalMxfpPolicy:
+    """Model-family rules that cannot be inferred from root quant metadata."""
+
+    architectures: frozenset[str]
+    quantized_stage_prefix: str
+    full_precision_architectures: frozenset[str]
+    full_precision_stage_prefixes: tuple[str, ...]
+    mxfp4_expert_pattern: re.Pattern[str]
+    model_label: str
+    mxfp8_cuda_moe_backend: str
+    mixed_cuda_moe_backend: str
+
+
+@dataclass(frozen=True)
+class StageLocalMxfpProfile:
+    """Runtime properties derived from a registered stage-local checkpoint."""
+
+    policy: StageLocalMxfpPolicy
+    has_mxfp4_experts: bool
+
+    @property
+    def preferred_cuda_moe_backend(self) -> str:
+        return (
+            self.policy.mixed_cuda_moe_backend
+            if self.has_mxfp4_experts
+            else self.policy.mxfp8_cuda_moe_backend
+        )
+
+
+_STAGE_LOCAL_MXFP_POLICIES = (
+    StageLocalMxfpPolicy(
+        architectures=frozenset(
+            {
+                "Qwen3OmniMoeForConditionalGeneration",
+                "Qwen3OmniThinkerForCausalLM",
+                "Qwen3OmniTalker",
+            }
+        ),
+        quantized_stage_prefix="thinker.",
+        full_precision_architectures=frozenset({"Qwen3OmniTalker"}),
+        full_precision_stage_prefixes=("talker.", "code2wav."),
+        mxfp4_expert_pattern=re.compile(
+            r"^thinker\\?\.model\\?\.layers\\?\..+\\?\.mlp\\?\.experts\\?\."
+            r".+\\?\.\(gate\|up\|down\)_proj$"
+        ),
+        model_label="Qwen3-Omni",
+        mxfp8_cuda_moe_backend="flashinfer_trtllm",
+        mixed_cuda_moe_backend="flashinfer_mxfp4",
+    ),
+)
+
+
+def get_stage_local_mxfp_policy(
+    architecture: str | None,
+) -> StageLocalMxfpPolicy | None:
+    """Return declarative stage-local MXFP rules for a model architecture."""
+    return next(
+        (
+            policy
+            for policy in _STAGE_LOCAL_MXFP_POLICIES
+            if architecture in policy.architectures
+        ),
+        None,
+    )
 
 
 def _to_mutable_dict(quant_config: Any, metadata_key: str) -> dict[str, Any]:
@@ -154,6 +230,267 @@ def needs_quant_config_normalization(quant_dict: dict[str, Any] | None) -> bool:
     return method == "auto-round"
 
 
+def _is_auto_round_mxfp(quant_config: dict[str, Any]) -> bool:
+    data_type = str(quant_config.get("data_type", "")).lower().replace("-", "_")
+    return quant_method_name(quant_config) == "auto-round" and data_type in _MXFP_NAMES
+
+
+def _mxfp_bits(config: dict[str, Any], defaults: dict[str, Any]) -> int | None:
+    try:
+        return int(config.get("bits", defaults.get("bits", 0)))
+    except (TypeError, ValueError):
+        return None
+
+
+def _has_mxfp4_overrides(quant_config: dict[str, Any]) -> bool:
+    extra_config = quant_config.get("extra_config")
+    if not isinstance(extra_config, dict):
+        return False
+    for entry in extra_config.values():
+        if not isinstance(entry, dict):
+            continue
+        data_type = str(
+            entry.get("data_type", quant_config.get("data_type", ""))
+        ).lower().replace("-", "_")
+        if _mxfp_bits(entry, quant_config) == 4 and data_type in _MXFP_NAMES:
+            return True
+    return False
+
+
+def resolve_stage_local_mxfp_profile(
+    config: Any,
+    architecture: str | None = None,
+) -> StageLocalMxfpProfile | None:
+    """Resolve registered model-family policy and checkpoint MXFP properties.
+
+    CUDA and other platform layers consume this result without embedding model
+    names or checkpoint pattern details. Supporting another Omni family only
+    requires registering its stage policy in this module.
+    """
+    hf_config = getattr(config, "hf_config", config)
+    if hf_config is None:
+        return None
+    if architecture is None:
+        architecture = (getattr(hf_config, "architectures", None) or [None])[0]
+    policy = get_stage_local_mxfp_policy(architecture)
+    quant_config = resolve_quant_config(hf_config)
+    if policy is None or not quant_config or not _is_auto_round_mxfp(quant_config):
+        return None
+    if _mxfp_bits(quant_config, {}) != 8:
+        return None
+    return StageLocalMxfpProfile(
+        policy=policy,
+        has_mxfp4_experts=_has_mxfp4_overrides(quant_config),
+    )
+
+
+def requires_fp8_gemm_initialization(
+    effective_quantization: str | None,
+    config: Any,
+) -> bool:
+    """Whether model construction can instantiate an FP8-backed dense method."""
+    method = (
+        effective_quantization.lower().replace("_", "-")
+        if effective_quantization
+        else None
+    )
+    if method == "fp8":
+        return True
+    quant_config = resolve_quant_config(config)
+    return bool(
+        method == "auto-round"
+        and quant_config
+        and _is_auto_round_mxfp(quant_config)
+        and _mxfp_bits(quant_config, {}) == 8
+    )
+
+
+def _compile_layer_pattern(pattern: Any) -> re.Pattern[str]:
+    if not isinstance(pattern, str) or not pattern:
+        raise ValueError(
+            "AutoRound quantization layer patterns must be non-empty strings"
+        )
+    try:
+        return re.compile(pattern)
+    except re.error as err:
+        raise ValueError(
+            f"Invalid quantization layer pattern {pattern!r}: {err}"
+        ) from err
+
+
+def _block_targets_stage(block: str, stage_prefix: str) -> bool:
+    """Match AutoRound's literal ``layer_name.startswith(block)`` semantics."""
+    return f"{stage_prefix}model.layers.0.self_attn.q_proj".startswith(block)
+
+
+def _pattern_targets_routed_expert(
+    pattern: str, policy: StageLocalMxfpPolicy
+) -> bool:
+    """Accept only the exported thinker routed-expert pattern shape.
+
+    Arbitrary regular expressions cannot be proven to exclude dense or other
+    stages. Constraining the shape keeps the MXFP4 exception fail-closed.
+    """
+    _compile_layer_pattern(pattern)
+    return policy.mxfp4_expert_pattern.fullmatch(pattern) is not None
+
+
+def _validate_mxfp_scheme(
+    config: dict[str, Any], *, defaults: dict[str, Any], context: str
+) -> tuple[int, str]:
+    try:
+        bits = int(config.get("bits", defaults.get("bits", 0)))
+    except (TypeError, ValueError) as err:
+        raise ValueError(f"{context} bits must be an integer") from err
+    data_type = str(
+        config.get("data_type", defaults.get("data_type", ""))
+    ).lower().replace("-", "_")
+    if data_type in _MXFP_NAMES:
+        if bits not in {4, 8}:
+            raise ValueError(f"{context} MXFP bits must be 4 or 8, got {bits}")
+        try:
+            group_size = int(
+                config.get("group_size", defaults.get("group_size", 32))
+            )
+        except (TypeError, ValueError) as err:
+            raise ValueError(f"{context} MXFP group_size must be 32") from err
+        if group_size != 32:
+            raise ValueError(f"{context} MXFP group_size must be 32, got {group_size}")
+        if config.get("sym", defaults.get("sym", True)) is not True:
+            raise ValueError(
+                f"{context} MXFP must use symmetric quantization (sym=true)"
+            )
+    elif bits != 16 or data_type not in {"float", "fp16", "bf16", "bfloat16"}:
+        raise ValueError(
+            f"{context} must be MXFP4/MXFP8 or an explicit 16-bit "
+            "floating-point exclusion"
+        )
+    return bits, data_type
+
+
+def validate_stage_local_mxfp_config(model_config: Any) -> None:
+    """Validate registered stage-local AutoRound MXFP checkpoint metadata."""
+    hf_config = getattr(model_config, "hf_config", None)
+    if hf_config is None:
+        return
+    architecture = (getattr(hf_config, "architectures", None) or [None])[0]
+    policy = get_stage_local_mxfp_policy(architecture)
+    if policy is None:
+        return
+    quant_config = resolve_quant_config(hf_config)
+    if not quant_config or not _is_auto_round_mxfp(quant_config):
+        return
+
+    default_bits, _default_data_type = _validate_mxfp_scheme(
+        quant_config, defaults={}, context="AutoRound default"
+    )
+    if quant_config.get("packing_format", "auto_round:sglang") != "auto_round:sglang":
+        raise ValueError("AutoRound MXFP requires packing_format='auto_round:sglang'")
+    extra_config = quant_config.get("extra_config") or {}
+    if not isinstance(extra_config, dict):
+        raise ValueError("AutoRound MXFP extra_config must be a mapping")
+
+    # MXFP4 has no supported dense LinearBase path in SGLang-Omni.
+    # A global 4-bit default necessarily selects dense projections, so mixed
+    # checkpoints must use MXFP8/BF16 globally and override routed experts only.
+    if default_bits == 4:
+        raise ValueError(
+            f"{policy.model_label} AutoRound MXFP4 is supported only for routed MoE "
+            "experts; a global MXFP4 default would quantize dense/attention "
+            "layers. Export a mixed checkpoint with MXFP8 or BF16 as the default."
+        )
+    for pattern, entry in extra_config.items():
+        if not isinstance(entry, dict):
+            raise ValueError(
+                f"AutoRound MXFP extra_config entry {pattern!r} must be a mapping"
+            )
+        _compile_layer_pattern(pattern)
+        entry_bits, entry_dtype = _validate_mxfp_scheme(
+            entry,
+            defaults=quant_config,
+            context=f"AutoRound layer pattern {pattern!r}",
+        )
+        if (
+            entry_bits == 4
+            and entry_dtype in _MXFP_NAMES
+            and not _pattern_targets_routed_expert(str(pattern), policy)
+        ):
+            raise ValueError(
+                f"{policy.model_label} AutoRound MXFP4 is supported only for registered "
+                f"routed MoE expert patterns, but {pattern!r} can select another "
+                "layer."
+            )
+
+    blocks = quant_config.get("block_name_to_quantize") or []
+    if isinstance(blocks, str):
+        blocks = [part.strip() for part in blocks.split(",") if part.strip()]
+
+    if not isinstance(blocks, list) or not all(
+        isinstance(block, str) and block for block in blocks
+    ):
+        raise ValueError(
+            "AutoRound MXFP block_name_to_quantize must contain non-empty strings"
+        )
+
+    if not any(
+        _block_targets_stage(block, policy.quantized_stage_prefix) for block in blocks
+    ):
+        raise ValueError(
+            f"{policy.model_label} AutoRound MXFP must target the registered "
+            "quantized stage via "
+            "block_name_to_quantize"
+        )
+
+    violations = []
+    for stage_prefix in policy.full_precision_stage_prefixes:
+        stage_selected = any(
+            _block_targets_stage(block, stage_prefix) for block in blocks
+        )
+        if not stage_selected:
+            continue
+        # A stage listed here inherits the quantized default. Exact BF16
+        # exceptions cannot prove that every speech-stage linear is excluded;
+        # a compliant SGLang export omits these stages from this field entirely.
+        violations.append(stage_prefix[:-1])
+
+    if violations:
+        raise ValueError(
+            f"{policy.model_label} AutoRound MXFP metadata selects "
+            "full-precision stages: "
+            f"{', '.join(violations)}. Re-export so only the intended stage is "
+            "quantized."
+        )
+
+
+def disable_quantization_for_full_precision_stage(
+    model_config: Any, architecture: str
+) -> bool:
+    """Prevent stage-local MXFP metadata from leaking into unquantized stages.
+
+    Omni checkpoints can store several stages under one root quantization
+    config. SGLang detects that config before Omni selects a sub-model, so a
+    full-precision stage must clear both the detected method and root metadata.
+    """
+    policy = get_stage_local_mxfp_policy(architecture)
+    if policy is None or architecture not in policy.full_precision_architectures:
+        return False
+    hf_config = getattr(model_config, "hf_config", None)
+    quant_config = resolve_quant_config(hf_config)
+    if not quant_config or not _is_auto_round_mxfp(quant_config):
+        return False
+
+    validate_stage_local_mxfp_config(model_config)
+    for key in _QUANT_METADATA_KEYS:
+        if isinstance(hf_config, dict):
+            hf_config.pop(key, None)
+        elif hasattr(hf_config, key):
+            setattr(hf_config, key, None)
+    model_config.quantization = None
+    if hasattr(model_config, "is_fp4_experts"):
+        model_config.is_fp4_experts = False
+    return True
+
+
 def _strip_stage_prefix(pattern: str, plain_prefix: str, escaped_prefix: str) -> str:
     """Strip the stage prefix from the start of a regex pattern."""
     if pattern.startswith(escaped_prefix):
@@ -182,6 +519,12 @@ def _normalize_extra_config_keys(
     for key, value in extra_config.items():
         normalized_key = _strip_stage_prefix(key, stage_prefix, escaped_prefix)
         changed = changed or normalized_key != key
+        if normalized_key in normalized_extra:
+            raise ValueError(
+                "AutoRound quantization patterns collide after stage-prefix "
+                f"normalization: {key!r} and another entry both map to "
+                f"{normalized_key!r}"
+            )
         normalized_extra[normalized_key] = value
 
     if not changed:

--- a/tests/unit_test/quantization/test_autoround.py
+++ b/tests/unit_test/quantization/test_autoround.py
@@ -8,8 +8,12 @@ from types import SimpleNamespace
 import pytest
 
 from sglang_omni.quantization import (
+    disable_quantization_for_full_precision_stage,
+    get_stage_local_mxfp_policy,
     needs_quant_config_normalization,
     normalize_quant_config,
+    resolve_stage_local_mxfp_profile,
+    validate_stage_local_mxfp_config,
 )
 
 
@@ -39,6 +43,153 @@ class TestNeedsStageLocalNormalization:
 
     def test_false_for_none(self) -> None:
         assert not needs_quant_config_normalization(None)
+
+
+class TestQwen3OmniMxfpConfig:
+    def test_policy_resolves_for_each_model_stage(self) -> None:
+        assert get_stage_local_mxfp_policy(
+            "Qwen3OmniMoeForConditionalGeneration"
+        ) is get_stage_local_mxfp_policy("Qwen3OmniThinkerForCausalLM")
+        assert get_stage_local_mxfp_policy("OtherOmniModel") is None
+
+    def test_runtime_profile_derives_backend_from_registered_policy(self) -> None:
+        quant_config = {
+            "quant_method": "auto-round",
+            "bits": 8,
+            "data_type": "mx_fp",
+            "extra_config": {
+                r"thinker\.model\.layers\..*\.mlp\.experts\..*\.(gate|up|down)_proj": {
+                    "bits": 4,
+                    "data_type": "mx_fp",
+                }
+            },
+        }
+        model_config = _make_model_config(
+            "Qwen3OmniThinkerForCausalLM", quant_config
+        )
+
+        profile = resolve_stage_local_mxfp_profile(model_config)
+
+        assert profile is not None
+        assert profile.has_mxfp4_experts
+        assert profile.preferred_cuda_moe_backend == "flashinfer_mxfp4"
+
+    def test_accepts_mxfp4_overrides_for_thinker_experts(self) -> None:
+        quant_config = {
+            "quant_method": "auto-round",
+            "packing_format": "auto_round:sglang",
+            "bits": 8,
+            "data_type": "mx_fp",
+            "group_size": 32,
+            "block_name_to_quantize": "thinker.model.layers",
+            "extra_config": {
+                r"thinker\.model\.layers\..*\.mlp\.experts\..*\.(gate|up|down)_proj": {
+                    "bits": 4,
+                    "data_type": "mx_fp",
+                }
+            },
+        }
+
+        validate_stage_local_mxfp_config(
+            _make_model_config("Qwen3OmniMoeForConditionalGeneration", quant_config)
+        )
+
+    @pytest.mark.parametrize(
+        "quant_config,error",
+        [
+            (
+                {
+                    "quant_method": "auto-round",
+                    "packing_format": "auto_round:sglang",
+                    "bits": 4,
+                    "data_type": "mx_fp",
+                    "group_size": 32,
+                    "block_name_to_quantize": "thinker.model.layers",
+                },
+                "only for routed MoE experts",
+            ),
+            (
+                {
+                    "quant_method": "auto-round",
+                    "packing_format": "auto_round:sglang",
+                    "bits": 8,
+                    "data_type": "mx_fp",
+                    "group_size": 32,
+                },
+                "must target the registered quantized stage",
+            ),
+            (
+                {
+                    "quant_method": "auto-round",
+                    "packing_format": "auto_round:sglang",
+                    "bits": 8,
+                    "data_type": "mx_fp",
+                    "group_size": 64,
+                    "block_name_to_quantize": "thinker.model.layers",
+                },
+                "group_size must be 32",
+            ),
+            (
+                {
+                    "quant_method": "auto-round",
+                    "packing_format": "auto_round:sglang",
+                    "bits": 8,
+                    "data_type": "mx_fp",
+                    "group_size": 32,
+                    "block_name_to_quantize": "thinker.model.layers,talker.model.layers",
+                },
+                "selects full-precision stages",
+            ),
+            (
+                {
+                    "quant_method": "auto-round",
+                    "packing_format": "auto_round:sglang",
+                    "bits": 8,
+                    "data_type": "mx_fp",
+                    "group_size": 32,
+                    "block_name_to_quantize": "thinker.model.layers",
+                    "extra_config": {
+                        r"thinker\.model\.layers\..*\.self_attn\.q_proj": {
+                            "bits": 4,
+                            "data_type": "mx_fp",
+                        }
+                    },
+                },
+                "only for registered routed MoE expert patterns",
+            ),
+        ],
+    )
+    def test_rejects_unsupported_mxfp_configs(
+        self, quant_config: dict[str, object], error: str
+    ) -> None:
+        with pytest.raises(ValueError, match=error):
+            validate_stage_local_mxfp_config(
+                _make_model_config(
+                    "Qwen3OmniMoeForConditionalGeneration", quant_config
+                )
+            )
+
+    def test_talker_drops_thinker_mxfp_metadata(self) -> None:
+        quant_config = {
+            "quant_method": "auto-round",
+            "packing_format": "auto_round:sglang",
+            "bits": 8,
+            "data_type": "mx_fp",
+            "group_size": 32,
+            "block_name_to_quantize": "thinker.model.layers",
+        }
+        model_config = _make_model_config(
+            "Qwen3OmniMoeForConditionalGeneration", quant_config
+        )
+        model_config.quantization = "auto-round"
+        model_config.is_fp4_experts = True
+
+        assert disable_quantization_for_full_precision_stage(
+            model_config, "Qwen3OmniTalker"
+        )
+        assert model_config.quantization is None
+        assert model_config.hf_config.quantization_config is None
+        assert model_config.is_fp4_experts is False
 
 
 class TestNormalizeStageLocalCheckpointConfig:
@@ -179,6 +330,22 @@ class TestNormalizeStageLocalCheckpointConfig:
         assert quant_config["extra_config"] == {
             r".*model\.layers\.\d+\.mlp\.gate.*": {"bits": 8},
         }
+
+    def test_rejects_pattern_collision_after_normalization(self) -> None:
+        quant_config = {
+            "quant_method": "auto-round",
+            "block_name_to_quantize": "thinker.model.layers",
+            "extra_config": {
+                r"thinker\.model\.layers\.0": {"bits": 4},
+                r"model\.layers\.0": {"bits": 8},
+            },
+        }
+        model_config = _make_model_config(
+            "Qwen3OmniThinkerForCausalLM", quant_config
+        )
+
+        with pytest.raises(ValueError, match="patterns collide"):
+            normalize_quant_config(model_config)
 
     def test_no_change_when_block_names_lack_prefix(self) -> None:
         quant_config = {

--- a/tests/unit_test/qwen3_omni/test_fp8_backend_config.py
+++ b/tests/unit_test/qwen3_omni/test_fp8_backend_config.py
@@ -86,6 +86,31 @@ def _model_config(
     )
 
 
+def _stage_local_mxfp_model_config(*, mixed_experts: bool) -> SimpleNamespace:
+    extra_config = {}
+    if mixed_experts:
+        extra_config[
+            r"thinker\.model\.layers\..*\.mlp\.experts\..*\.(gate|up|down)_proj"
+        ] = {"bits": 4, "data_type": "mx_fp"}
+    quantization_config = {
+        "quant_method": "auto-round",
+        "packing_format": "auto_round:sglang",
+        "bits": 8,
+        "data_type": "mx_fp",
+        "group_size": 32,
+        "block_name_to_quantize": "thinker.model.layers",
+        "extra_config": extra_config,
+    }
+    return SimpleNamespace(
+        quantization="auto-round",
+        hf_text_config=SimpleNamespace(num_experts_per_tok=8),
+        hf_config=SimpleNamespace(
+            architectures=["Qwen3OmniThinkerForCausalLM"],
+            quantization_config=quantization_config,
+        ),
+    )
+
+
 @pytest.mark.parametrize(
     "case",
     [
@@ -433,6 +458,54 @@ def test_model_worker_backend_policy_uses_strict_server_args_override(
     ]
 
 
+@pytest.mark.parametrize(
+    ("mixed_experts", "expected_backend"),
+    [(False, "flashinfer_trtllm"), (True, "flashinfer_mxfp4")],
+)
+def test_stage_local_mxfp_selects_required_sm100_moe_backend(
+    monkeypatch: pytest.MonkeyPatch,
+    mixed_experts: bool,
+    expected_backend: str,
+) -> None:
+    monkeypatch.setattr(model_worker, "_is_stage_local_mxfp_supported", lambda: True)
+    server_args = _server_args()
+
+    effective_quantization = model_worker._apply_model_worker_backend_policy(
+        server_args,
+        _stage_local_mxfp_model_config(mixed_experts=mixed_experts),
+        "Qwen3OmniThinkerForCausalLM",
+    )
+
+    assert effective_quantization == "auto-round"
+    assert server_args.moe_runner_backend == expected_backend
+
+
+def test_stage_local_mxfp_rejects_non_sm100_cuda(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    monkeypatch.setattr(model_worker, "_is_stage_local_mxfp_supported", lambda: False)
+
+    with pytest.raises(ValueError, match="requires SM100"):
+        model_worker._apply_model_worker_backend_policy(
+            _server_args(),
+            _stage_local_mxfp_model_config(mixed_experts=True),
+            "Qwen3OmniThinkerForCausalLM",
+        )
+
+
+def test_stage_local_mxfp_rejects_incompatible_explicit_backend(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    monkeypatch.setattr(model_worker, "_is_stage_local_mxfp_supported", lambda: True)
+
+    with pytest.raises(ValueError, match="moe_runner_backend='flashinfer_mxfp4'"):
+        model_worker._apply_model_worker_backend_policy(
+            _server_args(moe_runner_backend="triton"),
+            _stage_local_mxfp_model_config(mixed_experts=True),
+            "Qwen3OmniThinkerForCausalLM",
+        )
+
+
 def test_model_config_has_moe_prefers_effective_text_config() -> None:
     model_config = SimpleNamespace(
         hf_config=SimpleNamespace(text_config=SimpleNamespace()),
@@ -504,6 +577,18 @@ def test_backend_global_initialization_for_bf16_moe_omits_fp8(monkeypatch) -> No
     )
 
     assert calls == ["moe"]
+
+
+def test_backend_global_initialization_for_autoround_mxfp8(monkeypatch) -> None:
+    calls: list[str] = []
+
+    _install_fake_backend_modules(monkeypatch, calls)
+    model_config = _stage_local_mxfp_model_config(mixed_experts=True)
+    model_worker._initialize_model_worker_backend_globals(
+        _server_args(), model_config, "auto-round"
+    )
+
+    assert calls == ["moe", "fp8"]
 
 
 @dataclass(frozen=True)

--- a/tests/unit_test/qwen3_omni/test_thinker_weight_loading.py
+++ b/tests/unit_test/qwen3_omni/test_thinker_weight_loading.py
@@ -1,0 +1,109 @@
+# SPDX-License-Identifier: Apache-2.0
+"""Focused tests for the text-only thinker's fused expert weight loading."""
+
+from __future__ import annotations
+
+from types import SimpleNamespace
+
+import pytest
+
+torch = pytest.importorskip("torch")
+pytest.importorskip("sglang")
+
+from sglang_omni.models.qwen3_omni.components.sglang_thinker import (
+    Qwen3OmniThinkerForCausalLM,
+    _expert_parameter_mapping,
+    _load_expert_parameter,
+)
+
+
+@pytest.mark.parametrize(
+    ("name", "expected"),
+    [
+        (
+            "model.layers.0.mlp.experts.3.gate_proj.weight_scale",
+            ("model.layers.0.mlp.experts.w13_weight_scale", "w1", 3),
+        ),
+        (
+            "model.layers.0.mlp.experts.3.down_proj.weight_scale",
+            ("model.layers.0.mlp.experts.w2_weight_scale", "w2", 3),
+        ),
+    ],
+)
+def test_expert_parameter_mapping_routes_group_scales(name, expected):
+    mappings = [
+        ("experts.w13_weight", "experts.3.gate_proj.weight", 3, "w1"),
+        ("experts.w2_weight", "experts.3.down_proj.weight", 3, "w2"),
+    ]
+
+    assert _expert_parameter_mapping(name, mappings) == expected
+
+
+def test_expert_parameter_loader_uses_positional_coordinates():
+    calls: list[tuple[object, ...]] = []
+    param = torch.nn.Parameter(torch.empty(1), requires_grad=False)
+    param.weight_loader = lambda *args: calls.append(args)
+    loaded = torch.tensor([127], dtype=torch.uint8)
+
+    _load_expert_parameter(
+        param,
+        loaded,
+        "model.layers.0.mlp.experts.w13_weight_scale",
+        "w1",
+        3,
+    )
+
+    assert calls == [
+        (
+            param,
+            loaded,
+            "model.layers.0.mlp.experts.w13_weight_scale",
+            "w1",
+            3,
+        )
+    ]
+
+
+def test_thinker_routes_mxfp_expert_scales_to_fused_parameters():
+    calls: list[tuple[str, torch.Tensor, str, int]] = []
+    w13_scale = torch.nn.Parameter(torch.empty(1), requires_grad=False)
+    w2_scale = torch.nn.Parameter(torch.empty(1), requires_grad=False)
+    w13_scale.weight_loader = lambda _p, loaded, name, shard, expert: calls.append(
+        (name, loaded, shard, expert)
+    )
+    w2_scale.weight_loader = lambda _p, loaded, name, shard, expert: calls.append(
+        (name, loaded, shard, expert)
+    )
+
+    wrapper = object.__new__(Qwen3OmniThinkerForCausalLM)
+    torch.nn.Module.__init__(wrapper)
+    wrapper.config = SimpleNamespace(num_experts=1)
+    wrapper.root_config = SimpleNamespace(quantization_config=None)
+    wrapper.named_parameters = lambda: iter(
+        (
+            ("model.layers.0.mlp.experts.w13_weight_scale", w13_scale),
+            ("model.layers.0.mlp.experts.w2_weight_scale", w2_scale),
+        )
+    )
+    gate_scale = torch.tensor([127], dtype=torch.uint8)
+    down_scale = torch.tensor([126], dtype=torch.uint8)
+
+    wrapper.load_weights(
+        iter(
+            (
+                (
+                    "thinker.model.layers.0.mlp.experts.0.gate_proj.weight_scale",
+                    gate_scale,
+                ),
+                (
+                    "thinker.model.layers.0.mlp.experts.0.down_proj.weight_scale",
+                    down_scale,
+                ),
+            )
+        )
+    )
+
+    assert calls == [
+        ("model.layers.0.mlp.experts.w13_weight_scale", gate_scale, "w1", 0),
+        ("model.layers.0.mlp.experts.w2_weight_scale", down_scale, "w2", 0),
+    ]


### PR DESCRIPTION
<!-- Thank you for your contribution! We appreciate it. The following guidelines will help improve your pull request and facilitate feedback. If anything is unclear, don't hesitate to submit your pull request and ask the maintainers for assistance. -->

## Motivation

<!-- Explain the purpose of this PR and the goals it aims to achieve. -->

## Modifications

<!-- Describe the changes made in this PR. -->

## Related Issues

<!-- Link to any related issues here. e.g. "Fixes #123" or "Closes #456" -->

## Accuracy Test

<!-- If this PR affects model-side code (e.g., kernels, model architecture), please provide accuracy test results. Ref: https://docs.sglang.io/docs/developer_guide/evaluating_new_models -->

## Benchmark & Profiling

<!-- If this PR is expected to impact performance, please provide benchmark and profiling results. Ref: https://docs.sglang.io/docs/developer_guide/benchmark_and_profiling -->

## Checklist

- [ ] Format your code according with pre-commit.
- [ ] Add unit tests.
- [ ] Update documentation / docstrings / example tutorials as needed.
- [ ] Provide throughput / latency benchmark results and accuracy evaluation results as needed.
- [ ] For reviewers: If you haven't made any contributions to this PR and are only assisting with merging the main branch, please remove yourself as a co-author when merging the PR.

## CI

CI runs on self-hosted GPU runners and requires a maintainer to add the
`run-ci` label. Once labeled, every subsequent push re-triggers CI as
long as the label remains. Use `/tag-and-rerun-ci higgs` or
`/tag-and-rerun-ci moss` or `/tag-and-rerun-ci qwen3-tts` to select a TTS CI
model, and
`/tag-and-rerun-ci fun-asr`, `/tag-and-rerun-ci qwen3-asr` or
`/tag-and-rerun-ci whisper-asr` to select an ASR CI model. One selector from
each family can be combined, for example `/tag-and-rerun-ci moss fun-asr`.
Draft PRs are skipped even if labeled.
