### PR TITLE
[MUSA][Fun-CosyVoice3] Add MUSA support

### DIFF
--- a/sglang_omni/models/fun_cosyvoice3/engine_builder.py
+++ b/sglang_omni/models/fun_cosyvoice3/engine_builder.py
@@ -68,6 +68,7 @@ class FunCosyVoice3EngineBuilder(TtsEngineBuilder):
             "torch_compile_max_bs": 32,
             "dtype": dtype,
             "disable_cuda_graph": False,
+            "disable_piecewise_cuda_graph": False,
             "disable_overlap_schedule": True,
             "enable_torch_compile": False,
             "mem_fraction_static": 0.85,

--- a/sglang_omni/models/fun_cosyvoice3/model_runner.py
+++ b/sglang_omni/models/fun_cosyvoice3/model_runner.py
@@ -20,6 +20,25 @@ from sglang_omni.scheduling.messages import OutgoingMessage
 from .sglang_model import VOCAB_SIZE
 
 
+def _request_extend_length(req: Any) -> int:
+    value = getattr(req, "extend_input_len", None)
+    if value is not None:
+        return int(value)
+    extend_range = getattr(req, "extend_range", None)
+    if extend_range is not None:
+        length = getattr(extend_range, "length", None)
+        if length is not None:
+            return int(length)
+    prefix_len = len(getattr(req, "prefix_indices", []) or [])
+    fill_ids = getattr(req, "fill_ids", None)
+    if fill_ids is not None:
+        return max(len(fill_ids) - prefix_len, 0)
+    origin_input_ids = getattr(req, "origin_input_ids", None)
+    if origin_input_ids is not None:
+        return max(len(origin_input_ids) - prefix_len, 0)
+    raise AttributeError("Req does not expose an extend length")
+
+
 class FunCosyVoice3ModelRunner(ModelRunner):
     """Runs Fun-CosyVoice3 AR steps and collects generated speech tokens."""
 
@@ -191,7 +210,7 @@ class FunCosyVoice3ModelRunner(ModelRunner):
         for sched_req in requests:
             data = sched_req.data
             req = data.req
-            req_len = int(req.extend_range.length)
+            req_len = _request_extend_length(req)
             prefix_len = len(req.prefix_indices)
             prompt_embeds = data.prompt_input_embeds
             if prompt_embeds is None:


### PR DESCRIPTION
## Summary

Split the Fun-CosyVoice3 adaptation out of PR #1869. This PR is based directly on the latest upstream `main`; it depends logically on the shared runtime PR #2020.

## Scope

- Fun-CosyVoice3 model code and MUSA/CUDA compatibility changes
- model-specific tests where present
- no model weights, Docker image layers, logs, or installation documents

## Validation

- Python static compilation passed for the changed model branch
- `git diff --check` passed
- target image evidence: `sh-harbor.mthreads.com/mcctest/musa-sglang-omni-openbox-complete:20260904`

The image contains historical smoke evidence for this model. A fresh latest-`main` MUSA service smoke and real output artifact must still be attached before this PR is marked complete.

## Related

- Original aggregate: PR #1869
- Shared runtime: PR #2020
