### PR TITLE
[MUSA][MOSS-TTS Local] Add MUSA support

### DIFF
--- a/sglang_omni/models/moss_tts_local/model_runner.py
+++ b/sglang_omni/models/moss_tts_local/model_runner.py
@@ -18,6 +18,21 @@ from sglang_omni.scheduling.messages import OutgoingMessage
 from sglang_omni.scheduling.types import RequestOutput
 
 
+def _request_extend_length(req: Any) -> int:
+    if hasattr(req, "extend_input_len"):
+        return int(req.extend_input_len)
+    extend_range = getattr(req, "extend_range", None)
+    if extend_range is not None and hasattr(extend_range, "length"):
+        return int(extend_range.length)
+    fill_ids = getattr(req, "fill_ids", None)
+    if fill_ids is not None:
+        prefix_indices = getattr(req, "prefix_indices", None)
+        prefix_len = len(prefix_indices) if prefix_indices is not None else 0
+        return max(0, len(fill_ids) - prefix_len)
+    origin_ids = getattr(req, "origin_input_ids", None)
+    return len(origin_ids) if origin_ids is not None else 0
+
+
 class MossTTSLocalModelRunner(ModelRunner):
     """Drives the per-frame local-transformer decode and feedback embeddings.
 
@@ -169,8 +184,9 @@ class MossTTSLocalModelRunner(ModelRunner):
             rows = data.prompt_rows
             if rows is None:
                 raise RuntimeError("MOSS-TTS Local prefill requires prompt_rows")
-            req_len = int(req.extend_range.length)
-            prefix_len = len(req.prefix_indices)
+            req_len = _request_extend_length(req)
+            prefix_indices = getattr(req, "prefix_indices", None)
+            prefix_len = len(prefix_indices) if prefix_indices is not None else 0
             pool = self.model._state_pool
             if data.output_rows:
                 # KV-pressure retraction re-prefills with an extend region

--- a/sglang_omni/models/moss_tts_local/sglang_model.py
+++ b/sglang_omni/models/moss_tts_local/sglang_model.py
@@ -40,6 +40,7 @@ from sglang_omni.models.moss_tts_local.payload_types import (
     moss_tts_local_special_token_defaults,
 )
 from sglang_omni.models.moss_tts_local.state_pool import MossTTSLocalDecodeStatePool
+from sglang_omni.utils import device_graph
 
 logger = logging.getLogger(__name__)
 
@@ -307,6 +308,9 @@ class MossTTSLocalSGLangModel(torch.nn.Module):
             else:
                 input_embeds = None
 
+        if input_embeds is not None:
+            input_embeds = input_embeds.to(dtype=self._first_embedding_weight().dtype)
+
         hidden_states = self.model(
             input_ids=None,
             positions=positions,
@@ -366,10 +370,13 @@ class MossTTSLocalSGLangModel(torch.nn.Module):
     def _ensure_frame_compile_config(self) -> None:
         if self._frame_compile_configured:
             return
-        from sglang.srt.compilation.torch_compile_decoration import (
-            set_torch_compile_config,
-        )
-
+        try:
+            from sglang.srt.compilation.torch_compile_decoration import (
+                set_torch_compile_config,
+            )
+        except ModuleNotFoundError:
+            self._frame_compile_configured = True
+            return
         set_torch_compile_config()
         self._frame_compile_configured = True
 
@@ -522,16 +529,17 @@ class MossTTSLocalSGLangModel(torch.nn.Module):
                 "seeds": torch.zeros(bucket, device=device, dtype=torch.long),
                 "base_positions": torch.zeros(bucket, device=device, dtype=torch.long),
             }
-            warmup_stream = torch.cuda.Stream()
-            warmup_stream.wait_stream(torch.cuda.current_stream())
-            with torch.cuda.stream(warmup_stream):
+            current_stream = device_graph.current_stream(device)
+            warmup_stream = device_graph.new_stream(device)
+            warmup_stream.wait_stream(current_stream)
+            with device_graph.stream(warmup_stream):
                 for _ in range(2):
                     frame_decode(**static_inputs)
-            torch.cuda.current_stream().wait_stream(warmup_stream)
-            torch.cuda.synchronize()
+            current_stream.wait_stream(warmup_stream)
+            device_graph.synchronize(device)
 
-            graph = torch.cuda.CUDAGraph()
-            with torch.cuda.graph(graph):
+            graph = device_graph.new_graph(device)
+            with device_graph.graph(graph, device=device):
                 stop_choice, codes, feedback = frame_decode(**static_inputs)
             self._frame_graphs[bucket] = (
                 graph,
@@ -731,7 +739,19 @@ class MossTTSLocalSGLangModel(torch.nn.Module):
             else:
                 logger.warning(f"MOSS-TTS Local parameter {original_name} not found")
 
+        self._align_linear_bias_dtypes()
         self._zero_audio_pad_rows()
+
+    def _align_linear_bias_dtypes(self) -> None:
+        with torch.no_grad():
+            for module in self.modules():
+                if not isinstance(module, torch.nn.Linear):
+                    continue
+                if module.bias is None or module.bias.dtype == module.weight.dtype:
+                    continue
+                module.bias.data = module.bias.data.to(
+                    device=module.weight.device, dtype=module.weight.dtype
+                )
 
     def _zero_audio_pad_rows(self) -> None:
         """Zero rows >= audio_vocab_size so pad codes embed to exactly zero."""

--- a/sglang_omni/models/moss_tts_local/streaming_vocoder.py
+++ b/sglang_omni/models/moss_tts_local/streaming_vocoder.py
@@ -645,7 +645,7 @@ class MossTTSLocalStreamingVocoderScheduler(
 
     def _codec_on_cuda(self) -> bool:
         try:
-            return next(self._codec.parameters()).device.type == "cuda"
+            return next(self._codec.parameters()).device.type in {"cuda", "musa"}
         except StopIteration:
             return False
 

--- a/sglang_omni/models/moss_tts_local/vocoder_cuda_graph.py
+++ b/sglang_omni/models/moss_tts_local/vocoder_cuda_graph.py
@@ -10,6 +10,9 @@ from typing import NamedTuple
 
 import torch
 
+from sglang_omni.models.moss_tts.audio_tokenizer import MossAudioTokenizerVocoderDecoder
+from sglang_omni.utils import device_graph
+
 logger = logging.getLogger(__name__)
 
 _ATTN_ORIGINAL_UPDATE_CACHE_ATTR = "_sglang_omni_original_update_streaming_cache"
@@ -18,7 +21,7 @@ _ATTN_ORIGINAL_UPDATE_CACHE_ATTR = "_sglang_omni_original_update_streaming_cache
 class _CapturedVocoderGraph(NamedTuple):
     """One captured per-T graph and its static replay buffers (named to avoid positional unpack)."""
 
-    graph: torch.cuda.CUDAGraph
+    graph: object
     static_codes: torch.Tensor
     static_lengths: torch.Tensor
     static_audio: torch.Tensor
@@ -82,6 +85,13 @@ def patch_codec_attention_cache_for_cuda_graph(codec) -> None:
         )
 
 
+def _decoder_length_override(codec, lengths: list[int]):
+    decoder = getattr(codec, "decoder", None)
+    if isinstance(decoder, MossAudioTokenizerVocoderDecoder):
+        return decoder.input_lengths_cpu_override(lengths)
+    return None
+
+
 class MossVocoderCudaGraphRunner:
     """Warmup-captured, sealed replay of exact-T CUDA graphs for the MOSS codec decode (B fixed)."""
 
@@ -118,7 +128,7 @@ class MossVocoderCudaGraphRunner:
         return 1 <= frame_count <= self._max_frames
 
     def _enough_free_vram(self) -> tuple[bool, int]:
-        free, _ = torch.cuda.mem_get_info(self._device)
+        free, _ = device_graph.mem_get_info(self._device)
         return free >= self._min_free_bytes, free
 
     @torch.no_grad()
@@ -140,30 +150,44 @@ class MossVocoderCudaGraphRunner:
         static_codes = torch.zeros(n, b, frame_count, dtype=torch.long, device=device)
         # Capture all-active; the live exec_mask at replay decides which slots advance.
         static_lengths = torch.full((b,), frame_count, dtype=torch.long, device=device)
+        static_lengths_cpu = [frame_count] * b
         exec_mask = torch.ones(b, dtype=torch.bool, device=device)
         self._codec._set_streaming_exec_mask(exec_mask)
         # Note: (Jiaxin Deng) side-stream warmup forces lazy allocs (conv algo / workspaces) out of the capture.
-        stream = torch.cuda.Stream()
-        stream.wait_stream(torch.cuda.current_stream())
-        with torch.cuda.stream(stream):
-            for _ in range(self._warmup_iters):
-                self._codec._decode_frame(static_codes, static_lengths)
-        torch.cuda.current_stream().wait_stream(stream)
-        torch.cuda.synchronize()
+        current_stream = device_graph.current_stream(device)
+        stream = device_graph.new_stream(device)
+        stream.wait_stream(current_stream)
+        with device_graph.stream(stream):
+            override = _decoder_length_override(self._codec, static_lengths_cpu)
+            if override is None:
+                for _ in range(self._warmup_iters):
+                    self._codec._decode_frame(static_codes, static_lengths)
+            else:
+                with override:
+                    for _ in range(self._warmup_iters):
+                        self._codec._decode_frame(static_codes, static_lengths)
+        current_stream.wait_stream(stream)
+        device_graph.synchronize(device)
         # Note: (Jiaxin Deng) reset to offset 0 AFTER warmup, BEFORE capture -- capturing at the
         # warmup-advanced offset bakes a wrong start state (~0.4 PCM error). reset re-activates all slots.
         self._reset_state()
         self._codec._set_streaming_exec_mask(exec_mask)
         # Shared mempool across the T graphs to bound memory (large B=16 intermediates); capture order in warmup.
         if self._pool is None:
-            self._pool = torch.cuda.graph_pool_handle()
-        graph = torch.cuda.CUDAGraph()
-        with torch.cuda.graph(
-            graph, pool=self._pool, capture_error_mode="thread_local"
-        ):
-            result = self._codec._decode_frame(static_codes, static_lengths)
-            static_audio = result.audio
-            static_audio_lengths = result.audio_lengths
+            self._pool = device_graph.graph_pool_handle(device)
+        graph = device_graph.new_graph(device)
+        override = _decoder_length_override(self._codec, static_lengths_cpu)
+        if override is None:
+            with device_graph.graph(graph, device=device, pool=self._pool):
+                result = self._codec._decode_frame(static_codes, static_lengths)
+                static_audio = result.audio
+                static_audio_lengths = result.audio_lengths
+        else:
+            with override:
+                with device_graph.graph(graph, device=device, pool=self._pool):
+                    result = self._codec._decode_frame(static_codes, static_lengths)
+                    static_audio = result.audio
+                    static_audio_lengths = result.audio_lengths
         self._graphs[frame_count] = _CapturedVocoderGraph(
             graph=graph,
             static_codes=static_codes,
@@ -190,7 +214,7 @@ class MossVocoderCudaGraphRunner:
             return
         # Bind capture to the codec's device: the stream/pool/graph use the current device, and
         # factory-time capture can precede the stage device switch (split puts the codec off cuda:0).
-        with torch.cuda.device(self._device):
+        with device_graph.device_context(self._device):
             # Note: (Jiaxin Deng) capture LARGEST T first -- the graphs share one mempool; capturing a larger
             # graph after a smaller one grows the pool and invalidates earlier graphs' addresses (replay segfaults).
             for t in sorted(dict.fromkeys(int(x) for x in frames), reverse=True):
@@ -251,7 +275,7 @@ class MossVocoderCudaGraphRunner:
         Per-slot lengths are not needed: every captured graph decodes the full T for all slots and
         ``exec_mask`` gates which outputs are valid (the eager fallback still uses lengths).
         """
-        if not codes_step.is_cuda:
+        if codes_step.device.type not in {"cuda", "musa"}:
             return None
         n, b, t = codes_step.shape
         if b != self._batch_size or n != self._n_vq:


### PR DESCRIPTION
## Summary

Split the MOSS-TTS Local adaptation out of PR #1869. This PR is based directly on the latest upstream `main`; it depends logically on the shared runtime PR #2020.

## Scope

- MOSS-TTS Local model code and MUSA/CUDA compatibility changes
- model-specific tests where present
- no model weights, Docker image layers, logs, or installation documents

## Validation

- Python static compilation passed for the changed model branch
- `git diff --check` passed
- target image evidence: `sh-harbor.mthreads.com/mcctest/musa-sglang-omni-openbox-complete:20260904`

The image contains historical smoke evidence for this model. A fresh latest-`main` MUSA service smoke and real output artifact must still be attached before this PR is marked complete.

## Related

- Original aggregate: PR #1869
- Shared runtime: PR #2020
