### PR TITLE
[Apple][Fish S2-Pro] Add native MLX and Torch/MPS serving

### DIFF
--- a/docs/cookbook/fishaudio_s2_pro.md
+++ b/docs/cookbook/fishaudio_s2_pro.md
@@ -26,29 +26,39 @@ hf download fishaudio/s2-pro
 
 Follow the [Apple Silicon installation instructions](../get_started/installation.md#macos-apple-silicon),
 then install the DAC codec dependencies listed above into `.venv-apple`.
-S2-Pro runs through a Torch/MPS compatibility path; there is no native MLX
-implementation, and `SGLANG_USE_MLX=1` fails at startup instead of silently
-falling back. Use the official `fishaudio/s2-pro` checkpoint with unquantized
-BF16 weights.
+S2-Pro provides a native MLX path and a Torch/MPS compatibility path, selected
+with `SGLANG_USE_MLX`. Both use the official `fishaudio/s2-pro` checkpoint with
+unquantized BF16 weights; no converted MLX artifact or `mlx-audio` runtime
+package is needed. `SGLANG_USE_MLX=1` off Apple Metal fails at startup instead of
+silently falling back.
 
 ```bash
 source .venv-apple/bin/activate
 export DYLD_LIBRARY_PATH="$(brew --prefix ffmpeg@7)/lib${DYLD_LIBRARY_PATH:+:$DYLD_LIBRARY_PATH}"
 
+# Native MLX
+SGLANG_USE_MLX=1 sgl-omni serve \
+  --model-path fishaudio/s2-pro \
+  --config examples/configs/s2pro_tts.yaml \
+  --port 8000 --allowed-local-media-path .
+
+# Alternatively, stop the server and use Torch/MPS
 SGLANG_USE_MLX=0 sgl-omni serve \
   --model-path fishaudio/s2-pro \
   --config examples/configs/s2pro_tts.yaml \
   --port 8000 --allowed-local-media-path .
 ```
 
-The Apple profile serves one request at a time (`max_running_requests=1`);
-additional requests queue and complete in turn. It runs the Slow AR and Fast AR
-eagerly with the `torch_native` attention backend, so CUDA graphs, `torch.compile`,
-radix caching, and chunked prefill are all disabled, and the request context is
-bounded to 4,096 tokens. Quantized checkpoints are rejected. Plain TTS, voice
-cloning, streaming PCM, and the `seed` parameter use the shared Fish request
-and output adapters. Cross-device numerical or voice-quality parity with CUDA
-has not been established.
+Both paths share one Apple profile: they serve one request at a time
+(`max_running_requests=1`) and additional requests queue and complete in turn,
+CUDA graphs, `torch.compile`, radix caching, and chunked prefill are all
+disabled, the request context is bounded to 4,096 tokens, and quantized
+checkpoints are rejected. MLX runs the Slow AR and the whole Fast-AR residual
+chain natively and crosses only the semantic logits to CPU for the shared Fish
+sampler; Torch/MPS runs both eagerly with the `torch_native` attention backend.
+Plain TTS, voice cloning, streaming PCM, and the `seed` parameter use the shared
+Fish request and output adapters on either path. Cross-device numerical or
+voice-quality parity with CUDA has not been established.
 
 This is an experimental compatibility profile. It has not been qualified for
 real-time serving or production throughput. See the model README for validation

--- a/docs/cookbook/fishaudio_s2_pro.md
+++ b/docs/cookbook/fishaudio_s2_pro.md
@@ -22,6 +22,38 @@ Then download the model:
 hf download fishaudio/s2-pro
 ```
 
+## Experimental Apple Silicon support
+
+Follow the [Apple Silicon installation instructions](../get_started/installation.md#macos-apple-silicon),
+then install the DAC codec dependencies listed above into `.venv-apple`.
+S2-Pro runs through a Torch/MPS compatibility path; there is no native MLX
+implementation, and `SGLANG_USE_MLX=1` fails at startup instead of silently
+falling back. Use the official `fishaudio/s2-pro` checkpoint with unquantized
+BF16 weights.
+
+```bash
+source .venv-apple/bin/activate
+export DYLD_LIBRARY_PATH="$(brew --prefix ffmpeg@7)/lib${DYLD_LIBRARY_PATH:+:$DYLD_LIBRARY_PATH}"
+
+SGLANG_USE_MLX=0 sgl-omni serve \
+  --model-path fishaudio/s2-pro \
+  --config examples/configs/s2pro_tts.yaml \
+  --port 8000 --allowed-local-media-path .
+```
+
+The Apple profile serves one request at a time (`max_running_requests=1`);
+additional requests queue and complete in turn. It runs the Slow AR and Fast AR
+eagerly with the `torch_native` attention backend, so CUDA graphs, `torch.compile`,
+radix caching, and chunked prefill are all disabled, and the request context is
+bounded to 4,096 tokens. Quantized checkpoints are rejected. Plain TTS, voice
+cloning, streaming PCM, and the `seed` parameter use the shared Fish request
+and output adapters. Cross-device numerical or voice-quality parity with CUDA
+has not been established.
+
+This is an experimental compatibility profile. It has not been qualified for
+real-time serving or production throughput. See the model README for validation
+and the opt-in HTTP checks.
+
 ## Server Configuration
 
 ```bash

--- a/docs/get_started/installation.md
+++ b/docs/get_started/installation.md
@@ -88,7 +88,9 @@ defaults with `UV_HTTP_TIMEOUT` and `UV_HTTP_RETRIES`.
 This path currently supports macOS 14 or newer on `arm64` only (the pinned
 `torch==2.13.0`, `torchvision==0.28.0` and `torchcodec==0.15.0` wheels are built
 for `macosx_14_0_arm64`) and is intended for the Apple-Silicon Qwen3-ASR
-MLX/Torch-MPS paths. Other platforms should use the
+MLX/Torch-MPS paths and the experimental
+[Fish Audio S2-Pro Torch/MPS path](../cookbook/fishaudio_s2_pro.md#experimental-apple-silicon-support).
+Other platforms should use the
 Docker, manual, or Intel XPU instructions below. Common failures are a missing
 Homebrew/uv on `PATH`, an unavailable Python 3.12 toolchain, or forgetting the
 `DYLD_LIBRARY_PATH` export when starting an audio server.

--- a/docs/get_started/installation.md
+++ b/docs/get_started/installation.md
@@ -89,7 +89,7 @@ This path currently supports macOS 14 or newer on `arm64` only (the pinned
 `torch==2.13.0`, `torchvision==0.28.0` and `torchcodec==0.15.0` wheels are built
 for `macosx_14_0_arm64`) and is intended for the Apple-Silicon Qwen3-ASR
 MLX/Torch-MPS paths and the experimental
-[Fish Audio S2-Pro Torch/MPS path](../cookbook/fishaudio_s2_pro.md#experimental-apple-silicon-support).
+[Fish Audio S2-Pro Apple paths](../cookbook/fishaudio_s2_pro.md#experimental-apple-silicon-support).
 Other platforms should use the
 Docker, manual, or Intel XPU instructions below. Common failures are a missing
 Homebrew/uv on `PATH`, an unavailable Python 3.12 toolchain, or forgetting the

--- a/sglang_omni/model_runner/mlx_model_worker.py
+++ b/sglang_omni/model_runner/mlx_model_worker.py
@@ -4,9 +4,75 @@
 from __future__ import annotations
 
 from dataclasses import dataclass, replace
-from typing import Any
+from importlib import import_module
+from typing import Any, Callable
 
 from sglang_omni.model_runner.base import ModelRunner
+
+# Keep model imports lazy: importing the worker on CUDA/CPU must not import MLX.
+_MLX_RUNNER_FACTORIES: dict[str, str] = {
+    "Qwen3ASRForConditionalGeneration": (
+        "sglang_omni.models.qwen3_asr.mlx.runner:make_qwen3_asr_mlx_runner_class"
+    ),
+    "FishS2ProMlxModel": (
+        "sglang_omni.models.fishaudio_s2_pro.mlx.runner:make_fish_mlx_runner_class"
+    ),
+}
+
+
+def register_mlx_runner_factory(model_arch: str, factory_path: str) -> None:
+    """Register a lazy ``module:attribute`` runner-class factory."""
+    _MLX_RUNNER_FACTORIES[model_arch] = factory_path
+
+
+def resolve_mlx_runner_factory(model_arch: str | None) -> Callable[[], type]:
+    """Resolve an architecture without importing unrelated model backends."""
+    factory_path = _MLX_RUNNER_FACTORIES.get(model_arch)
+    if factory_path is None:
+        supported = ", ".join(sorted(_MLX_RUNNER_FACTORIES))
+        raise NotImplementedError(
+            f"Omni's MLX worker has no runner for architecture {model_arch!r}; "
+            f"supported architectures: {supported}"
+        )
+    module_name, _, attribute = factory_path.partition(":")
+    return getattr(import_module(module_name), attribute)
+
+
+def _create_registered_runner(runner_class: type) -> Any:
+    """Use SGLang's constructor contract unless the runner supplies an adapter.
+
+    Custom runners may expose ``from_runtime_config``, ``scheduler_model`` and
+    ``prepare_for_kv_cache_release(req)``. All runners expose ``pool_size``.
+    Absent hooks retain the standard SGLang MLX lifecycle. Both paths read the
+    published config bags, not the raw server args.
+    """
+    from sglang.srt.runtime_context import (
+        get_device,
+        get_exec,
+        get_memory,
+        get_model,
+        get_schedule,
+    )
+
+    custom_create = getattr(runner_class, "from_runtime_config", None)
+    if custom_create is not None:
+        return custom_create()
+    init_kwargs = {
+        "model_path": get_model().model_path,
+        "trust_remote_code": get_model().trust_remote_code,
+        "disable_radix_cache": get_memory().disable_radix_cache,
+        "mem_fraction_static": get_schedule().mem_fraction_static,
+        "quantization": get_model().quantization,
+        "revision": get_model().revision,
+        "enable_sampling": get_device().mlx_enable_sampling,
+        "sampling_rng_seed": get_device().random_seed,
+        "deterministic_seeding": (
+            get_exec().deterministic.enable_deterministic_inference
+        ),
+    }
+    if get_schedule().max_total_tokens is not None:
+        init_kwargs["pool_size"] = get_schedule().max_total_tokens
+    return runner_class(**init_kwargs)
 
 
 @dataclass(slots=True)
@@ -169,35 +235,13 @@ def create_mlx_model_worker(
     tp_rank: int = 0,
 ):
     """Construct an MLX worker with the same scheduler-facing contract as Omni."""
-    fish_mlx = config.model_arch_override == "FishS2ProMlxModel"
-    if config.model_arch_override == "Qwen3ASRForConditionalGeneration":
-        from sglang_omni.models.qwen3_asr.mlx.runner import (
-            make_qwen3_asr_mlx_runner_class,
-        )
-
-        runner_factory = make_qwen3_asr_mlx_runner_class
-    elif fish_mlx:
-        # Fish owns both AR networks and its codebook feedback. It uses the
-        # scheduler bookkeeping stub with a model-specific synchronous runner.
-        runner_factory = None
-    else:
-        raise NotImplementedError(
-            f"Omni's MLX worker does not support {config.model_arch_override}"
-        )
+    runner_factory = resolve_mlx_runner_factory(config.model_arch_override)
 
     from sglang.srt.distributed.parallel_state_wrapper import ParallelState
     from sglang.srt.hardware_backend.mlx.model_runner_stub import MlxModelRunnerStub
     from sglang.srt.hardware_backend.mlx.tp_worker import MlxTpModelWorker
     from sglang.srt.layers.dp_attention import compute_dp_attention_world_info
-    from sglang.srt.runtime_context import (
-        get_device,
-        get_exec,
-        get_memory,
-        get_model,
-        get_parallel,
-        get_schedule,
-        publish,
-    )
+    from sglang.srt.runtime_context import get_parallel, get_schedule, publish
     from sglang.srt.server_args import PortArgs
 
     class OmniMlxWorker(MlxTpModelWorker):
@@ -207,33 +251,7 @@ def create_mlx_model_worker(
 
         def _init_model_runner(self):
             MlxModelRunnerStub.validate_startup_weight_load_mode(self.server_args)
-            if fish_mlx:
-                from sglang_omni.models.fishaudio_s2_pro.mlx.runner import FishMlxModel
-
-                self._mlx_runner = FishMlxModel(
-                    get_model().model_path,
-                    context_length=get_model().context_length,
-                )
-                pool_size = get_schedule().max_total_tokens
-            else:
-                runner_class = runner_factory()
-                init_kwargs = {
-                    "model_path": get_model().model_path,
-                    "trust_remote_code": get_model().trust_remote_code,
-                    "disable_radix_cache": get_memory().disable_radix_cache,
-                    "mem_fraction_static": get_schedule().mem_fraction_static,
-                    "quantization": get_model().quantization,
-                    "revision": get_model().revision,
-                    "enable_sampling": get_device().mlx_enable_sampling,
-                    "sampling_rng_seed": get_device().random_seed,
-                    "deterministic_seeding": (
-                        get_exec().deterministic.enable_deterministic_inference
-                    ),
-                }
-                if get_schedule().max_total_tokens is not None:
-                    init_kwargs["pool_size"] = get_schedule().max_total_tokens
-                self._mlx_runner = runner_class(**init_kwargs)
-                pool_size = self._mlx_runner.pool_size
+            self._mlx_runner = _create_registered_runner(runner_factory())
             self._model_runner = MlxModelRunnerStub(
                 model_config=self.model_config,
                 mem_fraction_static=get_schedule().mem_fraction_static,
@@ -245,18 +263,20 @@ def create_mlx_model_worker(
                 req_to_token_pool=self.req_to_token_pool,
                 token_to_kv_pool_allocator=self.token_to_kv_pool_allocator,
                 memory_pool_config=self.memory_pool_config,
-                mlx_pool_size=pool_size,
+                mlx_pool_size=self._mlx_runner.pool_size,
             )
-            if fish_mlx:
-                self._model_runner.model = self._mlx_runner
+            scheduler_model = getattr(self._mlx_runner, "scheduler_model", None)
+            if scheduler_model is not None:
+                self._model_runner.model = scheduler_model
             self._mlx_active_rids = set()
             self._mlx_pool_initialized = False
 
         def prepare_for_kv_cache_release(self, req):
-            if not fish_mlx:
+            prepare = getattr(self._mlx_runner, "prepare_for_kv_cache_release", None)
+            if prepare is not None:
+                prepare(req)
+            else:
                 super().prepare_for_kv_cache_release(req)
-            # Fish has no auxiliary/radix state. Its scheduler completion/abort
-            # callbacks release the native per-request cache.
 
         def get_tp_group(self):
             return self.model_runner.tp_group

--- a/sglang_omni/model_runner/mlx_model_worker.py
+++ b/sglang_omni/model_runner/mlx_model_worker.py
@@ -169,10 +169,20 @@ def create_mlx_model_worker(
     tp_rank: int = 0,
 ):
     """Construct an MLX worker with the same scheduler-facing contract as Omni."""
-    if config.model_arch_override != "Qwen3ASRForConditionalGeneration":
+    fish_mlx = config.model_arch_override == "FishS2ProMlxModel"
+    if config.model_arch_override == "Qwen3ASRForConditionalGeneration":
+        from sglang_omni.models.qwen3_asr.mlx.runner import (
+            make_qwen3_asr_mlx_runner_class,
+        )
+
+        runner_factory = make_qwen3_asr_mlx_runner_class
+    elif fish_mlx:
+        # Fish owns both AR networks and its codebook feedback. It uses the
+        # scheduler bookkeeping stub with a model-specific synchronous runner.
+        runner_factory = None
+    else:
         raise NotImplementedError(
-            "Omni's MLX worker currently supports only "
-            "Qwen3ASRForConditionalGeneration"
+            f"Omni's MLX worker does not support {config.model_arch_override}"
         )
 
     from sglang.srt.distributed.parallel_state_wrapper import ParallelState
@@ -190,32 +200,40 @@ def create_mlx_model_worker(
     )
     from sglang.srt.server_args import PortArgs
 
-    from sglang_omni.models.qwen3_asr.mlx.runner import make_qwen3_asr_mlx_runner_class
-
-    class OmniQwen3ASRMlxWorker(MlxTpModelWorker):
+    class OmniMlxWorker(MlxTpModelWorker):
         @property
         def tp_rank(self) -> int:
             return self.ps.tp_rank
 
         def _init_model_runner(self):
             MlxModelRunnerStub.validate_startup_weight_load_mode(self.server_args)
-            runner_class = make_qwen3_asr_mlx_runner_class()
-            init_kwargs = {
-                "model_path": get_model().model_path,
-                "trust_remote_code": get_model().trust_remote_code,
-                "disable_radix_cache": get_memory().disable_radix_cache,
-                "mem_fraction_static": get_schedule().mem_fraction_static,
-                "quantization": get_model().quantization,
-                "revision": get_model().revision,
-                "enable_sampling": get_device().mlx_enable_sampling,
-                "sampling_rng_seed": get_device().random_seed,
-                "deterministic_seeding": (
-                    get_exec().deterministic.enable_deterministic_inference
-                ),
-            }
-            if get_schedule().max_total_tokens is not None:
-                init_kwargs["pool_size"] = get_schedule().max_total_tokens
-            self._mlx_runner = runner_class(**init_kwargs)
+            if fish_mlx:
+                from sglang_omni.models.fishaudio_s2_pro.mlx.runner import FishMlxModel
+
+                self._mlx_runner = FishMlxModel(
+                    get_model().model_path,
+                    context_length=get_model().context_length,
+                )
+                pool_size = get_schedule().max_total_tokens
+            else:
+                runner_class = runner_factory()
+                init_kwargs = {
+                    "model_path": get_model().model_path,
+                    "trust_remote_code": get_model().trust_remote_code,
+                    "disable_radix_cache": get_memory().disable_radix_cache,
+                    "mem_fraction_static": get_schedule().mem_fraction_static,
+                    "quantization": get_model().quantization,
+                    "revision": get_model().revision,
+                    "enable_sampling": get_device().mlx_enable_sampling,
+                    "sampling_rng_seed": get_device().random_seed,
+                    "deterministic_seeding": (
+                        get_exec().deterministic.enable_deterministic_inference
+                    ),
+                }
+                if get_schedule().max_total_tokens is not None:
+                    init_kwargs["pool_size"] = get_schedule().max_total_tokens
+                self._mlx_runner = runner_class(**init_kwargs)
+                pool_size = self._mlx_runner.pool_size
             self._model_runner = MlxModelRunnerStub(
                 model_config=self.model_config,
                 mem_fraction_static=get_schedule().mem_fraction_static,
@@ -227,10 +245,18 @@ def create_mlx_model_worker(
                 req_to_token_pool=self.req_to_token_pool,
                 token_to_kv_pool_allocator=self.token_to_kv_pool_allocator,
                 memory_pool_config=self.memory_pool_config,
-                mlx_pool_size=self._mlx_runner.pool_size,
+                mlx_pool_size=pool_size,
             )
+            if fish_mlx:
+                self._model_runner.model = self._mlx_runner
             self._mlx_active_rids = set()
             self._mlx_pool_initialized = False
+
+        def prepare_for_kv_cache_release(self, req):
+            if not fish_mlx:
+                super().prepare_for_kv_cache_release(req)
+            # Fish has no auxiliary/radix state. Its scheduler completion/abort
+            # callbacks release the native per-request cache.
 
         def get_tp_group(self):
             return self.model_runner.tp_group
@@ -275,7 +301,7 @@ def create_mlx_model_worker(
     nccl_port = config.nccl_port
     if nccl_port is None:
         nccl_port = PortArgs.init_new(server_args).nccl_port
-    return OmniQwen3ASRMlxWorker(
+    return OmniMlxWorker(
         server_args=server_args,
         gpu_id=gpu_id,
         ps=ps,

--- a/sglang_omni/model_runner/sglang_model_runner.py
+++ b/sglang_omni/model_runner/sglang_model_runner.py
@@ -569,6 +569,7 @@ class SGLModelRunner(ModelRunner):
         from sglang.srt.models.registry import ModelRegistry
 
         sglang_omni_models = {
+            "S2ProTorchMpsTextModel": "sglang_omni.models.fishaudio_s2_pro.torch_mps:S2ProTorchMpsTextModel",
             "S2ProSGLangTextModel": "sglang_omni.models.fishaudio_s2_pro.sglang_model:S2ProSGLangTextModel",
             "Qwen3OmniTalker": "sglang_omni.models.qwen3_omni.components.talker:Qwen3OmniTalker",
             "Qwen3OmniThinkerForCausalLM": "sglang_omni.models.qwen3_omni.components.sglang_thinker:Qwen3OmniThinkerForCausalLM",

--- a/sglang_omni/models/fishaudio_s2_pro/README.md
+++ b/sglang_omni/models/fishaudio_s2_pro/README.md
@@ -105,15 +105,34 @@ the accelerator and software stacks differ from the NPU run.
 
 ## Apple Silicon Support (Experimental)
 
-S2-Pro also runs on Apple Metal through a Torch/MPS compatibility path. There is
-no native MLX implementation: `SGLANG_USE_MLX=1` fails at startup rather than
-falling back silently.
+S2-Pro also runs on Apple Metal, through a native MLX path
+(`SGLANG_USE_MLX=1`) or a Torch/MPS compatibility path (`SGLANG_USE_MLX=0`).
+`SGLANG_USE_MLX=1` off Apple Metal fails at startup rather than falling back
+silently. Both share the Fish request, sampler, and stream adapters, the
+`max_running_requests=1` admission profile, and the same rejection of quantized
+weights and unqualified overrides.
 
-- The Slow AR runs as a native eager Torch module (`S2ProTorchMpsTextModel`)
-  that keeps Fish's interleaved BF16 RoPE, VQ embedding injection, and codebook
-  sampler, and replaces only the CUDA attention/KV-cache contract. One scheduler
-  request owns the native cache at a time, so the profile pins
-  `max_running_requests=1` and additional requests queue.
+Native MLX (`FishS2ProMlxModel`):
+
+- The Slow AR transformer, its KV cache, and the entire Fast-AR greedy residual
+  chain run in MLX. Only the semantic logits cross to CPU, for the shared Fish
+  mask/RAS/top-k sampler. The residual chain then synchronizes once to publish
+  all codebooks, instead of once per codebook.
+- RoPE phases are taken from the canonical Torch `precompute_freqs_cis` and cast
+  once to BF16, rather than recomputed in MLX, because recomputation can round
+  across a BF16 boundary and drift from the CUDA reference.
+- Weights load straight from the official checkpoint's safetensors under their
+  own names, strictly: a missing, extra, or mis-shaped tensor is an error. There
+  is no `mlx-audio` dependency and no converted MLX artifact.
+- Fish owns its per-request MLX cache, so the worker skips SGLang's MLX
+  KV-release bookkeeping and releases on scheduler completion/abort instead.
+
+Torch/MPS (`S2ProTorchMpsTextModel`):
+
+- The Slow AR runs as a native eager Torch module that keeps Fish's interleaved
+  BF16 RoPE, VQ embedding injection, and codebook sampler, and replaces only the
+  CUDA attention/KV-cache contract. One scheduler request owns the native cache
+  at a time.
 - Fast-AR attention appends one position per step into the dense NHD cache and
   attends over its initialized prefix with `scaled_dot_product_attention`, with
   GQA expanded explicitly because MPS has no grouped kernel.
@@ -131,12 +150,17 @@ Validation uses the official `fishaudio/s2-pro` checkpoint at revision
 `1de9996b6be38b745688de084d87a5633f714e4e` on an Apple M5 Pro with 48 GB RAM.
 The unit suite covers cached versus full prefill on CPU and MPS, Fast-AR cache
 masking, strict weight loading, deterministic sampler vectors, and request-cache
-cleanup. All six live HTTP checks passed. Three additional English plain-TTS,
-English reference-conditioned, and Chinese smoke clips produced finite mono
+cleanup; the MLX suite additionally checks the native Slow AR against the Torch
+module, the native Fast-AR chain against the MPS decoder, and reference-codebook
+mixing. All six live HTTP checks passed on both the MLX and the Torch/MPS
+server. Three additional English plain-TTS, English reference-conditioned, and
+Chinese smoke clips produced finite mono
 44.1 kHz audio and stopped at EOS. Local Fun-ASR recovered the intended text
 (ignoring punctuation). These short samples took about 3.4–3.6 seconds of wall
-time per second of generated audio, excluding ASR scoring; this is a smoke
-measurement, not a controlled throughput benchmark.
+time per second of generated audio on Torch/MPS and 2.3–2.5 on MLX, excluding
+ASR scoring; these are smoke measurements, not controlled throughput benchmarks. On the same host, steady-state
+Slow-AR decode was about 10 tokens/s under MLX against about 8 tokens/s under
+Torch/MPS, both at batch size 1.
 
 Run the live checks against a server started with the Apple cookbook command:
 
@@ -146,9 +170,15 @@ FISH_APPLE_URL=http://127.0.0.1:8000 python -m pytest \
 ```
 
 These exercise seeded repetition, reference-audio transport, streaming,
-queued requests, and disconnect recovery. They do not measure speaker similarity,
-corpus-level transcription accuracy, or cross-device numerical parity. Native
-MLX and production performance qualification remain future work.
+queued requests, and disconnect recovery, and are backend-agnostic: run them once
+per `SGLANG_USE_MLX` setting. They do not measure speaker similarity,
+corpus-level transcription accuracy, or cross-device numerical parity.
+Production performance qualification remains future work.
+
+The MLX numerical test compares MLX against Torch on a tiny random model. On M5,
+MLX defaults to reduced-precision (TF32) FP32 GEMM, so that check runs against a
+tolerance scaled to the logit magnitude; set `MLX_ENABLE_TF32=0` to run it at
+full FP32 precision (2e-5).
 
 ## Optimizations with SGLang Omni
 

--- a/sglang_omni/models/fishaudio_s2_pro/README.md
+++ b/sglang_omni/models/fishaudio_s2_pro/README.md
@@ -103,6 +103,53 @@ python -m benchmarks.eval.benchmark_tts_seedtts \
 The CUDA rows are official reference results and are directional comparisons;
 the accelerator and software stacks differ from the NPU run.
 
+## Apple Silicon Support (Experimental)
+
+S2-Pro also runs on Apple Metal through a Torch/MPS compatibility path. There is
+no native MLX implementation: `SGLANG_USE_MLX=1` fails at startup rather than
+falling back silently.
+
+- The Slow AR runs as a native eager Torch module (`S2ProTorchMpsTextModel`)
+  that keeps Fish's interleaved BF16 RoPE, VQ embedding injection, and codebook
+  sampler, and replaces only the CUDA attention/KV-cache contract. One scheduler
+  request owns the native cache at a time, so the profile pins
+  `max_running_requests=1` and additional requests queue.
+- Fast-AR attention appends one position per step into the dense NHD cache and
+  attends over its initialized prefix with `scaled_dot_product_attention`, with
+  GQA expanded explicitly because MPS has no grouped kernel.
+- The seeded semantic sampler reproduces SGLang's MurmurHash3/Gumbel draw on CPU
+  in int64: MPS supports neither uint64 nor float64, and the Triton kernel is
+  unavailable. Only the small top-k distribution crosses to CPU, so seeded
+  draws are deterministic for a fixed probability distribution.
+- CUDA graphs, `torch.compile`, radix caching, and chunked prefill are disabled;
+  `attention_backend="torch_native"` with `sampling_backend="pytorch"`. Quantized
+  weights are rejected, and unqualified overrides fail fast rather than degrade.
+
+### Apple Validation
+
+Validation uses the official `fishaudio/s2-pro` checkpoint at revision
+`1de9996b6be38b745688de084d87a5633f714e4e` on an Apple M5 Pro with 48 GB RAM.
+The unit suite covers cached versus full prefill on CPU and MPS, Fast-AR cache
+masking, strict weight loading, deterministic sampler vectors, and request-cache
+cleanup. All six live HTTP checks passed. Three additional English plain-TTS,
+English reference-conditioned, and Chinese smoke clips produced finite mono
+44.1 kHz audio and stopped at EOS. Local Fun-ASR recovered the intended text
+(ignoring punctuation). These short samples took about 3.4–3.6 seconds of wall
+time per second of generated audio, excluding ASR scoring; this is a smoke
+measurement, not a controlled throughput benchmark.
+
+Run the live checks against a server started with the Apple cookbook command:
+
+```bash
+FISH_APPLE_URL=http://127.0.0.1:8000 python -m pytest \
+  tests/test_model/test_fish_apple.py -q
+```
+
+These exercise seeded repetition, reference-audio transport, streaming,
+queued requests, and disconnect recovery. They do not measure speaker similarity,
+corpus-level transcription accuracy, or cross-device numerical parity. Native
+MLX and production performance qualification remain future work.
+
 ## Optimizations with SGLang Omni
 
 By integrating S2's Dual-AR backbone into SGLang's paged-attention engine, we inherit LLM-native optimizations:

--- a/sglang_omni/models/fishaudio_s2_pro/README.md
+++ b/sglang_omni/models/fishaudio_s2_pro/README.md
@@ -114,6 +114,10 @@ weights and unqualified overrides.
 
 Native MLX (`FishS2ProMlxModel`):
 
+The shared MLX worker resolves Fish through the lazy runner registry. Its
+`FishMlxWorkerAdapter` provides model initialization, the scheduler-facing model,
+and the KV-release hook; Fish-specific dispatch is confined to its registration.
+
 - The Slow AR transformer, its KV cache, and the entire Fast-AR greedy residual
   chain run in MLX. Only the semantic logits cross to CPU, for the shared Fish
   mask/RAS/top-k sampler. The residual chain then synchronizes once to publish

--- a/sglang_omni/models/fishaudio_s2_pro/engine_builder.py
+++ b/sglang_omni/models/fishaudio_s2_pro/engine_builder.py
@@ -67,8 +67,21 @@ class FishS2ProEngineBuilder(TtsEngineBuilder):
         self.ras_window = ras_window
         self.adapter: Any | None = None
         self.tokenizer: Any | None = None
+        self._torch_mps_runner: Any | None = None
+
+    def _uses_torch_mps(self) -> bool:
+        return str(getattr(self, "device", "")).split(":")[0] == "mps"
 
     def pre_infra_setup(self, checkpoint_dir: str) -> None:
+        from sglang.srt.hardware_backend.mlx.runtime import use_mlx
+
+        if use_mlx():
+            raise ValueError(
+                "Fish S2-Pro native MLX is not implemented; use SGLANG_USE_MLX=0 "
+                "for the experimental Torch/MPS path"
+            )
+        if self._uses_torch_mps():
+            self.model_arch_override = "S2ProTorchMpsTextModel"
         del checkpoint_dir
         from sglang_omni.models.fishaudio_s2_pro import bootstrap as fish_bootstrap
 
@@ -80,6 +93,20 @@ class FishS2ProEngineBuilder(TtsEngineBuilder):
         dtype: str,
     ) -> dict[str, Any]:
         del dtype
+        if self._uses_torch_mps():
+            return {
+                "max_running_requests": 1,
+                "disable_cuda_graph": True,
+                "disable_overlap_schedule": True,
+                "disable_radix_cache": True,
+                "enable_torch_compile": False,
+                "max_total_tokens": self.context_length,
+                "max_prefill_tokens": self.context_length,
+                "chunked_prefill_size": -1,
+                "attention_backend": "torch_native",
+                "sampling_backend": "pytorch",
+                "dtype": "bfloat16",
+            }
         if current_platform.is_npu():
             # NPU graph decode avoids the ascend backend's eager concurrent-
             # decode content corruption. Limit concurrency to the validated NPU
@@ -109,6 +136,14 @@ class FishS2ProEngineBuilder(TtsEngineBuilder):
         }
 
     def adjust_overrides(self, overrides: dict[str, Any]) -> None:
+        if self._uses_torch_mps():
+            expected = self.generation_defaults(dtype="bfloat16")
+            for key, value in expected.items():
+                if overrides.get(key) != value:
+                    raise ValueError(f"Fish Torch/MPS requires {key}={value!r}")
+            if overrides.get("quantization") is not None:
+                raise ValueError("Fish Torch/MPS requires unquantized weights")
+            return
         fast_ar_backend = _resolve_fast_ar_attention_backend(gpu_id=self.gpu_id)
         if overrides.get("attention_backend") is None:
             overrides["attention_backend"] = fast_ar_backend
@@ -141,7 +176,8 @@ class FishS2ProEngineBuilder(TtsEngineBuilder):
         from sglang_omni.models.fishaudio_s2_pro.tokenizer import S2ProTokenizerAdapter
 
         model = model_worker.model_runner.model
-        fish_bootstrap.truncate_rope_to_bf16(model)
+        if not self._uses_torch_mps():
+            fish_bootstrap.truncate_rope_to_bf16(model)
         audio_decoder, num_codebooks, codebook_size, tokenizer = (
             fish_bootstrap.load_audio_decoder(
                 checkpoint_dir,
@@ -180,11 +216,23 @@ class FishS2ProEngineBuilder(TtsEngineBuilder):
             )
 
     def make_model_runner(self, model_worker: Any, output_proc: Any) -> Any:
+        if self._uses_torch_mps():
+            from sglang_omni.models.fishaudio_s2_pro.torch_mps import (
+                FishS2ProTorchMpsRunner,
+            )
+
+            self._torch_mps_runner = FishS2ProTorchMpsRunner(model_worker, output_proc)
+            return self._torch_mps_runner
         model_runner_mod = importlib.import_module(
             "sglang_omni.models.fishaudio_s2_pro.model_runner"
         )
 
         return model_runner_mod.FishS2ProModelRunner(model_worker, output_proc)
+
+    def make_abort_callback(self) -> Any | None:
+        if self._torch_mps_runner is not None:
+            return self._torch_mps_runner.abort_request
+        return None
 
     def make_adapters(self, model: Any) -> tuple[Any, Any]:
         del model

--- a/sglang_omni/models/fishaudio_s2_pro/engine_builder.py
+++ b/sglang_omni/models/fishaudio_s2_pro/engine_builder.py
@@ -67,7 +67,7 @@ class FishS2ProEngineBuilder(TtsEngineBuilder):
         self.ras_window = ras_window
         self.adapter: Any | None = None
         self.tokenizer: Any | None = None
-        self._torch_mps_runner: Any | None = None
+        self._apple_runner: Any | None = None
 
     def _uses_torch_mps(self) -> bool:
         return str(getattr(self, "device", "")).split(":")[0] == "mps"
@@ -76,11 +76,10 @@ class FishS2ProEngineBuilder(TtsEngineBuilder):
         from sglang.srt.hardware_backend.mlx.runtime import use_mlx
 
         if use_mlx():
-            raise ValueError(
-                "Fish S2-Pro native MLX is not implemented; use SGLANG_USE_MLX=0 "
-                "for the experimental Torch/MPS path"
-            )
-        if self._uses_torch_mps():
+            if not current_platform.is_mps():
+                raise ValueError("Fish MLX requires Apple Metal")
+            self.model_arch_override = "FishS2ProMlxModel"
+        elif self._uses_torch_mps():
             self.model_arch_override = "S2ProTorchMpsTextModel"
         del checkpoint_dir
         from sglang_omni.models.fishaudio_s2_pro import bootstrap as fish_bootstrap
@@ -92,8 +91,10 @@ class FishS2ProEngineBuilder(TtsEngineBuilder):
         *,
         dtype: str,
     ) -> dict[str, Any]:
+        from sglang.srt.hardware_backend.mlx.runtime import use_mlx
+
         del dtype
-        if self._uses_torch_mps():
+        if use_mlx() or self._uses_torch_mps():
             return {
                 "max_running_requests": 1,
                 "disable_cuda_graph": True,
@@ -136,13 +137,15 @@ class FishS2ProEngineBuilder(TtsEngineBuilder):
         }
 
     def adjust_overrides(self, overrides: dict[str, Any]) -> None:
-        if self._uses_torch_mps():
+        from sglang.srt.hardware_backend.mlx.runtime import use_mlx
+
+        if use_mlx() or self._uses_torch_mps():
             expected = self.generation_defaults(dtype="bfloat16")
             for key, value in expected.items():
                 if overrides.get(key) != value:
-                    raise ValueError(f"Fish Torch/MPS requires {key}={value!r}")
+                    raise ValueError(f"Fish Apple requires {key}={value!r}")
             if overrides.get("quantization") is not None:
-                raise ValueError("Fish Torch/MPS requires unquantized weights")
+                raise ValueError("Fish Apple requires unquantized weights")
             return
         fast_ar_backend = _resolve_fast_ar_attention_backend(gpu_id=self.gpu_id)
         if overrides.get("attention_backend") is None:
@@ -176,6 +179,15 @@ class FishS2ProEngineBuilder(TtsEngineBuilder):
         from sglang_omni.models.fishaudio_s2_pro.tokenizer import S2ProTokenizerAdapter
 
         model = model_worker.model_runner.model
+        from sglang.srt.hardware_backend.mlx.runtime import use_mlx
+
+        if use_mlx():
+            from transformers import PreTrainedTokenizerFast
+
+            self.tokenizer = PreTrainedTokenizerFast.from_pretrained(checkpoint_dir)
+            self.adapter = S2ProTokenizerAdapter(self.tokenizer)
+            model.configure(self.adapter, self.ras_window)
+            return
         if not self._uses_torch_mps():
             fish_bootstrap.truncate_rope_to_bf16(model)
         audio_decoder, num_codebooks, codebook_size, tokenizer = (
@@ -199,6 +211,10 @@ class FishS2ProEngineBuilder(TtsEngineBuilder):
         )
 
     def get_model_buffer_bs(self, model: Any) -> int | None:
+        from sglang.srt.hardware_backend.mlx.runtime import use_mlx
+
+        if use_mlx():
+            return model.vq_decode_max_batch_size
         return fish_stages._resolve_s2pro_model_buffer_bs(model)
 
     def compile_model(self, model: Any, server_args: Any) -> None:
@@ -216,13 +232,22 @@ class FishS2ProEngineBuilder(TtsEngineBuilder):
             )
 
     def make_model_runner(self, model_worker: Any, output_proc: Any) -> Any:
+        from sglang.srt.hardware_backend.mlx.runtime import use_mlx
+
+        if use_mlx():
+            from sglang_omni.models.fishaudio_s2_pro.mlx.runner import (
+                FishMlxSchedulerRunner,
+            )
+
+            self._apple_runner = FishMlxSchedulerRunner(model_worker, output_proc)
+            return self._apple_runner
         if self._uses_torch_mps():
             from sglang_omni.models.fishaudio_s2_pro.torch_mps import (
                 FishS2ProTorchMpsRunner,
             )
 
-            self._torch_mps_runner = FishS2ProTorchMpsRunner(model_worker, output_proc)
-            return self._torch_mps_runner
+            self._apple_runner = FishS2ProTorchMpsRunner(model_worker, output_proc)
+            return self._apple_runner
         model_runner_mod = importlib.import_module(
             "sglang_omni.models.fishaudio_s2_pro.model_runner"
         )
@@ -230,8 +255,8 @@ class FishS2ProEngineBuilder(TtsEngineBuilder):
         return model_runner_mod.FishS2ProModelRunner(model_worker, output_proc)
 
     def make_abort_callback(self) -> Any | None:
-        if self._torch_mps_runner is not None:
-            return self._torch_mps_runner.abort_request
+        if self._apple_runner is not None:
+            return self._apple_runner.abort_request
         return None
 
     def make_adapters(self, model: Any) -> tuple[Any, Any]:

--- a/sglang_omni/models/fishaudio_s2_pro/fish_speech/models/text2semantic/audio_decoder.py
+++ b/sglang_omni/models/fishaudio_s2_pro/fish_speech/models/text2semantic/audio_decoder.py
@@ -202,9 +202,13 @@ def flash_attn_kvcache_op(
             num_splits=num_splits,
             cache_position=cache_position,
         )
+    elif device_type == "mps":
+        from sglang_omni.models.fishaudio_s2_pro.torch_mps import fast_attention
+
+        output = fast_attention(q, k_cache, v_cache, k, v, cache_position)
     else:
         raise RuntimeError(
-            "FishAudio S2-Pro Fast-AR attention supports CUDA and NPU, "
+            "FishAudio S2-Pro Fast-AR attention supports CUDA, NPU, and MPS, "
             f"but got device type {device_type!r}"
         )
     return output

--- a/sglang_omni/models/fishaudio_s2_pro/mlx/__init__.py
+++ b/sglang_omni/models/fishaudio_s2_pro/mlx/__init__.py
@@ -1,0 +1,2 @@
+# SPDX-License-Identifier: Apache-2.0
+"""Native MLX Fish S2-Pro execution (loaded only with SGLANG_USE_MLX=1)."""

--- a/sglang_omni/models/fishaudio_s2_pro/mlx/model.py
+++ b/sglang_omni/models/fishaudio_s2_pro/mlx/model.py
@@ -1,0 +1,221 @@
+# SPDX-License-Identifier: Apache-2.0
+"""Native MLX Fish Slow-AR and Fast-AR, using official checkpoint names.
+
+The prompt and sampler live in Omni. This module owns only embeddings,
+transformers, and their native caches; it has no mlx-audio dependency.
+"""
+from __future__ import annotations
+
+import json
+from pathlib import Path
+from types import SimpleNamespace
+
+import mlx.core as mx
+import mlx.nn as nn
+import numpy as np
+from mlx_lm.models.cache import KVCache
+
+
+class FishRoPE:
+    def __init__(self, config):
+        # Construct the canonical cached BF16 phases once on CPU. Recomputing
+        # phases in another math library can round across a BF16 boundary.
+        from sglang_omni.models.fishaudio_s2_pro.fish_speech.models.text2semantic.utils import (
+            precompute_freqs_cis,
+        )
+
+        phases = precompute_freqs_cis(
+            config.max_seq_len, config.head_dim, config.rope_base
+        )
+        self.phases = mx.array(phases.float().numpy()).astype(mx.bfloat16)
+        mx.eval(self.phases)
+
+    def __call__(self, x, offset):
+        end = offset + x.shape[2]
+        if end > self.phases.shape[0]:
+            raise ValueError("Fish MLX request exceeds the RoPE context")
+        phases = self.phases[offset:end]
+        even, odd = x[..., ::2].astype(mx.float32), x[..., 1::2].astype(mx.float32)
+        cos, sin = phases[..., 0], phases[..., 1]
+        return (
+            mx.stack((even * cos - odd * sin, odd * cos + even * sin), axis=-1)
+            .reshape(x.shape)
+            .astype(x.dtype)
+        )
+
+
+class Attention(nn.Module):
+    def __init__(self, c):
+        super().__init__()
+        self._config = c
+        self.wqkv = nn.Linear(
+            c.dim,
+            (c.n_head + 2 * c.n_local_heads) * c.head_dim,
+            bias=c.attention_qkv_bias,
+        )
+        self.wo = nn.Linear(c.n_head * c.head_dim, c.dim, bias=c.attention_o_bias)
+        if c.attention_qk_norm:
+            self.q_norm = nn.RMSNorm(c.head_dim, eps=c.norm_eps)
+            self.k_norm = nn.RMSNorm(c.head_dim, eps=c.norm_eps)
+
+    def __call__(self, x, cache, rope):
+        c = self._config
+        b, s, _ = x.shape
+        q, k, v = mx.split(
+            self.wqkv(x),
+            [c.n_head * c.head_dim, (c.n_head + c.n_local_heads) * c.head_dim],
+            axis=-1,
+        )
+        q = q.reshape(b, s, c.n_head, c.head_dim).transpose(0, 2, 1, 3)
+        k, v = (
+            z.reshape(b, s, c.n_local_heads, c.head_dim).transpose(0, 2, 1, 3)
+            for z in (k, v)
+        )
+        if c.attention_qk_norm:
+            q, k = self.q_norm(q), self.k_norm(k)
+        q, k = rope(q, cache.offset), rope(k, cache.offset)
+        k, v = cache.update_and_fetch(k, v)
+        y = mx.fast.scaled_dot_product_attention(
+            q, k, v, scale=c.head_dim**-0.5, mask="causal" if s > 1 else None
+        )
+        return self.wo(y.transpose(0, 2, 1, 3).reshape(b, s, -1))
+
+
+class FeedForward(nn.Module):
+    def __init__(self, c):
+        super().__init__()
+        self.w1 = nn.Linear(c.dim, c.intermediate_size, bias=False)
+        self.w2 = nn.Linear(c.intermediate_size, c.dim, bias=False)
+        self.w3 = nn.Linear(c.dim, c.intermediate_size, bias=False)
+
+    def __call__(self, x):
+        return self.w2(nn.silu(self.w1(x)) * self.w3(x))
+
+
+class TransformerBlock(nn.Module):
+    def __init__(self, c):
+        super().__init__()
+        self.attention = Attention(c)
+        self.feed_forward = FeedForward(c)
+        self.attention_norm = nn.RMSNorm(c.dim, eps=c.norm_eps)
+        self.ffn_norm = nn.RMSNorm(c.dim, eps=c.norm_eps)
+
+    def __call__(self, x, cache, rope):
+        x = x + self.attention(self.attention_norm(x), cache, rope)
+        return x + self.feed_forward(self.ffn_norm(x))
+
+
+class Transformer(nn.Module):
+    def __init__(self, c):
+        super().__init__()
+        if c.use_moe:
+            raise ValueError("Fish MLX requires a dense checkpoint")
+        self.embeddings = nn.Embedding(c.vocab_size, c.dim)
+        self.layers = [TransformerBlock(c) for _ in range(c.n_layer)]
+        self.norm = nn.RMSNorm(c.dim, eps=c.norm_eps)
+        self._rope = FishRoPE(c)
+
+    def make_cache(self, *, step=256):
+        caches = [KVCache() for _ in self.layers]
+        for cache in caches:
+            cache.step = step
+        return caches
+
+    def __call__(self, x, cache):
+        if len(cache) != len(self.layers):
+            raise ValueError("Fish MLX cache layer count mismatch")
+        for layer, state in zip(self.layers, cache):
+            x = layer(x, state, self._rope)
+        return self.norm(x)
+
+
+class TextModel(nn.Module):
+    def __init__(self, c):
+        super().__init__()
+        self.model = Transformer(c)
+        self._tied = c.tie_word_embeddings
+        if not self._tied:
+            self.lm_head = nn.Linear(c.dim, c.vocab_size, bias=False)
+
+    def __call__(self, x, cache):
+        hidden = self.model(x, cache)[:, -1]
+        logits = (
+            self.model.embeddings.as_linear(hidden)
+            if self._tied
+            else self.lm_head(hidden)
+        )
+        return logits, hidden
+
+
+class AudioDecoder(Transformer):
+    def __init__(self, c):
+        super().__init__(c)
+        self._config = c
+        self.codebook_embeddings = nn.Embedding(
+            c.vocab_size * c.num_codebooks, c.text_dim
+        )
+        self.project_in = (
+            nn.Linear(c.text_dim, c.dim) if c.text_dim != c.dim else nn.Identity()
+        )
+        self.output = nn.Linear(c.dim, c.vocab_size, bias=False)
+
+    def generate(self, hidden, semantic_code):
+        # Fast-AR history lasts one frame. Evaluate the full greedy residual
+        # chain together, without synchronizing the host for every codebook.
+        cache = self.make_cache(step=self._config.num_codebooks + 1)
+        self(self.project_in(hidden)[:, None], cache)
+        code = mx.array([semantic_code], dtype=mx.int32)
+        codes = [code]
+        for _ in range(1, self._config.num_codebooks):
+            hidden = self(self.embeddings(code)[:, None], cache)
+            code = mx.argmax(self.output(hidden)[:, 0], axis=-1)
+            codes.append(code)
+        return mx.stack(codes, axis=-1)
+
+    def mix_embeddings(self, text, codes):
+        offsets = mx.arange(self._config.num_codebooks) * self._config.vocab_size
+        vq = self.codebook_embeddings(codes + offsets).sum(axis=-2).astype(text.dtype)
+        return (text + vq) * (self._config.num_codebooks + 1) ** -0.5
+
+
+class FishModel(nn.Module):
+    def __init__(self, config):
+        super().__init__()
+        self.text_model = TextModel(SimpleNamespace(**config["text_config"]))
+        self.audio_decoder = AudioDecoder(
+            SimpleNamespace(**config["audio_decoder_config"])
+        )
+        self._config = config
+
+    @classmethod
+    def from_pretrained(cls, model_path):
+        path = Path(model_path)
+        config = json.loads((path / "config.json").read_text())
+        if config.get("quantization") or config.get("quantization_config"):
+            raise ValueError("Fish MLX currently requires unquantized BF16 weights")
+        model = cls(config)
+        weights = {}
+        for shard in sorted(path.glob("*.safetensors")):
+            loaded = mx.load(str(shard))
+            if weights.keys() & loaded.keys():
+                raise ValueError("Duplicate Fish MLX checkpoint tensor")
+            weights.update(loaded)
+        model.load_weights(list(weights.items()), strict=True)
+        model.eval()
+        mx.eval(model.parameters())
+        return model
+
+
+def to_mlx(tensor):
+    tensor = tensor.detach().cpu()
+    # NumPy has no BF16 dtype. Widening is exact and only used for reference
+    # integer codes / test fixtures, not transformer activations in serving.
+    if str(tensor.dtype) == "torch.bfloat16":
+        return mx.array(tensor.float().numpy()).astype(mx.bfloat16)
+    return mx.array(tensor.numpy())
+
+
+def to_torch(array):
+    import torch
+
+    return torch.from_numpy(np.array(array.astype(mx.float32)))

--- a/sglang_omni/models/fishaudio_s2_pro/mlx/runner.py
+++ b/sglang_omni/models/fishaudio_s2_pro/mlx/runner.py
@@ -1,0 +1,150 @@
+# SPDX-License-Identifier: Apache-2.0
+"""Fish's synchronous native MLX adapter for the shared OmniScheduler."""
+from __future__ import annotations
+
+import mlx.core as mx
+import numpy as np
+import torch
+
+from sglang_omni.models.fishaudio_s2_pro.model_runner import FishS2ProModelRunner
+from sglang_omni.models.fishaudio_s2_pro.sglang_model import S2ProSGLangTextModel
+from sglang_omni.models.fishaudio_s2_pro.torch_mps import seeded_choice
+
+from .model import FishModel, to_mlx, to_torch
+
+
+class FishMlxModel(S2ProSGLangTextModel):
+    """CPU sampler/output buffers around native MLX transformer weights.
+
+    The inherited sampler is the same one used by CUDA/MPS. Only logits cross
+    to CPU for semantic sampling; the entire Fast-AR greedy chain stays in MLX.
+    """
+
+    def __init__(self, model_path, *, context_length):
+        torch.nn.Module.__init__(self)
+        self.native = FishModel.from_pretrained(model_path)
+        self.vocab_size = self.native._config["text_config"]["vocab_size"]
+        self.context_length = context_length
+        self._request_caches = {}
+        self._vq_ready = False
+
+    def configure(self, tokenizer, ras_window):
+        c = self.native._config["audio_decoder_config"]
+        self.setup_decode_buffers(
+            device="cpu",
+            num_codebooks=c["num_codebooks"],
+            codebook_size=c["vocab_size"],
+            semantic_begin_id=tokenizer.semantic_begin_id,
+            semantic_end_id=tokenizer.semantic_end_id,
+            im_end_token_id=tokenizer.eos_token_ids[0],
+            max_batch_size=1,
+            rep_history_len=ras_window,
+        )
+
+    def _sample_semantic_choice(self, probs, seeds, positions):
+        return (
+            torch.multinomial(probs, num_samples=1)
+            if int(seeds[0]) < 0
+            else seeded_choice(probs, seeds, positions)
+        )
+
+    def clear_request(self, request_id):
+        self._request_caches.pop(request_id, None)
+
+    def forward_request(self, request, *, prefill):
+        data = request.data
+        rid = request.request_id
+        native = self.native
+        if prefill:
+            if len(data.req.prefix_indices):
+                raise ValueError("Fish MLX requires radix caching disabled")
+            self._request_caches.clear()
+            cache = native.text_model.model.make_cache()
+            tokens = mx.array(data.req.origin_input_ids, dtype=mx.int32)
+        else:
+            if rid not in self._request_caches:
+                raise RuntimeError(f"Fish MLX has no cache for {rid}")
+            cache = self._request_caches[rid]
+            tokens = mx.array([data.req.output_ids[-1]], dtype=mx.int32)
+        if cache[0].offset + tokens.size > self.context_length:
+            raise ValueError("Fish MLX request exceeds the maximum allowed length")
+        embeds = native.text_model.model.embeddings(tokens)
+        if prefill and data.vq_parts:
+            if data.vq_mask_tokens is None:
+                raise ValueError("Fish MLX reference codes require a prompt mask")
+            mask = data.vq_mask_tokens.cpu().reshape(-1).numpy().astype(bool)
+            parts = [to_mlx(part.T) for part in data.vq_parts]
+            codes = mx.concatenate(parts, axis=0)
+            if len(mask) != tokens.size or mask.sum() != codes.shape[0]:
+                raise ValueError("Fish MLX reference mask/code length mismatch")
+            indices = mx.array(np.flatnonzero(mask), dtype=mx.int32)
+            embeds[indices] = native.audio_decoder.mix_embeddings(
+                embeds[indices], codes
+            )
+        elif not prefill:
+            token = data.req.output_ids[-1]
+            if self._semantic_begin_id <= token <= self._semantic_end_id:
+                if data.last_codebook_values is None:
+                    raise RuntimeError("Fish MLX decode is missing codebook feedback")
+                codes = to_mlx(data.last_codebook_values).reshape(1, -1)
+                embeds = native.audio_decoder.mix_embeddings(embeds, codes)
+        logits, hidden = native.text_model(embeds[None], cache)
+        mx.eval(logits, hidden, [state.state for state in cache])
+        semantic = self._sample_semantic_token(to_torch(logits))
+        token = int(semantic[0])
+        semantic_code = (
+            0
+            if token == self._im_end_token_id
+            else max(0, min(token - self._semantic_begin_id, self._codebook_size - 1))
+        )
+        codes = native.audio_decoder.generate(hidden, semantic_code)
+        mx.eval(codes)
+        self._output_codes[0, 0] = token
+        self._output_codes[0, 1:] = torch.from_numpy(np.array(codes[0], dtype=np.int64))
+        self._output_semantic_ids[0] = token
+        self._request_caches[rid] = cache
+
+
+class FishMlxSchedulerRunner(FishS2ProModelRunner):
+    """Keep Fish's state/stream adapters and Omni's admission/completion path."""
+
+    def lookahead_eligible(self, batch):
+        return False
+
+    def _build_forward_batch(self, scheduler_output):
+        batch = scheduler_output.batch_data
+        if batch is None:
+            return None
+        return None, batch, bool(batch.forward_mode.is_extend())
+
+    def before_prefill(self, forward_batch, schedule_batch, requests):
+        if len(requests) != 1:
+            raise ValueError("Fish MLX requires max_running_requests=1")
+        self._sync_decode_state(requests)
+
+    def before_decode(
+        self, forward_batch, schedule_batch, requests, *, is_lookahead=False
+    ):
+        self.before_prefill(forward_batch, schedule_batch, requests)
+
+    def _forward(self, requests, *, prefill):
+        from sglang.srt.managers.scheduler import GenerationBatchResult
+
+        self.model.forward_request(requests[0], prefill=prefill)
+        return GenerationBatchResult(
+            logits_output=None,
+            next_token_ids=self.model._output_semantic_ids.clone(),
+            can_run_cuda_graph=False,
+        )
+
+    def custom_prefill_forward(self, forward_batch, schedule_batch, requests):
+        return self._forward(requests, prefill=True)
+
+    def custom_decode_forward(self, forward_batch, schedule_batch, requests):
+        return self._forward(requests, prefill=False)
+
+    def on_request_finished(self, request_id, req_data):
+        self.model.clear_request(request_id)
+
+    def abort_request(self, request_id):
+        self.model.clear_request(request_id)

--- a/sglang_omni/models/fishaudio_s2_pro/mlx/runner.py
+++ b/sglang_omni/models/fishaudio_s2_pro/mlx/runner.py
@@ -148,3 +148,27 @@ class FishMlxSchedulerRunner(FishS2ProModelRunner):
 
     def abort_request(self, request_id):
         self.model.clear_request(request_id)
+
+
+class FishMlxWorkerAdapter:
+    """Connect Fish's synchronous model to the registry-based MLX worker."""
+
+    @classmethod
+    def from_runtime_config(cls):
+        from sglang.srt.runtime_context import get_model, get_schedule
+
+        adapter = cls()
+        adapter.pool_size = get_schedule().max_total_tokens
+        adapter.scheduler_model = FishMlxModel(
+            get_model().model_path, context_length=get_model().context_length
+        )
+        return adapter
+
+    def prepare_for_kv_cache_release(self, req):
+        # Fish has no SGLang auxiliary/radix state to snapshot. The scheduler's
+        # completion/abort callbacks release its native per-request cache.
+        pass
+
+
+def make_fish_mlx_runner_class():
+    return FishMlxWorkerAdapter

--- a/sglang_omni/models/fishaudio_s2_pro/sglang_model.py
+++ b/sglang_omni/models/fishaudio_s2_pro/sglang_model.py
@@ -444,12 +444,9 @@ class S2ProSGLangTextModel(nn.Module):
         )
         # Seeded rows draw reproducibly from (seed, step); unseeded rows keep the
         # legacy torch.multinomial draw, so unseeded decode is unchanged.
-        seeds = self._sampling_seeds[:bs]
-        unseeded_choice = torch.multinomial(probs, num_samples=1)
-        seeded_choice = multinomial_with_seed(
-            torch.log(probs), seeds.clamp_min(0), self._step_count[:bs]
+        choice = self._sample_semantic_choice(
+            probs, self._sampling_seeds[:bs], self._step_count[:bs]
         )
-        choice = torch.where((seeds >= 0).unsqueeze(-1), seeded_choice, unseeded_choice)
         semantic_token = top_k_indices.gather(-1, choice).squeeze(-1)
 
         # Batched codebook loop
@@ -479,6 +476,13 @@ class S2ProSGLangTextModel(nn.Module):
             self._output_codes[:bs, cb_idx + 1] = cb_token
 
         self._output_semantic_ids[:bs] = semantic_token
+
+    def _sample_semantic_choice(self, probs, seeds, positions):
+        unseeded_choice = torch.multinomial(probs, num_samples=1)
+        seeded_choice = multinomial_with_seed(
+            torch.log(probs), seeds.clamp_min(0), positions
+        )
+        return torch.where((seeds >= 0).unsqueeze(-1), seeded_choice, unseeded_choice)
 
     def get_embed_tokens(self):
         return self.embed_tokens

--- a/sglang_omni/models/fishaudio_s2_pro/sglang_model.py
+++ b/sglang_omni/models/fishaudio_s2_pro/sglang_model.py
@@ -256,17 +256,41 @@ class S2ProSGLangTextModel(nn.Module):
 
         # Audio decoder (fast head)
         self._audio_decoder = audio_decoder
-        self._codebook_size = codebook_size
-        self._num_codebooks = num_codebooks
-        self._semantic_begin_id = semantic_begin_id
-        self._semantic_end_id = semantic_end_id
-        self._im_end_token_id = int(im_end_token_id)
 
         # Shared codebook embedding from audio decoder (for VQ input combination)
         self._vq_codebook_embeddings = audio_decoder.codebook_embeddings
         self._vq_codebook_offsets = audio_decoder.codebook_offsets.to(device)
         self._vq_scale = 1.0 / math.sqrt(num_codebooks + 1)
 
+        self.setup_decode_buffers(
+            device=device,
+            num_codebooks=num_codebooks,
+            codebook_size=codebook_size,
+            semantic_begin_id=semantic_begin_id,
+            semantic_end_id=semantic_end_id,
+            im_end_token_id=im_end_token_id,
+            max_batch_size=max_batch_size,
+            rep_history_len=rep_history_len,
+        )
+
+    def setup_decode_buffers(
+        self,
+        *,
+        device,
+        num_codebooks,
+        codebook_size,
+        semantic_begin_id,
+        semantic_end_id,
+        im_end_token_id,
+        max_batch_size,
+        rep_history_len=16,
+    ) -> None:
+        """Allocate request/sampler state independently of transformer execution."""
+        self._codebook_size = codebook_size
+        self._num_codebooks = num_codebooks
+        self._semantic_begin_id = semantic_begin_id
+        self._semantic_end_id = semantic_end_id
+        self._im_end_token_id = int(im_end_token_id)
         # Input buffers: VQ codes from previous step (updated by ModelRunner)
         self._vq_codes = torch.zeros(
             max_batch_size, num_codebooks, dtype=torch.long, device=device
@@ -396,6 +420,39 @@ class S2ProSGLangTextModel(nn.Module):
         """
         bs = logits.shape[0]
 
+        semantic_token = self._sample_semantic_token(logits)
+
+        # Batched codebook loop
+        self._audio_decoder.reset_caches()
+        fast_input = self._audio_decoder.project_in(hidden_states)
+        fast_input = fast_input.unsqueeze(1)  # [bs, 1, fast_dim]
+        self._audio_decoder.forward_kvcached(fast_input, codebook_idx=0)
+
+        is_eos = semantic_token == self._im_end_token_id
+        sem_id = (semantic_token - self._semantic_begin_id).clamp(
+            min=0,
+            max=self._codebook_size - 1,
+        )
+        sem_id = torch.where(is_eos, torch.zeros_like(sem_id), sem_id)
+        cb_hidden = self._audio_decoder.embeddings(sem_id).unsqueeze(1)
+
+        self._output_codes[:bs, 0] = semantic_token
+        self._output_codes[:bs, 1] = sem_id
+
+        for cb_idx in range(1, self._num_codebooks):
+            cb_logits = self._audio_decoder.forward_kvcached(
+                cb_hidden, codebook_idx=cb_idx
+            )
+            cb_logits = cb_logits[:, 0, : self._codebook_size]
+            cb_token = torch.argmax(cb_logits, dim=-1)  # [bs]
+            cb_hidden = self._audio_decoder.embeddings(cb_token).unsqueeze(1)
+            self._output_codes[:bs, cb_idx + 1] = cb_token
+
+        self._output_semantic_ids[:bs] = semantic_token
+
+    def _sample_semantic_token(self, logits: Tensor) -> Tensor:
+        """Shared Fish semantic mask, RAS, repetition penalty, and top-k/top-p."""
+        bs = logits.shape[0]
         biased_logits = logits + self._semantic_bias
         biased_logits = biased_logits.to(torch.bfloat16).to(torch.float32)
 
@@ -449,33 +506,7 @@ class S2ProSGLangTextModel(nn.Module):
         )
         semantic_token = top_k_indices.gather(-1, choice).squeeze(-1)
 
-        # Batched codebook loop
-        self._audio_decoder.reset_caches()
-        fast_input = self._audio_decoder.project_in(hidden_states)
-        fast_input = fast_input.unsqueeze(1)  # [bs, 1, fast_dim]
-        self._audio_decoder.forward_kvcached(fast_input, codebook_idx=0)
-
-        is_eos = semantic_token == self._im_end_token_id
-        sem_id = (semantic_token - self._semantic_begin_id).clamp(
-            min=0,
-            max=self._codebook_size - 1,
-        )
-        sem_id = torch.where(is_eos, torch.zeros_like(sem_id), sem_id)
-        cb_hidden = self._audio_decoder.embeddings(sem_id).unsqueeze(1)
-
-        self._output_codes[:bs, 0] = semantic_token
-        self._output_codes[:bs, 1] = sem_id
-
-        for cb_idx in range(1, self._num_codebooks):
-            cb_logits = self._audio_decoder.forward_kvcached(
-                cb_hidden, codebook_idx=cb_idx
-            )
-            cb_logits = cb_logits[:, 0, : self._codebook_size]
-            cb_token = torch.argmax(cb_logits, dim=-1)  # [bs]
-            cb_hidden = self._audio_decoder.embeddings(cb_token).unsqueeze(1)
-            self._output_codes[:bs, cb_idx + 1] = cb_token
-
-        self._output_semantic_ids[:bs] = semantic_token
+        return semantic_token
 
     def _sample_semantic_choice(self, probs, seeds, positions):
         unseeded_choice = torch.multinomial(probs, num_samples=1)

--- a/sglang_omni/models/fishaudio_s2_pro/torch_mps.py
+++ b/sglang_omni/models/fishaudio_s2_pro/torch_mps.py
@@ -1,0 +1,248 @@
+# SPDX-License-Identifier: Apache-2.0
+"""Eager Fish Slow-AR and Fast-AR execution for the Torch/MPS backend.
+
+Keep Fish's interleaved BF16 RoPE, reference embeddings, and codebook sampler;
+only replace the CUDA attention/cache execution contract. One scheduler request
+owns the native Slow-AR cache at a time.
+"""
+
+from __future__ import annotations
+
+from typing import Any, Iterable
+
+import torch
+from torch import nn
+from torch.nn import functional as F
+
+from sglang_omni.models.fishaudio_s2_pro.fish_speech.models.text2semantic.audio_decoder import (
+    TransformerBlock,
+)
+from sglang_omni.models.fishaudio_s2_pro.fish_speech.models.text2semantic.utils import (
+    apply_rotary_emb,
+    precompute_freqs_cis,
+)
+from sglang_omni.models.fishaudio_s2_pro.model_runner import FishS2ProModelRunner
+from sglang_omni.models.fishaudio_s2_pro.sglang_model import S2ProSGLangTextModel
+
+
+def sdpa_attention(q, k, v, *, causal: bool = False):
+    """Fish NHD attention, with explicit GQA expansion supported by MPS."""
+    q, k, v = (x.transpose(1, 2) for x in (q, k, v))
+    repeats = q.shape[1] // k.shape[1]
+    if repeats != 1:
+        k = k.repeat_interleave(repeats, dim=1)
+        v = v.repeat_interleave(repeats, dim=1)
+    return F.scaled_dot_product_attention(q, k, v, is_causal=causal).transpose(1, 2)
+
+
+def fast_attention(q, k_cache, v_cache, k, v, cache_position: int):
+    """Append one Fast-AR position and attend only to its initialized prefix."""
+    if k is None or v is None:
+        raise ValueError("Fish MPS Fast-AR expects one new key/value position")
+    if q.shape[1] != 1 or k.shape[1] != 1 or v.shape[1] != 1:
+        raise ValueError("Fish MPS Fast-AR expects one new key/value position")
+    if q.shape[0] != k.shape[0] or q.shape[0] != v.shape[0]:
+        raise ValueError("Fish MPS Fast-AR query/key/value batch sizes must match")
+    if not 0 <= cache_position < k_cache.shape[1]:
+        raise ValueError("Fish MPS Fast-AR cache position is out of bounds")
+    k_cache[:, cache_position : cache_position + 1].copy_(k)
+    v_cache[:, cache_position : cache_position + 1].copy_(v)
+    return sdpa_attention(
+        q, k_cache[:, : cache_position + 1], v_cache[:, : cache_position + 1]
+    )
+
+
+def seeded_choice(probs, seeds, positions):
+    """CPU equivalent of SGLang's MurmurHash3/Gumbel sampler for a small top-k.
+
+    MurmurHash3 x86_32 hashes four little-endian words: seed low/high, step,
+    column. int64 arithmetic plus a uint32 mask avoids both Triton and MPS's
+    unsupported uint64/float64 operations. No process-global RNG is modified.
+    """
+    mask = 0xFFFFFFFF
+    seed = seeds.cpu().long().reshape(-1, 1)
+    step = positions.cpu().long().reshape(-1, 1)
+    columns = torch.arange(probs.shape[1], dtype=torch.long)[None]
+    h = torch.zeros((probs.shape[0], probs.shape[1]), dtype=torch.long)
+    for word in (seed & mask, (seed >> 32) & mask, step & mask, columns):
+        k = (word * 0xCC9E2D51) & mask
+        k = ((k << 15) | (k >> 17)) & mask
+        k = (k * 0x1B873593) & mask
+        h = h ^ k
+        h = ((h << 13) | (h >> 19)) & mask
+        h = (h * 5 + 0xE6546B64) & mask
+    h = h ^ 16
+    h = h ^ (h >> 16)
+    h = (h * 0x85EBCA6B) & mask
+    h = h ^ (h >> 13)
+    h = (h * 0xC2B2AE35) & mask
+    h = h ^ (h >> 16)
+    uniform = h.double() / mask
+    noise = -(
+        -uniform.log().clamp(min=torch.finfo(torch.float64).min, max=-(2.0**-32))
+    ).log()
+    return (
+        (noise + probs.log().cpu().double())
+        .argmax(dim=1, keepdim=True)
+        .to(probs.device)
+    )
+
+
+class S2ProTorchMpsTextModel(S2ProSGLangTextModel):
+    """Native Torch Slow-AR layers with the existing Fish decode-buffer API."""
+
+    def __init__(self, config: Any, quant_config: Any = None, **kwargs):
+        nn.Module.__init__(self)
+        if quant_config is not None:
+            raise ValueError("Fish Torch/MPS currently requires unquantized weights")
+        tc = config.text_config
+        if tc.use_moe:
+            raise ValueError("Fish Torch/MPS requires the dense S2-Pro checkpoint")
+        self.vocab_size = tc.vocab_size
+        self.hidden_size = tc.dim
+        self.num_layers = tc.n_layer
+        self.start_layer, self.end_layer = 0, tc.n_layer
+        self.tie_word_embeddings = tc.tie_word_embeddings
+        self._vq_ready = False
+        self.embed_tokens = nn.Embedding(tc.vocab_size, tc.dim)
+        self.layers = nn.ModuleList([TransformerBlock(tc) for _ in range(tc.n_layer)])
+        self.norm = nn.RMSNorm(tc.dim, eps=tc.norm_eps)
+        if not tc.tie_word_embeddings:
+            self.lm_head = nn.Linear(tc.dim, tc.vocab_size, bias=False)
+        # torch.polar used by the canonical helper is constructed on CPU.
+        with torch.device("cpu"):
+            phases = precompute_freqs_cis(tc.max_seq_len, tc.head_dim, tc.rope_base)
+        self.register_buffer("freqs_cis", phases, persistent=False)
+        self._request_caches: dict[str, list[tuple[torch.Tensor, torch.Tensor]]] = {}
+
+    def load_weights(self, weights: Iterable[tuple[str, torch.Tensor]]):
+        parameters = dict(self.named_parameters())
+        loaded = set()
+        for name, value in weights:
+            if name.startswith("text_model.model."):
+                target = name.removeprefix("text_model.model.")
+                if target == "embeddings.weight":
+                    target = "embed_tokens.weight"
+            elif name == "text_model.lm_head.weight" and not self.tie_word_embeddings:
+                target = "lm_head.weight"
+            else:
+                continue
+            if target not in parameters:
+                raise ValueError(f"Unexpected Fish Torch/MPS text weight: {name}")
+            parameter = parameters[target]
+            if parameter.shape != value.shape:
+                raise ValueError(f"Fish Torch/MPS weight shape mismatch: {name}")
+            parameter.data.copy_(value)
+            loaded.add(target)
+        missing = parameters.keys() - loaded
+        if missing:
+            raise ValueError(f"Missing Fish Torch/MPS weights: {sorted(missing)}")
+        return loaded
+
+    def clear_request(self, request_id: str) -> None:
+        self._request_caches.pop(request_id, None)
+
+    def _sample_semantic_choice(self, probs, seeds, positions):
+        # The upstream seeded sampler uses uint64 and float64, unsupported by
+        # MPS. Only its small top-k distribution crosses to CPU; preserve its
+        # exact hash/Gumbel algorithm without invoking torch.compile.
+        if int(seeds[0]) < 0:
+            return torch.multinomial(probs, num_samples=1)
+        return seeded_choice(probs, seeds, positions)
+
+    @torch.inference_mode()
+    def forward_native(
+        self, input_ids, *, request_id, input_embeds=None, prefill=False
+    ):
+        if prefill:
+            self._request_caches.clear()
+            previous = [None] * len(self.layers)
+            offset = 0
+        else:
+            if request_id not in self._request_caches:
+                raise RuntimeError(f"Fish Torch/MPS has no cache for {request_id}")
+            previous = self._request_caches[request_id]
+            offset = previous[0][0].shape[1]
+        if input_ids.ndim != 1 or (not prefill and input_ids.numel() != 1):
+            raise ValueError("Fish Torch/MPS requires one unchunked request")
+        end = offset + input_ids.numel()
+        if end > self.freqs_cis.shape[0]:
+            raise ValueError("Fish Torch/MPS request exceeds the RoPE context")
+        x = self.embed_tokens(input_ids) if input_embeds is None else input_embeds
+        if input_embeds is None and not prefill and self._vq_ready:
+            codes = self._vq_codes[:1] + self._vq_codebook_offsets[None]
+            combined = (x + self._vq_codebook_embeddings(codes).sum(1)) * self._vq_scale
+            x = torch.where(self._vq_mask[:1, None], combined, x)
+        x = x.unsqueeze(0)
+        freqs = self.freqs_cis[offset:end].to(x.device)
+        caches = []
+        for layer, cache in zip(self.layers, previous):
+            attn = layer.attention
+            h = layer.attention_norm(x)
+            q_size, kv_size = (
+                attn.n_head * attn.head_dim,
+                attn.n_local_heads * attn.head_dim,
+            )
+            q, k, v = attn.wqkv(h).split([q_size, kv_size, kv_size], dim=-1)
+            q = q.view(1, h.shape[1], attn.n_head, attn.head_dim)
+            k = k.view(1, h.shape[1], attn.n_local_heads, attn.head_dim)
+            v = v.view(1, h.shape[1], attn.n_local_heads, attn.head_dim)
+            if attn.attention_qk_norm:
+                q, k = attn.q_norm(q), attn.k_norm(k)
+            q, k = apply_rotary_emb(q, freqs), apply_rotary_emb(k, freqs)
+            if cache is not None:
+                k, v = torch.cat((cache[0], k), dim=1), torch.cat((cache[1], v), dim=1)
+            caches.append((k, v))
+            h = sdpa_attention(q, k, v, causal=prefill).reshape(1, h.shape[1], q_size)
+            x = x + attn.wo(h)
+            x = x + layer.feed_forward(layer.ffn_norm(x))
+        hidden = self.norm(x[:, -1])
+        logits = (
+            F.linear(hidden, self.embed_tokens.weight)
+            if self.tie_word_embeddings
+            else self.lm_head(hidden)
+        )
+        if self._vq_ready:
+            self._decode_codebooks(logits, hidden)
+        self._request_caches[request_id] = caches
+        return logits, hidden
+
+
+class FishS2ProTorchMpsRunner(FishS2ProModelRunner):
+    """Preserve Fish request/stream adapters and scheduler-owned completion."""
+
+    def lookahead_eligible(self, batch):
+        return False
+
+    def _forward_native(self, forward_batch, schedule_batch, requests, *, prefill):
+        from sglang.srt.managers.scheduler import GenerationBatchResult
+
+        if len(requests) != 1:
+            raise RuntimeError("Fish Torch/MPS requires max_running_requests=1")
+        self.model.forward_native(
+            schedule_batch.input_ids,
+            request_id=requests[0].request_id,
+            input_embeds=forward_batch.input_embeds if prefill else None,
+            prefill=prefill,
+        )
+        return GenerationBatchResult(
+            logits_output=None,
+            next_token_ids=self.model._output_semantic_ids[:1].clone(),
+            can_run_cuda_graph=False,
+        )
+
+    def custom_prefill_forward(self, forward_batch, schedule_batch, requests):
+        return self._forward_native(
+            forward_batch, schedule_batch, requests, prefill=True
+        )
+
+    def custom_decode_forward(self, forward_batch, schedule_batch, requests):
+        return self._forward_native(
+            forward_batch, schedule_batch, requests, prefill=False
+        )
+
+    def on_request_finished(self, request_id, req_data):
+        self.model.clear_request(request_id)
+
+    def abort_request(self, request_id):
+        self.model.clear_request(request_id)

--- a/sglang_omni/serve/openai_errors.py
+++ b/sglang_omni/serve/openai_errors.py
@@ -31,6 +31,7 @@ _BAD_REQUEST_PATTERNS = (
     re.compile(
         r"\bAuK (?:nfe|cfg_strength|sway_sampling_coef|max_seconds) is a server-level setting"
     ),
+    re.compile(r"^S2-Pro top_k must be -1 or between 1 and 30; got "),
     re.compile(r"^Request\s+\S+\s+exceeds the maximum number of tokens:"),
     re.compile(r"^Request\s+\S+\s+requires too many SWA KV tokens for"),
     re.compile(r"^stop_regex is \d+ bytes, over the \d+-byte limit"),

--- a/tests/test_model/test_fish_apple.py
+++ b/tests/test_model/test_fish_apple.py
@@ -1,0 +1,135 @@
+# SPDX-License-Identifier: Apache-2.0
+"""Opt-in HTTP checks against an already running Fish Apple server.
+
+FISH_APPLE_URL=http://127.0.0.1:18170 pytest tests/test_model/test_fish_apple.py -q
+"""
+
+from __future__ import annotations
+
+import base64
+import io
+import os
+import time
+from concurrent.futures import ThreadPoolExecutor
+
+import numpy as np
+import pytest
+import requests
+import soundfile as sf
+
+URL = os.environ.get("FISH_APPLE_URL", "").rstrip("/")
+pytestmark = pytest.mark.skipif(
+    not URL, reason="set FISH_APPLE_URL for live Apple tests"
+)
+TEXT = "Hello! This is a local speech test."
+
+
+def speech(**kwargs):
+    return requests.post(
+        f"{URL}/v1/audio/speech",
+        json={"input": TEXT, "max_new_tokens": 100, "seed": 42, **kwargs},
+        timeout=180,
+    )
+
+
+def waveform(response):
+    assert response.status_code == 200, (
+        response.text[:500] if response.status_code != 200 else ""
+    )
+    audio, sr = sf.read(io.BytesIO(response.content))
+    assert sr == 44100
+    assert audio.ndim == 1 and 0.25 < len(audio) / sr < 10
+    assert np.isfinite(audio).all() and np.max(np.abs(audio)) > 1e-3
+    return audio, sr
+
+
+@pytest.fixture(scope="module")
+def baseline():
+    response = speech()
+    waveform(response)
+    return response
+
+
+def test_seeded_requests_repeat(baseline):
+    repeated = speech()
+    audio, _ = waveform(repeated)
+    original, _ = waveform(baseline)
+    np.testing.assert_array_equal(audio, original)
+
+
+def test_reference_audio_cloning(baseline):
+    response = speech(
+        input="Welcome back. The voice reference is ready.",
+        references=[
+            {
+                "data": base64.b64encode(baseline.content).decode("ascii"),
+                "media_type": "audio/wav",
+                "text": TEXT,
+            }
+        ],
+    )
+    waveform(response)
+
+
+def test_streaming_pcm_is_bounded_and_complete(baseline):
+    chunks = []
+    with requests.post(
+        f"{URL}/v1/audio/speech",
+        json={
+            "input": TEXT,
+            "max_new_tokens": 100,
+            "seed": 42,
+            "stream": True,
+            "response_format": "pcm",
+        },
+        stream=True,
+        timeout=180,
+    ) as response:
+        assert response.status_code == 200
+        for chunk in response.iter_content(chunk_size=None):
+            if chunk:
+                chunks.append(chunk)
+    pcm = np.frombuffer(b"".join(chunks), dtype="<i2")
+    original, sr = waveform(baseline)
+    assert len(chunks) >= 2
+    assert abs(len(pcm) - len(original)) <= sr * 0.1
+    assert np.max(np.abs(pcm.astype(np.int32))) > 32
+
+
+def test_concurrent_requests_queue_and_complete():
+    with ThreadPoolExecutor(max_workers=2) as pool:
+        responses = list(
+            pool.map(
+                lambda text: speech(input=text), ["Good morning.", "Good evening."]
+            )
+        )
+    for response in responses:
+        waveform(response)
+
+
+def test_disconnect_recovers():
+    with requests.post(
+        f"{URL}/v1/audio/speech",
+        json={
+            "input": "This is a longer sentence. " * 12,
+            "max_new_tokens": 200,
+            "stream": True,
+            "response_format": "pcm",
+            "seed": 9,
+        },
+        stream=True,
+        timeout=180,
+    ) as response:
+        assert response.status_code == 200
+        assert next(response.iter_content(chunk_size=4096))
+    deadline = time.monotonic() + 20
+    while requests.get(f"{URL}/health", timeout=5).json()["pending_completions"]:
+        assert time.monotonic() < deadline
+        time.sleep(0.1)
+    waveform(speech(input="Ready again."))
+
+
+def test_invalid_sampling_leaves_server_healthy():
+    response = speech(top_k=31)
+    assert response.status_code == 400, response.text
+    requests.get(f"{URL}/health", timeout=10).raise_for_status()

--- a/tests/unit_test/fishaudio_s2_pro/test_mlx.py
+++ b/tests/unit_test/fishaudio_s2_pro/test_mlx.py
@@ -1,0 +1,212 @@
+# SPDX-License-Identifier: Apache-2.0
+"""Numerical checks for the native Fish MLX networks and cache lifecycle."""
+import os
+from types import SimpleNamespace
+
+import numpy as np
+import pytest
+import torch
+
+mx = pytest.importorskip("mlx.core")
+if not mx.metal.is_available():
+    pytest.skip("requires Apple Metal", allow_module_level=True)
+
+from sglang_omni.models.fishaudio_s2_pro.fish_speech.models.text2semantic.audio_decoder import (
+    FishQwen3AudioDecoder,
+)
+from sglang_omni.models.fishaudio_s2_pro.fish_speech.models.text2semantic.configuration import (
+    FishQwen3AudioDecoderConfig,
+    FishQwen3Config,
+)
+from sglang_omni.models.fishaudio_s2_pro.mlx.model import FishModel, to_mlx, to_torch
+from sglang_omni.models.fishaudio_s2_pro.torch_mps import S2ProTorchMpsTextModel
+
+
+def models():
+    torch.manual_seed(73)
+    common = dict(
+        dim=32,
+        n_layer=2,
+        n_head=4,
+        n_local_heads=2,
+        head_dim=8,
+        intermediate_size=48,
+        max_seq_len=32,
+        use_moe=False,
+    )
+    text_config = FishQwen3Config(vocab_size=64, attention_qk_norm=True, **common)
+    audio_config = FishQwen3AudioDecoderConfig(
+        vocab_size=8, text_dim=32, num_codebooks=3, attention_qk_norm=False, **common
+    )
+    text = S2ProTorchMpsTextModel(SimpleNamespace(text_config=text_config)).eval()
+    audio = FishQwen3AudioDecoder(audio_config).eval()
+    native = FishModel(
+        dict(
+            text_config=text_config.to_dict(),
+            audio_decoder_config=audio_config.to_dict(),
+        )
+    )
+    weights = [
+        ("text_model.model." + k.replace("embed_tokens.", "embeddings."), to_mlx(v))
+        for k, v in text.named_parameters()
+    ]
+    weights += [("audio_decoder." + k, to_mlx(v)) for k, v in audio.named_parameters()]
+    native.load_weights(weights, strict=True)
+    native.eval()
+    return text, audio, native
+
+
+def test_native_slow_matches_torch_and_cached_prefill():
+    text, _, native = models()
+    tokens = torch.tensor([1, 5, 8, 3, 2])
+    expected, _ = text.forward_native(tokens, request_id="r", prefill=True)
+    cache = native.text_model.model.make_cache()
+    embeds = native.text_model.model.embeddings(to_mlx(tokens))
+    native.text_model(embeds[None, :3], cache)
+    native.text_model(embeds[None, 3:4], cache)
+    actual, _ = native.text_model(embeds[None, 4:], cache)
+    full, _ = native.text_model(embeds[None], native.text_model.model.make_cache())
+    # M5 MLX defaults to reduced-precision FP32 GEMM (TF32), whose ~1e-3
+    # relative error lands near 2e-2 on these logits (|max| ~ 20). Tolerate that
+    # against the logit scale rather than absolutely; a real port bug is O(1).
+    # Run with MLX_ENABLE_TF32=0 for the strict cross-framework check.
+    strict = os.environ.get("MLX_ENABLE_TF32") == "0"
+    atol, rtol = (2e-5, 2e-5) if strict else (5e-2, 2e-3)
+    torch.testing.assert_close(to_torch(actual), expected, atol=atol, rtol=rtol)
+    torch.testing.assert_close(to_torch(actual), to_torch(full), atol=atol, rtol=rtol)
+    assert all(state.offset == 5 for state in cache)
+
+
+def test_reference_codebook_embedding_matches_torch():
+    _, audio, native = models()
+    text = torch.randn(2, 32)
+    codes = torch.tensor([[1, 2, 3], [4, 2, 0]])
+    expected = (
+        text + audio.codebook_embeddings(codes + audio.codebook_offsets).sum(1)
+    ) / 4**0.5
+    actual = native.audio_decoder.mix_embeddings(to_mlx(text), to_mlx(codes))
+    torch.testing.assert_close(to_torch(actual), expected, atol=1e-6, rtol=1e-6)
+
+
+def test_native_fast_chain_matches_mps_and_resets_every_frame():
+    _, audio, native = models()
+    audio = audio.to("mps")
+    audio.setup_caches(1, dtype=torch.float32)
+    hidden = torch.randn(1, 32)
+    for semantic_code in [2, 0, 2]:
+        audio.reset_caches()
+        audio.forward_kvcached(audio.project_in(hidden.to("mps"))[:, None], 0)
+        code = torch.tensor([semantic_code], device="mps")
+        expected = [semantic_code]
+        for index in range(1, 3):
+            logits = audio.forward_kvcached(audio.embeddings(code)[:, None], index)
+            code = logits[:, 0].argmax(-1)
+            expected.append(code.item())
+        actual = native.audio_decoder.generate(to_mlx(hidden), semantic_code)
+        assert np.array(actual).tolist() == [expected]
+
+
+def test_native_loader_rejects_missing_extra_and_wrong_shapes(tmp_path):
+    import json
+
+    from mlx.utils import tree_flatten
+
+    _, _, native = models()
+    (tmp_path / "config.json").write_text(json.dumps(native._config))
+    weights = dict(tree_flatten(native.parameters()))
+    path = str(tmp_path / "model.safetensors")
+    mx.save_safetensors(path, weights)
+    loaded = FishModel.from_pretrained(tmp_path)
+    assert len(tree_flatten(loaded.parameters())) == len(weights)
+    name = next(iter(weights))
+    for malformed in [
+        {key: value for key, value in weights.items() if key != name},
+        {**weights, "unexpected.weight": mx.zeros((1,))},
+        {**weights, name: mx.zeros((1,))},
+    ]:
+        mx.save_safetensors(path, malformed)
+        with pytest.raises(ValueError):
+            FishModel.from_pretrained(tmp_path)
+
+
+def test_native_request_reference_feedback_and_cache_cleanup():
+    from sglang_omni.models.fishaudio_s2_pro.mlx.runner import (
+        FishMlxModel,
+        FishMlxSchedulerRunner,
+    )
+
+    _, _, native = models()
+    model = object.__new__(FishMlxModel)
+    torch.nn.Module.__init__(model)
+    model.native = native
+    model.vocab_size = 64
+    model.context_length = 32
+    model._request_caches = {}
+    model.configure(
+        SimpleNamespace(semantic_begin_id=32, semantic_end_id=39, eos_token_ids=[40]),
+        16,
+    )
+    model._sampling_seeds.fill_(42)
+    request = SimpleNamespace(
+        request_id="r",
+        data=SimpleNamespace(
+            req=SimpleNamespace(
+                prefix_indices=[], origin_input_ids=[1, 33, 34, 5], output_ids=[]
+            ),
+            vq_parts=[torch.tensor([[1, 2], [3, 4], [5, 6]])],
+            vq_mask_tokens=torch.tensor([False, True, True, False]),
+            last_codebook_values=None,
+        ),
+    )
+    model.forward_request(request, prefill=True)
+    assert model._request_caches["r"][0].offset == 4
+    assert model._output_codes.shape == (1, 4)
+    # Explicit semantic feedback makes this branch independent of the sampled
+    # EOS choice of the random tiny checkpoint.
+    request.data.req.output_ids = [33]
+    request.data.last_codebook_values = torch.tensor([1, 2, 3])
+    model.forward_request(request, prefill=False)
+    assert model._request_caches["r"][0].offset == 5
+    runner = object.__new__(FishMlxSchedulerRunner)
+    runner.model = model
+    runner.abort_request("r")
+    assert not model._request_caches
+    runner.abort_request("r")
+    with pytest.raises(RuntimeError, match="no cache"):
+        model.forward_request(request, prefill=False)
+    model.forward_request(request, prefill=True)
+    runner.on_request_finished("r", None)
+    assert not model._request_caches
+
+
+def test_native_profile_rejects_unsafe_overrides(monkeypatch):
+    import sglang.srt.hardware_backend.mlx.runtime as mlx_runtime
+
+    from sglang_omni.models.fishaudio_s2_pro.engine_builder import (
+        FishS2ProEngineBuilder,
+    )
+
+    monkeypatch.setattr(mlx_runtime, "use_mlx", lambda: True)
+    builder = FishS2ProEngineBuilder(max_new_tokens=32, ras_window=16)
+    defaults = builder.generation_defaults(dtype="bfloat16")
+    builder.adjust_overrides(defaults)
+    for key, value in [
+        ("max_running_requests", 2),
+        ("quantization", "int8"),
+        ("disable_radix_cache", False),
+        ("chunked_prefill_size", 128),
+    ]:
+        with pytest.raises(ValueError, match="Fish Apple requires"):
+            builder.adjust_overrides({**defaults, key: value})
+
+
+def test_native_mlx_requires_apple_metal(monkeypatch):
+    import sglang.srt.hardware_backend.mlx.runtime as mlx_runtime
+
+    from sglang_omni.models.fishaudio_s2_pro import engine_builder
+
+    monkeypatch.setattr(mlx_runtime, "use_mlx", lambda: True)
+    monkeypatch.setattr(engine_builder.current_platform, "is_mps", lambda: False)
+    builder = engine_builder.FishS2ProEngineBuilder(max_new_tokens=32, ras_window=16)
+    with pytest.raises(ValueError, match="Fish MLX requires Apple Metal"):
+        builder.pre_infra_setup("unused")

--- a/tests/unit_test/fishaudio_s2_pro/test_mlx.py
+++ b/tests/unit_test/fishaudio_s2_pro/test_mlx.py
@@ -210,3 +210,33 @@ def test_native_mlx_requires_apple_metal(monkeypatch):
     builder = engine_builder.FishS2ProEngineBuilder(max_new_tokens=32, ras_window=16)
     with pytest.raises(ValueError, match="Fish MLX requires Apple Metal"):
         builder.pre_infra_setup("unused")
+
+
+def test_registry_adapter_binds_fish_model_and_preserves_cache_ownership(monkeypatch):
+    from sglang.srt.runtime_context import get_context
+
+    from sglang_omni.model_runner.mlx_model_worker import (
+        _create_registered_runner,
+        resolve_mlx_runner_factory,
+    )
+    from sglang_omni.models.fishaudio_s2_pro.mlx import runner
+
+    calls = []
+    model = SimpleNamespace(clear_request=lambda rid: calls.append(rid))
+
+    def create_model(path, *, context_length):
+        assert path == "checkpoint" and context_length == 4096
+        return model
+
+    monkeypatch.setattr(runner, "FishMlxModel", create_model)
+    factory = resolve_mlx_runner_factory("FishS2ProMlxModel")
+    with get_context().override_server_args(
+        model_path="checkpoint", context_length=4096, max_total_tokens=4096
+    ):
+        adapter = _create_registered_runner(factory())
+    assert adapter.scheduler_model is model
+    assert adapter.pool_size == 4096
+    adapter.prepare_for_kv_cache_release(SimpleNamespace(rid="r"))
+    # Preparing a release must not prematurely clear Fish's native state;
+    # completion/abort owns that operation.
+    assert calls == []

--- a/tests/unit_test/fishaudio_s2_pro/test_npu_adaptation.py
+++ b/tests/unit_test/fishaudio_s2_pro/test_npu_adaptation.py
@@ -114,7 +114,7 @@ def test_fast_ar_attention_rejects_unsupported_device_clearly() -> None:
     k_cache = torch.zeros(1, 11, 4, 8)
     v_cache = torch.zeros(1, 11, 4, 8)
 
-    with pytest.raises(RuntimeError, match="supports CUDA and NPU"):
+    with pytest.raises(RuntimeError, match="supports CUDA, NPU, and MPS"):
         fish_audio_decoder.flash_attn_kvcache_op(
             q=q,
             k_cache=k_cache,

--- a/tests/unit_test/fishaudio_s2_pro/test_torch_mps.py
+++ b/tests/unit_test/fishaudio_s2_pro/test_torch_mps.py
@@ -1,0 +1,191 @@
+# SPDX-License-Identifier: Apache-2.0
+"""Numerical and lifecycle coverage for Fish's bounded Apple runner."""
+
+from types import SimpleNamespace
+
+import pytest
+import torch
+
+from sglang_omni.models.fishaudio_s2_pro.engine_builder import FishS2ProEngineBuilder
+from sglang_omni.models.fishaudio_s2_pro.fish_speech.models.text2semantic.configuration import (
+    FishQwen3Config,
+)
+from sglang_omni.models.fishaudio_s2_pro.torch_mps import (
+    FishS2ProTorchMpsRunner,
+    S2ProTorchMpsTextModel,
+    fast_attention,
+)
+
+
+def tiny_model():
+    torch.manual_seed(19)
+    config = FishQwen3Config(
+        vocab_size=64,
+        dim=32,
+        n_layer=2,
+        n_head=4,
+        n_local_heads=2,
+        head_dim=8,
+        intermediate_size=48,
+        max_seq_len=32,
+        attention_qk_norm=True,
+    )
+    return S2ProTorchMpsTextModel(SimpleNamespace(text_config=config)).eval()
+
+
+@pytest.mark.parametrize("device", ["cpu", "mps"])
+def test_cached_decode_matches_full_prefill(device):
+    if device == "mps" and not torch.backends.mps.is_available():
+        pytest.skip("requires Apple Metal")
+    model = tiny_model().to(device)
+    tokens = torch.tensor([1, 4, 9, 3, 8], device=device)
+    model.forward_native(tokens[:3], request_id="a", prefill=True)
+    model.forward_native(tokens[3:4], request_id="a")
+    cached, _ = model.forward_native(tokens[4:], request_id="a")
+    full, _ = model.forward_native(tokens, request_id="b", prefill=True)
+    torch.testing.assert_close(cached, full, atol=2e-5, rtol=2e-5)
+    assert set(model._request_caches) == {"b"}
+
+
+@pytest.mark.parametrize("device", ["cpu", "mps"])
+def test_fast_attention_masks_uninitialized_slots_and_matches_manual_gqa(device):
+    if device == "mps" and not torch.backends.mps.is_available():
+        pytest.skip("requires Apple Metal")
+    from sglang_omni.models.fishaudio_s2_pro.fish_speech.models.text2semantic.audio_decoder import (
+        flash_attn_kvcache_op,
+    )
+
+    torch.manual_seed(9)
+    keys, values = torch.randn(1, 3, 2, 8).to(device), torch.randn(1, 3, 2, 8).to(
+        device
+    )
+    q = torch.randn(1, 1, 4, 8).to(device)
+    kc, vc = torch.full((1, 11, 2, 8), float("nan"), device=device), torch.full(
+        (1, 11, 2, 8), float("nan"), device=device
+    )
+    attention = flash_attn_kvcache_op if device == "mps" else fast_attention
+    for i in range(3):
+        actual = attention(
+            q, kc, vc, keys[:, i : i + 1], values[:, i : i + 1], cache_position=i
+        )
+    k = keys.repeat_interleave(2, dim=2).transpose(1, 2)
+    v = values.repeat_interleave(2, dim=2).transpose(1, 2)
+    probs = (q.transpose(1, 2) @ k.transpose(-2, -1) / 8**0.5).softmax(-1)
+    expected = (probs @ v).transpose(1, 2)
+    torch.testing.assert_close(actual, expected)
+
+
+def test_weight_loader_requires_complete_matching_checkpoint():
+    source, target = tiny_model(), tiny_model()
+    weights = [
+        ("text_model.model." + k.replace("embed_tokens.", "embeddings."), v)
+        for k, v in source.named_parameters()
+    ]
+    target.load_weights(iter(weights))
+    for key, value in source.state_dict().items():
+        torch.testing.assert_close(target.state_dict()[key], value)
+    with pytest.raises(ValueError, match="Missing Fish"):
+        target.load_weights(iter(weights[:-1]))
+    with pytest.raises(ValueError, match="Unexpected Fish"):
+        target.load_weights(iter([("text_model.model.unexpected", torch.zeros(1))]))
+    with pytest.raises(ValueError, match="shape mismatch"):
+        target.load_weights(iter([(weights[0][0], torch.zeros(1))]))
+
+
+def test_completion_and_abort_release_native_caches():
+    model = tiny_model()
+    runner = object.__new__(FishS2ProTorchMpsRunner)
+    runner.model = model
+    for finish in [
+        lambda: runner.on_request_finished("r", None),
+        lambda: runner.abort_request("r"),
+    ]:
+        model.forward_native(torch.tensor([1, 2]), request_id="r", prefill=True)
+        finish()
+        assert not model._request_caches
+        finish()  # Cleanup is idempotent.
+        with pytest.raises(RuntimeError, match="no cache"):
+            model.forward_native(torch.tensor([3]), request_id="r")
+
+
+@pytest.mark.parametrize(
+    "key,value",
+    [
+        ("max_running_requests", 2),
+        ("disable_radix_cache", False),
+        ("chunked_prefill_size", 128),
+        ("quantization", "int8"),
+        ("enable_torch_compile", True),
+    ],
+)
+def test_apple_profile_rejects_unqualified_overrides(key, value):
+    builder = FishS2ProEngineBuilder(max_new_tokens=32, ras_window=16)
+    builder.device = "mps"
+    overrides = builder.generation_defaults(dtype="bfloat16")
+    builder.adjust_overrides(overrides)
+    overrides[key] = value
+    with pytest.raises(ValueError, match="Fish Torch/MPS requires"):
+        builder.adjust_overrides(overrides)
+
+
+def test_native_mlx_switch_fails_before_loading(monkeypatch):
+    import sglang.srt.hardware_backend.mlx.runtime as mlx_runtime
+
+    monkeypatch.setattr(mlx_runtime, "use_mlx", lambda: True)
+    builder = FishS2ProEngineBuilder(max_new_tokens=32, ras_window=16)
+    with pytest.raises(ValueError, match="native MLX is not implemented"):
+        builder.pre_infra_setup("unused")
+
+
+@pytest.mark.parametrize("device", ["cpu", "mps"])
+@pytest.mark.parametrize(
+    "seed,step,expected", [(42, 17, 1), (0, 0, 2), (2**40 + 3, 19, 1), (42, 18, 2)]
+)
+def test_seeded_sampler_matches_independent_murmur3_vectors(
+    device, seed, step, expected
+):
+    if device == "mps" and not torch.backends.mps.is_available():
+        pytest.skip("requires Apple Metal")
+    # Expected draws calculated with mmh3.hash(struct.pack('<QII', seed,
+    # step, column), signed=False) and the documented Gumbel transform.
+    model = tiny_model()
+    probs = torch.tensor([[0.15, 0.25, 0.6]])
+    seeds, steps = torch.tensor([seed]), torch.tensor([step])
+    actual = model._sample_semantic_choice(
+        probs.to(device), seeds.to(device), steps.to(device)
+    )
+    assert actual.item() == expected
+
+
+@pytest.mark.parametrize(
+    "device,expected", [("mps", "S2ProTorchMpsTextModel"), ("cuda:0", None)]
+)
+def test_apple_device_selects_the_native_architecture(monkeypatch, device, expected):
+    from sglang_omni.models.fishaudio_s2_pro import bootstrap as fish_bootstrap
+
+    monkeypatch.setattr(fish_bootstrap, "patch_fish_config_for_sglang", lambda: None)
+    builder = FishS2ProEngineBuilder(max_new_tokens=32, ras_window=16)
+    builder.device = device
+    builder.pre_infra_setup("unused")
+    assert builder.model_arch_override == expected
+
+
+def test_apple_runner_supplies_the_scheduler_abort_callback(monkeypatch):
+    import sglang_omni.models.fishaudio_s2_pro.torch_mps as torch_mps
+
+    class StubRunner:
+        def __init__(self, model_worker, output_proc):
+            self.model_worker = model_worker
+            self.output_proc = output_proc
+
+        def abort_request(self, request_id):
+            raise AssertionError("not called")
+
+    monkeypatch.setattr(torch_mps, "FishS2ProTorchMpsRunner", StubRunner)
+    builder = FishS2ProEngineBuilder(max_new_tokens=32, ras_window=16)
+    builder.device = "mps"
+    assert builder.make_abort_callback() is None
+
+    runner = builder.make_model_runner("worker", "output")
+    assert isinstance(runner, StubRunner)
+    assert builder.make_abort_callback() == runner.abort_request

--- a/tests/unit_test/fishaudio_s2_pro/test_torch_mps.py
+++ b/tests/unit_test/fishaudio_s2_pro/test_torch_mps.py
@@ -124,17 +124,20 @@ def test_apple_profile_rejects_unqualified_overrides(key, value):
     overrides = builder.generation_defaults(dtype="bfloat16")
     builder.adjust_overrides(overrides)
     overrides[key] = value
-    with pytest.raises(ValueError, match="Fish Torch/MPS requires"):
+    with pytest.raises(ValueError, match="Fish Apple requires"):
         builder.adjust_overrides(overrides)
 
 
-def test_native_mlx_switch_fails_before_loading(monkeypatch):
+def test_native_mlx_switch_selects_native_architecture(monkeypatch):
     import sglang.srt.hardware_backend.mlx.runtime as mlx_runtime
 
+    from sglang_omni.models.fishaudio_s2_pro import engine_builder
+
     monkeypatch.setattr(mlx_runtime, "use_mlx", lambda: True)
+    monkeypatch.setattr(engine_builder.current_platform, "is_mps", lambda: True)
     builder = FishS2ProEngineBuilder(max_new_tokens=32, ras_window=16)
-    with pytest.raises(ValueError, match="native MLX is not implemented"):
-        builder.pre_infra_setup("unused")
+    builder.pre_infra_setup("unused")
+    assert builder.model_arch_override == "FishS2ProMlxModel"
 
 
 @pytest.mark.parametrize("device", ["cpu", "mps"])

--- a/tests/unit_test/fishaudio_s2_pro/test_tts.py
+++ b/tests/unit_test/fishaudio_s2_pro/test_tts.py
@@ -298,6 +298,9 @@ def test_fish_s2pro_accepts_default_top_k_sentinel() -> None:
 def test_fish_s2pro_setup_vq_decode_allocates_sampling_state() -> None:
     model = SimpleNamespace(
         vocab_size=80,
+        setup_decode_buffers=lambda **kwargs: S2ProSGLangTextModel.setup_decode_buffers(
+            model, **kwargs
+        ),
         embed_tokens=SimpleNamespace(weight=torch.empty(1, device="cpu")),
     )
     audio_decoder = SimpleNamespace(
@@ -384,6 +387,9 @@ def test_fish_s2pro_decode_codebooks_keeps_eos_out_of_audio_embedding(
         _ras_top_p=torch.ones(1),
         _sampling_top_p=torch.ones(1),
         _sampling_rep_penalty=torch.ones(1),
+        _sample_semantic_token=lambda logits: S2ProSGLangTextModel._sample_semantic_token(
+            model, logits
+        ),
         _sample_semantic_choice=lambda probs, seeds, positions: S2ProSGLangTextModel._sample_semantic_choice(
             None, probs, seeds, positions
         ),
@@ -466,6 +472,9 @@ def test_fish_s2pro_seeded_sampler_preserves_probability_distribution() -> None:
         _ras_top_p=torch.ones(batch, device=device),
         _sampling_top_p=torch.ones(batch, device=device),
         _sampling_rep_penalty=torch.ones(batch, device=device),
+        _sample_semantic_token=lambda logits: S2ProSGLangTextModel._sample_semantic_token(
+            model, logits
+        ),
         _sample_semantic_choice=lambda probs, seeds, positions: S2ProSGLangTextModel._sample_semantic_choice(
             None, probs, seeds, positions
         ),

--- a/tests/unit_test/fishaudio_s2_pro/test_tts.py
+++ b/tests/unit_test/fishaudio_s2_pro/test_tts.py
@@ -384,6 +384,9 @@ def test_fish_s2pro_decode_codebooks_keeps_eos_out_of_audio_embedding(
         _ras_top_p=torch.ones(1),
         _sampling_top_p=torch.ones(1),
         _sampling_rep_penalty=torch.ones(1),
+        _sample_semantic_choice=lambda probs, seeds, positions: S2ProSGLangTextModel._sample_semantic_choice(
+            None, probs, seeds, positions
+        ),
         _sampling_seeds=torch.full((1,), -1, dtype=torch.long),
         _step_count=torch.zeros(1, dtype=torch.long),
         _rep_positions=torch.arange(4),
@@ -463,6 +466,9 @@ def test_fish_s2pro_seeded_sampler_preserves_probability_distribution() -> None:
         _ras_top_p=torch.ones(batch, device=device),
         _sampling_top_p=torch.ones(batch, device=device),
         _sampling_rep_penalty=torch.ones(batch, device=device),
+        _sample_semantic_choice=lambda probs, seeds, positions: S2ProSGLangTextModel._sample_semantic_choice(
+            None, probs, seeds, positions
+        ),
         _sampling_seeds=torch.arange(1, batch + 1, dtype=torch.long, device=device),
         _step_count=torch.zeros(batch, dtype=torch.long, device=device),
         _rep_positions=torch.arange(4, device=device),

--- a/tests/unit_test/model_runner/test_mlx_runner_registry.py
+++ b/tests/unit_test/model_runner/test_mlx_runner_registry.py
@@ -1,0 +1,108 @@
+# SPDX-License-Identifier: Apache-2.0
+"""Lazy registration and compatibility with standard/custom MLX runners."""
+from types import SimpleNamespace
+
+import pytest
+
+from sglang_omni.model_runner import mlx_model_worker as worker
+
+
+@pytest.mark.parametrize(
+    "architecture,module,attribute",
+    [
+        (
+            "Qwen3ASRForConditionalGeneration",
+            "sglang_omni.models.qwen3_asr.mlx.runner",
+            "make_qwen3_asr_mlx_runner_class",
+        ),
+        (
+            "FishS2ProMlxModel",
+            "sglang_omni.models.fishaudio_s2_pro.mlx.runner",
+            "make_fish_mlx_runner_class",
+        ),
+    ],
+)
+def test_resolution_imports_only_selected_model(
+    monkeypatch, architecture, module, attribute
+):
+    calls = []
+    sentinel = object()
+
+    def import_selected(name):
+        calls.append(name)
+        return SimpleNamespace(**{attribute: sentinel})
+
+    monkeypatch.setattr(worker, "import_module", import_selected)
+    assert worker.resolve_mlx_runner_factory(architecture) is sentinel
+    assert calls == [module]
+
+
+@pytest.mark.parametrize("architecture", [None, "UnknownModel"])
+def test_unknown_architecture_fails_before_import(monkeypatch, architecture):
+    def unexpected_import(name):
+        pytest.fail(f"Unexpected import: {name}")
+
+    monkeypatch.setattr(worker, "import_module", unexpected_import)
+    with pytest.raises(NotImplementedError, match="supported architectures:"):
+        worker.resolve_mlx_runner_factory(architecture)
+
+
+def test_external_registration(monkeypatch):
+    monkeypatch.setattr(worker, "_MLX_RUNNER_FACTORIES", {})
+    worker.register_mlx_runner_factory("ExternalModel", "external.runner:factory")
+    factory = lambda: object
+    monkeypatch.setattr(
+        worker, "import_module", lambda name: SimpleNamespace(factory=factory)
+    )
+    assert worker.resolve_mlx_runner_factory("ExternalModel") is factory
+
+
+@pytest.mark.parametrize("pool_size", [None, 4096])
+def test_standard_runner_preserves_sglang_constructor(pool_size):
+    from sglang.srt.runtime_context import get_context
+
+    class Runner:
+        def __init__(self, **kwargs):
+            self.kwargs = kwargs
+
+    with get_context().override_server_args(
+        model_path="model",
+        trust_remote_code=False,
+        disable_radix_cache=True,
+        mem_fraction_static=0.5,
+        quantization=None,
+        revision="revision",
+        mlx_enable_sampling=False,
+        random_seed=42,
+        enable_deterministic_inference=True,
+        max_total_tokens=pool_size,
+    ):
+        runner = worker._create_registered_runner(Runner)
+    expected = dict(
+        model_path="model",
+        trust_remote_code=False,
+        disable_radix_cache=True,
+        mem_fraction_static=0.5,
+        quantization=None,
+        revision="revision",
+        enable_sampling=False,
+        sampling_rng_seed=42,
+        deterministic_seeding=True,
+    )
+    if pool_size is not None:
+        expected["pool_size"] = pool_size
+    assert runner.kwargs == expected
+
+
+def test_custom_runner_owns_initialization():
+    sentinel = object()
+
+    class Runner:
+        @classmethod
+        def from_runtime_config(cls):
+            return sentinel
+
+        def __init__(self, **kwargs):
+            pytest.fail("Standard constructor must not run for custom adapter")
+
+    assert worker._create_registered_runner(Runner) is sentinel

--- a/tests/unit_test/serve/test_speech_errors.py
+++ b/tests/unit_test/serve/test_speech_errors.py
@@ -9,6 +9,18 @@ from sglang_omni.admission import QueueFullError
 from sglang_omni.serve.speech_errors import speech_generation_error
 
 
+def test_fish_invalid_top_k_survives_pipeline_error_serialization() -> None:
+    # The coordinator reconstructs stage errors as RuntimeError across processes.
+    err = speech_generation_error(
+        RuntimeError("S2-Pro top_k must be -1 or between 1 and 30; got 31")
+    )
+    assert err.status_code == 400
+    assert err.error_type == "BadRequestError"
+
+    unrelated = speech_generation_error(RuntimeError("S2-Pro decoder failed"))
+    assert unrelated.status_code == 500
+
+
 @pytest.mark.parametrize(
     "exc",
     [QueueFullError(), RuntimeError(QueueFullError.MESSAGE)],


### PR DESCRIPTION
## Summary

Add Fish Audio S2-Pro serving on Apple Silicon through native MLX (`SGLANG_USE_MLX=1`) and Torch/MPS (`SGLANG_USE_MLX=0`). Both paths load the official unquantized BF16 checkpoint and preserve the existing speech API, reference-audio conditioning, streaming, and scheduler request lifecycle.

Related to #1967. Draft for review of the implementation and shared worker integration; broader quality and performance qualification remains outstanding.

Rebased onto `main` at 80b5aaed (SGLang-Omni 0.1.5), which carries the SGLang 0.5.19 bump (#2040) and the shared Apple ASR runners (#1981). See **Rebase onto 0.5.19** below for what that changed here and what was re-run.

## Implementation

- Torch/MPS: run Slow-AR with eager SDPA and a native request cache, and Fast-AR with attention over the initialized cache prefix. Preserve Fish's interleaved BF16 RoPE and codebook feedback.
- MLX: run both AR transformers and the complete greedy residual-codebook chain natively. Reuse the shared Fish semantic sampler on CPU, the CPU reference encoder, and the MPS codec decoder. No converted checkpoint or `mlx-audio` runtime dependency is required.
- Preserve seeded semantic sampling using the existing MurmurHash3/Gumbel algorithm without unsupported MPS uint64/float64 operations.
- Add the lazy MLX runner registry API used by #1960/#1991, with a Fish adapter for initialization, scheduler model binding, and cache-release ownership. Both the standard constructor path and the custom `from_runtime_config` adapter hook read the published 0.5.19 config bags rather than raw server args. Standard SGLang MLX runners retain their constructor/lifecycle contract. Fish-specific branches are removed from the shared worker.
- Classify invalid Fish `top_k` requests as HTTP 400 rather than 500.
- Document installation, backend selection, limitations, and opt-in HTTP tests.

The initial Apple profile permits one active request, queues additional requests, and uses a 4,096-token context. Quantization, radix caching, chunked prefill, CUDA graphs, compilation, and decode lookahead are disabled. This PR does not depend on the ASR-specific runners or prefill-ordering fix in #1981, which has since merged; the two only meet in the shared MLX worker.

## Rebase onto 0.5.19

Carrying the branch onto current `main` needed three adaptations, all in this PR's own code:

- Every `use_mlx` import moved from `sglang.srt.utils.tensor_bridge` to `sglang.srt.hardware_backend.mlx.runtime`, matching what #2040 did to the rest of the tree.
- The MLX worker's runner construction reads the published config bags (`get_model()`, `get_schedule()`, `get_device()`, `get_memory()`, `get_exec()`) instead of `server_args` attributes. The custom adapter hook is therefore `from_runtime_config()` with no arguments, not `from_server_args(server_args)`; its unit tests drive it through `get_context().override_server_args(...)`.
- The `top_k` bad-request pattern and the Apple installation note merged alongside main's new AuK server-level-setting pattern and its pinned-wheel platform text.

Re-run after the rebase on the 0.5.19 / Torch 2.13.0 Apple stack: the unit selection below (**196 passed, 1 skipped**, up from 190 as main added tests), `black`/`isort`/`autoflake`/`py_compile` over every changed file, and import checks of the new Torch/MPS and MLX modules. Six failures in `unit_test/model_runner/test_weight_share_load_path.py`, `unit_test/serve/test_mps_dp_support.py` and `unit_test/serve/test_openai_api.py` reproduce identically at `main` 80b5aaed on this host and are unrelated to this branch.

**Live HTTP re-run on 0.5.19, both backends.** Servers started from the documented cookbook command on the rebased head, after installing the documented `descript-audiotools==0.7.2` / `descript-audio-codec==1.0.0` pair into the 0.5.19 environment (again 25 pure additions; nothing downgraded or removed).

| backend | startup profile confirmed in log | `tests/test_model/test_fish_apple.py` | server-reported decode |
| --- | --- | --- | --- |
| MLX | MLX stub, `max_total_num_tokens=4096`, `max_running_requests=1` | 6 passed in 41.9 s | ~9.9–12.1 tok/s |
| Torch/MPS | `S2ProTorchMpsTextModel`, `attention_backend=torch_native`, 7.77 GB weights | 6 passed in 64.1 s | ~5.6–7.0 tok/s |

Each server logged exactly one traceback, in both cases the `top_k=31` rejection raised by `test_invalid_sampling` — the path this PR reclassifies as HTTP 400. No other errors.

**Intelligibility re-run.** Three English sentences per backend, all returned finite mono 44.1 kHz audio. Transcribed with Whisper `medium.en`: **word error rate 0.000 on both**. With `base.en` (the model used pre-rebase) MLX is 0.000 and Torch/MPS is 0.037: on one clip `base.en` and `small.en` hear "quick-brom" for "quick brown", which `medium.en` resolves correctly. That is one word on one utterance, consistent with this PR's documented finding that the two backends sample differently for the same seed, not a systematic defect — but it is why the earlier flat "0.000 on both" is now qualified by scorer.

The determinism and performance measurements further below were taken before the rebase, on the Torch 2.11 / SGLang 0.5.18 stack, and have not been re-measured; the decode-throughput column above is the only post-rebase performance figure.

## Validation

Hardware: Apple M5 Pro with 48 GB RAM. Checkpoint: `fishaudio/s2-pro` revision `1de9996b6be38b745688de084d87a5633f714e4e`. Everything below except the unit selection was measured pre-rebase on Torch 2.11.0, MLX 0.32.2 and SGLang 0.5.18; the unit selection was re-run on the 0.5.19 / Torch 2.13.0 stack.

**Unit and numerical.**

- Final registry/Fish/Qwen3-ASR MLX unit selection, including `tests/unit_test/serve/test_speech_errors.py`: **196 passed, 1 skipped** (the skip is CUDA-only) at the rebased head on SGLang 0.5.19. The same selection was 190 passed, 1 skipped before the rebase; main added the difference.
- Strict numerical checks ran with `MLX_ENABLE_TF32=0`. Coverage includes cached versus full prefill, MLX versus Torch Slow-AR, MLX versus MPS Fast-AR, reference embeddings, strict loading, seeded sampling, lazy registry dispatch, and cleanup.
- The seeded CPU sampler was diffed against `sglang/kernels/ops/sampling/murmur_hash.py` block for block: same four little-endian words, same mix and finalizer constants, same `h / UINT32_MAX` uniform, and the same clamp/negate/log ordering and float64 Gumbel as `sampler.py`.

**Live HTTP, both backends.** Servers started from the documented cookbook command, after installing the documented `descript-audiotools==0.7.2` / `descript-audio-codec==1.0.0` pair (25 pure additions; no downgrade to torch, numpy, MLX, SGLang, or transformers).

| backend | startup profile confirmed in log | `tests/test_model/test_fish_apple.py` |
| --- | --- | --- |
| MLX | MLX stub, `max_total_num_tokens=4096`, `max_running_requests=1` | 6 passed in 50.4 s |
| Torch/MPS | `S2ProTorchMpsTextModel`, `attention_backend=torch_native`, 7.57 GB weights | 6 passed in 52.6 s |

These exercise seeded repetition, reference audio, streaming PCM, queued concurrency, disconnect/recovery, and invalid sampling.

**Intelligibility.** Three English sentences per backend, transcribed with Whisper `base.en`: **word error rate 0.000 on both**, all clips finite mono 44.1 kHz stopping at EOS. English reference-conditioned and Chinese smoke clips were also checked with local Fun-ASR, which recovered the intended text ignoring punctuation. A reference-audio request as the first request on a fresh MPS server produced audio sample-for-sample identical to the previously verified reference-conditioned clip.

**Cross-backend determinism (measured, and a limitation).** With identical sampler state, an identical prompt, and identical teacher-forced decode inputs on the real checkpoint, the two Apple backends' semantic logits differ by at most **0.156 absolute**, one to two BF16 ULP at the magnitude of the top candidates (|logit| ≈ 13–17.5). Localizing that stage by stage under `inference_mode`: weights, embedding lookup, RMSNorm and the RoPE phase table are **bit-identical**; the QKV GEMM differs on a negligible fraction of elements; the divergence originates in the attention kernel, where `mx.fast.scaled_dot_product_attention` and the MPS `F.scaled_dot_product_attention` disagree on about 5–10% of elements by one ULP. Against an exact float64 reference each is within ~0.5 ULP, so neither is more correct — they simply round differently, and in float32 they agree to 1e-7. Through 36 layers this compounds only mildly, from ~1 ULP to ~3.5 ULP of the residual stream.

That irreducible residue is still enough to change the output: the sampled semantic token differed on 2 of 9 steps and the codebook rows on 6 of 9. Two mechanisms amplify it — the seeded draw indexes into `torch.topk` output order, so a one-ULP wobble (one step was an exact BF16 tie) remaps the same seed to a different token; and the greedy Fast-AR chain has no error tolerance, so one flipped argmax cascades through the remaining codebooks. Three of the diverging steps kept the *same* semantic token and still produced different codebooks.

**`seed` reproducibility is therefore per-backend and per-host, not portable across `SGLANG_USE_MLX`.** Same-backend, same-host repetition does hold and is covered by `test_seeded_requests_repeat`.

Applicable repository pre-commit hooks passed.

```bash
SGLANG_USE_MLX=0 MLX_ENABLE_TF32=0 python -m pytest \
  tests/unit_test/model_runner/test_mlx_runner_registry.py \
  tests/unit_test/fishaudio_s2_pro \
  tests/unit_test/qwen3_asr/test_mlx_model.py \
  tests/unit_test/qwen3_asr/test_mlx_scheduler_runner.py -q

# Against an already running Fish server; run once per backend.
FISH_APPLE_URL=http://127.0.0.1:8000 python -m pytest \
  tests/test_model/test_fish_apple.py -q
```

## Performance

These are smoke measurements on one host, not controlled throughput benchmarks. Both paths are slower than real time.

**End to end, through the HTTP API.** Wall time per second of generated audio, excluding ASR scoring:

| request | MLX | Torch/MPS |
| --- | ---: | ---: |
| Short plain TTS (3 sentences, 3.2–4.0 s of audio each) | 2.27× | 2.38× |
| One long-form paragraph (~50 s of audio) | 2.33× | 3.07× |
| Server-reported decode throughput, 250 → 1200 tokens | ~10.3 tok/s, flat | 9.8 → 6.6 tok/s |

On short utterances the two backends are within about 5% of each other. The gap opens with context length, not with the backend as such.

**Slow-AR decode latency versus context** (36 layers, BF16, batch 1, transformer only, real weights):

| prompt context | Torch/MPS | MLX |
| ---: | ---: | ---: |
| 32 | 37.3 ms | 33.7 ms |
| 256 | 42.9 ms | 35.0 ms |
| 1024 | 79.9 ms | 36.1 ms |
| 2048 | 138.3 ms | 38.1 ms |
| 3968 | 197.3 ms | 40.8 ms |

MLX is essentially flat (+21% over a 124× context increase); Torch/MPS grows 5.3×, reaching 4.8× slower at the profile's own 4,096-token bound.

The cause is one kernel. Isolating 36 layer-attentions at decode shapes `q(1,32,1,128) × k,v(1,8,N,128)` in BF16:

| N | `F.scaled_dot_product_attention` (MPS) | `mx.fast.scaled_dot_product_attention` |
| ---: | ---: | ---: |
| 1024 | 27.7 ms | 0.25 ms |
| 3968 | 131.3 ms | 0.34 ms |

131 ms of the 197 ms Torch/MPS step is that call: MLX has a dedicated single-query decode kernel and PyTorch's MPS backend does not. Neither `enable_gqa=True` (bit-exact on Torch 2.11 MPS, but no faster) nor a preallocated KV buffer closes the gap on its own; a grouped manual matmul flips the curve (81 ms at N=3968) but costs about 2× at short context and loses precision in a BF16 softmax. Left as follow-up work rather than fixed here.

**Memory.** MPS driver-allocated memory on the Torch/MPS path grows from 7.8 GiB to **16.5 GiB** across the 4,096-token context, against 8.6 → 10.5 GiB peak for MLX, even though the real KV at that length is only 585 MiB. The excess is churn: the per-layer cache is rebuilt with `torch.cat` every decode step and the attention materializes a 4×-expanded copy of it. A preallocated buffer plus `enable_gqa=True` is bit-identical to the current path and brings this to 13.5 GiB. The Torch/MPS path at full context does not fit a 16 GB machine.

**Where the time goes at short context.** One Fast-AR frame — 10 sequential single-token forwards through the 4-layer audio decoder — costs 35.2 ms on MLX and 50.6 ms on Torch/MPS, against 33.7 ms and 37.3 ms for the entire 36-layer Slow AR. The "fast" head is about half of per-token latency on both backends and is launch-bound, so it, not the Slow AR, is where further Apple optimization has to go for utterances under roughly 1,000 tokens.

## Remaining qualification

Not yet established: speaker-similarity/MOS evaluation, corpus-level transcription accuracy, long-form quality qualification, or cross-device numerical/voice-quality parity with CUDA. Because the two Apple backends already diverge from each other for a given seed, a future CUDA parity claim has to name which Apple backend it compares against. CUDA/NPU hardware execution was not available for this change; their existing sampler behavior is preserved by extraction and covered where possible by unit tests.



