### PR TITLE
[MUSA][MOSS-TTS v1.5] Add MUSA support

### DIFF
--- a/sglang_omni/models/moss_tts/attention.py
+++ b/sglang_omni/models/moss_tts/attention.py
@@ -49,11 +49,15 @@ def validate_attention_backend(attention_backend: str) -> str:
 
 def _packed_flash_device_unavailable_reason(device: torch.device) -> str | None:
     device = torch.device(device)
-    if device.type != "cuda":
-        return f"device type {device.type!r} is not CUDA"
-    if not torch.cuda.is_available():
+    if device.type not in {"cuda", "musa"}:
+        return f"device type {device.type!r} is not CUDA/MUSA"
+    if device.type == "cuda" and not torch.cuda.is_available():
         return "the CUDA runtime is unavailable"
-    if not _is_fa3_supported():
+    if device.type == "musa":
+        musa_mod = getattr(torch, "musa", None)
+        if musa_mod is None or not musa_mod.is_available():
+            return "the MUSA runtime is unavailable"
+    if device.type == "cuda" and not _is_fa3_supported():
         return "SGLang packed FlashAttention (FA3) is unavailable"
     return None
 
@@ -61,6 +65,8 @@ def _packed_flash_device_unavailable_reason(device: torch.device) -> str | None:
 @cache
 def _packed_flash_requires_query_chunks(device: torch.device) -> bool:
     device = torch.device(device)
+    if device.type == "musa":
+        return True
     if device.type != "cuda" or not torch.cuda.is_available():
         return True
     major, minor = torch.cuda.get_device_capability(device)
@@ -640,6 +646,9 @@ class MossAudioTokenizerAttention(nn.Module):
         self._packed_rope_cache = packed_rope_cache or MossPackedRopeCache(
             max_period=max_period
         )
+        self._local_flash_plan_cache: dict[
+            tuple[str, int | None, int | None, tuple[int, ...]], _LocalCausalFlashPlan
+        ] = {}
 
     @classmethod
     def from_module(
@@ -705,7 +714,14 @@ class MossAudioTokenizerAttention(nn.Module):
     @staticmethod
     def get_backend_dtype(x: torch.Tensor) -> torch.dtype:
         backend_dtype = x.dtype
-        if x.device.type != "cuda":
+        if x.device.type not in {"cuda", "musa"}:
+            return backend_dtype
+        if x.device.type == "musa":
+            try:
+                if torch.is_autocast_enabled("musa"):
+                    return torch.get_autocast_dtype("musa")
+            except (AttributeError, TypeError):
+                pass
             return backend_dtype
         try:
             autocast_enabled = torch.is_autocast_enabled("cuda")
@@ -732,6 +748,24 @@ class MossAudioTokenizerAttention(nn.Module):
             or max_seqlen <= _LOCAL_CAUSAL_FLASH_QUERY_CHUNK_SIZE
         ):
             return None
+        if sequence_lengths is not None:
+            lengths_key = tuple(int(length) for length in sequence_lengths)
+            cache_key = (
+                cu_seqlens.device.type,
+                cu_seqlens.device.index,
+                int(self.context),
+                lengths_key,
+            )
+            cached = self._local_flash_plan_cache.get(cache_key)
+            if cached is not None:
+                return cached
+            plan = _build_local_causal_flash_plan(
+                cu_seqlens,
+                context=int(self.context),
+                sequence_lengths=lengths_key,
+            )
+            self._local_flash_plan_cache[cache_key] = plan
+            return plan
         return _build_local_causal_flash_plan(
             cu_seqlens,
             context=int(self.context),

--- a/sglang_omni/models/moss_tts/engine_builder.py
+++ b/sglang_omni/models/moss_tts/engine_builder.py
@@ -13,6 +13,7 @@ from sglang_omni.models.moss_tts.hf_loading import (
     resolve_moss_tts_context_length,
 )
 from sglang_omni.scheduling.engine_factory import TtsEngineBuilder
+from sglang_omni.scheduling.generation_batch_policy import get_decode_cuda_graph_bs
 
 
 class MossTtsEngineBuilder(TtsEngineBuilder):
@@ -75,11 +76,15 @@ class MossTtsEngineBuilder(TtsEngineBuilder):
         self._model_runner = model_worker.model_runner
 
     def post_cuda_graph_setup(self, model: Any, server_args: Any) -> None:
-        del server_args
-        graph_runner = self._model_runner.decode_cuda_graph_runner
+        graph_runner = getattr(self._model_runner, "decode_cuda_graph_runner", None)
+        if graph_runner is None:
+            graph_runner = getattr(self._model_runner, "piecewise_cuda_graph_runner", None)
+        capture_bs = getattr(graph_runner, "capture_bs", None)
+        if capture_bs is None:
+            capture_bs = get_decode_cuda_graph_bs(server_args)
         model.init_sampling_graphs(
-            list(graph_runner.capture_bs),
-            disable_padding=graph_runner.disable_padding,
+            list(capture_bs),
+            disable_padding=bool(getattr(graph_runner, "disable_padding", False)),
         )
 
     def make_model_runner(self, model_worker: Any, output_proc: Any) -> Any:

--- a/sglang_omni/models/moss_tts/sampler.py
+++ b/sglang_omni/models/moss_tts/sampler.py
@@ -203,7 +203,7 @@ class MossTTSDelayAudioGraphSampler(nn.Module):
             generation_steps * self.num_channels,
             self.text_control_token_ids,
         )
-        sampled_text = self.text_control_token_ids[sampled_control]
+        sampled_text = self.text_control_token_ids[sampled_control].reshape(batch_size)
         next_text = torch.where(sampling_text_mask, sampled_text, next_text)
         is_audio = (is_audio | (next_text == self.audio_start_token_id)) & (
             next_text != self.im_end_token_id
@@ -265,5 +265,11 @@ class MossTTSDelayAudioGraphSampler(nn.Module):
         next_delay_state = torch.stack(
             (next_audio_lengths, next_delayed, is_audio.long()), dim=1
         )
-        rows = torch.cat((next_text.unsqueeze(1), next_audio), dim=1)
+        next_text = next_text.reshape(batch_size)
+        next_audio = next_audio.reshape(batch_size, self.n_vq)
+        rows = torch.empty(
+            (batch_size, self.n_vq + 1), dtype=torch.long, device=next_audio.device
+        )
+        rows[:, 0] = next_text
+        rows[:, 1:] = next_audio
         return DelaySamplingOutput(rows=rows, next_delay_state=next_delay_state)

--- a/sglang_omni/models/moss_tts/sampling_cuda_graph.py
+++ b/sglang_omni/models/moss_tts/sampling_cuda_graph.py
@@ -77,6 +77,13 @@ class MossTTSDelaySamplingCudaGraphRunner:
             capture_bs=capture_bs,
             disable_padding=disable_padding,
         )
+        if getattr(model.device, "type", "") == "musa":
+            logger.warning(
+                "MOSS-TTS Delay sampling CUDA graph capture is disabled on "
+                "MUSA because torch-musa stream capture rejects bool/cat "
+                "sampling ops; using eager sampling for this small tail"
+            )
+            return runner
         capture_failed = False
         try:
             with torch.cuda.device(model.device):
@@ -142,6 +149,14 @@ class MossTTSDelaySamplingCudaGraphRunner:
                     "backbone_bucket=%s; that bucket will use eager",
                     bucket,
                 )
+                if getattr(self.model.device, "type", "") == "musa":
+                    logger.warning(
+                        "MOSS-TTS Delay sampling CUDA graph capture is not "
+                        "fully supported on MUSA for this bucket; discarding "
+                        "partial graphs and using eager sampling"
+                    )
+                    self.clear()
+                    return
 
     @staticmethod
     def _is_cuda_oom(exc: BaseException) -> bool:

--- a/sglang_omni/models/moss_tts/sampling_kernels.py
+++ b/sglang_omni/models/moss_tts/sampling_kernels.py
@@ -6,9 +6,38 @@ from __future__ import annotations
 import torch
 import triton
 import triton.language as tl
-from sglang.kernels.ops.sampling.murmur_hash import fmix32, murmur3_mix, murmur_hash32
-from sglang.srt.layers.sampler import multinomial_with_seed
 from triton.language.extra import libdevice
+
+try:
+    from sglang.kernels.ops.sampling.murmur_hash import (
+        fmix32,
+        murmur3_mix,
+        murmur_hash32,
+    )
+except ModuleNotFoundError:
+    fmix32 = None
+    murmur3_mix = None
+    murmur_hash32 = None
+
+try:
+    from sglang.srt.layers.sampler import multinomial_with_seed
+except (ImportError, ModuleNotFoundError):
+
+    def multinomial_with_seed(
+        probs: torch.Tensor, seeds: torch.Tensor, positions: torch.Tensor
+    ) -> torch.Tensor:
+        del positions
+        outputs = []
+        for row, seed in zip(probs, seeds):
+            generator = torch.Generator(device=row.device)
+            generator.manual_seed(int(seed.item()))
+            row = row.to(torch.float32)
+            row = torch.nan_to_num(row, nan=0.0, posinf=0.0, neginf=0.0)
+            if row.sum() <= 0:
+                outputs.append(torch.argmax(row).view(1))
+            else:
+                outputs.append(torch.multinomial(row, 1, generator=generator))
+        return torch.cat(outputs)
 
 _UINT32_MAX_F64 = tl.constexpr(float(torch.iinfo(torch.uint32).max))
 
@@ -141,6 +170,9 @@ def multinomial_with_seed_and_token_ids(
 ) -> torch.Tensor:
     """Seeded Gumbel-max using original vocabulary ids as RNG columns."""
 
+    if murmur_hash32 is None:
+        probs = torch.softmax(logprobs, dim=-1)
+        return multinomial_with_seed(probs, seed, positions)
     seed = seed.to(torch.uint64)
     hashed = murmur_hash32(seed, positions, token_ids)
     noise = hashed.to(torch.float64) / torch.iinfo(torch.uint32).max


### PR DESCRIPTION
## Summary

Split the MOSS-TTS v1.5 adaptation out of PR #1869. This PR is based directly on the latest upstream `main`; it depends logically on the shared runtime PR #2020.

## Scope

- MOSS-TTS v1.5 model code and MUSA/CUDA compatibility changes
- model-specific tests where present
- no model weights, Docker image layers, logs, or installation documents

## Validation

- Python static compilation passed for the changed model branch
- `git diff --check` passed
- target image evidence: `sh-harbor.mthreads.com/mcctest/musa-sglang-omni-openbox-complete:20260904`

The image contains historical smoke evidence for this model. A fresh latest-`main` MUSA service smoke and real output artifact must still be attached before this PR is marked complete.

## Related

- Original aggregate: PR #1869
- Shared runtime: PR #2020
