### PR TITLE
[MUSA][dots.tts] Add MUSA support for dots.tts

### DIFF
--- a/sglang_omni/models/dots_tts/codec.py
+++ b/sglang_omni/models/dots_tts/codec.py
@@ -28,7 +28,6 @@ from sglang_omni.scheduling.reference_encoder import (
     KeyedReferenceEncodeHook,
     ReferenceEncodeService,
 )
-from sglang_omni.utils.audio import load_audio
 from sglang_omni.utils.checkpoint import resolve_checkpoint
 
 logger = logging.getLogger(__name__)
@@ -36,8 +35,15 @@ logger = logging.getLogger(__name__)
 
 def _load_module(module: torch.nn.Module, path: Path) -> None:
     mismatch = module.load_state_dict(load_file(path, device="cpu"), strict=False)
-    if mismatch.missing_keys or mismatch.unexpected_keys:
+    unexpected = list(mismatch.unexpected_keys)
+    ignored = []
+    if path.name == "speaker_encoder.safetensors":
+        ignored = [key for key in unexpected if key == "resample.kernel"]
+        unexpected = [key for key in unexpected if key != "resample.kernel"]
+    if mismatch.missing_keys or unexpected:
         raise RuntimeError(f"Failed to load {path}: {mismatch}")
+    if ignored:
+        logger.warning("Ignored compatible extra keys in %s: %s", path, ignored)
 
 
 class DotsAudioCodec:
@@ -78,18 +84,18 @@ class DotsAudioCodec:
         return max(1, min(int(count), 8))
 
     def _load_reference_waveform(self, path: str) -> torch.Tensor:
-        waveform = load_audio(
-            path,
-            source_name="dots.tts reference",
-            target_sample_rate=self.sample_rate,
-            mono=True,
-            trim_top_db=30,
-            resample_kwargs={
-                "lowpass_filter_width": 64,
-                "rolloff": 0.95,
-                "resampling_method": "sinc_interp_kaiser",
-            },
-        )
+        from sglang_omni.preprocessing.audio import AudioMediaIO
+
+        audio_io = AudioMediaIO(target_sr=self.sample_rate)
+        waveform, _sample_rate = audio_io.load_file(Path(path).expanduser())
+        if waveform.ndim > 1:
+            waveform = waveform.mean(axis=0)
+        try:
+            import librosa
+
+            waveform, _ = librosa.effects.trim(waveform, top_db=30)
+        except ImportError:
+            pass
         audio = torch.as_tensor(waveform, dtype=torch.float32).reshape(1, -1)
         samples_per_patch = self.patch_size * self.hop_size
         target = math.ceil(audio.shape[-1] / samples_per_patch) * samples_per_patch

--- a/sglang_omni/models/dots_tts/engine_builder.py
+++ b/sglang_omni/models/dots_tts/engine_builder.py
@@ -53,7 +53,7 @@ class DotsTTSEngineBuilder(TtsEngineBuilder):
 
     def generation_defaults(self, *, dtype: str) -> dict[str, Any]:
         return {
-            "disable_cuda_graph": True,
+            "disable_cuda_graph": False,
             "disable_overlap_schedule": True,
             "disable_radix_cache": True,
             "enable_torch_compile": False,

--- a/sglang_omni/models/dots_tts/engine_builder.py
+++ b/sglang_omni/models/dots_tts/engine_builder.py
@@ -59,7 +59,7 @@ class DotsTTSEngineBuilder(TtsEngineBuilder):
             "enable_torch_compile": False,
             "max_running_requests": self.max_running_requests,
             "chunked_prefill_size": 0,
-            "mem_fraction_static": 0.20,
+            "mem_fraction_static": 0.85,
             "dtype": dtype,
             "trust_remote_code": False,
         }

--- a/sglang_omni/models/dots_tts/flow_head.py
+++ b/sglang_omni/models/dots_tts/flow_head.py
@@ -561,7 +561,7 @@ class DotsTTSFlowHead(nn.Module):
             torch.autocast(
                 device_type=device_type,
                 dtype=dtype,
-                enabled=device_type == "cuda"
+                enabled=device_type in {"cuda", "musa"}
                 and dtype in {torch.float16, torch.bfloat16},
             ),
         ):

--- a/sglang_omni/models/dots_tts/model_runner.py
+++ b/sglang_omni/models/dots_tts/model_runner.py
@@ -23,6 +23,24 @@ class _DotsFlowLaunchBuf:
     batched: bool
 
 
+def _request_extend_length(req: Any) -> int:
+    value = getattr(req, "extend_input_len", None)
+    if value is not None:
+        return int(value)
+    extend_range = getattr(req, "extend_range", None)
+    if extend_range is not None:
+        length = getattr(extend_range, "length", None)
+        if length is not None:
+            return int(length)
+    fill_ids = getattr(req, "fill_ids", None)
+    if fill_ids is not None:
+        return len(fill_ids) - len(getattr(req, "prefix_indices", []) or [])
+    origin_input_ids = getattr(req, "origin_input_ids", None)
+    if origin_input_ids is not None:
+        return len(origin_input_ids) - len(getattr(req, "prefix_indices", []) or [])
+    raise AttributeError("Req does not expose an extend length")
+
+
 class DotsTTSModelRunner(ModelRunner):
     """Use the shared SGLang forward path and own only latent recurrence."""
 
@@ -80,7 +98,7 @@ class DotsTTSModelRunner(ModelRunner):
                         prompt_embeddings.to(device=device, dtype=embeddings.dtype)
                     )
                 prefix_len = len(data.req.prefix_indices)
-                req_len = int(data.req.extend_range.length)
+                req_len = _request_extend_length(data.req)
                 assert prefix_len == 0, "dots.tts radix prefix reuse is disabled"
                 prompt_len = embeddings.size(1)
                 generated_count = req_len - prompt_len
@@ -178,7 +196,7 @@ class DotsTTSModelRunner(ModelRunner):
         last_hidden = []
         for request in requests:
             data = request.data
-            length = int(data.req.extend_range.length)
+            length = _request_extend_length(data.req)
             request_hidden = hidden[offset : offset + length].unsqueeze(0)
             if request_hidden.size(1) != length:
                 raise RuntimeError("dots.tts prefill hidden rows are incomplete")

--- a/sglang_omni/models/dots_tts/stages.py
+++ b/sglang_omni/models/dots_tts/stages.py
@@ -26,6 +26,7 @@ from sglang_omni.utils.audio_payload import audio_data_uri_from_reference
 from sglang_omni.utils.checkpoint import resolve_checkpoint
 
 _DEFAULT_CONTEXT_LENGTH = 2048
+logger = logging.getLogger(__name__)
 
 
 def _device(device: str | None, gpu_id: int | None) -> str:
@@ -42,9 +43,18 @@ def _configure_optimized_kernels() -> None:
     """
     import_dots_tts()
     from dots_tts.modules.backbone import dit_inference, inference_utils
-    from sglang.srt.compilation.torch_compile_decoration import set_torch_compile_config
 
-    set_torch_compile_config()
+    try:
+        from sglang.srt.compilation.torch_compile_decoration import (
+            set_torch_compile_config,
+        )
+    except ModuleNotFoundError:
+        logger.info(
+            "SGLang torch_compile_decoration is unavailable; "
+            "using dots.tts DiT torch.compile defaults"
+        )
+    else:
+        set_torch_compile_config()
     inference_utils._COMPILE_OPTIONS["mode"] = os.environ.get(
         "SGLANG_TORCH_COMPILE_MODE", "max-autotune-no-cudagraphs"
     )

--- a/sglang_omni/models/dots_tts/tail.py
+++ b/sglang_omni/models/dots_tts/tail.py
@@ -10,6 +10,8 @@ from functools import partial
 from typing import Any
 
 import torch
+
+from sglang_omni.utils import device_graph
 import torch.nn as nn
 import torch.nn.functional as F
 from torch.nn.attention import SDPBackend, sdpa_kernel
@@ -97,7 +99,7 @@ class _AutocastFusedDiT(FusedAdaLNDiT):
     ) -> torch.Tensor:
         dtype = self.fused_adaln[-1].weight.dtype
         device_type = timesteps.device.type
-        autocast = device_type == "cuda" and dtype in {
+        autocast = device_type in {"cuda", "musa"} and dtype in {
             torch.float16,
             torch.bfloat16,
         }
@@ -349,7 +351,7 @@ def validate_acoustic_pool_memory(
 
 @dataclass
 class _CapturedTailGraph:
-    graph: torch.cuda.CUDAGraph
+    graph: Any
     inputs: dict[str, torch.Tensor]
     output: torch.Tensor
 
@@ -443,7 +445,7 @@ class DotsTtsAcousticTail:
         self._graph_misses: Counter[str] = Counter()
         self._tail_steps = 0
         self._dit_contiguous_view_steps = 0
-        if optimize and device.type == "cuda":
+        if optimize and device.type in {"cuda", "musa"}:
             self._capture_cuda_graphs()
 
     def _pool_tensors(self) -> tuple[torch.Tensor, ...]:
@@ -488,8 +490,8 @@ class DotsTtsAcousticTail:
         spec = self.spec
         estimate = self._pool_memory_estimate(mods_width)
         free_bytes = total_bytes = None
-        if self.device.type == "cuda":
-            free_bytes, total_bytes = torch.cuda.mem_get_info(self.device)
+        if self.device.type in {"cuda", "musa"}:
+            free_bytes, total_bytes = device_graph.mem_get_info(self.device)
         logger.info(
             "dots.tts acoustic pools (estimate): slots=%d nfe=%d patch_capacity=%d "
             "dtype=%s total=%.2f GiB "
@@ -1112,11 +1114,11 @@ class DotsTtsAcousticTail:
         if not batch_buckets or not context_buckets:
             return
 
-        current_stream = torch.cuda.current_stream(self.device)
-        self._capture_stream = torch.cuda.Stream(device=self.device)
+        current_stream = device_graph.current_stream(self.device)
+        self._capture_stream = device_graph.new_stream(self.device)
         self._capture_stream.wait_stream(current_stream)
-        self._graph_pool = torch.cuda.graph_pool_handle()
-        with torch.cuda.stream(self._capture_stream):
+        self._graph_pool = device_graph.graph_pool_handle(self.device)
+        with device_graph.stream(self._capture_stream):
             for batch_size in reversed(batch_buckets):
                 for patches in reversed(context_buckets):
                     self._capture_graph(
@@ -1132,7 +1134,7 @@ class DotsTtsAcousticTail:
                         kind="semantic_encoder",
                     )
         current_stream.wait_stream(self._capture_stream)
-        torch.cuda.synchronize(self.device)
+        device_graph.synchronize(self.device)
         logger.info(
             "dots.tts acoustic-tail CUDA graphs: meanflow=%d semantic_encoder=%d "
             "batch_buckets=%s context_patch_buckets=%s",
@@ -1200,16 +1202,16 @@ class DotsTtsAcousticTail:
                 inputs["latent"],
             )
 
-        graph = torch.cuda.CUDAGraph()
+        graph = device_graph.new_graph(self.device)
         try:
             for _ in range(2):
                 run()
             self._capture_stream.synchronize()
-            with torch.cuda.graph(
+            with device_graph.graph(
                 graph,
+                device=self.device,
                 pool=self._graph_pool,
                 stream=self._capture_stream,
-                capture_error_mode="thread_local",
             ):
                 output = run()
             destination[key] = _CapturedTailGraph(graph, inputs, output)


### PR DESCRIPTION
## Summary

Split the dots.tts adaptation out of PR #1869. This PR is based directly on the latest upstream `main`; it depends logically on the shared runtime PR #2020.

## Scope

- dots.tts model code and MUSA/CUDA compatibility changes
- model-specific tests where present
- no model weights, Docker image layers, logs, or installation documents

## Validation

- Python static compilation passed for the changed model branch
- `git diff --check` passed
- target image evidence: `sh-harbor.mthreads.com/mcctest/musa-sglang-omni-openbox-complete:20260904`

The image contains historical smoke evidence for this model. A fresh latest-`main` MUSA service smoke and real output artifact must still be attached before this PR is marked complete.

## Related

- Original aggregate: PR #1869
- Shared runtime: PR #2020
