### PR TITLE
[MUSA][Audar TTS] Add MUSA support for Audar TTS V1 Turbo

### DIFF
--- a/sglang_omni/models/audar_tts/stages.py
+++ b/sglang_omni/models/audar_tts/stages.py
@@ -52,10 +52,52 @@ class _ReferenceInput:
 def _load_codec(model: str, revision: str, device: str) -> Any:
     try:
         from neucodec import NeuCodec
+        import neucodec.model as neucodec_model
     except ImportError as exc:
         raise RuntimeError(
             "Audar-TTS requires the 'audar-tts' optional dependencies"
         ) from exc
+    path = Path(model).expanduser()
+    if path.is_dir():
+        ckpt_path = path / "pytorch_model.bin"
+        w2v_path = path.parent / "facebook_w2v_bert_2_0"
+        if not ckpt_path.is_file():
+            raise FileNotFoundError(f"Audar-TTS NeuCodec checkpoint not found: {ckpt_path}")
+        if not w2v_path.is_dir():
+            raise FileNotFoundError(
+                f"Audar-TTS local Wav2Vec2-BERT checkpoint not found: {w2v_path}"
+            )
+        orig_w2v_from_pretrained = neucodec_model.Wav2Vec2BertModel.from_pretrained
+        orig_feature_from_pretrained = neucodec_model.AutoFeatureExtractor.from_pretrained
+
+        def local_w2v_from_pretrained(name: str, *args: Any, **kwargs: Any) -> Any:
+            if name == "facebook/w2v-bert-2.0":
+                name = str(w2v_path)
+                kwargs["local_files_only"] = True
+            return orig_w2v_from_pretrained(name, *args, **kwargs)
+
+        def local_feature_from_pretrained(name: str, *args: Any, **kwargs: Any) -> Any:
+            if name == "facebook/w2v-bert-2.0":
+                name = str(w2v_path)
+                kwargs["local_files_only"] = True
+            return orig_feature_from_pretrained(name, *args, **kwargs)
+
+        neucodec_model.Wav2Vec2BertModel.from_pretrained = local_w2v_from_pretrained
+        neucodec_model.AutoFeatureExtractor.from_pretrained = local_feature_from_pretrained
+        try:
+            codec = NeuCodec(OUTPUT_SAMPLE_RATE, 480)
+        finally:
+            neucodec_model.Wav2Vec2BertModel.from_pretrained = orig_w2v_from_pretrained
+            neucodec_model.AutoFeatureExtractor.from_pretrained = orig_feature_from_pretrained
+        state_dict = torch.load(ckpt_path, map_location="cpu")
+        ignore_keys = ("fc_post_s", "SemanticDecoder")
+        state_dict = {
+            key: value
+            for key, value in state_dict.items()
+            if not any(ignored in key for ignored in ignore_keys)
+        }
+        codec.load_state_dict(state_dict, strict=False)
+        return codec.eval().to(device)
     return NeuCodec.from_pretrained(model, revision=revision).eval().to(device)
 
 
@@ -65,7 +107,11 @@ def _codec_lock(model: str, revision: str, device: str) -> threading.Lock:
 
 
 def _device(gpu_id: int | None) -> str:
-    return f"cuda:{gpu_id}" if gpu_id is not None else "cpu"
+    if gpu_id is None:
+        return "cpu"
+    if hasattr(torch, "musa") and torch.musa.is_available():
+        return f"musa:{gpu_id}"
+    return f"cuda:{gpu_id}"
 
 
 def _normalize_reference(raw_input: Any) -> _ReferenceInput:

--- a/sglang_omni/models/audar_tts/stages.py
+++ b/sglang_omni/models/audar_tts/stages.py
@@ -39,6 +39,7 @@ REFERENCE_SAMPLE_RATE = 16000
 OUTPUT_SAMPLE_RATE = 24000
 MIN_REFERENCE_SECONDS = 5.0
 MAX_REFERENCE_SECONDS = 15.0
+_NEUCODEC_INIT_LOCK = threading.Lock()
 
 
 @dataclass(frozen=True)
@@ -62,13 +63,17 @@ def _load_codec(model: str, revision: str, device: str) -> Any:
         ckpt_path = path / "pytorch_model.bin"
         w2v_path = path.parent / "facebook_w2v_bert_2_0"
         if not ckpt_path.is_file():
-            raise FileNotFoundError(f"Audar-TTS NeuCodec checkpoint not found: {ckpt_path}")
+            raise FileNotFoundError(
+                f"Audar-TTS NeuCodec checkpoint not found: {ckpt_path}"
+            )
         if not w2v_path.is_dir():
             raise FileNotFoundError(
                 f"Audar-TTS local Wav2Vec2-BERT checkpoint not found: {w2v_path}"
             )
         orig_w2v_from_pretrained = neucodec_model.Wav2Vec2BertModel.from_pretrained
-        orig_feature_from_pretrained = neucodec_model.AutoFeatureExtractor.from_pretrained
+        orig_feature_from_pretrained = (
+            neucodec_model.AutoFeatureExtractor.from_pretrained
+        )
 
         def local_w2v_from_pretrained(name: str, *args: Any, **kwargs: Any) -> Any:
             if name == "facebook/w2v-bert-2.0":
@@ -82,13 +87,22 @@ def _load_codec(model: str, revision: str, device: str) -> Any:
                 kwargs["local_files_only"] = True
             return orig_feature_from_pretrained(name, *args, **kwargs)
 
-        neucodec_model.Wav2Vec2BertModel.from_pretrained = local_w2v_from_pretrained
-        neucodec_model.AutoFeatureExtractor.from_pretrained = local_feature_from_pretrained
-        try:
-            codec = NeuCodec(OUTPUT_SAMPLE_RATE, 480)
-        finally:
-            neucodec_model.Wav2Vec2BertModel.from_pretrained = orig_w2v_from_pretrained
-            neucodec_model.AutoFeatureExtractor.from_pretrained = orig_feature_from_pretrained
+        with _NEUCODEC_INIT_LOCK:
+            neucodec_model.Wav2Vec2BertModel.from_pretrained = (
+                local_w2v_from_pretrained
+            )
+            neucodec_model.AutoFeatureExtractor.from_pretrained = (
+                local_feature_from_pretrained
+            )
+            try:
+                codec = NeuCodec(OUTPUT_SAMPLE_RATE, 480)
+            finally:
+                neucodec_model.Wav2Vec2BertModel.from_pretrained = (
+                    orig_w2v_from_pretrained
+                )
+                neucodec_model.AutoFeatureExtractor.from_pretrained = (
+                    orig_feature_from_pretrained
+                )
         state_dict = torch.load(ckpt_path, map_location="cpu")
         ignore_keys = ("fc_post_s", "SemanticDecoder")
         state_dict = {


### PR DESCRIPTION
## Summary

Split the Audar TTS V1 Turbo adaptation out of PR #1869. This PR is based directly on the latest upstream `main`; it depends logically on the shared runtime PR #2020.

## Scope

- Audar TTS V1 Turbo model code and MUSA/CUDA compatibility changes
- model-specific tests where present
- no model weights, Docker image layers, logs, or installation documents

## Validation

- Python static compilation passed for the changed model branch
- `git diff --check` passed
- target image evidence: `sh-harbor.mthreads.com/mcctest/musa-sglang-omni-openbox-complete:20260904`

The image contains historical smoke evidence for this model. A fresh latest-`main` MUSA service smoke and real output artifact must still be attached before this PR is marked complete.

## Related

- Original aggregate: PR #1869
- Shared runtime: PR #2020
