### PR TITLE
[MUSA][ZONOS2] Add MUSA support

### DIFF
--- a/sglang_omni/models/zonos2/components/speaker_encoder.py
+++ b/sglang_omni/models/zonos2/components/speaker_encoder.py
@@ -9,6 +9,7 @@ from __future__ import annotations
 
 import hashlib
 import io
+import os
 import subprocess
 import threading
 import wave
@@ -20,15 +21,100 @@ from typing import Any
 import torch
 import torch.nn as nn
 import torch.nn.functional as F
-import torchaudio
+try:
+    import torchaudio
+except ImportError:
+    torchaudio = None  # type: ignore[assignment]
 from transformers import AutoModel
 
 from sglang_omni.scheduling.reference_encoder import (
     ReferenceEncodeService,
     TensorReferenceEncodeHook,
 )
+from sglang_omni.utils.audio import _cached_resample
 
 SPEAKER_EMBEDDING_DIM = 2048
+
+
+class _TorchMelSpectrogram(nn.Module):
+    def __init__(
+        self,
+        *,
+        sample_rate: int,
+        n_fft: int,
+        win_length: int,
+        hop_length: int,
+        f_min: float,
+        f_max: float,
+        n_mels: int,
+    ) -> None:
+        super().__init__()
+        self.sample_rate = float(sample_rate)
+        self.n_fft = int(n_fft)
+        self.win_length = int(win_length)
+        self.hop_length = int(hop_length)
+        self.register_buffer(
+            "window",
+            torch.hann_window(self.win_length, periodic=True),
+            persistent=False,
+        )
+        self.register_buffer(
+            "mel_fb",
+            self._build_mel_fb(
+                n_fft=self.n_fft,
+                n_mels=int(n_mels),
+                sample_rate=float(sample_rate),
+                f_min=float(f_min),
+                f_max=float(f_max),
+            ),
+            persistent=False,
+        )
+
+    @staticmethod
+    def _hz_to_mel(freq: torch.Tensor) -> torch.Tensor:
+        return 2595.0 * torch.log10(1.0 + freq / 700.0)
+
+    @staticmethod
+    def _mel_to_hz(mel: torch.Tensor) -> torch.Tensor:
+        return 700.0 * (10.0 ** (mel / 2595.0) - 1.0)
+
+    @classmethod
+    def _build_mel_fb(
+        cls,
+        *,
+        n_fft: int,
+        n_mels: int,
+        sample_rate: float,
+        f_min: float,
+        f_max: float,
+    ) -> torch.Tensor:
+        freqs = torch.linspace(0.0, sample_rate / 2.0, n_fft // 2 + 1)
+        mel_min = cls._hz_to_mel(torch.tensor(float(f_min)))
+        mel_max = cls._hz_to_mel(torch.tensor(float(f_max)))
+        mels = torch.linspace(mel_min, mel_max, n_mels + 2)
+        hz = cls._mel_to_hz(mels)
+        lower = hz[:-2].unsqueeze(1)
+        center = hz[1:-1].unsqueeze(1)
+        upper = hz[2:].unsqueeze(1)
+        left = (freqs - lower) / torch.clamp(center - lower, min=1e-6)
+        right = (upper - freqs) / torch.clamp(upper - center, min=1e-6)
+        return torch.clamp(torch.minimum(left, right), min=0.0)
+
+    def forward(self, wav: torch.Tensor) -> torch.Tensor:
+        spectrum = torch.stft(
+            wav,
+            n_fft=self.n_fft,
+            hop_length=self.hop_length,
+            win_length=self.win_length,
+            window=self.window.to(device=wav.device, dtype=wav.dtype),
+            center=False,
+            return_complex=True,
+        ).abs()
+        mel = torch.matmul(
+            self.mel_fb.to(device=wav.device, dtype=spectrum.dtype),
+            spectrum,
+        )
+        return mel
 
 
 class Qwen3SpeakerEmbedding(nn.Module):
@@ -53,25 +139,36 @@ class Qwen3SpeakerEmbedding(nn.Module):
         self._compile_forward = compile_forward
         self._compiled = None
         self.model = AutoModel.from_pretrained(
-            self.MODEL_NAME,
+            os.getenv("ZONOS2_SPEAKER_EMBEDDING_PATH", self.MODEL_NAME),
             trust_remote_code=True,
         )
         self.model.to(device)
         self.model.eval()
 
-        self.mel_transform = torchaudio.transforms.MelSpectrogram(
-            sample_rate=self.TARGET_SAMPLE_RATE,
-            n_fft=self.N_FFT,
-            win_length=self.WIN_LENGTH,
-            hop_length=self.HOP_LENGTH,
-            f_min=self.F_MIN,
-            f_max=self.F_MAX,
-            n_mels=self.N_MELS,
-            power=1.0,
-            center=False,
-            norm="slaney",
-            mel_scale="slaney",
-        ).to(device)
+        if torchaudio is not None:
+            self.mel_transform = torchaudio.transforms.MelSpectrogram(
+                sample_rate=self.TARGET_SAMPLE_RATE,
+                n_fft=self.N_FFT,
+                win_length=self.WIN_LENGTH,
+                hop_length=self.HOP_LENGTH,
+                f_min=self.F_MIN,
+                f_max=self.F_MAX,
+                n_mels=self.N_MELS,
+                power=1.0,
+                center=False,
+                norm="slaney",
+                mel_scale="slaney",
+            ).to(device)
+        else:
+            self.mel_transform = _TorchMelSpectrogram(
+                sample_rate=self.TARGET_SAMPLE_RATE,
+                n_fft=self.N_FFT,
+                win_length=self.WIN_LENGTH,
+                hop_length=self.HOP_LENGTH,
+                f_min=self.F_MIN,
+                f_max=self.F_MAX,
+                n_mels=self.N_MELS,
+            ).to(device)
 
         self.requires_grad_(False).eval()
 
@@ -81,6 +178,8 @@ class Qwen3SpeakerEmbedding(nn.Module):
 
     @cache
     def _get_resampler(self, orig_sample_rate: int):
+        if torchaudio is None:
+            return None
         return torchaudio.transforms.Resample(
             orig_sample_rate, self.TARGET_SAMPLE_RATE
         ).to(self.device)
@@ -91,7 +190,12 @@ class Qwen3SpeakerEmbedding(nn.Module):
             wav = wav.mean(0, keepdim=True)
         wav = wav.to(self.device, torch.float32)
         if sample_rate != self.TARGET_SAMPLE_RATE:
-            wav = self._get_resampler(sample_rate)(wav)
+            resampler = self._get_resampler(sample_rate)
+            if resampler is not None:
+                wav = resampler(wav)
+            else:
+                wav = _cached_resample(wav, sample_rate, self.TARGET_SAMPLE_RATE, None)
+                wav = wav.to(self.device, torch.float32)
         return wav
 
     def _make_mel(self, wav: torch.Tensor) -> torch.Tensor:
@@ -161,6 +265,10 @@ def _transcode_audio_bytes_to_wav(audio_bytes: bytes) -> bytes:
             "Reference file must contain an audio stream supported by ffmpeg." + suffix
         )
     return proc.stdout
+
+
+def _is_wav_container(audio_bytes: bytes) -> bool:
+    return audio_bytes.startswith(b"RIFF") and audio_bytes[8:12] == b"WAVE"
 
 
 def _decode_wav_bytes(wav_bytes: bytes) -> tuple[torch.Tensor, int]:
@@ -333,7 +441,12 @@ class SpeakerEncoder(TensorReferenceEncodeHook[_Zonos2RefInput]):
 
     def encode_one(self, item: _Zonos2RefInput) -> torch.Tensor:
         if item.kind == "raw":
-            wav, sr = _decode_wav_bytes(_transcode_audio_bytes_to_wav(item.raw))
+            wav_bytes = (
+                item.raw
+                if _is_wav_container(item.raw)
+                else _transcode_audio_bytes_to_wav(item.raw)
+            )
+            wav, sr = _decode_wav_bytes(wav_bytes)
         else:
             wav, sr = item.wav, item.sr
         embedder = self._get_embedder()

--- a/sglang_omni/models/zonos2/model_runner.py
+++ b/sglang_omni/models/zonos2/model_runner.py
@@ -21,6 +21,22 @@ from sglang_omni.models.zonos2.sampler import sample_tts
 from sglang_omni.models.zonos2.streaming_contract import (
     DEFAULT_ZONOS2_PRODUCER_FIRST_FLUSH_ROWS,
 )
+from sglang_omni.utils import device_graph
+
+
+def _request_extend_length(req: Any) -> int:
+    if hasattr(req, "extend_input_len"):
+        return int(req.extend_input_len)
+    extend_range = getattr(req, "extend_range", None)
+    if extend_range is not None and hasattr(extend_range, "length"):
+        return int(extend_range.length)
+    fill_ids = getattr(req, "fill_ids", None)
+    if fill_ids is not None:
+        prefix_indices = getattr(req, "prefix_indices", None)
+        prefix_len = len(prefix_indices) if prefix_indices is not None else 0
+        return max(0, len(fill_ids) - prefix_len)
+    origin_ids = getattr(req, "origin_input_ids", None)
+    return len(origin_ids) if origin_ids is not None else 0
 
 
 class Zonos2ModelRunner(ModelRunner):
@@ -99,8 +115,9 @@ class Zonos2ModelRunner(ModelRunner):
         for sr in requests:
             data = sr.data
             req = data.req
-            prefix_len = len(req.prefix_indices)
-            req_len = int(req.extend_range.length)
+            prefix_indices = getattr(req, "prefix_indices", None)
+            prefix_len = len(prefix_indices) if prefix_indices is not None else 0
+            req_len = _request_extend_length(req)
             rows = data.prompt_rows[prefix_len : prefix_len + req_len].to(model.device)
             emb = model.embed_frames(rows)
             if data.speaker_emb is not None:
@@ -182,10 +199,16 @@ class Zonos2ModelRunner(ModelRunner):
         params = requests[0].data.params
         p = [sr.data.params for sr in requests]
         dev = hidden.device
+        top_k_max = max(
+            (x.top_k for x in p if 0 < x.top_k < model.audio_vocab), default=0
+        )
+        any_top_p = any(0.0 < x.top_p < 1.0 for x in p)
+        any_min_p = any(x.min_p > 0.0 for x in p)
 
-        # Compose with the tail CUDA-graph (ZONOS2_FRAME_GRAPH): when armed, run
-        # head+sample+embed+hash as one captured replay, with rep_ids/break_mask
-        # fed from the ON-DEVICE ring (not host-built) so no host work re-enters.
+        # Compose with the tail CUDA-graph (ZONOS2_FRAME_GRAPH): when armed,
+        # replay the deterministic head logits graph with rep_ids/break_mask fed
+        # from the on-device ring. Sampling stays on the normal GPU launch path
+        # because torch.multinomial is not MUSA-graph-capture safe.
         use_graph = (
             self._frame_graph
             and not is_prefill
@@ -198,7 +221,7 @@ class Zonos2ModelRunner(ModelRunner):
                 row_t, n, int(params.repetition_window), cb_size, dev
             )
             break_mask = self._break_mask_ring(row_t, model.audio_vocab, dev)
-            codes, keys, feedback = model.run_tail_graph(
+            logits = model.run_tail_graph(
                 hidden,
                 torch.tensor([x.temperature for x in p], device=dev),
                 torch.tensor([x.top_k for x in p], device=dev),
@@ -212,31 +235,24 @@ class Zonos2ModelRunner(ModelRunner):
             logits = model.compute_logits(hidden).float()  # [B, 9, 1026]
             rep_ids = self._rep_window(row_t, n, cb_size, params)
             self._break_frame_loops(logits, row_t)
-            top_k_max = max(
-                (x.top_k for x in p if 0 < x.top_k < model.audio_vocab), default=0
-            )
-            any_top_p = any(0.0 < x.top_p < 1.0 for x in p)
-            any_min_p = any(x.min_p > 0.0 for x in p)
-            codes = self._sampler(
-                logits,
-                temperature=torch.tensor([x.temperature for x in p], device=dev),
-                top_k=torch.tensor([x.top_k for x in p], device=dev),
-                top_p=torch.tensor([x.top_p for x in p], device=dev),
-                min_p=torch.tensor([x.min_p for x in p], device=dev),
-                repetition_penalty=torch.tensor(
-                    [x.repetition_penalty for x in p], device=dev
-                ),
-                top_k_max=top_k_max,
-                rep_token_ids=rep_ids,
-                any_top_p=any_top_p,
-                any_min_p=any_min_p,
-            )  # [B, 9]
-            text_col = torch.full(
-                (b, 1), text_pad, device=codes.device, dtype=torch.long
-            )
-            rows = torch.cat([codes, text_col], dim=1)
-            feedback = model.embed_frames(rows)  # [B, dim]
-            keys = poly_row_hash(rows)  # [B] (< RADIX_HASH_SPACE)
+        codes = self._sampler(
+            logits,
+            temperature=torch.tensor([x.temperature for x in p], device=dev),
+            top_k=torch.tensor([x.top_k for x in p], device=dev),
+            top_p=torch.tensor([x.top_p for x in p], device=dev),
+            min_p=torch.tensor([x.min_p for x in p], device=dev),
+            repetition_penalty=torch.tensor(
+                [x.repetition_penalty for x in p], device=dev
+            ),
+            top_k_max=top_k_max,
+            rep_token_ids=rep_ids,
+            any_top_p=any_top_p,
+            any_min_p=any_min_p,
+        )  # [B, 9]
+        text_col = torch.full((b, 1), text_pad, device=codes.device, dtype=torch.long)
+        rows = torch.cat([codes, text_col], dim=1)
+        feedback = model.embed_frames(rows)  # [B, dim]
+        keys = poly_row_hash(rows)  # [B] (< RADIX_HASH_SPACE)
 
         # Stage next-step feedback into the on-device pool row (one batched scatter).
         pool.feedback_embeds[row_t] = feedback.detach()
@@ -290,7 +306,7 @@ class Zonos2ModelRunner(ModelRunner):
             dim=1,
         )
         packed = torch.cat((codes, meta), dim=1)  # [B, n+2] int64
-        ev = torch.cuda.Event()
+        ev = device_graph.new_event(packed.device)
         ev.record()
         return (requests, packed, n, next_ids.clone(), ev)
 
@@ -310,9 +326,9 @@ class Zonos2ModelRunner(ModelRunner):
         # and runs on a separate stream, so this no longer whole-stream-syncs on
         # forward(N+1). One D2H of the packed [B, n+2] snapshot.
         if self._copy_stream is None:
-            self._copy_stream = torch.cuda.Stream(device=packed.device)
+            self._copy_stream = device_graph.new_stream(packed.device)
         self._copy_stream.wait_event(ev)
-        with torch.cuda.stream(self._copy_stream):
+        with device_graph.stream(self._copy_stream):
             packed_cpu = packed.to("cpu", non_blocking=True)
         self._copy_stream.synchronize()
         codes_cpu = packed_cpu[:, :n]

--- a/sglang_omni/models/zonos2/sglang_model.py
+++ b/sglang_omni/models/zonos2/sglang_model.py
@@ -21,6 +21,7 @@ from sglang_omni.models.zonos2.components.text_frontend import TTSSamplingParams
 from sglang_omni.models.zonos2.hf_config import Zonos2Config
 from sglang_omni.models.zonos2.radix_hash import poly_row_hash
 from sglang_omni.models.zonos2.sampler import sample_tts
+from sglang_omni.utils import device_graph
 from sglang_omni.vendor.sglang.core import ForwardBatch
 from sglang_omni.vendor.sglang.layers import (
     RadixAttention,
@@ -260,10 +261,10 @@ class Zonos2SGLangModel(nn.Module):
             False
         )  # inference-only; sglang in-place ops reject grad tensors
 
-        # Opt-in tail CUDA graph (ZONOS2_FRAME_GRAPH): captures the launch-heavy
-        # per-frame tail (head GEMM + per-request sample + embed + radix hash) into
-        # one replay per decode bucket, cutting host dispatch in the host-bound
-        # decode loop. Built by capture_tail_graphs; empty -> eager runner path.
+        # Opt-in tail CUDA graph (ZONOS2_FRAME_GRAPH): captures the deterministic
+        # per-frame head GEMM into one replay per decode bucket. Random sampling
+        # runs after graph replay because torch.multinomial is not capture-safe
+        # on MUSA. Built by capture_tail_graphs; empty -> eager runner path.
         self._tail_buckets: list[int] = []
         self._tail_graphs: dict[int, Any] = {}
         self._tail_params: Optional[TTSSamplingParams] = None
@@ -350,31 +351,11 @@ class Zonos2SGLangModel(nn.Module):
 
     @torch.no_grad()
     def _tail_compute(self, bs: int) -> None:
-        """Graph-capturable per-frame tail over the first ``bs`` static rows: head
-        GEMM -> break-mask -> per-request sample (torch.multinomial, capturable)
-        -> embed -> radix hash. Reads/writes the ``_cg`` buffers in place."""
+        """Graph-capturable deterministic tail over the first ``bs`` rows."""
         cg = self._cg
         logits = self.compute_logits(cg["hidden"][:bs]).float()
         logits[:, 0].add_(cg["break_mask"][:bs])
-        codes = sample_tts(
-            logits,
-            temperature=cg["temperature"][:bs],
-            top_k=cg["top_k"][:bs],
-            top_p=cg["top_p"][:bs],
-            min_p=cg["min_p"][:bs],
-            repetition_penalty=cg["rep_pen"][:bs],
-            top_k_max=self._tail_top_k_max,
-            rep_token_ids=cg["rep_ids"][:bs],
-            any_top_p=self._tail_any_top_p,
-            any_min_p=self._tail_any_min_p,
-        )
-        text_col = torch.full(
-            (bs, 1), self.config.text_vocab, device=codes.device, dtype=torch.long
-        )
-        rows = torch.cat([codes, text_col], dim=1)
-        cg["codes"][:bs].copy_(codes)
-        cg["feedback"][:bs].copy_(self.embed_frames(rows))
-        cg["keys"][:bs].copy_(poly_row_hash(rows))
+        cg["logits"][:bs].copy_(logits)
 
     @torch.no_grad()
     def capture_tail_graphs(
@@ -398,6 +379,7 @@ class Zonos2SGLangModel(nn.Module):
             ),
             "rep_ids": torch.full((mb, n, W), -1, device=dev, dtype=i64),
             "break_mask": torch.zeros(mb, V, device=dev, dtype=f32),
+            "logits": torch.zeros(mb, n, V, device=dev, dtype=f32),
             "codes": torch.zeros(mb, n, device=dev, dtype=i64),
             "keys": torch.zeros(mb, device=dev, dtype=i64),
             "feedback": torch.zeros(mb, dim, device=dev, dtype=dt),
@@ -408,20 +390,21 @@ class Zonos2SGLangModel(nn.Module):
         self._tail_any_min_p = params.min_p > 0.0
         self._tail_buckets = sorted(buckets)
         self._tail_graphs = {}
-        s = torch.cuda.Stream()
-        s.wait_stream(torch.cuda.current_stream())
-        with torch.cuda.stream(s):
+        current_stream = device_graph.current_stream(dev)
+        s = device_graph.new_stream(dev)
+        s.wait_stream(current_stream)
+        with device_graph.stream(s):
             for bs in self._tail_buckets:
                 for _ in range(3):
                     self._tail_compute(bs)
-        torch.cuda.current_stream().wait_stream(s)
-        torch.cuda.synchronize()
+        current_stream.wait_stream(s)
+        device_graph.synchronize(dev)
         for bs in self._tail_buckets:
-            g = torch.cuda.CUDAGraph()
-            with torch.cuda.graph(g):
+            g = device_graph.new_graph(dev)
+            with device_graph.graph(g, device=dev):
                 self._tail_compute(bs)
             self._tail_graphs[bs] = g
-        torch.cuda.synchronize()
+        device_graph.synchronize(dev)
 
     @torch.no_grad()
     def run_tail_graph(
@@ -429,7 +412,7 @@ class Zonos2SGLangModel(nn.Module):
     ):
         """Stage inputs into the static buffers, replay the bs-bucket graph (padded
         up to the next bucket; extra rows compute on stale data and are ignored),
-        and return views of (codes [bs,n], keys [bs], feedback [bs,dim])."""
+        and return logits [bs,n,V]."""
         bs = hidden.shape[0]
         bucket = next(g for g in self._tail_buckets if g >= bs)
         cg = self._cg
@@ -442,7 +425,7 @@ class Zonos2SGLangModel(nn.Module):
         cg["rep_ids"][:bs].copy_(rep_ids)
         cg["break_mask"][:bs].copy_(break_mask)
         self._tail_graphs[bucket].replay()
-        return cg["codes"][:bs], cg["keys"][:bs], cg["feedback"][:bs]
+        return cg["logits"][:bs]
 
     @torch.no_grad()
     def load_weights(self, weights: Iterable[Tuple[str, torch.Tensor]]) -> None:


### PR DESCRIPTION
## Summary

Split the ZONOS2 adaptation out of PR #1869. This PR is based directly on the latest upstream `main`; it depends logically on the shared runtime PR #2020.

## Scope

- ZONOS2 model code and MUSA/CUDA compatibility changes
- model-specific tests where present
- no model weights, Docker image layers, logs, or installation documents

## Validation

- Python static compilation passed for the changed model branch
- `git diff --check` passed
- target image evidence: `sh-harbor.mthreads.com/mcctest/musa-sglang-omni-openbox-complete:20260904`

The image contains historical smoke evidence for this model. A fresh latest-`main` MUSA service smoke and real output artifact must still be attached before this PR is marked complete.

## Related

- Original aggregate: PR #1869
- Shared runtime: PR #2020
