### PR TITLE
[MUSA][Higgs Audio v3 TTS] Add MUSA support

### DIFF
--- a/sglang_omni/models/higgs_tts/audio_codec.py
+++ b/sglang_omni/models/higgs_tts/audio_codec.py
@@ -22,10 +22,16 @@ from typing import Any
 import numpy as np
 import torch
 import torch.nn.functional as F
-import torchaudio
+try:
+    import torchaudio
+except ImportError:
+    torchaudio = None  # type: ignore[assignment]
 from huggingface_hub import snapshot_download
 from safetensors import safe_open
 from transformers import HiggsAudioV2TokenizerConfig, HiggsAudioV2TokenizerModel
+
+from sglang_omni.utils.audio import _cached_resample
+from sglang_omni.utils import device_graph
 
 WaveformInput = torch.Tensor | np.ndarray
 logger = logging.getLogger(__name__)
@@ -44,7 +50,7 @@ _BUNDLED_CODEC_CONFIG_PATH = os.path.join(
 
 @dataclass
 class _DecodeCudaGraph:
-    graph: torch.cuda.CUDAGraph
+    graph: Any
     input_codes: torch.Tensor
     output_audio: torch.Tensor
 
@@ -207,8 +213,8 @@ class HiggsAudioCodec:
         still use eager decode. Capture finishes before the stage becomes
         ready, so it cannot race SGLang's independently owned AR graphs.
         """
-        if self.device.type != "cuda":
-            raise RuntimeError("Higgs codec CUDA graphs require a CUDA device")
+        if self.device.type not in {"cuda", "musa"}:
+            raise RuntimeError("Higgs codec graphs require a CUDA or MUSA device")
         # Descending so the shared mempool is sized once from the largest shape
         # rather than grown across captures: 130 vs 146 MiB reserved on the
         # default 1..150 domain.
@@ -217,8 +223,8 @@ class HiggsAudioCodec:
             raise ValueError("decode CUDA graph frame counts must be positive")
 
         num_quantizers = int(self.model.config.num_quantizers)
-        current_stream = torch.cuda.current_stream(self.device)
-        capture_stream = torch.cuda.Stream(device=self.device)
+        current_stream = device_graph.current_stream(self.device)
+        capture_stream = device_graph.new_stream(self.device)
         capture_stream.wait_stream(current_stream)
         original_quantizer_decode = self.model.quantizer.decode
         self.model.quantizer.decode = types.MethodType(
@@ -229,12 +235,12 @@ class HiggsAudioCodec:
         try:
             # Bind the device: CUDAGraph and graph_pool_handle act on the
             # current device, which need not be the codec's.
-            with torch.cuda.device(self.device):
+            with device_graph.device_context(self.device):
                 # Initialize shape-specialized CUDA-library state outside
                 # capture. One eager pass per shape is sufficient after model
                 # startup; doing three passes made comprehensive tail-shape
                 # capture needlessly expensive.
-                with torch.cuda.stream(capture_stream):
+                with device_graph.stream(capture_stream):
                     for frame_count in frames:
                         warm_codes = torch.zeros(
                             (1, num_quantizers, frame_count),
@@ -249,7 +255,7 @@ class HiggsAudioCodec:
                 # 130 MiB on the default 1..150 domain. Aliasing across shapes
                 # is safe because decode() replays one graph at a time and
                 # copies the output to host before returning.
-                graph_pool = torch.cuda.graph_pool_handle()
+                graph_pool = device_graph.graph_pool_handle(self.device)
                 for frame_count in frames:
                     # Outside the capture, so the static input is not drawn from
                     # the shared pool.
@@ -258,9 +264,12 @@ class HiggsAudioCodec:
                         dtype=torch.long,
                         device=self.device,
                     )
-                    graph = torch.cuda.CUDAGraph()
-                    with torch.cuda.graph(
-                        graph, pool=graph_pool, stream=capture_stream
+                    graph = device_graph.new_graph(self.device)
+                    with device_graph.graph(
+                        graph,
+                        device=self.device,
+                        pool=graph_pool,
+                        stream=capture_stream,
                     ):
                         output_audio = self.model.decode(input_codes).audio_values
                     captured[frame_count] = _DecodeCudaGraph(
@@ -272,7 +281,7 @@ class HiggsAudioCodec:
             self.model.quantizer.decode = original_quantizer_decode
 
         current_stream.wait_stream(capture_stream)
-        torch.cuda.synchronize(self.device)
+        device_graph.synchronize(self.device)
         self._decode_cuda_graphs = captured
         logger.info(
             f"Captured {len(captured)} Higgs codec decode CUDA graphs for "
@@ -295,7 +304,10 @@ class HiggsAudioCodec:
         wav = _to_mono_3d(waveform).to(torch.float32)
         sr = sample_rate or self.SAMPLE_RATE
         if sr != self.SAMPLE_RATE:
-            wav = torchaudio.functional.resample(wav, sr, self.SAMPLE_RATE)
+            if torchaudio is not None:
+                wav = torchaudio.functional.resample(wav, sr, self.SAMPLE_RATE)
+            else:
+                wav = _cached_resample(wav, sr, self.SAMPLE_RATE, None)
         if wav.shape[-1] < self.SAMPLE_RATE:
             wav = F.pad(wav, (0, self.SAMPLE_RATE - wav.shape[-1]))
 

--- a/sglang_omni/models/higgs_tts/model.py
+++ b/sglang_omni/models/higgs_tts/model.py
@@ -449,9 +449,9 @@ class HiggsTTSModel(nn.Module):
                     "Higgs prefill requires runner-composed input_embeds"
                 )
             if omni_prefill_rids is None:
-                raise RuntimeError(
-                    "Higgs prefill requires omni_prefill_rids from ForwardBatch.rids"
-                )
+                omni_prefill_rids = getattr(forward_batch, "rids", None)
+            if omni_prefill_rids is None:
+                raise RuntimeError("Higgs prefill requires ForwardBatch.rids")
             req_ids, gen_params = self._extract_batch_metadata(
                 forward_batch, omni_prefill_rids
             )
@@ -477,7 +477,11 @@ class HiggsTTSModel(nn.Module):
                 hidden_states_last = hidden_states_last[:, -1, :]
 
         if is_decode:
-            text_logits_BV = self.decode_codebooks_batch_cg(hidden_states_last)
+            text_logits_BV = torch.zeros(
+                (hidden_states_last.shape[0], self.backbone.config.vocab_size),
+                device=hidden_states_last.device,
+                dtype=torch.float32,
+            )
         else:
             text_logits_BV = self.decode_codebooks_batch(
                 hidden_states_last, req_ids, gen_params

--- a/sglang_omni/models/higgs_tts/model_runner.py
+++ b/sglang_omni/models/higgs_tts/model_runner.py
@@ -49,6 +49,32 @@ def _syncfree_launch_enabled() -> bool:
     )
 
 
+def _request_extend_length(req: Any) -> int:
+    if hasattr(req, "extend_input_len"):
+        return int(req.extend_input_len)
+    extend_range = getattr(req, "extend_range", None)
+    if extend_range is not None and hasattr(extend_range, "length"):
+        return int(extend_range.length)
+    fill_ids = getattr(req, "fill_ids", None)
+    if fill_ids is not None:
+        prefix_len = int(getattr(req, "prefix_indices", []) is not None and len(getattr(req, "prefix_indices", [])))
+        return max(0, len(fill_ids) - prefix_len)
+    origin_ids = getattr(req, "origin_input_ids", None)
+    return len(origin_ids) if origin_ids is not None else 0
+
+
+def _request_extend_start(req: Any) -> int:
+    extend_range = getattr(req, "extend_range", None)
+    if extend_range is not None and hasattr(extend_range, "start"):
+        return int(extend_range.start)
+    prefix_indices = getattr(req, "prefix_indices", None)
+    return len(prefix_indices) if prefix_indices is not None else 0
+
+
+def _request_inflight_middle_chunks(req: Any) -> int:
+    return int(getattr(req, "inflight_middle_chunks", 0))
+
+
 class HiggsTTSModelRunner(ModelRunner):
     """ModelRunner for :class:`HiggsTTSModel`."""
 
@@ -87,12 +113,13 @@ class HiggsTTSModelRunner(ModelRunner):
             self.model.set_request_seed(
                 req.request_id, req.data.req.sampling_params.sampling_seed
             )
-        attach_omni_prefill_inputs(
-            forward_batch,
-            OmniPrefillInputs(
-                input_embeds=self._build_prefill_input_embeds(forward_batch, requests),
-            ),
+        prefill_inputs = OmniPrefillInputs(
+            input_embeds=self._build_prefill_input_embeds(forward_batch, requests),
         )
+        attach_omni_prefill_inputs(forward_batch, prefill_inputs)
+        # Older SGLang runners do not call Omni's _extend_forward_kwargs hook;
+        # direct prefill embeds keep the graph-enabled path compatible.
+        forward_batch.input_embeds = prefill_inputs.input_embeds
 
     def post_prefill(self, result, forward_batch, schedule_batch, requests):
         del schedule_batch
@@ -111,6 +138,7 @@ class HiggsTTSModelRunner(ModelRunner):
 
     def post_decode(self, result, forward_batch, schedule_batch, requests):
         del schedule_batch
+        self._sample_decode_codes(result, forward_batch)
         self._collect_step_outputs_cg(result, forward_batch, requests)
 
     def post_decode_launch(self, result, forward_batch, requests):
@@ -127,6 +155,7 @@ class HiggsTTSModelRunner(ModelRunner):
             raise ValueError(
                 f"forward_batch.batch_size ({bs}) < len(requests) ({n_real})"
             )
+        self._sample_decode_codes(result, forward_batch)
         staging = self._decode_pack_gpu(n_real)
         collect_staging = self.model._cg_collect_staging
         host_buf = self._next_host_staging(collect_staging.shape, collect_staging.dtype)
@@ -164,6 +193,20 @@ class HiggsTTSModelRunner(ModelRunner):
         if n_real == 0:
             return None
         return self.model._cg_codes_BN[:n_real, 0].clamp_min(0).to(torch.long)
+
+    def _sample_decode_codes(self, result: Any, forward_batch: Any) -> None:
+        """Run Higgs' random multi-codebook sampler after graph replay.
+
+        SGLang's decode CUDA/MUSA graph owns the deterministic backbone forward.
+        ``torch.multinomial`` is not capture-safe on MUSA, so graph replay
+        returns hidden states and the runner performs sampling on the normal
+        GPU launch path before packaging outputs and next-token ids.
+        """
+        hidden_states = result.logits_output.hidden_states
+        if hidden_states.ndim == 3:
+            hidden_states = hidden_states[:, -1, :]
+        bs = int(forward_batch.batch_size)
+        self.model.decode_codebooks_batch_cg(hidden_states[:bs])
 
     def post_decode_resolve(
         self, host_buf, result, forward_batch, schedule_batch, requests
@@ -378,7 +421,7 @@ class HiggsTTSModelRunner(ModelRunner):
         for b, sched_req in enumerate(requests):
             data = sched_req.data
             req = data.req
-            if req.inflight_middle_chunks > 0:
+            if _request_inflight_middle_chunks(req) > 0:
                 cb0_per_row.append(0)
                 continue
             # Already finished in an earlier step? Skip its append. Under async
@@ -426,7 +469,7 @@ class HiggsTTSModelRunner(ModelRunner):
         offset = 0
         for sched_req in requests:
             data = sched_req.data
-            end = offset + int(data.req.extend_range.length)
+            end = offset + _request_extend_length(data.req)
             codes_rows = data.reference_codes_delayed
             if not codes_rows:
                 offset = end
@@ -444,7 +487,7 @@ class HiggsTTSModelRunner(ModelRunner):
             # absolute prompt position instead of request-local progress.
             consumed = sum(
                 token == AUDIO_PLACEHOLDER_ID
-                for token in data.req.origin_input_ids[: data.req.extend_range.start]
+                for token in data.req.origin_input_ids[: _request_extend_start(data.req)]
             )
             if consumed + n_placeholders > len(codes_rows):
                 raise RuntimeError(
@@ -483,7 +526,7 @@ class HiggsTTSModelRunner(ModelRunner):
             row = model._rid_to_row.get(rid)
             codes_log = model._output_codes.get(rid)
             if (
-                req.inflight_middle_chunks > 0
+                _request_inflight_middle_chunks(req) > 0
                 or row is None
                 or not codes_log
                 or req.finished()


### PR DESCRIPTION
## Summary

Split the Higgs Audio v3 TTS adaptation out of PR #1869. This PR is based directly on the latest upstream `main`; it depends logically on the shared runtime PR #2020.

## Scope

- Higgs Audio v3 TTS model code and MUSA/CUDA compatibility changes
- model-specific tests where present
- no model weights, Docker image layers, logs, or installation documents

## Validation

- Python static compilation passed for the changed model branch
- `git diff --check` passed
- target image evidence: `sh-harbor.mthreads.com/mcctest/musa-sglang-omni-openbox-complete:20260904`

The image contains historical smoke evidence for this model. A fresh latest-`main` MUSA service smoke and real output artifact must still be attached before this PR is marked complete.

## Related

- Original aggregate: PR #1869
- Shared runtime: PR #2020
