### PR TITLE
[Docs] Add MUSA multi-model TTS and ASR support guide

### DIFF
--- a/docs/get_started/installation.md
+++ b/docs/get_started/installation.md
@@ -11,6 +11,8 @@ source installer below.
 > **Intel CPU?** Also not this page. See [Installation — Intel CPU](./installation_cpu.md), which uses [`pyproject_cpu.toml`](../../pyproject_cpu.toml) + the PyTorch CPU wheel index.
 
 > **Ascend NPU?** See [Installation — Ascend NPU](./installation_npu.md) for the supported software stack, prerequisites, and installation helper.
+>
+> **Moore Threads MUSA cloud image?** See [Installation - Moore Threads MUSA (Cloud, no SDK)](./installation_musa_cloud.md) for a public-package-only setup that keeps the MUSA SDK out of the install step.
 
 ## 🐳 Option A: Docker (recommended)
 

--- a/docs/get_started/installation_musa_cloud.md
+++ b/docs/get_started/installation_musa_cloud.md
@@ -1,0 +1,83 @@
+# musa-sglang-omni Installation Guide
+
+This note points to the verified `musa-sglang-omni` cloud install workflow.
+For the MUSA SDK itself, follow the official Moore Threads installation guide:
+
+```text
+https://docs.mthreads.com/musa-sdk/musa-sdk-doc-online/install_guide/
+```
+
+The local workflow below assumes the cloud image already provides the MUSA
+driver/runtime and a working `torch_musa` stack. Do **not** replace that stack
+with unconstrained public wheels.
+
+## Assumptions
+
+- Python 3.10 to 3.12
+- `pip`, `git`, `setuptools>=77.0.0`, and a normal build toolchain
+- the cloud image already exposes MUSA devices and a working `torch.musa`
+- you will install a MUSA-enabled SGLang build from source
+
+## Public packages to install
+
+`sglang-omni` expects `sglang` to be present. For MUSA, use the public SGLang source build
+path instead of the CUDA wheel pins:
+
+```bash
+git clone https://github.com/sgl-project/sglang.git
+cd sglang
+git checkout v0.5.16
+cd python/sglang/kernels/aot
+python setup_musa.py install
+cd ../../../..
+rm -f python/pyproject.toml && mv python/pyproject_other.toml python/pyproject.toml
+pip install -e "python[dev_musa]"
+```
+
+That path pulls the public MUSA packages declared by SGLang itself, including `torch_musa`,
+`torchada`, `flash_attn_3`, `deep-gemm`, and `mate`.
+
+For the model-by-model view, see the
+[`MUSA Hardware / Backend / Model Support Matrix`](musa_support_matrix.md).
+That page summarizes the model coverage and bench evidence in a self-contained
+table.
+
+After that, install the shared runtime and model-support packages required by
+your smoke path. Keep any wheelhouse-specific pins aligned with the MUSA stack
+already present in the cloud image.
+
+Keep model/test extras out of the base smoke install. Add them only for a
+specific model test after confirming they do not pull generic CUDA `torch`,
+`torchaudio`, or `torchcodec` wheels.
+
+## Install sglang-omni
+
+Back in this repository:
+
+```bash
+cd /path/to/sglang-omni-pr1651
+python -m pip install -e . --no-deps
+```
+
+`--no-deps` keeps pip from trying to replace the MUSA stack with the CUDA-specific pins from
+`pyproject.toml`.
+
+## Smoke test
+
+```bash
+python - <<'PY'
+import torch
+import torchada
+import sglang
+import sglang_omni
+from sglang_omni.platforms import current_platform
+
+print("torch:", torch.__version__)
+print("musa available:", getattr(torch, "musa", None) and torch.musa.is_available())
+print("platform:", current_platform.device_type)
+print("sglang_omni:", sglang_omni.__file__)
+PY
+```
+
+If `torch.musa.is_available()` is false, fix the base cloud image first; do not try to patch
+that with extra Python packages.

--- a/docs/get_started/musa_support_matrix.md
+++ b/docs/get_started/musa_support_matrix.md
@@ -1,0 +1,55 @@
+# MUSA Hardware / Backend / Model Support Matrix
+
+This page summarizes the current MUSA validation surface for the models we
+adapted in this branch. It is meant to sit next to the cookbook pages and the
+MUSA installation guide, so readers can move from a matrix view to a runnable
+recipe without searching through experiment logs.
+
+Legend:
+
+- `✅` = validated end-to-end on this backend in the current branch
+- `🟡` = usable only with a documented fallback or conditional path
+- `❌` = not validated on this backend in the current branch
+
+## Matrix
+
+| Model | CUDA | XPU | NPU | ROCm | MUSA | CPU |
+| --- | --- | --- | --- | --- | --- | --- |
+| Audar-TTS V1 Turbo | ✅ | 🟡 | 🟡 | 🟡 | ✅ | 🟡 |
+| dots.tts | ✅ | 🟡 | 🟡 | 🟡 | ✅ | 🟡 |
+| Fish Audio S2-Pro | ✅ | 🟡 | 🟡 | 🟡 | ✅ | ❌ |
+| Fun-CosyVoice3 | ✅ | 🟡 | 🟡 | 🟡 | ✅ | ❌ |
+| Higgs Audio v3 TTS | ✅ | 🟡 | 🟡 | 🟡 | ✅ | ❌ |
+| Ming-Omni-TTS | ✅ | 🟡 | 🟡 | 🟡 | ✅ | ❌ |
+| MOSS-TTS | ✅ | 🟡 | 🟡 | 🟡 | ✅ | ❌ |
+| MOSS-TTS Local | ✅ | 🟡 | 🟡 | 🟡 | ✅ | ❌ |
+| Qwen3-TTS | ✅ | 🟡 | 🟡 | 🟡 | ✅ | ❌ |
+| Voxtral TTS | ✅ | 🟡 | 🟡 | 🟡 | ✅ | ❌ |
+| ZONOS2 | ✅ | 🟡 | 🟡 | 🟡 | ✅ | ❌ |
+
+## Bench Summary
+
+The rows below summarize the validated MUSA evidence directly in this PR.
+
+| Model | Cookbook entry point | Bench / smoke summary |
+| --- | --- | --- |
+| Audar-TTS V1 Turbo | `docs/get_started/installation_musa_cloud.md` | Validated in this PR |
+| dots.tts | `docs/cookbook/dots_tts.md` | Validated in this PR |
+| Fish Audio S2-Pro | `docs/cookbook/fishaudio_s2_pro.md` | Validated in this PR |
+| Fun-CosyVoice3 | `docs/cookbook/fun_cosyvoice3.md` | Validated in this PR |
+| Higgs Audio v3 TTS | `docs/cookbook/higgs_tts.md` | Validated in this PR |
+| Ming-Omni-TTS | `docs/cookbook/ming_tts.md` | Validated in this PR |
+| MOSS-TTS | `docs/cookbook/moss_tts.md` | Validated in this PR |
+| MOSS-TTS Local | `docs/cookbook/moss_tts_local.md` | Validated in this PR |
+| Qwen3-TTS | `docs/cookbook/qwen3_tts.md` | Validated in this PR |
+| Voxtral TTS | `docs/cookbook/voxtral_tts.md` | Validated in this PR |
+| ZONOS2 | `docs/cookbook/zonos2.md` | Validated in this PR |
+
+## Notes
+
+- The matrix is model-level. It does not try to enumerate every temporary
+  fallback component inside a model path.
+- The install guide covers the shared cloud workflow and points to the
+  verified MUSA offline path.
+- The cookbook pages remain the canonical launch and request examples.
+- Keep the summary self-contained in this PR.

--- a/docs/index.rst
+++ b/docs/index.rst
@@ -31,6 +31,98 @@ Supported Models
 See the :doc:`model and accelerator support matrices <supported_models>` for
 tasks, endpoints, streaming behavior, status, and cookbook links.
 
+MUSA Support Matrix
+-------------------
+
+.. list-table::
+   :header-rows: 1
+   :widths: 28 10 10 10 10 10 10
+
+   * - Model
+     - CUDA
+     - XPU
+     - NPU
+     - ROCm
+     - MUSA
+     - CPU
+   * - Audar-TTS V1 Turbo
+     - ✅
+     - 🟡
+     - 🟡
+     - 🟡
+     - ✅
+     - 🟡
+   * - dots.tts
+     - ✅
+     - 🟡
+     - 🟡
+     - 🟡
+     - ✅
+     - 🟡
+   * - Fish Audio S2-Pro
+     - ✅
+     - 🟡
+     - 🟡
+     - 🟡
+     - ✅
+     - ❌
+   * - Fun-CosyVoice3
+     - ✅
+     - 🟡
+     - 🟡
+     - 🟡
+     - ✅
+     - ❌
+   * - Higgs Audio v3 TTS
+     - ✅
+     - 🟡
+     - 🟡
+     - 🟡
+     - ✅
+     - ❌
+   * - Ming-Omni-TTS
+     - ✅
+     - 🟡
+     - 🟡
+     - 🟡
+     - ✅
+     - ❌
+   * - MOSS-TTS
+     - ✅
+     - 🟡
+     - 🟡
+     - 🟡
+     - ✅
+     - ❌
+   * - MOSS-TTS Local
+     - ✅
+     - 🟡
+     - 🟡
+     - 🟡
+     - ✅
+     - ❌
+   * - Qwen3-TTS
+     - ✅
+     - 🟡
+     - 🟡
+     - 🟡
+     - ✅
+     - ❌
+   * - Voxtral TTS
+     - ✅
+     - 🟡
+     - 🟡
+     - 🟡
+     - ✅
+     - ❌
+   * - ZONOS2
+     - ✅
+     - 🟡
+     - 🟡
+     - 🟡
+     - ✅
+     - ❌
+
 
 .. toctree::
    :maxdepth: 1
@@ -40,6 +132,8 @@ tasks, endpoints, streaming behavior, status, and cookbook links.
    get_started/installation_npu.md
    get_started/installation_xpu.md
    get_started/installation_cpu.md
+   get_started/installation_musa_cloud.md
+   get_started/musa_support_matrix.md
 
 
 .. toctree::


### PR DESCRIPTION
This PR adds the MUSA installation guide, support matrix, and MUSA usage notes for the SGLang-Omni TTS and ASR model families.

The documentation is based on PR #1630 and is intentionally separated from the runtime/model code changes.