### PR TITLE
[MUSA][Ming-Omni-TTS] Add MUSA support

### DIFF
--- a/sglang_omni/models/ming_omni/talker/modeling_ming_omni_talker.py
+++ b/sglang_omni/models/ming_omni/talker/modeling_ming_omni_talker.py
@@ -21,9 +21,13 @@ from typing import Any, Iterable, Optional, Tuple
 
 import torch
 import torch.nn as nn
-import torchaudio
+try:
+    import torchaudio
+except ImportError:
+    torchaudio = None  # type: ignore[assignment]
 from transformers import Qwen2Config, Qwen2Model, StaticCache
 
+from sglang_omni.utils.audio import _cached_resample
 from sglang_omni.utils.audio_features import cached_fbank
 
 from .configuration_bailing_talker import MingOmniTalkerConfig
@@ -37,6 +41,25 @@ from .talker_module.dit import DiT
 logger = logging.getLogger(__name__)
 
 _TOKEN_DONE = object()
+
+
+def _load_prompt_audio(path: str) -> tuple[torch.Tensor, int]:
+    if torchaudio is not None:
+        return torchaudio.load(path, backend="soundfile")
+    import soundfile as sf
+
+    audio, sample_rate = sf.read(path, dtype="float32", always_2d=True)
+    return torch.from_numpy(audio.T.copy()), int(sample_rate)
+
+
+def _resample_prompt_audio(
+    speech: torch.Tensor, sample_rate: int, target_sample_rate: int
+) -> torch.Tensor:
+    if sample_rate == target_sample_rate:
+        return speech
+    if torchaudio is not None:
+        return torchaudio.transforms.Resample(sample_rate, target_sample_rate)(speech)
+    return _cached_resample(speech, sample_rate, target_sample_rate, None)
 
 # ---------- Optional: onnxruntime for speaker embedding ----------
 try:
@@ -998,19 +1021,17 @@ class MingOmniTalker(nn.Module):
         speech_parts = []
         spk_emb_list = []
         for x in prompt_wav_path:
-            speech_tmp, sample_rate = torchaudio.load(x, backend="soundfile")
+            speech_tmp, sample_rate = _load_prompt_audio(x)
             speech_tmp1 = speech_tmp.clone()
-            if sample_rate != audio_detokenizer.config.sample_rate:
-                speech_tmp = torchaudio.transforms.Resample(
-                    sample_rate, audio_detokenizer.config.sample_rate
-                )(speech_tmp)
+            speech_tmp = _resample_prompt_audio(
+                speech_tmp,
+                sample_rate,
+                audio_detokenizer.config.sample_rate,
+            )
             speech_parts.append(speech_tmp)
 
             if self.spkemb_extractor is not None:
-                if sample_rate != 16000:
-                    speech_tmp1 = torchaudio.transforms.Resample(
-                        orig_freq=sample_rate, new_freq=16000
-                    )(speech_tmp1)
+                speech_tmp1 = _resample_prompt_audio(speech_tmp1, sample_rate, 16000)
                 se = self.spkemb_extractor(speech_tmp1)
                 se = self.spk_head(se.to(device=self.device, dtype=self.dtype))
                 spk_emb_list.append(se)

--- a/sglang_omni/models/ming_omni/talker/talker_module/aggregator.py
+++ b/sglang_omni/models/ming_omni/talker/talker_module/aggregator.py
@@ -80,6 +80,7 @@ class Aggregator(nn.Module):
         t: (N,) tensor of diffusion timesteps
         y: (N,) tensor of class labels
         """
+        x = x.to(dtype=self.x_embedder.weight.dtype)
         x = self.x_embedder(x)
         cls_embed = self.word_embedder(
             torch.zeros((x.shape[0], 1), dtype=torch.long, device=x.device)

--- a/sglang_omni/models/ming_omni/talker/talker_module/dit.py
+++ b/sglang_omni/models/ming_omni/talker/talker_module/dit.py
@@ -48,7 +48,7 @@ class TimestepEmbedder(nn.Module):
 
     def forward(self, timestep):
         time_hidden = self.time_embed(timestep)
-        time_hidden = time_hidden.to(timestep.dtype)
+        time_hidden = time_hidden.to(dtype=self.time_mlp[0].weight.dtype)
         time = self.time_mlp(time_hidden)  # b d
         return time
 
@@ -85,7 +85,7 @@ class CondEmbedder(nn.Module):
         if train and use_dropout:
             llm_cond = self.cond_drop(llm_cond)
 
-        llm_cond = self.cond_embedder(llm_cond)
+        llm_cond = self.cond_embedder(llm_cond.to(dtype=self.cond_embedder.weight.dtype))
 
         return llm_cond
 
@@ -170,6 +170,7 @@ class DiT(nn.Module):
         y: (N,) tensor of class labels
         """
         x = torch.cat([latent_history, x], dim=1)
+        x = x.to(dtype=self.x_embedder.weight.dtype)
         x = self.x_embedder(x)
         t = self.t_embedder(t).unsqueeze(1)  # (N, D)
         c = self.c_embedder(c, self.training)  # (N, 1, 896) -> (N, 1, D)
@@ -178,6 +179,7 @@ class DiT(nn.Module):
             assert self.spk_embedder is None
             x = torch.cat([y, x], dim=1)  # # (N, 1 + patch_size *2, D)
         else:
+            spk_emb = spk_emb.to(dtype=self.spk_embedder.weight.dtype)
             x = torch.cat([self.spk_embedder(spk_emb), y, x], dim=1)
         rope = self.rotary_embed.forward_from_seq_len(x.shape[1])
 

--- a/sglang_omni/models/ming_tts/engine_builder.py
+++ b/sglang_omni/models/ming_tts/engine_builder.py
@@ -104,7 +104,7 @@ class MingTtsEngineBuilder(TtsEngineBuilder):
         return {
             "max_running_requests": 8,
             "dtype": dtype,
-            "disable_cuda_graph": True,
+            "disable_cuda_graph": False,
             "disable_overlap_schedule": True,
             "disable_radix_cache": True,
             "enable_torch_compile": False,
@@ -186,13 +186,19 @@ class MingTtsEngineBuilder(TtsEngineBuilder):
         return int(model._decode_input_embedding.num_embeddings)
 
     def post_cuda_graph_setup(self, model: Any, server_args: Any) -> None:
-        del server_args
         # Note (yzxiao): Only the acoustic owner captures tail graphs because
         # follower ranks run the backbone graph without latent sampling.
         if self.tp_rank != 0:
             return
+        runner = self._model_worker.model_runner
+        graph_runner = getattr(runner, "decode_cuda_graph_runner", None)
+        if graph_runner is None:
+            graph_runner = getattr(runner, "piecewise_cuda_graph_runner", None)
+        capture_bs = getattr(graph_runner, "capture_bs", None)
+        if capture_bs is None:
+            capture_bs = get_decode_cuda_graph_bs(server_args)
         model.init_tail_graphs(
-            list(self._model_worker.model_runner.decode_cuda_graph_runner.capture_bs)
+            list(capture_bs)
         )
 
     def make_model_runner(self, model_worker: Any, output_proc: Any) -> Any:

--- a/sglang_omni/models/ming_tts/model_runner.py
+++ b/sglang_omni/models/ming_tts/model_runner.py
@@ -195,7 +195,7 @@ class MingTTSModelRunner(ModelRunner):
             request_state = self._request_states[sched_req.request_id]
             req = data.req
             prefix_len = len(req.prefix_indices)
-            extend_len = int(req.extend_range.length)
+            extend_len = _req_extend_len(req)
             end = prefix_len + extend_len
             prompt_ids = data.input_ids
             prompt_len = int(prompt_ids.shape[0])
@@ -529,3 +529,10 @@ class MingTTSModelRunner(ModelRunner):
             return getter()
         model_runner = getattr(self.tp_worker, "model_runner", None)
         return getattr(model_runner, "tp_group", None)
+
+
+def _req_extend_len(req: Any) -> int:
+    extend_range = getattr(req, "extend_range", None)
+    if extend_range is not None and hasattr(extend_range, "length"):
+        return int(extend_range.length)
+    return int(getattr(req, "extend_input_len"))

--- a/sglang_omni/models/ming_tts/reference_encode.py
+++ b/sglang_omni/models/ming_tts/reference_encode.py
@@ -7,8 +7,12 @@ from typing import Any
 
 import onnxruntime
 import torch
-import torchaudio
-import torchaudio.functional as F
+try:
+    import torchaudio
+    import torchaudio.functional as F
+except ImportError:
+    torchaudio = None  # type: ignore[assignment]
+    F = None  # type: ignore[assignment]
 
 from sglang_omni.models.ming_omni.talker.audio_vae.modeling_audio_vae import AudioVAE
 from sglang_omni.models.ming_tts.payload_types import (
@@ -24,7 +28,25 @@ from sglang_omni.scheduling.reference_encoder import (
     KeyedReferenceEncodeHook,
     ReferenceEncodeService,
 )
+from sglang_omni.utils.audio import _cached_resample
 from sglang_omni.utils.audio_features import cached_fbank
+
+
+def _load_audio(path: str) -> tuple[torch.Tensor, int]:
+    if torchaudio is not None:
+        return torchaudio.load(path)
+    import soundfile as sf
+
+    audio, sample_rate = sf.read(path, dtype="float32", always_2d=True)
+    return torch.from_numpy(audio.T.copy()), int(sample_rate)
+
+
+def _resample_audio(waveform: torch.Tensor, orig_freq: int, new_freq: int) -> torch.Tensor:
+    if int(orig_freq) == int(new_freq):
+        return waveform
+    if F is not None:
+        return F.resample(waveform, orig_freq=int(orig_freq), new_freq=int(new_freq))
+    return _cached_resample(waveform, int(orig_freq), int(new_freq), None)
 
 
 class MingSpeakerEmbeddingExtractor:
@@ -204,7 +226,7 @@ class MingTTSReferenceEncoder:
         return store_ming_tts_state(payload, state)
 
     def _load_reference_waveform(self, path: str) -> tuple[Any, Any]:
-        waveform, sample_rate = torchaudio.load(path)
+        waveform, sample_rate = _load_audio(path)
         if waveform.ndim != 2 or int(waveform.shape[0]) != 1:
             raise ValueError(
                 "Ming-Omni-TTS currently supports only mono reference audio, "
@@ -212,13 +234,13 @@ class MingTTSReferenceEncoder:
             )
         speaker_waveform = waveform
         if int(sample_rate) != self.sample_rate:
-            waveform = F.resample(
+            waveform = _resample_audio(
                 waveform,
                 orig_freq=int(sample_rate),
                 new_freq=self.sample_rate,
             )
         if int(sample_rate) != self.speaker_encoder.target_sr:
-            speaker_waveform = F.resample(
+            speaker_waveform = _resample_audio(
                 speaker_waveform,
                 orig_freq=int(sample_rate),
                 new_freq=self.speaker_encoder.target_sr,


### PR DESCRIPTION
## Summary

Split the Ming-Omni-TTS (ming_omni and ming_tts) adaptation out of PR #1869. This PR is based directly on the latest upstream `main`; it depends logically on the shared runtime PR #2020.

## Scope

- Ming-Omni-TTS (ming_omni and ming_tts) model code and MUSA/CUDA compatibility changes
- model-specific tests where present
- no model weights, Docker image layers, logs, or installation documents

## Validation

- Python static compilation passed for the changed model branch
- `git diff --check` passed
- target image evidence: `sh-harbor.mthreads.com/mcctest/musa-sglang-omni-openbox-complete:20260904`

The image contains historical smoke evidence for this model. A fresh latest-`main` MUSA service smoke and real output artifact must still be attached before this PR is marked complete.

## Related

- Original aggregate: PR #1869
- Shared runtime: PR #2020
