### PR TITLE
[MUSA][Qwen3-ASR] Add MUSA support for Qwen3-ASR 1.7B

### DIFF
--- a/sglang_omni/models/qwen3_asr/request_builders.py
+++ b/sglang_omni/models/qwen3_asr/request_builders.py
@@ -556,7 +556,7 @@ def make_qwen3_asr_stream_output_builder(
         request_id: str, req_data: Any, req_output: Any
     ) -> list[OutgoingMessage]:
         req = req_data.req
-        if req is None or req.inflight_middle_chunks > 0:
+        if req is None or getattr(req, "inflight_middle_chunks", 0) > 0:
             return token_stream_builder(request_id, req_data, req_output)
         stage_payload = req_data.stage_payload
         if stage_payload is None or not (stage_payload.request.params or {}).get(


### PR DESCRIPTION
## Summary

Split the Qwen3-ASR 1.7B adaptation out of PR #1869. This PR is based directly on the latest upstream `main`; it depends logically on the shared runtime PR #2020.

## Scope

- Qwen3-ASR 1.7B model code and MUSA/CUDA compatibility changes
- model-specific tests where present
- no model weights, Docker image layers, logs, or installation documents

## Validation

- Python static compilation passed for the changed model branch
- `git diff --check` passed
- target image evidence: `sh-harbor.mthreads.com/mcctest/musa-sglang-omni-openbox-complete:20260904`

The image contains historical smoke evidence for this model. A fresh latest-`main` MUSA service smoke and real output artifact must still be attached before this PR is marked complete.

## Related

- Original aggregate: PR #1869
- Shared runtime: PR #2020
