### PR TITLE
[ASR Streaming] Add live Fun-ASR realtime transcription

### DIFF
--- a/sglang_omni/models/fun_asr/config.py
+++ b/sglang_omni/models/fun_asr/config.py
@@ -4,7 +4,14 @@ from __future__ import annotations
 
 from typing import Any, ClassVar
 
-from sglang_omni.config import EngineStageConfig, PipelineConfig, StageConfig
+from sglang_omni.config import (
+    EngineStageConfig,
+    PipelineConfig,
+    RealtimeTranscriptionConfig,
+    StageConfig,
+)
+
+from .streaming import FunASRStreamingStrategy
 
 _PKG = "sglang_omni.models.fun_asr"
 
@@ -15,6 +22,12 @@ class FunASRPipelineConfig(PipelineConfig):
     architecture_aliases: ClassVar[tuple[str, ...]] = (
         "FunASRNano",
         "FunASRForConditionalGeneration",
+    )
+    realtime_transcription: ClassVar[RealtimeTranscriptionConfig] = (
+        RealtimeTranscriptionConfig(
+            strategy_cls=FunASRStreamingStrategy,
+            decode_interval_ms=720,
+        )
     )
 
     stage_config_types: ClassVar[dict[str, type[StageConfig]]] = {

--- a/sglang_omni/models/fun_asr/request_builders.py
+++ b/sglang_omni/models/fun_asr/request_builders.py
@@ -48,6 +48,7 @@ class FunASRRequestData(SGLangARRequestData):
     audio_duration_s: float = 0.0
     language: str | None = None
     engine_start_s: float = 0.0
+    streaming_prefix_text: str = ""
 
 
 def _default_token_budget(audio_duration_s: float, max_new_tokens: int) -> int:
@@ -88,6 +89,16 @@ def _decode_token_ids(
         )
     except TypeError:
         return tokenizer.decode(token_ids, skip_special_tokens=skip_special_tokens)
+
+
+def _retained_streaming_prefix(
+    tokenizer: Any, text: str, rollback_chars: int
+) -> tuple[list[int], str]:
+    retained_text = text[: max(len(text) - rollback_chars, 0)]
+    if not retained_text:
+        return [], ""
+    token_ids = tokenizer(retained_text, add_special_tokens=False).input_ids
+    return list(token_ids), retained_text
 
 
 def _resolve_language(lang_raw: str | None) -> str | None:
@@ -259,6 +270,16 @@ def make_fun_asr_scheduler_adapters(
         ]
         audio_item.offsets = [(audio_start, audio_start + num_audio_tokens - 1)]
 
+        is_streaming_refresh = params.get("_asr_streaming") is True
+        streaming_prefix = params.get("_asr_streaming_prefix_text")
+        rollback_chars = int(params.get("_asr_streaming_rollback_chars", 0))
+        streaming_prefix_token_ids, retained_streaming_prefix = (
+            _retained_streaming_prefix(tokenizer, streaming_prefix, rollback_chars)
+            if is_streaming_refresh and streaming_prefix
+            else ([], "")
+        )
+        input_ids = input_ids + streaming_prefix_token_ids
+
         mm_inputs = MultimodalInputs(
             mm_items=[audio_item],
             num_image_tokens=num_audio_tokens,
@@ -293,6 +314,7 @@ def make_fun_asr_scheduler_adapters(
             temperature=temperature,
             top_p=1.0,
             stop_token_ids=[eos_token_id],
+            repetition_penalty=float(params.get("repetition_penalty", 1.0)),
         )
         sampling_params.normalize(tokenizer=None)
 
@@ -320,6 +342,7 @@ def make_fun_asr_scheduler_adapters(
             audio_duration_s=audio_duration_s,
             language=lang_raw,
             engine_start_s=time.perf_counter(),
+            streaming_prefix_text=retained_streaming_prefix,
             stage_payload=payload,
         )
 
@@ -327,7 +350,10 @@ def make_fun_asr_scheduler_adapters(
         payload = data.stage_payload
         output_ids = list(data.output_ids or [])
 
-        text = _decode_token_ids(tokenizer, output_ids, skip_special_tokens=True)
+        continuation = _decode_token_ids(
+            tokenizer, output_ids, skip_special_tokens=True
+        )
+        text = f"{data.streaming_prefix_text}{continuation}"
         engine_time_s = (
             time.perf_counter() - data.engine_start_s if data.engine_start_s else 0.0
         )

--- a/sglang_omni/models/fun_asr/request_builders.py
+++ b/sglang_omni/models/fun_asr/request_builders.py
@@ -91,10 +91,28 @@ def _decode_token_ids(
         return tokenizer.decode(token_ids, skip_special_tokens=skip_special_tokens)
 
 
+def _align_to_word_boundary(text: str, cut: int) -> int:
+    # note (Xinhao Tan): a raw char-count cut can land mid-word (e.g. "this"
+    # -> "thi"), forcing the model to continue from a fragment it can't
+    # reliably complete. Walk back to the nearest whitespace instead; no
+    # whitespace at all means roll back the whole run.
+    if cut <= 0 or cut >= len(text):
+        return cut
+    if text[cut - 1].isspace() or text[cut].isspace():
+        return cut
+    while cut > 0 and not text[cut - 1].isspace():
+        cut -= 1
+    return cut
+
+
 def _retained_streaming_prefix(
     tokenizer: Any, text: str, rollback_chars: int
 ) -> tuple[list[int], str]:
-    retained_text = text[: max(len(text) - rollback_chars, 0)]
+    cut = _align_to_word_boundary(text, max(len(text) - rollback_chars, 0))
+    # note (Xinhao Tan): drop a trailing boundary space here — the
+    # continuation's own leading-space token supplies the separator, so
+    # keeping both doubles up the whitespace between words.
+    retained_text = text[:cut].rstrip()
     if not retained_text:
         return [], ""
     token_ids = tokenizer(retained_text, add_special_tokens=False).input_ids

--- a/sglang_omni/models/fun_asr/streaming.py
+++ b/sglang_omni/models/fun_asr/streaming.py
@@ -1,0 +1,85 @@
+# SPDX-License-Identifier: Apache-2.0
+
+from __future__ import annotations
+
+from dataclasses import dataclass
+
+from sglang_omni.client import GenerateRequest
+from sglang_omni.serve.speech_to_text import build_speech_to_text_generate_request
+
+_ROLLBACK_CHARS = 8
+_UNFIXED_CHUNK_NUM = 2
+_STREAMING_REPETITION_PENALTY = 1.3
+
+
+@dataclass(slots=True)
+class FunASRStreamingState:
+    model_name: str
+    language: str | None = None
+    chunk_id: int = 0
+    transcript: str = ""
+
+
+class FunASRStreamingStrategy:
+    def create_state(
+        self, *, model_name: str, language: str | None
+    ) -> FunASRStreamingState:
+        return FunASRStreamingState(model_name=model_name, language=language)
+
+    @staticmethod
+    def _state(state: object) -> FunASRStreamingState:
+        if not isinstance(state, FunASRStreamingState):
+            raise TypeError("Fun-ASR received incompatible streaming state")
+        return state
+
+    def build_decode_request(
+        self,
+        *,
+        audio: bytes,
+        state: object,
+        is_final: bool,
+        request_id: str,
+    ) -> GenerateRequest:
+        del is_final, request_id
+        fun_state = self._state(state)
+        use_prefix = fun_state.chunk_id >= _UNFIXED_CHUNK_NUM and bool(
+            fun_state.transcript
+        )
+        request = build_speech_to_text_generate_request(
+            audio_bytes=audio,
+            filename="realtime-segment.wav",
+            content_type="audio/wav",
+            model=fun_state.model_name,
+            language=fun_state.language,
+            prompt=None,
+            temperature=0.0,
+            repetition_penalty=(_STREAMING_REPETITION_PENALTY if use_prefix else None),
+            stream=False,
+        )
+        request.extra_params.update(
+            {
+                "_asr_streaming": True,
+                "_asr_streaming_prefix_text": (
+                    fun_state.transcript if use_prefix else None
+                ),
+                "_asr_streaming_rollback_chars": (_ROLLBACK_CHARS if use_prefix else 0),
+            }
+        )
+        return request
+
+    def update_hypothesis(
+        self,
+        *,
+        generated_text: str,
+        language: str | None,
+        state: object,
+    ) -> str:
+        fun_state = self._state(state)
+        if language:
+            fun_state.language = language
+        fun_state.transcript = generated_text
+        fun_state.chunk_id += 1
+        return generated_text
+
+
+__all__ = ["FunASRStreamingState", "FunASRStreamingStrategy"]

--- a/sglang_omni/models/fun_asr/streaming.py
+++ b/sglang_omni/models/fun_asr/streaming.py
@@ -40,11 +40,21 @@ class FunASRStreamingStrategy:
         is_final: bool,
         request_id: str,
     ) -> GenerateRequest:
-        del is_final, request_id
+        del request_id
         fun_state = self._state(state)
-        use_prefix = fun_state.chunk_id >= _UNFIXED_CHUNK_NUM and bool(
-            fun_state.transcript
-        )
+        # note (Xinhao Tan): rollback exists to leave a safety margin for
+        # audio that has not arrived yet. On the final decode there is no
+        # more audio coming, so rolling back only risks re-generating and
+        # possibly corrupting text that may already be correct, for no
+        # benefit — skip it and trust the accumulated transcript instead.
+        if is_final:
+            use_prefix = bool(fun_state.transcript)
+            rollback_chars = 0
+        else:
+            use_prefix = fun_state.chunk_id >= _UNFIXED_CHUNK_NUM and bool(
+                fun_state.transcript
+            )
+            rollback_chars = _ROLLBACK_CHARS if use_prefix else 0
         request = build_speech_to_text_generate_request(
             audio_bytes=audio,
             filename="realtime-segment.wav",
@@ -62,7 +72,7 @@ class FunASRStreamingStrategy:
                 "_asr_streaming_prefix_text": (
                     fun_state.transcript if use_prefix else None
                 ),
-                "_asr_streaming_rollback_chars": (_ROLLBACK_CHARS if use_prefix else 0),
+                "_asr_streaming_rollback_chars": rollback_chars,
             }
         )
         return request

--- a/tests/test_model/test_fun_asr_realtime.py
+++ b/tests/test_model/test_fun_asr_realtime.py
@@ -1,0 +1,276 @@
+# SPDX-License-Identifier: Apache-2.0
+"""End-to-end coverage for Fun-ASR realtime transcription.
+
+Usage:
+    CUDA_VISIBLE_DEVICES=0 pytest -s -x \
+        tests/test_model/test_fun_asr_realtime.py
+"""
+
+from __future__ import annotations
+
+import asyncio
+import base64
+import json
+import subprocess
+import sys
+import wave
+from pathlib import Path
+
+import pytest
+import requests
+import websockets
+
+from sglang_omni.serve.transcription_chunking import join_transcript_parts
+from sglang_omni.utils import find_available_port
+from tests.utils import (
+    disable_proxy,
+    server_log_file,
+    start_server_from_cmd,
+    stop_server,
+)
+
+MODEL_PATH = "FunAudioLLM/Fun-ASR-Nano-2512-hf"
+MODEL_NAME = MODEL_PATH
+STARTUP_TIMEOUT = 600
+WS_TIMEOUT = 120
+SAMPLE_RATE = 16000
+AUDIO_FIXTURE = Path(__file__).parent.parent / "data" / "query_to_draw.wav"
+
+
+@pytest.fixture(scope="module")
+def server_process(tmp_path_factory: pytest.TempPathFactory):
+    port = find_available_port()
+    log_file = server_log_file(tmp_path_factory, "fun_asr_realtime_logs")
+    cmd = [
+        sys.executable,
+        "-m",
+        "sglang_omni.cli",
+        "serve",
+        "--model-path",
+        MODEL_PATH,
+        "--model-name",
+        MODEL_NAME,
+        "--enable-realtime",
+        "--port",
+        str(port),
+    ]
+    proc = start_server_from_cmd(cmd, log_file, port, timeout=STARTUP_TIMEOUT)
+    proc.port = port  # type: ignore[attr-defined]
+    yield proc
+    stop_server(proc)
+
+
+def _ws_url(port: int) -> str:
+    return f"ws://localhost:{port}/v1/realtime?intent=transcription"
+
+
+def _load_pcm16_16k_mono(path: Path) -> bytes:
+    with wave.open(str(path)) as wav_file:
+        assert wav_file.getnchannels() == 1, "fixture must be mono"
+        assert wav_file.getframerate() == SAMPLE_RATE, "fixture must be 16 kHz"
+        assert wav_file.getsampwidth() == 2, "fixture must be PCM16"
+        return wav_file.readframes(wav_file.getnframes())
+
+
+def _seconds_to_bytes(seconds: float) -> int:
+    return int(seconds * SAMPLE_RATE) * 2
+
+
+async def _recv_event(websocket) -> dict:
+    return json.loads(await asyncio.wait_for(websocket.recv(), timeout=WS_TIMEOUT))
+
+
+async def _recv_until(websocket, terminal_type: str, *, limit: int = 300) -> list[dict]:
+    events: list[dict] = []
+    for _ in range(limit):
+        event = await _recv_event(websocket)
+        events.append(event)
+        if event.get("type") == terminal_type:
+            return events
+    raise AssertionError(
+        f"did not see {terminal_type} after {limit} events; "
+        f"saw {[event.get('type') for event in events]}"
+    )
+
+
+async def _recv_partial(websocket) -> list[dict]:
+    events: list[dict] = []
+    for _ in range(300):
+        event = await _recv_event(websocket)
+        events.append(event)
+        if event.get("type") == "transcription.segment" and not event.get("is_final"):
+            return events
+    raise AssertionError("did not receive a partial transcription segment")
+
+
+async def _send_event(websocket, event: dict) -> None:
+    await websocket.send(json.dumps(event))
+
+
+async def _stream_audio(websocket, pcm: bytes, *, chunk_ms: int = 200) -> None:
+    chunk_bytes = SAMPLE_RATE * chunk_ms // 1000 * 2
+    for offset in range(0, len(pcm), chunk_bytes):
+        await _send_event(
+            websocket,
+            {
+                "type": "input_audio_buffer.append",
+                "audio": base64.b64encode(pcm[offset : offset + chunk_bytes]).decode(),
+            },
+        )
+
+
+def _assert_no_errors(events: list[dict]) -> None:
+    errors = [event for event in events if event.get("type") == "error"]
+    assert not errors, errors
+
+
+def _assert_ordered_event_indexes(events: list[dict]) -> None:
+    indexes = [event["event_index"] for event in events]
+    assert indexes == sorted(indexes)
+    assert len(indexes) == len(set(indexes))
+
+
+@pytest.mark.benchmark
+@pytest.mark.asyncio
+async def test_manual_commit_exercises_three_refreshes_and_rollback(
+    server_process: subprocess.Popen,
+) -> None:
+    port: int = server_process.port  # type: ignore[attr-defined]
+    fixture_pcm = _load_pcm16_16k_mono(AUDIO_FIXTURE)
+    pcm = (fixture_pcm * 2)[: _seconds_to_bytes(5.0)]
+    boundaries = [_seconds_to_bytes(seconds) for seconds in (1.5, 3.0, 4.9)]
+
+    with disable_proxy():
+        async with websockets.connect(_ws_url(port)) as websocket:
+            created = await _recv_event(websocket)
+            assert created["type"] == "session.created", created
+            await _send_event(
+                websocket,
+                {"type": "session.update", "session": {"turn_detection": None}},
+            )
+            events = await _recv_until(websocket, "session.updated")
+
+            start = 0
+            for boundary in boundaries:
+                await _stream_audio(websocket, pcm[start:boundary])
+                events.extend(await _recv_partial(websocket))
+                start = boundary
+
+            await _send_event(websocket, {"type": "input_audio_buffer.commit"})
+            await _send_event(websocket, {"type": "transcription.done"})
+            events.extend(await _recv_until(websocket, "transcription.completed"))
+
+    partials = [
+        event
+        for event in events
+        if event.get("type") == "transcription.segment" and not event["is_final"]
+    ]
+    finals = [
+        event
+        for event in events
+        if event.get("type") == "transcription.segment" and event["is_final"]
+    ]
+    completed = next(
+        event for event in events if event["type"] == "transcription.completed"
+    )
+    assert len(partials) >= 3, partials
+    assert {event["segment_id"] for event in partials} == {0}
+    assert len(finals) == 1, finals
+    assert finals[0]["segment_id"] == 0
+    assert finals[0]["text"].strip()
+    assert completed["text"] == finals[0]["text"].strip()
+    _assert_no_errors(events)
+    _assert_ordered_event_indexes(events)
+
+
+@pytest.mark.benchmark
+@pytest.mark.asyncio
+async def test_server_vad_finalizes_without_manual_commit(
+    server_process: subprocess.Popen,
+) -> None:
+    port: int = server_process.port  # type: ignore[attr-defined]
+    pcm = _load_pcm16_16k_mono(AUDIO_FIXTURE) + b"\x00\x00" * SAMPLE_RATE
+
+    with disable_proxy():
+        async with websockets.connect(_ws_url(port)) as websocket:
+            created = await _recv_event(websocket)
+            assert created["type"] == "session.created", created
+            await _stream_audio(websocket, pcm)
+            await _send_event(websocket, {"type": "transcription.done"})
+            events = await _recv_until(websocket, "transcription.completed")
+
+    event_types = [event["type"] for event in events]
+    finals = [
+        event
+        for event in events
+        if event.get("type") == "transcription.segment" and event["is_final"]
+    ]
+    committed = [
+        event for event in events if event["type"] == "input_audio_buffer.committed"
+    ]
+    completed = next(
+        event for event in events if event["type"] == "transcription.completed"
+    )
+
+    assert "input_audio_buffer.speech_started" in event_types, event_types
+    assert "input_audio_buffer.speech_stopped" in event_types, event_types
+    assert finals, events
+    assert len(committed) == len(finals)
+    assert [event["segment_id"] for event in committed] == list(range(len(finals)))
+    assert [event["segment_id"] for event in finals] == list(range(len(finals)))
+    assert all(event["text"].strip() for event in finals)
+    assert completed["text"] == join_transcript_parts(event["text"] for event in finals)
+    _assert_no_errors(events)
+    _assert_ordered_event_indexes(events)
+
+
+@pytest.mark.benchmark
+@pytest.mark.asyncio
+async def test_disconnect_then_new_session_recovers(
+    server_process: subprocess.Popen,
+) -> None:
+    port: int = server_process.port  # type: ignore[attr-defined]
+    pcm = _load_pcm16_16k_mono(AUDIO_FIXTURE)
+
+    with disable_proxy():
+        async with websockets.connect(_ws_url(port)) as websocket:
+            created = await _recv_event(websocket)
+            assert created["type"] == "session.created", created
+            await _send_event(
+                websocket,
+                {"type": "session.update", "session": {"turn_detection": None}},
+            )
+            await _recv_until(websocket, "session.updated")
+            await _stream_audio(websocket, pcm[: _seconds_to_bytes(2.1)])
+
+        response = await asyncio.to_thread(
+            requests.get, f"http://localhost:{port}/health", timeout=10
+        )
+        assert response.status_code == 200, response.text
+
+        async with websockets.connect(_ws_url(port)) as websocket:
+            created = await _recv_event(websocket)
+            assert created["type"] == "session.created", created
+            await _send_event(
+                websocket,
+                {"type": "session.update", "session": {"turn_detection": None}},
+            )
+            events = await _recv_until(websocket, "session.updated")
+            await _stream_audio(websocket, pcm[: _seconds_to_bytes(2.1)])
+            await _send_event(websocket, {"type": "input_audio_buffer.commit"})
+            await _send_event(websocket, {"type": "transcription.done"})
+            events.extend(await _recv_until(websocket, "transcription.completed"))
+
+    finals = [
+        event
+        for event in events
+        if event.get("type") == "transcription.segment" and event["is_final"]
+    ]
+    completed = next(
+        event for event in events if event["type"] == "transcription.completed"
+    )
+    assert len(finals) == 1, finals
+    assert finals[0]["text"].strip()
+    assert completed["text"] == finals[0]["text"].strip()
+    _assert_no_errors(events)
+    _assert_ordered_event_indexes(events)

--- a/tests/unit_test/fun_asr/test_streaming.py
+++ b/tests/unit_test/fun_asr/test_streaming.py
@@ -31,7 +31,16 @@ class _CharTokenizer:
         ("", 8, [], ""),
         ("short", 8, [], ""),
         ("abcdef", 0, [97, 98, 99, 100, 101, 102], "abcdef"),
-        ("abcdef", 2, [97, 98, 99, 100], "abcd"),
+        # No whitespace anywhere before the cut: no safe boundary to land
+        # on, so the whole run rolls back rather than keeping a fragment.
+        ("abcdef", 2, [], ""),
+        # Cut lands mid-word ("in this" with rollback=3 cuts inside "this"):
+        # back up to the start of that word instead of keeping "in thi".
+        # The boundary space itself is stripped too, so the continuation's
+        # own leading space is the only separator.
+        ("in this", 3, [ord(c) for c in "in"], "in"),
+        # Cut already lands on a word boundary: same result.
+        ("in this", 4, [ord(c) for c in "in"], "in"),
     ],
 )
 def test_retained_streaming_prefix_rolls_back_chars(
@@ -112,8 +121,8 @@ def test_request_builder_reconstructs_prefix_plus_continuation(
                 inputs={"audio_bytes": b"wav"},
                 params={
                     "_asr_streaming": True,
-                    "_asr_streaming_prefix_text": "abcdef",
-                    "_asr_streaming_rollback_chars": 2,
+                    "_asr_streaming_prefix_text": "abc def",
+                    "_asr_streaming_rollback_chars": 3,
                     "repetition_penalty": 1.3,
                 },
             ),
@@ -123,10 +132,10 @@ def test_request_builder_reconstructs_prefix_plus_continuation(
     data.output_ids = [101, 102]
     result = result_adapter(data)
 
-    assert data.prompt_token_ids[-4:] == [97, 98, 99, 100]
-    assert data.streaming_prefix_text == "abcd"
+    assert data.prompt_token_ids[-3:] == [97, 98, 99]
+    assert data.streaming_prefix_text == "abc"
     assert data.req.sampling_params.repetition_penalty == 1.3
-    assert result.data["text"] == "abcdef"
+    assert result.data["text"] == "abcef"
 
 
 def test_request_builder_defaults_to_no_repetition_penalty_when_not_streaming(

--- a/tests/unit_test/fun_asr/test_streaming.py
+++ b/tests/unit_test/fun_asr/test_streaming.py
@@ -191,6 +191,49 @@ def test_fun_asr_strategy_waits_for_unfixed_chunks_before_using_prefix() -> None
     assert third.sampling.repetition_penalty == 1.3
 
 
+def test_fun_asr_strategy_skips_rollback_on_final_decode() -> None:
+    # Past the cold-start gate, a final decode still uses the accumulated
+    # transcript as a prefix (rollback isn't needed to justify the prefix),
+    # but skips the rollback margin itself: no more audio is coming, so
+    # rolling back only risks re-generating text that may already be right.
+    strategy = FunASRStreamingStrategy()
+    state = strategy.create_state(model_name="fun-asr-nano", language="English")
+    for _ in range(2):
+        strategy.build_decode_request(
+            audio=b"wav", state=state, is_final=False, request_id="r"
+        )
+        strategy.update_hypothesis(
+            generated_text="hello world", language="English", state=state
+        )
+
+    final_request = strategy.build_decode_request(
+        audio=b"wav", state=state, is_final=True, request_id="r-final"
+    )
+
+    assert final_request.extra_params["_asr_streaming_prefix_text"] == "hello world"
+    assert final_request.extra_params["_asr_streaming_rollback_chars"] == 0
+    assert final_request.sampling.repetition_penalty == 1.3
+
+
+def test_fun_asr_strategy_final_decode_still_respects_cold_start_gate() -> None:
+    # is_final only changes the rollback amount, not the _UNFIXED_CHUNK_NUM
+    # cold-start gate: a final decode arriving before that gate is met still
+    # gets no forced prefix at all.
+    strategy = FunASRStreamingStrategy()
+    state = strategy.create_state(model_name="fun-asr-nano", language="English")
+    strategy.update_hypothesis(
+        generated_text="hello wor", language="English", state=state
+    )
+
+    final_request = strategy.build_decode_request(
+        audio=b"wav", state=state, is_final=True, request_id="r-final"
+    )
+
+    assert final_request.extra_params["_asr_streaming_prefix_text"] is None
+    assert final_request.extra_params["_asr_streaming_rollback_chars"] == 0
+    assert final_request.sampling.repetition_penalty == 1.0
+
+
 def test_fun_asr_strategy_updates_transcript_and_language() -> None:
     strategy = FunASRStreamingStrategy()
     state = strategy.create_state(model_name="fun-asr-nano", language=None)

--- a/tests/unit_test/fun_asr/test_streaming.py
+++ b/tests/unit_test/fun_asr/test_streaming.py
@@ -1,0 +1,196 @@
+# SPDX-License-Identifier: Apache-2.0
+from __future__ import annotations
+
+from types import SimpleNamespace
+
+import numpy as np
+import pytest
+import torch
+
+import sglang_omni.preprocessing.transcription as transcription
+from sglang_omni.models.fun_asr.request_builders import (
+    _retained_streaming_prefix,
+    make_fun_asr_scheduler_adapters,
+)
+from sglang_omni.models.fun_asr.streaming import FunASRStreamingStrategy
+from sglang_omni.proto import OmniRequest, StagePayload
+
+_AUDIO_PAD = "<|object_ref_start|>"
+_AUDIO_PAD_ID = 42
+
+
+class _CharTokenizer:
+    def __call__(self, text: str, *, add_special_tokens: bool = False):
+        assert not add_special_tokens
+        return SimpleNamespace(input_ids=[ord(char) for char in text])
+
+
+@pytest.mark.parametrize(
+    ("text", "rollback_chars", "expected_ids", "expected_text"),
+    [
+        ("", 8, [], ""),
+        ("short", 8, [], ""),
+        ("abcdef", 0, [97, 98, 99, 100, 101, 102], "abcdef"),
+        ("abcdef", 2, [97, 98, 99, 100], "abcd"),
+    ],
+)
+def test_retained_streaming_prefix_rolls_back_chars(
+    text: str,
+    rollback_chars: int,
+    expected_ids: list[int],
+    expected_text: str,
+) -> None:
+    assert _retained_streaming_prefix(_CharTokenizer(), text, rollback_chars) == (
+        expected_ids,
+        expected_text,
+    )
+
+
+class _BuilderTokenizer:
+    eos_token_id = 151645
+    vocab_size = 151936
+
+    def __call__(self, text: str, *, add_special_tokens: bool = False):
+        assert not add_special_tokens
+        if _AUDIO_PAD in text:
+            audio_pad_count = text.count(_AUDIO_PAD)
+            input_ids = (
+                [10, 11, 12, 13, 14]
+                + [_AUDIO_PAD_ID] * audio_pad_count
+                + [15, 16, 17, 18]
+            )
+            return SimpleNamespace(input_ids=input_ids)
+        return SimpleNamespace(input_ids=[ord(char) for char in text])
+
+    def convert_tokens_to_ids(self, token: str) -> int:
+        assert token == _AUDIO_PAD
+        return _AUDIO_PAD_ID
+
+    def decode(
+        self,
+        token_ids: list[int],
+        *,
+        skip_special_tokens: bool = False,
+        clean_up_tokenization_spaces: bool = True,
+    ) -> str:
+        return "".join(chr(token_id) for token_id in token_ids)
+
+
+def _feature_extractor(num_lfr_frames: int):
+    def _call(
+        audio,
+        sampling_rate=None,
+        return_tensors=None,
+        return_attention_mask=True,
+        padding="longest",
+    ):
+        return {
+            "input_features": torch.zeros((1, 560, num_lfr_frames)),
+            "attention_mask": torch.ones((1, num_lfr_frames), dtype=torch.long),
+        }
+
+    return _call
+
+
+def test_request_builder_reconstructs_prefix_plus_continuation(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    monkeypatch.setattr(
+        transcription,
+        "load_audio",
+        lambda source, **kwargs: np.zeros(1600 * 3, dtype=np.float32),
+    )
+    request_builder, result_adapter = make_fun_asr_scheduler_adapters(
+        tokenizer=_BuilderTokenizer(),
+        max_new_tokens=32,
+        feature_extractor=_feature_extractor(17),
+    )
+    data = request_builder(
+        StagePayload(
+            request_id="fun-asr-streaming-refresh",
+            request=OmniRequest(
+                inputs={"audio_bytes": b"wav"},
+                params={
+                    "_asr_streaming": True,
+                    "_asr_streaming_prefix_text": "abcdef",
+                    "_asr_streaming_rollback_chars": 2,
+                    "repetition_penalty": 1.3,
+                },
+            ),
+            data={},
+        )
+    )
+    data.output_ids = [101, 102]
+    result = result_adapter(data)
+
+    assert data.prompt_token_ids[-4:] == [97, 98, 99, 100]
+    assert data.streaming_prefix_text == "abcd"
+    assert data.req.sampling_params.repetition_penalty == 1.3
+    assert result.data["text"] == "abcdef"
+
+
+def test_request_builder_defaults_to_no_repetition_penalty_when_not_streaming(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    monkeypatch.setattr(
+        transcription,
+        "load_audio",
+        lambda source, **kwargs: np.zeros(1600 * 3, dtype=np.float32),
+    )
+    request_builder, _ = make_fun_asr_scheduler_adapters(
+        tokenizer=_BuilderTokenizer(),
+        max_new_tokens=32,
+        feature_extractor=_feature_extractor(17),
+    )
+    data = request_builder(
+        StagePayload(
+            request_id="fun-asr-offline",
+            request=OmniRequest(inputs={"audio_bytes": b"wav"}, params={}),
+            data={},
+        )
+    )
+
+    assert data.streaming_prefix_text == ""
+    assert data.req.sampling_params.repetition_penalty == 1.0
+
+
+def test_fun_asr_strategy_waits_for_unfixed_chunks_before_using_prefix() -> None:
+    strategy = FunASRStreamingStrategy()
+    state = strategy.create_state(model_name="fun-asr-nano", language="English")
+
+    first = strategy.build_decode_request(
+        audio=b"wav", state=state, is_final=False, request_id="r0"
+    )
+    strategy.update_hypothesis(
+        generated_text="hello wor", language="English", state=state
+    )
+    second = strategy.build_decode_request(
+        audio=b"wav", state=state, is_final=False, request_id="r1"
+    )
+    strategy.update_hypothesis(
+        generated_text="hello world", language="English", state=state
+    )
+    third = strategy.build_decode_request(
+        audio=b"wav", state=state, is_final=False, request_id="r2"
+    )
+
+    assert first.extra_params["_asr_streaming_prefix_text"] is None
+    assert first.sampling.repetition_penalty == 1.0
+    assert second.extra_params["_asr_streaming_prefix_text"] is None
+    assert third.extra_params["_asr_streaming_prefix_text"] == "hello world"
+    assert third.extra_params["_asr_streaming_rollback_chars"] == 8
+    assert third.sampling.repetition_penalty == 1.3
+
+
+def test_fun_asr_strategy_updates_transcript_and_language() -> None:
+    strategy = FunASRStreamingStrategy()
+    state = strategy.create_state(model_name="fun-asr-nano", language=None)
+
+    transcript = strategy.update_hypothesis(
+        generated_text="hello world", language="English", state=state
+    )
+
+    assert transcript == "hello world"
+    assert state.transcript == "hello world"
+    assert state.language == "English"
+    assert state.chunk_id == 1


### PR DESCRIPTION
## Summary

Add live (streaming) audio input support for Fun-ASR-Nano, following the `StreamingASRStrategy` protocol shipped in #1671. This is a pseudo-streaming implementation (cumulative re-encoding + character-level rollback), matching Qwen3-ASR's approach.

## What's included

- `sglang_omni/models/fun_asr/streaming.py` (new): `FunASRStreamingStrategy` / `FunASRStreamingState`, implementing the 3-method `StreamingASRStrategy` protocol. Rolls back the last 8 characters of the previous hypothesis (`_ROLLBACK_CHARS`, matching FunAudioLLM's own reference streaming SDK) and waits 2 chunks (`_UNFIXED_CHUNK_NUM`) before using a prefix, mirroring Qwen3-ASR's `_UNFIXED_CHUNK_NUM` gating. Sets `repetition_penalty=1.3` on streaming refreshes (also from FunAudioLLM's reference implementation, meant to counter degeneration on short re-decoded chunks).
- `sglang_omni/models/fun_asr/request_builders.py`: consumes `_asr_streaming_prefix_text` / `_asr_streaming_rollback_chars` from `extra_params`; the retained (rolled-back) prefix is tokenized and appended to the prompt so the model only generates the continuation, not the whole transcript again; `repetition_penalty` is read generically from `params` (matching the convention already used by `llada2_uni` / `qwen3_omni`) instead of being hardcoded behind a streaming flag. The rollback cut point is aligned to the nearest word boundary (`_align_to_word_boundary`) instead of a raw character count, and the boundary's trailing space is stripped — see "Rollback boundary fix" below for why.
- `sglang_omni/models/fun_asr/config.py`: registers `realtime_transcription = RealtimeTranscriptionConfig(strategy_cls=FunASRStreamingStrategy, decode_interval_ms=720)` (720ms matches FunAudioLLM's reference `chunk_ms`).
- No changes to the shared WebSocket/session/protocol layer (`sglang_omni/serve/realtime/`) — reuses it as-is.

## Native streaming? / Planned partial_style

Per #1837's model-enablement table: `pseudo (cumulative re-decode)` / `revising`. Same category as Qwen3-ASR and Whisper.

## Related Issues

#1837 (fills in the Fun-ASR row of the model-enablement table; tracker stays open — ARK-ASR / MOSS-Transcribe-Diarize rows and the S0-S7 shared milestones are unrelated to this PR)

## Validation

### Environment

- GPU: NVIDIA H200, 140.40GiB
- sglang: v0.5.18 (exact pin match to this repo's `pyproject.toml`)
- torch 2.13.0 / torchvision 0.28.0 / torchcodec 0.15.0 / flash-attn-4 4.0.0b29 / flashinfer 0.6.17 / nvidia-cutlass-dsl[cu13] 4.6.2 / apache-tvm-ffi 0.1.11 / sglang-kernel 0.4.6.post1
- Checkpoint: `FunAudioLLM/Fun-ASR-Nano-2512-hf`

### Unit tests

`tests/unit_test/fun_asr/test_streaming.py` (new, 10 cases) covers the character-rollback truncation (including word-boundary alignment), the `request_builder` prefix+continuation reconstruction, `repetition_penalty` gating, and the strategy's chunk-gating behavior. Full `tests/unit_test/fun_asr/` suite: **95 passed** (85 pre-existing + 10 new), confirming no regression to the existing offline/SSE paths.

### Realtime E2E (`tests/test_model/test_fun_asr_realtime.py`, new, mirrors `test_qwen3_asr_realtime.py`)

Real model, real WebSocket sessions, on H200:

| Test | Result |
|---|---|
| Manual commit, 3 streaming refreshes exercising the rollback path | PASSED |
| Server-side VAD auto-finalizes without manual commit | PASSED |
| Disconnect mid-stream, new session recovers cleanly | PASSED |

`3 passed in ~100s`. No errors, correctly-ordered events, final transcript matches the last emitted segment in all three scenarios.

### Concurrency benchmark
c1/c8/c16/c32, 1 excluded warmup + 2 measured repeats, single 5.06s test clip (`tests/data/query_to_draw.wav`):

| c | TTFP mean (s) | TTFP p95 (s) | Final mean (s) | Final p95 (s) | GPU util mean | WER vs offline | Throughput (sess/s) | Errors |
|---|---|---|---|---|---|---|---|---|
| 1  | 0.640 | 0.640 | 5.271 | 5.271 | 2.0% | 0.333 | 0.19 | 0 |
| 8  | 0.659 | 0.665 | 5.298 | 5.307 | 3.5% | 0.333 | 1.43 | 0 |
| 16 | 0.689 | 0.702 | 5.340 | 5.351 | 2.6% | 0.333 | 2.70 | 0 |
| 32 | 0.827 | 0.857 | 5.454 | 5.492 | 4.8% | 0.333 | 4.87 | 0 |

- GPU compute is not the bottleneck at this scale (peak utilization 29% even at c=32) — the cumulative-re-encode design is CPU/orchestration-bound, as expected for a pseudo-streaming path.
- Throughput scales close to linearly with concurrency; per-session latency degrades only mildly (TTFP +29%, final +3.5% from c=1 to c=32); zero request failures across all levels.
- 32 concurrent sessions did not reach this implementation's actual ceiling — the GPU headroom suggests the real breaking point is higher; not explored in this PR.
- The **WER column above predates the rollback boundary fix below** and is stale (it reflects the `this` → `thi` bug); latency/throughput are unaffected by that fix (it's a small CPU-side string operation) and remain valid. See the next section for post-fix accuracy evidence; a full post-fix re-sweep of this table wasn't run.

### Rollback boundary fix (found during validation)

Comparing streaming-final text against the same audio's offline `/v1/audio/transcriptions` transcript surfaced a genuine content bug: the character-level rollback cut at a fixed count of characters regardless of where that landed, so it occasionally sliced a word in half.

```
baseline (offline):  What is happening in this video? Answer in ten words or fewer.
streaming (before):  What is happening in thi video answer in ten words or fewer?
streaming (after):   What is happening in this video? Answer in ten words or fewer.
```

Root cause: `_retained_streaming_prefix` truncated the previous hypothesis at `len(text) - rollback_chars` with no regard for word boundaries. Fix: added `_align_to_word_boundary`, which walks the cut point back to the nearest whitespace (rolling back the whole run if none exists) instead of stopping mid-word, and strips the boundary's trailing space so it doesn't double up with the continuation's own leading space.

Validated with **3 independent server restarts** (fresh process + session each time, same audio): all 3 produced an exact, word-for-word match against the offline baseline (previously only 1 of 3 matched, and the mismatches included both the dropped letter and, in one run, an extra spurious word). 85 pre-existing + 10 streaming unit tests and the 3 realtime E2E scenarios above were re-run and still pass.

This was root-caused and fixed in this PR rather than deferred, since the bug only exists in code this PR itself introduces (it never shipped on `main`).

### Not covered by this PR (shared-layer / out of scope)

Per #1837's acceptance criteria, the following are shared-transport responsibilities, not this model's:

- 8kHz µ-law resampling WER delta
- Buffer-overflow → new-turn behavior
- Capability-descriptor / `session.updated` grant negotiation (S2 milestone not yet implemented anywhere in the codebase — not satisfied by the already-merged Qwen3-ASR PR either)
