### PR TITLE
[MUSA][Fish Audio S2-Pro] Add MUSA support

### DIFF
--- a/sglang_omni/models/fishaudio_s2_pro/fast_ar_backends.py
+++ b/sglang_omni/models/fishaudio_s2_pro/fast_ar_backends.py
@@ -1,0 +1,114 @@
+# SPDX-License-Identifier: Apache-2.0
+"""Fast-AR attention backend policy for FishAudio S2-Pro."""
+
+from __future__ import annotations
+
+from dataclasses import dataclass
+from typing import Callable
+
+from sglang_omni.utils.gpu_compat import get_visible_gpu_sm_version
+
+
+@dataclass(frozen=True)
+class FastARBackendPlan:
+    backend: str
+    enable_torch_compile: bool
+    device_type: str
+    enable_cuda_graph: bool = True
+
+
+_CUDA_BACKENDS_BY_SM = {
+    89: FastARBackendPlan(
+        backend="flashinfer", enable_torch_compile=False, device_type="cuda"
+    ),
+    90: FastARBackendPlan(
+        backend="fa3", enable_torch_compile=True, device_type="cuda"
+    ),
+    100: FastARBackendPlan(
+        backend="flashinfer", enable_torch_compile=False, device_type="cuda"
+    ),
+    120: FastARBackendPlan(
+        backend="flashinfer", enable_torch_compile=False, device_type="cuda"
+    ),
+}
+
+_MUSA_BACKEND = FastARBackendPlan(
+    backend="fa3",
+    enable_torch_compile=True,
+    device_type="musa",
+)
+
+
+def _current_device_type() -> str:
+    try:
+        from sglang_omni.platforms import current_platform
+
+        return current_platform.device_type
+    except Exception:
+        return "cuda"
+
+
+def resolve_fast_ar_backend_plan(
+    *,
+    gpu_id: int,
+    device_type: str | None = None,
+    sm_resolver: Callable[[int], int | None] = get_visible_gpu_sm_version,
+    flashinfer_available: Callable[[], bool] | None = None,
+) -> FastARBackendPlan:
+    """Resolve the FishAudio Fast-AR backend for the active accelerator."""
+
+    device_type = device_type or _current_device_type()
+    if device_type == "musa":
+        return _MUSA_BACKEND
+    if device_type != "cuda":
+        raise RuntimeError(
+            "FishAudio S2-Pro Fast-AR attention supports CUDA and MUSA; "
+            f"got device_type={device_type!r}."
+        )
+
+    sm_version = sm_resolver(gpu_id)
+    if sm_version is None:
+        raise RuntimeError(
+            "FishAudio S2-Pro cannot validate Fast-AR attention because "
+            f"CUDA compute capability for gpu_id={gpu_id} could not be detected."
+        )
+
+    plan = _CUDA_BACKENDS_BY_SM.get(sm_version)
+    if plan is None:
+        raise RuntimeError(
+            f"FishAudio S2-Pro Fast-AR does not support SM{sm_version}; "
+            "supported architectures are SM89, SM90, SM100, and SM120. "
+            "A Slow-AR attention_backend override cannot bypass this requirement."
+        )
+
+    if flashinfer_available is None:
+        from sglang_omni.vendor.sglang.utils import is_flashinfer_available
+
+        flashinfer_available = is_flashinfer_available
+
+    if plan.backend == "flashinfer" and not flashinfer_available():
+        raise RuntimeError(
+            f"FishAudio S2-Pro Fast-AR requires FlashInfer on SM{sm_version}, but "
+            "FlashInfer is unavailable. Install and enable FlashInfer and ensure "
+            "SGLANG_IS_FLASHINFER_AVAILABLE is not false; a Slow-AR "
+            "attention_backend override cannot bypass this requirement."
+        )
+    return plan
+
+
+def cuda_fast_ar_uses_fa3(
+    *,
+    device_index: int,
+    capability_resolver: Callable[[int], tuple[int, int]],
+) -> bool:
+    major, minor = capability_resolver(device_index)
+    sm_version = major * 10 + minor
+    return (
+        resolve_fast_ar_backend_plan(
+            gpu_id=device_index,
+            device_type="cuda",
+            sm_resolver=lambda _gpu_id: sm_version,
+            flashinfer_available=lambda: True,
+        ).backend
+        == "fa3"
+    )

--- a/sglang_omni/models/fishaudio_s2_pro/model_runner.py
+++ b/sglang_omni/models/fishaudio_s2_pro/model_runner.py
@@ -8,8 +8,23 @@ from typing import Any
 import torch
 
 from sglang_omni.model_runner.base import ModelRunner
-from sglang_omni.models.fishaudio_s2_pro.sglang_model import _NO_SEED
 from sglang_omni.sampling.seed import resolve_row_seed
+
+
+def _request_extend_length(req: Any) -> int:
+    if hasattr(req, "extend_input_len"):
+        return int(req.extend_input_len)
+    extend_range = getattr(req, "extend_range", None)
+    if extend_range is not None and hasattr(extend_range, "length"):
+        return int(extend_range.length)
+    prefix_len = len(getattr(req, "prefix_indices", []) or [])
+    fill_ids = getattr(req, "fill_ids", None)
+    if fill_ids is not None:
+        return max(len(fill_ids) - prefix_len, 0)
+    origin_input_ids = getattr(req, "origin_input_ids", None)
+    if origin_input_ids is not None:
+        return max(len(origin_input_ids) - prefix_len, 0)
+    raise AttributeError("request has no extend length field")
 
 
 def collect_s2pro_step_outputs(
@@ -30,7 +45,7 @@ def collect_s2pro_step_outputs(
 
     for row_idx, sched_req in enumerate(requests):
         data = sched_req.data
-        if data.req.inflight_middle_chunks > 0:
+        if int(getattr(data.req, "inflight_middle_chunks", 0)) > 0:
             continue
 
         semantic_token = semantic_tokens[row_idx]
@@ -134,9 +149,7 @@ class FishS2ProModelRunner(ModelRunner):
         self.model._sampling_rep_penalty[row_idx] = data.repetition_penalty
         self.model._ras_temperature[row_idx] = data.ras_temperature
         self.model._ras_top_p[row_idx] = data.ras_top_p
-        self.model._sampling_seeds[row_idx] = (
-            _NO_SEED if data.seed is None else resolve_row_seed(data.seed)
-        )
+        self.model._sampling_seeds[row_idx] = resolve_row_seed(data.seed)
         # semantic_history_count is the uncapped per-request AR step (pre-step).
         self.model._step_count[row_idx] = int(data.semantic_history_count)
 
@@ -172,7 +185,7 @@ class FishS2ProModelRunner(ModelRunner):
         for sched_req in requests:
             data = sched_req.data
             req = data.req
-            req_len = int(req.extend_range.length)
+            req_len = _request_extend_length(req)
 
             if (
                 data.vq_mask_tokens is None

--- a/sglang_omni/models/fishaudio_s2_pro/sglang_model.py
+++ b/sglang_omni/models/fishaudio_s2_pro/sglang_model.py
@@ -31,7 +31,7 @@ logger = logging.getLogger(__name__)
 # Note (Ratish): fixed top-k width keeps decode graph shape stable;
 # per-request top_k is masked inside _decode_codebooks.
 _GRAPH_TOP_K = 30
-_NO_SEED = -1  # sentinel: keep the legacy unseeded torch.multinomial draw
+_NO_SEED = -1
 _DEFAULT_TEMPERATURE = 0.8
 _DEFAULT_TOP_P = 0.8
 _DEFAULT_REP_PENALTY = 1.1
@@ -302,8 +302,8 @@ class S2ProSGLangTextModel(nn.Module):
         self._sampling_rep_penalty = torch.full(
             (max_batch_size,), _DEFAULT_REP_PENALTY, device=device
         )
-        # Per-request seed (``_NO_SEED`` = unseeded) + AR step for reproducible
-        # semantic-token sampling via multinomial_with_seed.
+        # Per-request seed plus AR step for graph-friendly semantic-token
+        # sampling via multinomial_with_seed.
         self._sampling_seeds = torch.full(
             (max_batch_size,), _NO_SEED, dtype=torch.long, device=device
         )
@@ -442,14 +442,12 @@ class S2ProSGLangTextModel(nn.Module):
         probs = torch.nn.functional.softmax(
             top_k_logits / temperature.clamp(min=1e-5), dim=-1
         )
-        # Seeded rows draw reproducibly from (seed, step); unseeded rows keep the
-        # legacy torch.multinomial draw, so unseeded decode is unchanged.
+        # Requests without a public seed receive a fresh per-row seed before
+        # forward, keeping sampling random without graph-unsafe torch.multinomial.
         seeds = self._sampling_seeds[:bs]
-        unseeded_choice = torch.multinomial(probs, num_samples=1)
-        seeded_choice = multinomial_with_seed(
+        choice = multinomial_with_seed(
             torch.log(probs), seeds.clamp_min(0), self._step_count[:bs]
         )
-        choice = torch.where((seeds >= 0).unsqueeze(-1), seeded_choice, unseeded_choice)
         semantic_token = top_k_indices.gather(-1, choice).squeeze(-1)
 
         # Batched codebook loop


### PR DESCRIPTION
## Summary

Split the Fish Audio S2-Pro adaptation out of PR #1869. This PR is based directly on the latest upstream `main`; it depends logically on the shared runtime PR #2020.

## Scope

- Fish Audio S2-Pro model code and MUSA/CUDA compatibility changes
- model-specific tests where present
- no model weights, Docker image layers, logs, or installation documents

## Validation

- Python static compilation passed for the changed model branch
- `git diff --check` passed
- target image evidence: `sh-harbor.mthreads.com/mcctest/musa-sglang-omni-openbox-complete:20260904`

The image contains historical smoke evidence for this model. A fresh latest-`main` MUSA service smoke and real output artifact must still be attached before this PR is marked complete.

## Related

- Original aggregate: PR #1869
- Shared runtime: PR #2020
