### PR TITLE
[Feature] Add session lifecycle to the Omni pipeline

### DIFF
--- a/sglang_omni/pipeline/coordinator.py
+++ b/sglang_omni/pipeline/coordinator.py
@@ -161,7 +161,6 @@ class Coordinator(CoordinatorSessions):
         self._running = False
         message = str(error)
         self._fatal_error = message
-        await self._fail_sessions(message)
         for request_id, info in list(self._requests.items()):
             info.state = RequestState.FAILED
             info.error = message
@@ -178,6 +177,8 @@ class Coordinator(CoordinatorSessions):
                 )
         self._requests.clear()
         self._partial_results.clear()
+        # Note (Junnan Li): Session pumps await request futures; wake them before waiting for cleanup.
+        await self._fail_sessions(message)
 
     async def shutdown_stages(self, stage_names: Sequence[str] | None = None) -> None:
         """Send shutdown to registered stages, or only to *stage_names*."""

--- a/sglang_omni/pipeline/coordinator.py
+++ b/sglang_omni/pipeline/coordinator.py
@@ -17,6 +17,7 @@ from sglang_omni.pipeline.replicas import (
     RoundRobinBindingPolicy,
     assign_replica_bindings,
 )
+from sglang_omni.pipeline.sessions import CoordinatorSessions
 from sglang_omni.profiler.event_recorder import emit as _emit_event
 from sglang_omni.proto import (
     AbortMessage,
@@ -46,7 +47,7 @@ class _AdminPendingOperation:
     future: asyncio.Future | None = None
 
 
-class Coordinator:
+class Coordinator(CoordinatorSessions):
     """Central coordinator for the multi-stage pipeline.
 
     Responsibilities:
@@ -70,6 +71,7 @@ class Coordinator:
         logical_process_plan: LogicalProcessPlan | None = None,
         binding_policy: BindingPolicy | None = None,
         max_in_flight: int | None = None,
+        max_sessions: int = 64,
     ):
         """Initialize coordinator.
 
@@ -86,6 +88,7 @@ class Coordinator:
                 are already tracked. Intended as generation capacity
                 (max_running_requests + max_queued_requests).
         """
+        self._init_sessions(max_sessions)
         self.entry_stage = entry_stage
         self._terminal_stages: set[str] = (
             set(terminal_stages) if terminal_stages else set()
@@ -148,6 +151,7 @@ class Coordinator:
 
     async def stop(self) -> None:
         """Stop the coordinator."""
+        await self._stop_sessions()
         self._running = False
         self.control_plane.close()
         logger.info("Coordinator stopped")
@@ -157,6 +161,7 @@ class Coordinator:
         self._running = False
         message = str(error)
         self._fatal_error = message
+        await self._fail_sessions(message)
         for request_id, info in list(self._requests.items()):
             info.state = RequestState.FAILED
             info.error = message
@@ -177,6 +182,7 @@ class Coordinator:
     async def shutdown_stages(self, stage_names: Sequence[str] | None = None) -> None:
         """Send shutdown to registered stages, or only to *stage_names*."""
         selected = None if stage_names is None else set(stage_names)
+        await self._shutdown_stage_sessions(selected)
         for name, info in self._stages.items():
             if selected is not None and name not in selected:
                 continue
@@ -408,6 +414,10 @@ class Coordinator:
         request: OmniRequest | Any,
         *,
         stream_queue: asyncio.Queue[CompleteMessage | StreamMessage] | None = None,
+        target_stage: str | None = None,
+        terminal_stages: set[str] | None = None,
+        replica_bindings: dict[str, int] | None = None,
+        bypass_admission: bool = False,
     ) -> None:
         """Submit a request without waiting for completion."""
         if self._fatal_error is not None:
@@ -415,7 +425,11 @@ class Coordinator:
         if self._request_id_is_reserved(request_id):
             raise ValueError(f"Request {request_id} already exists")
 
-        if self.max_in_flight is not None and len(self._requests) >= self.max_in_flight:
+        if (
+            not bypass_admission
+            and self.max_in_flight is not None
+            and len(self._requests) >= self.max_in_flight
+        ):
             logger.warning(
                 "Rejecting request %s before pipeline submit: in-flight cap "
                 "(max_in_flight=%s)",
@@ -427,11 +441,12 @@ class Coordinator:
         if not isinstance(request, OmniRequest):
             request = OmniRequest(inputs=request)
 
-        replica_bindings = assign_replica_bindings(
-            self._logical_process_plan, self._binding_policy, request_id
-        )
+        if replica_bindings is None:
+            replica_bindings = assign_replica_bindings(
+                self._logical_process_plan, self._binding_policy, request_id
+            )
         bindings = replica_bindings or {}
-        entry_instance = (
+        entry_instance = target_stage or (
             self._replica_topology.resolve(self.entry_stage, bindings[self.entry_stage])
             if self._replica_topology.is_replicated(self.entry_stage)
             else self.entry_stage
@@ -445,7 +460,11 @@ class Coordinator:
             request_id=request_id,
             state=RequestState.PENDING,
             current_stage=self.entry_stage,
-            terminal_stages=self._resolve_terminal_stages(request),
+            terminal_stages=(
+                self._resolve_terminal_stages(request)
+                if terminal_stages is None
+                else terminal_stages
+            ),
         )
 
         # Create future for completion
@@ -722,6 +741,10 @@ class Coordinator:
     async def _handle_stream(self, msg: StreamMessage) -> None:
         """Handle a stream chunk from a stage."""
         request_id = msg.request_id
+        handler = self._session_stream_handlers.get(request_id)
+        if handler is not None:
+            handler(msg)
+            return
         if request_id not in self._stream_queues:
             return
         _emit_event(

--- a/sglang_omni/pipeline/sessions.py
+++ b/sglang_omni/pipeline/sessions.py
@@ -6,6 +6,7 @@ import asyncio
 import secrets
 import uuid
 from collections import deque
+from collections.abc import Coroutine
 from dataclasses import asdict, dataclass, field, replace
 from typing import Any, AsyncIterator
 
@@ -408,7 +409,12 @@ class CoordinatorSessions:
                 "session cleanup incomplete; capacity remains reserved"
             ) from session.cleanup_error
 
-    async def _close_session_state(self, session: _Session) -> None:
+    def _close_session_state(self, session: _Session) -> Coroutine[Any, Any, None]:
+        session.closing = True
+        session.wake.set()
+        return self._finish_session_close(session)
+
+    async def _finish_session_close(self, session: _Session) -> None:
         async with session.lock:
             if session.closed:
                 return

--- a/sglang_omni/pipeline/sessions.py
+++ b/sglang_omni/pipeline/sessions.py
@@ -394,10 +394,11 @@ class CoordinatorSessions:
         return discarded
 
     async def close_session(self, ref: SessionRef) -> None:
+        """Close the referenced incarnation regardless of its current output epoch."""
         session = self._sessions.get(ref.session_id)
         if session is None:
             return
-        if session.ref != ref:
+        if session.ref.incarnation != ref.incarnation:
             raise ValueError("stale session reference")
         await asyncio.shield(
             self._owned_session_task(self._close_session_state(session))

--- a/sglang_omni/pipeline/sessions.py
+++ b/sglang_omni/pipeline/sessions.py
@@ -1,0 +1,463 @@
+# SPDX-License-Identifier: Apache-2.0
+"""Coordinator-owned session sequencing over ordinary pipeline requests."""
+from __future__ import annotations
+
+import asyncio
+import secrets
+import uuid
+from collections import deque
+from dataclasses import asdict, dataclass, field, replace
+from typing import Any, AsyncIterator
+
+import msgpack
+
+from sglang_omni.admission import QueueFullError
+from sglang_omni.pipeline.replicas import assign_replica_bindings
+from sglang_omni.proto import OmniRequest, StreamMessage
+from sglang_omni.proto.session import (
+    SESSION_METADATA_KEY,
+    OutputChunk,
+    SessionLimits,
+    SessionRef,
+    TimedChunk,
+    wire_size,
+)
+
+
+@dataclass
+class _Session:
+    ref: SessionRef
+    request: OmniRequest
+    stages: tuple[str, ...]
+    bindings: dict[str, int]
+    limits: SessionLimits
+    opened: list[str] = field(default_factory=list)
+    pending: deque = field(default_factory=deque)
+    pending_bytes: int = 0
+    pending_count: int = 0
+    outputs: deque = field(default_factory=deque)
+    output_bytes: int = 0
+    next_input: int = 0
+    next_output: int = 0
+    ends: dict[str, float] = field(default_factory=dict)
+    eos: set[str] = field(default_factory=set)
+    wake: asyncio.Event = field(default_factory=asyncio.Event)
+    output_wake: asyncio.Event = field(default_factory=asyncio.Event)
+    lock: asyncio.Lock = field(default_factory=asyncio.Lock)
+    unit_lock: asyncio.Lock = field(default_factory=asyncio.Lock)
+    pump: asyncio.Task | None = None
+    closing: bool = False
+    closed: bool = False
+    reading: bool = False
+    error: BaseException | None = None
+    cleanup_error: BaseException | None = None
+
+
+class CoordinatorSessions:
+    """Opt-in session API; ordinary submit/stream keep their existing behavior."""
+
+    def _init_sessions(self, max_sessions: int) -> None:
+        if max_sessions <= 0:
+            raise ValueError("max_sessions must be positive")
+        self.max_sessions = max_sessions
+        self._sessions_stopping = False
+        self._session_unavailable_stages: set[str] = set()
+        self._sessions: dict[str, _Session] = {}
+        self._session_stream_handlers: dict[str, Any] = {}
+        self._session_cleanup_tasks: set[asyncio.Task] = set()
+
+    def _owned_session_task(self, coroutine) -> asyncio.Task:
+        task = asyncio.create_task(coroutine)
+        self._session_cleanup_tasks.add(task)
+        task.add_done_callback(self._session_task_done)
+        return task
+
+    def _session_task_done(self, task: asyncio.Task) -> None:
+        self._session_cleanup_tasks.discard(task)
+        if not task.cancelled():
+            task.exception()
+
+    def _session(self, ref: SessionRef) -> _Session:
+        session = self._sessions.get(ref.session_id)
+        if session is None or session.ref != ref:
+            raise ValueError("unknown or stale session reference")
+        return session
+
+    async def open_session(
+        self,
+        request: OmniRequest,
+        *,
+        stages: list[str],
+        limits: SessionLimits | None = None,
+        session_id: str | None = None,
+    ) -> SessionRef:
+        """Open a fixed linear route, upstream to downstream, before accepting input."""
+        if (
+            self._sessions_stopping
+            or not self._running
+            or self._fatal_error is not None
+        ):
+            raise RuntimeError(self._fatal_error or "Coordinator is not running")
+        if (
+            not stages
+            or stages[0] != self.entry_stage
+            or len(set(stages)) != len(stages)
+        ):
+            raise ValueError("stages must be a unique route beginning at entry_stage")
+        if len(self._sessions) >= self.max_sessions:
+            raise QueueFullError()
+        session_id = session_id or str(uuid.uuid4())
+        if session_id in self._sessions:
+            raise ValueError("session ID already reserved")
+        bindings = (
+            assign_replica_bindings(
+                self._logical_process_plan, self._binding_policy, session_id
+            )
+            or {}
+        )
+        owners = tuple(
+            (
+                self._replica_topology.resolve(stage, bindings[stage])
+                if self._replica_topology.is_replicated(stage)
+                else stage
+            )
+            for stage in stages
+        )
+        if any(
+            owner not in self._stages or owner in self._session_unavailable_stages
+            for owner in owners
+        ):
+            raise ValueError("session route contains an unregistered owner")
+        session = _Session(
+            SessionRef(session_id, secrets.randbelow((1 << 63) - 1) + 1),
+            request,
+            owners,
+            bindings,
+            limits or SessionLimits(),
+        )
+        self._sessions[session_id] = session
+        try:
+            async with session.lock:
+                for owner in owners:
+                    # Include attempts: open may allocate before its reply is lost.
+                    session.opened.append(owner)
+                    await self._session_command(session, "open", owner=owner)
+                if (
+                    self._sessions_stopping
+                    or self._session_unavailable_stages.intersection(owners)
+                ):
+                    raise RuntimeError("session owners are shutting down")
+        except BaseException:
+            await asyncio.shield(
+                self._owned_session_task(self._close_session_state(session))
+            )
+            raise
+        session.pump = asyncio.create_task(self._pump_session(session))
+        return session.ref
+
+    async def append_session(self, ref: SessionRef, chunk: TimedChunk) -> int:
+        """Accept a bounded input without waiting for the current output unit."""
+        session = self._session(ref)
+        if session.closing or session.closed:
+            raise RuntimeError("session is closing")
+        if chunk.seq != session.next_input:
+            raise ValueError("input seq must be contiguous within an incarnation")
+        if chunk.modality in session.eos:
+            raise ValueError("input after EOS")
+        if chunk.t_start_ms < session.ends.get(chunk.modality, 0):
+            raise ValueError("input timing overlaps or moves backwards")
+        encoded = msgpack.packb(asdict(chunk), use_bin_type=True)
+        size = len(encoded)
+        limits = session.limits
+        if (
+            size > limits.max_chunk_bytes
+            or session.pending_count >= limits.max_pending_chunks
+            or session.pending_bytes + size > limits.max_pending_bytes
+        ):
+            raise QueueFullError()
+        if (
+            chunk.modality not in session.ends
+            and len(session.ends) >= limits.max_modalities
+        ):
+            raise QueueFullError()
+        chunk = TimedChunk(**msgpack.unpackb(encoded, raw=False))
+        session.pending.append((chunk, size))
+        session.pending_count += 1
+        session.pending_bytes += size
+        session.next_input += 1
+        session.ends[chunk.modality] = chunk.t_start_ms + chunk.duration_ms
+        if chunk.eos:
+            session.eos.add(chunk.modality)
+        session.wake.set()
+        return chunk.seq
+
+    async def session_outputs(self, ref: SessionRef) -> AsyncIterator[OutputChunk]:
+        """One output consumer; disconnect closes the owned session."""
+        session = self._session(ref)
+        if session.reading:
+            raise RuntimeError("session already has an output consumer")
+        session.reading = True
+        try:
+            while True:
+                while session.outputs:
+                    output, size = session.outputs.popleft()
+                    session.output_bytes -= size
+                    if output.ref == session.ref or (
+                        output.kind == "input_done"
+                        and output.ref.incarnation == session.ref.incarnation
+                    ):
+                        yield output
+                if session.closed:
+                    if session.error is not None:
+                        raise session.error
+                    return
+                session.output_wake.clear()
+                await session.output_wake.wait()
+        finally:
+            session.reading = False
+            await asyncio.shield(
+                self._owned_session_task(self._close_session_state(session))
+            )
+
+    def _emit_session_output(
+        self,
+        session: _Session,
+        ref: SessionRef,
+        input_seq: int,
+        chunk: TimedChunk,
+        *,
+        kind: str = "data",
+    ) -> None:
+        if session.closing or (session.ref != ref and kind != "input_done"):
+            return
+        output = OutputChunk(
+            ref,
+            session.next_output,
+            input_seq,
+            chunk.modality,
+            chunk.t_start_ms,
+            chunk.duration_ms,
+            chunk.payload,
+            chunk.format,
+            chunk.eos,
+            kind,
+        )
+        size = wire_size(asdict(output))
+        if (
+            len(session.outputs) >= session.limits.max_output_chunks
+            or session.output_bytes + size > session.limits.max_output_bytes
+        ):
+            raise QueueFullError()
+        session.outputs.append((output, size))
+        session.output_bytes += size
+        session.next_output += 1
+        session.output_wake.set()
+
+    async def _pump_session(self, session: _Session) -> None:
+        try:
+            while not session.closing:
+                if not session.pending:
+                    session.wake.clear()
+                    await asyncio.wait_for(
+                        session.wake.wait(), session.limits.idle_timeout_s
+                    )
+                    continue
+                async with session.unit_lock:
+                    if session.closing:
+                        break
+                    chunk, size = session.pending.popleft()
+                    ref = session.ref
+                    try:
+                        await self._session_command(session, "append", chunk=chunk)
+                        self._emit_session_output(
+                            session,
+                            ref,
+                            chunk.seq,
+                            replace(chunk, payload=None),
+                            kind="input_done",
+                        )
+                    finally:
+                        session.pending_count -= 1
+                        session.pending_bytes -= size
+        except asyncio.CancelledError:
+            raise
+        except Exception as exc:
+            session.error = exc
+            self._owned_session_task(self._close_session_state(session))
+
+    async def _session_command(
+        self,
+        session: _Session,
+        op: str,
+        *,
+        owner: str | None = None,
+        chunk: TimedChunk | None = None,
+    ) -> Any:
+        ref = session.ref
+        command = {
+            "op": op,
+            "ref": asdict(ref),
+            "stages": list(session.stages),
+            "output_limits": {
+                "chunks": session.limits.max_output_chunks,
+                "bytes": session.limits.max_output_bytes,
+            },
+        }
+        if chunk is not None:
+            command["chunk"] = asdict(chunk)
+        request = replace(
+            session.request,
+            metadata={**session.request.metadata, SESSION_METADATA_KEY: command},
+        )
+        request_id = f"session-{uuid.uuid4()}"
+
+        def output(msg: StreamMessage) -> None:
+            try:
+                self._emit_session_output(
+                    session, ref, chunk.seq, TimedChunk(**msg.chunk)
+                )
+            except Exception as exc:
+                self._reject_completion_future(request_id, exc)
+
+        if chunk is not None:
+            self._session_stream_handlers[request_id] = output
+        try:
+            async with asyncio.timeout(session.limits.command_timeout_s):
+                await self._submit_request(
+                    request_id,
+                    request,
+                    target_stage=owner,
+                    terminal_stages=(
+                        {self._replica_topology.logical_name(owner)}
+                        if owner
+                        else {self._replica_topology.logical_name(session.stages[-1])}
+                    ),
+                    replica_bindings=session.bindings,
+                    bypass_admission=op in {"abort", "close"},
+                )
+                return await self._completion_futures[request_id]
+        finally:
+            self._session_stream_handlers.pop(request_id, None)
+            if request_id in self._requests:
+                await self.abort(request_id)
+            future = self._completion_futures.pop(request_id, None)
+            if future is not None and not future.done():
+                future.cancel()
+
+    async def abort_session(self, ref: SessionRef) -> SessionRef:
+        """Fence output immediately; finish the active unit before changing stage state."""
+        task = self._owned_session_task(self._abort_session(ref))
+        return await asyncio.shield(task)
+
+    async def _abort_session(self, ref: SessionRef) -> SessionRef:
+        session = self._session(ref)
+        async with session.lock:
+            if session.closing:
+                raise RuntimeError("session is closing")
+            session.ref = replace(ref, epoch=ref.epoch + 1)
+            session.outputs = deque(
+                (output, size)
+                for output, size in session.outputs
+                if output.kind == "input_done"
+            )
+            session.output_bytes = sum(size for _, size in session.outputs)
+            try:
+                # Normal unit completion transfers KV back to its core session.
+                # Canceling the pump here would abort that request and free KV.
+                async with session.unit_lock:
+                    for owner in reversed(session.opened):
+                        await self._session_command(session, "abort", owner=owner)
+            except BaseException as exc:
+                session.error = exc
+                await self._cleanup_session(session)
+                raise
+            return session.ref
+
+    async def clear_session_input(self, ref: SessionRef) -> list[TimedChunk]:
+        """Discard queued input only; accepted sequence, timing and EOS stay committed."""
+        session = self._session(ref)
+        if session.closing:
+            raise RuntimeError("session is closing")
+        discarded = [chunk for chunk, _ in session.pending]
+        session.pending_count -= len(discarded)
+        session.pending_bytes -= sum(size for _, size in session.pending)
+        session.pending.clear()
+        return discarded
+
+    async def close_session(self, ref: SessionRef) -> None:
+        session = self._sessions.get(ref.session_id)
+        if session is None:
+            return
+        if session.ref != ref:
+            raise ValueError("stale session reference")
+        await asyncio.shield(
+            self._owned_session_task(self._close_session_state(session))
+        )
+        if session.cleanup_error is not None:
+            raise RuntimeError(
+                "session cleanup incomplete; capacity remains reserved"
+            ) from session.cleanup_error
+
+    async def _close_session_state(self, session: _Session) -> None:
+        async with session.lock:
+            if session.closed:
+                return
+            await self._cleanup_session(session)
+
+    async def _cleanup_session(self, session: _Session) -> None:
+        session.closing = True
+        session.wake.set()
+        if session.pump is not None and session.pump is not asyncio.current_task():
+            try:
+                await asyncio.wait_for(
+                    asyncio.shield(session.pump), session.limits.command_timeout_s
+                )
+            except asyncio.TimeoutError as exc:
+                session.cleanup_error = session.error = exc
+                session.pump.cancel()
+                await asyncio.gather(session.pump, return_exceptions=True)
+                session.closed = True
+                session.output_wake.set()
+                return
+        session.pending.clear()
+        session.pending_count = session.pending_bytes = 0
+        for owner in reversed(session.opened):
+            try:
+                await self._session_command(session, "close", owner=owner)
+            except Exception as exc:
+                session.cleanup_error = exc
+                session.error = session.error or exc
+                # An unacknowledged downstream owner may still use upstream data.
+                break
+        session.closed = True
+        session.output_wake.set()
+        # Never reclaim capacity on an unacknowledged close: a worker may still
+        # own buffers or be finishing a command. Worker teardown owns that case.
+        if session.cleanup_error is None:
+            self._sessions.pop(session.ref.session_id, None)
+
+    async def _shutdown_stage_sessions(self, selected: set[str] | None) -> None:
+        affected = set(self._stages) if selected is None else selected
+        self._session_unavailable_stages.update(affected)
+        if selected is None:
+            await self._stop_sessions()
+        else:
+            await asyncio.gather(
+                *(
+                    self._close_session_state(session)
+                    for session in list(self._sessions.values())
+                    if affected.intersection(session.stages)
+                )
+            )
+
+    async def _stop_sessions(self) -> None:
+        self._sessions_stopping = True
+        await asyncio.gather(
+            *(self._close_session_state(s) for s in list(self._sessions.values()))
+        )
+        await asyncio.gather(*self._session_cleanup_tasks, return_exceptions=True)
+
+    async def _fail_sessions(self, message: str) -> None:
+        for session in list(self._sessions.values()):
+            session.error = RuntimeError(message)
+        await self._stop_sessions()

--- a/sglang_omni/pipeline/sessions.py
+++ b/sglang_omni/pipeline/sessions.py
@@ -152,6 +152,7 @@ class CoordinatorSessions:
                 self._owned_session_task(self._close_session_state(session))
             )
             raise
+        session.request = replace(request, inputs=None)
         session.pump = asyncio.create_task(self._pump_session(session))
         return session.ref
 
@@ -166,8 +167,11 @@ class CoordinatorSessions:
             raise ValueError("input after EOS")
         if chunk.t_start_ms < session.ends.get(chunk.modality, 0):
             raise ValueError("input timing overlaps or moves backwards")
-        encoded = msgpack.packb(asdict(chunk), use_bin_type=True)
-        size = len(encoded)
+        if isinstance(chunk.payload, bytes):
+            size = wire_size(asdict(chunk))
+        else:
+            encoded = msgpack.packb(asdict(chunk), use_bin_type=True)
+            size = len(encoded)
         limits = session.limits
         if (
             size > limits.max_chunk_bytes
@@ -180,7 +184,8 @@ class CoordinatorSessions:
             and len(session.ends) >= limits.max_modalities
         ):
             raise QueueFullError()
-        chunk = TimedChunk(**msgpack.unpackb(encoded, raw=False))
+        if not isinstance(chunk.payload, bytes):
+            chunk = TimedChunk(**msgpack.unpackb(encoded, raw=False))
         session.pending.append((chunk, size))
         session.pending_count += 1
         session.pending_bytes += size

--- a/sglang_omni/pipeline/sessions.py
+++ b/sglang_omni/pipeline/sessions.py
@@ -157,7 +157,11 @@ class CoordinatorSessions:
         return session.ref
 
     async def append_session(self, ref: SessionRef, chunk: TimedChunk) -> int:
-        """Accept a bounded input without waiting for the current output unit."""
+        """Accept input in global seq order, independently of output consumption.
+
+        Adapters map per-stream seq to this order. Rejected input keeps its seq
+        for retry; accepted input advances it and must not be resubmitted.
+        """
         session = self._session(ref)
         if session.closing or session.closed:
             raise RuntimeError("session is closing")

--- a/sglang_omni/pipeline/sessions.py
+++ b/sglang_omni/pipeline/sessions.py
@@ -124,11 +124,12 @@ class CoordinatorSessions:
             )
             for stage in stages
         )
-        if any(
-            owner not in self._stages or owner in self._session_unavailable_stages
-            for owner in owners
-        ):
+        if any(owner not in self._stages for owner in owners):
             raise ValueError("session route contains an unregistered owner")
+        if self._session_unavailable_stages.intersection(owners):
+            raise ValueError(
+                "session route contains an unregistered owner or unavailable owner"
+            )
         session = _Session(
             SessionRef(session_id, secrets.randbelow((1 << 63) - 1) + 1),
             request,
@@ -419,6 +420,7 @@ class CoordinatorSessions:
                 )
             except asyncio.TimeoutError as exc:
                 session.cleanup_error = session.error = exc
+                self._session_unavailable_stages.update(session.opened)
                 session.pump.cancel()
                 await asyncio.gather(session.pump, return_exceptions=True)
                 session.closed = True
@@ -426,13 +428,16 @@ class CoordinatorSessions:
                 return
         session.pending.clear()
         session.pending_count = session.pending_bytes = 0
+        unconfirmed = list(session.opened)
         for owner in reversed(session.opened):
             try:
                 await self._session_command(session, "close", owner=owner)
+                unconfirmed.pop()
             except Exception as exc:
                 session.cleanup_error = exc
                 session.error = session.error or exc
                 # An unacknowledged downstream owner may still use upstream data.
+                self._session_unavailable_stages.update(unconfirmed)
                 break
         session.closed = True
         session.output_wake.set()

--- a/sglang_omni/pipeline/sessions.py
+++ b/sglang_omni/pipeline/sessions.py
@@ -347,6 +347,10 @@ class CoordinatorSessions:
                     bypass_admission=op in {"abort", "close"},
                 )
                 return await self._completion_futures[request_id]
+        except BaseException:
+            # Note (Junnan Li): Request abort can yield before the pump sees this fatal failure.
+            self._begin_session_close(session)
+            raise
         finally:
             self._session_stream_handlers.pop(request_id, None)
             if request_id in self._requests:
@@ -399,9 +403,12 @@ class CoordinatorSessions:
                 "session cleanup incomplete; capacity remains reserved"
             ) from session.cleanup_error
 
-    def _close_session_state(self, session: _Session) -> Coroutine[Any, Any, None]:
+    def _begin_session_close(self, session: _Session) -> None:
         session.closing = True
         session.wake.set()
+
+    def _close_session_state(self, session: _Session) -> Coroutine[Any, Any, None]:
+        self._begin_session_close(session)
         return self._finish_session_close(session)
 
     async def _finish_session_close(self, session: _Session) -> None:

--- a/sglang_omni/pipeline/sessions.py
+++ b/sglang_omni/pipeline/sessions.py
@@ -55,7 +55,7 @@ class _Session:
 
 
 class CoordinatorSessions:
-    """Opt-in session API; ordinary submit/stream keep their existing behavior."""
+    """Coordinator-owned sessions over fixed stage routes."""
 
     def _init_sessions(self, max_sessions: int) -> None:
         if max_sessions <= 0:
@@ -382,17 +382,6 @@ class CoordinatorSessions:
                 await self._cleanup_session(session)
                 raise
             return session.ref
-
-    async def clear_session_input(self, ref: SessionRef) -> list[TimedChunk]:
-        """Discard queued input only; accepted sequence, timing and EOS stay committed."""
-        session = self._session(ref)
-        if session.closing:
-            raise RuntimeError("session is closing")
-        discarded = [chunk for chunk, _ in session.pending]
-        session.pending_count -= len(discarded)
-        session.pending_bytes -= sum(size for _, size in session.pending)
-        session.pending.clear()
-        return discarded
 
     async def close_session(self, ref: SessionRef) -> None:
         """Close the referenced incarnation regardless of its current output epoch."""

--- a/sglang_omni/pipeline/stage/runtime.py
+++ b/sglang_omni/pipeline/stage/runtime.py
@@ -49,6 +49,7 @@ from sglang_omni.proto import (
     StreamMessage,
     SubmitMessage,
 )
+from sglang_omni.proto.session import SESSION_METADATA_KEY
 from sglang_omni.relay.base import Relay
 from sglang_omni.scheduling.messages import IncomingMessage
 
@@ -1171,6 +1172,44 @@ class Stage:
         if not self._owns_external_io:
             self._clear_request_state(request_id)
             return
+        command = (
+            result.request.metadata.get(SESSION_METADATA_KEY)
+            if isinstance(result, StagePayload)
+            else None
+        )
+        if command is not None and command["op"] != "append":
+            await self.control_plane.send_complete(
+                CompleteMessage(
+                    request_id=request_id,
+                    from_stage=self.name,
+                    success=True,
+                    result=result.data,
+                )
+            )
+            self._clear_request_state(request_id)
+            return
+        if command is not None:
+            owners = command["stages"]
+            if self.name not in owners or self._stream_targets:
+                await self._send_failure(
+                    request_id, "session route must use fixed, linear payload edges"
+                )
+                return
+            index = owners.index(self.name)
+            expected = (
+                self._logical_source(owners[index + 1])
+                if index + 1 < len(owners)
+                else None
+            )
+            actual = self.get_next(request_id, result)
+            actual_target = (
+                actual[0] if isinstance(actual, list) and len(actual) == 1 else actual
+            )
+            if actual_target != expected:
+                await self._send_failure(
+                    request_id, "session route differs from the stage payload route"
+                )
+                return
         # Send stream done to the active stream targets for this request.
         stream_targets = self._stream_targets
         if self.get_stream_done_targets is not None:
@@ -1189,7 +1228,7 @@ class Stage:
                 is_done=True,
             )
 
-        next_stages = self.get_next(request_id, result)
+        next_stages = self.get_next(request_id, result) if command is None else actual
         if next_stages is None:
             # Terminal: notify coordinator
             _emit_event(

--- a/sglang_omni/proto/session.py
+++ b/sglang_omni/proto/session.py
@@ -96,4 +96,14 @@ class SessionLimits:
 
 def wire_size(value: Any) -> int:
     """Inputs/outputs use the existing control plane's msgpack value domain."""
+    if isinstance(value, dict) and isinstance(value.get("payload"), bytes):
+        size = len(value["payload"])
+        # Note (Junnan Li): Account for the larger bin header without serializing
+        # the full payload just to measure its wire size.
+        header_growth = 0 if size < 256 else 1 if size < 65536 else 3
+        return (
+            len(msgpack.packb({**value, "payload": b""}, use_bin_type=True))
+            + size
+            + header_growth
+        )
     return len(msgpack.packb(value, use_bin_type=True))

--- a/sglang_omni/proto/session.py
+++ b/sglang_omni/proto/session.py
@@ -99,11 +99,10 @@ class SessionLimits:
 
 
 def wire_size(value: Any) -> int:
-    """Inputs/outputs use the existing control plane's msgpack value domain."""
+    """Return the msgpack wire size without copying a binary payload."""
     if isinstance(value, dict) and isinstance(value.get("payload"), bytes):
         size = len(value["payload"])
-        # Note (Junnan Li): Account for the larger bin header without serializing
-        # the full payload just to measure its wire size.
+        # Note (Junnan Li): Msgpack bin headers grow by 1 byte at 256 bytes and 3 bytes at 65536.
         header_growth = 0 if size < 256 else 1 if size < 65536 else 3
         return (
             len(msgpack.packb({**value, "payload": b""}, use_bin_type=True))

--- a/sglang_omni/proto/session.py
+++ b/sglang_omni/proto/session.py
@@ -28,6 +28,8 @@ class SessionRef:
 
 @dataclass(frozen=True)
 class TimedChunk:
+    """Input seq is global across modalities within a session incarnation."""
+
     modality: str
     t_start_ms: float
     duration_ms: float
@@ -47,6 +49,8 @@ class TimedChunk:
 
 @dataclass(frozen=True)
 class OutputChunk:
+    """input_seq identifies the originating pipeline input, not a stream seq."""
+
     ref: SessionRef
     seq: int
     input_seq: int

--- a/sglang_omni/proto/session.py
+++ b/sglang_omni/proto/session.py
@@ -1,0 +1,99 @@
+# SPDX-License-Identifier: Apache-2.0
+"""Model-independent, bounded session command and output contracts."""
+from __future__ import annotations
+
+import math
+from dataclasses import asdict, dataclass, field
+from typing import Any, Literal
+
+import msgpack
+
+SESSION_METADATA_KEY = "omni_session"
+
+
+@dataclass(frozen=True)
+class SessionRef:
+    session_id: str
+    incarnation: int = 1
+    epoch: int = 0
+
+    def __post_init__(self):
+        if not self.session_id or not isinstance(self.session_id, str):
+            raise ValueError("session_id must be a nonempty string")
+        if type(self.incarnation) is not int or self.incarnation < 1:
+            raise ValueError("incarnation must be a positive integer")
+        if type(self.epoch) is not int or self.epoch < 0:
+            raise ValueError("epoch must be a nonnegative integer")
+
+
+@dataclass(frozen=True)
+class TimedChunk:
+    modality: str
+    t_start_ms: float
+    duration_ms: float
+    seq: int
+    payload: Any
+    format: str | None = None
+    eos: bool = False
+
+    def __post_init__(self):
+        if not self.modality or type(self.seq) is not int or self.seq < 0:
+            raise ValueError("modality and nonnegative seq are required")
+        if any(
+            not math.isfinite(v) or v < 0 for v in (self.t_start_ms, self.duration_ms)
+        ):
+            raise ValueError("chunk timing must be finite and nonnegative")
+
+
+@dataclass(frozen=True)
+class OutputChunk:
+    ref: SessionRef
+    seq: int
+    input_seq: int
+    modality: str
+    t_start_ms: float
+    duration_ms: float
+    payload: Any
+    format: str | None = None
+    eos: bool = False
+    kind: Literal["data", "input_done"] = "data"
+
+
+@dataclass(frozen=True)
+class ResourceUsage:
+    kv_tokens: int = 0
+    slots: dict[str, int] = field(default_factory=dict)
+    bytes: int = 0
+
+    def __post_init__(self):
+        values = [self.kv_tokens, self.bytes, *self.slots.values()]
+        if any(type(value) is not int or value < 0 for value in values):
+            raise ValueError("resource usage cannot be negative")
+
+
+@dataclass(frozen=True)
+class SessionLimits:
+    max_modalities: int = 8
+    max_pending_chunks: int = 16
+    max_pending_bytes: int = 4 * 1024 * 1024
+    max_output_chunks: int = 64
+    max_output_bytes: int = 4 * 1024 * 1024
+    max_chunk_bytes: int = 1024 * 1024
+    command_timeout_s: float = 30.0
+    idle_timeout_s: float = 300.0
+
+    def __post_init__(self):
+        values = asdict(self)
+        if any(
+            type(value) is not int
+            for key, value in values.items()
+            if key.startswith("max_")
+        ):
+            raise ValueError("queue limits must be integers")
+        if any(not math.isfinite(v) or v <= 0 for v in values.values()):
+            raise ValueError("session limits must be finite and positive")
+
+
+def wire_size(value: Any) -> int:
+    """Inputs/outputs use the existing control plane's msgpack value domain."""
+    return len(msgpack.packb(value, use_bin_type=True))

--- a/sglang_omni/scheduling/session.py
+++ b/sglang_omni/scheduling/session.py
@@ -1,0 +1,295 @@
+# SPDX-License-Identifier: Apache-2.0
+"""Persistent stage state using the existing scheduler inbox/outbox contract."""
+from __future__ import annotations
+
+import queue
+import threading
+from dataclasses import asdict, dataclass, field
+from typing import Any, Callable
+
+from sglang_omni.admission import QueueFullError
+from sglang_omni.proto import OmniRequest, StagePayload
+from sglang_omni.proto.session import (
+    SESSION_METADATA_KEY,
+    ResourceUsage,
+    SessionRef,
+    TimedChunk,
+    wire_size,
+)
+from sglang_omni.scheduling.messages import OutgoingMessage
+from sglang_omni.scheduling.simple_scheduler import SimpleScheduler
+
+
+@dataclass
+class SessionContext:
+    ref: SessionRef
+    cancelled: threading.Event
+    emit: Callable[[TimedChunk], None]
+
+
+class SessionHooks:
+    """Hooks run serially per session; different sessions may run concurrently.
+
+    Failed open must release allocations it has not returned. append must stop
+    using state before returning, including on cancellation. close is idempotent.
+    """
+
+    def open(self, ref: SessionRef, request: OmniRequest) -> Any:
+        raise NotImplementedError
+
+    def append(
+        self,
+        state: Any,
+        chunk: TimedChunk,
+        payload: StagePayload,
+        context: SessionContext,
+    ) -> StagePayload:
+        raise NotImplementedError
+
+    def abort(self, state: Any, ref: SessionRef) -> None:
+        """Retain a usable context or raise to require closing the session."""
+        raise NotImplementedError("this stage cannot retain context after abort")
+
+    def close(self, state: Any) -> None:
+        raise NotImplementedError
+
+    def usage(self, state: Any) -> ResourceUsage:
+        return ResourceUsage()
+
+
+@dataclass
+class _StageSession:
+    ref: SessionRef
+    state: Any
+    lock: threading.Lock = field(default_factory=threading.Lock)
+    usage: ResourceUsage = field(default_factory=ResourceUsage)
+
+
+class _SessionInbox(queue.Queue):
+    def __init__(self, register):
+        super().__init__()
+        self._register = register
+
+    def put(self, message, block=True, timeout=None):
+        if message.type == "new_request":
+            self._register(message)
+        super().put(message, block, timeout)
+
+
+class SessionScheduler(SimpleScheduler):
+    """Opt-in scheduler for persistent hooks, with bounded stage admission."""
+
+    def __init__(
+        self,
+        hooks: SessionHooks,
+        *,
+        max_sessions: int = 64,
+        max_concurrency: int = 4,
+        max_state_bytes: int = 1 << 30,
+    ):
+        if max_sessions <= 0 or max_state_bytes <= 0:
+            raise ValueError("session capacity must be positive")
+        self.hooks = hooks
+        self.max_sessions = max_sessions
+        self.max_state_bytes = max_state_bytes
+        self._sessions: dict[tuple[str, int], _StageSession] = {}
+        self._commands: dict[str, threading.Event] = {}
+        self._session_lock = threading.Lock()
+        self._closing = False
+        self._tickets = {}
+        self._tails = {}
+        super().__init__(
+            self._compute,
+            max_concurrency=max_concurrency,
+            abort_callback=self._cancel_command,
+            shutdown_callback=self._shutdown_sessions,
+        )
+        self.inbox = _SessionInbox(self._register_command)
+
+    def _register_command(self, message) -> None:
+        ref = message.data.request.metadata[SESSION_METADATA_KEY]["ref"]
+        key = (ref["session_id"], ref["incarnation"])
+        with self._session_lock:
+            done = threading.Event()
+            ticket = (key, self._tails.get(key), done)
+            self._tickets[message.request_id] = ticket
+            self._tails[key] = ticket
+
+    def _finish_command(self, request_id) -> None:
+        with self._session_lock:
+            ticket = self._tickets.pop(request_id, None)
+            if ticket is not None:
+                key, _, done = ticket
+                done.set()
+                tail = self._tails.get(key)
+                cursor = tail
+                while cursor is not None and cursor[2].is_set():
+                    cursor = cursor[1]
+                if cursor is None:
+                    self._tails.pop(key, None)
+
+    def _consume_if_aborted(self, request_id):
+        aborted = super()._consume_if_aborted(request_id)
+        if aborted:
+            self._finish_command(request_id)
+        return aborted
+
+    def _compute(self, payload: StagePayload) -> StagePayload:
+        ref = payload.request.metadata[SESSION_METADATA_KEY]["ref"]
+        key = (ref["session_id"], ref["incarnation"])
+        with self._session_lock:
+            ticket = self._tickets.get(payload.request_id)
+        try:
+            predecessor = ticket[1] if ticket is not None else None
+            while predecessor is not None:
+                predecessor[2].wait()
+                predecessor = predecessor[1]
+            return self._compute_session(payload)
+        finally:
+            try:
+                # Once the hook released its owner lock, either stop observes
+                # that unlocked owner or this completion observes shutdown.
+                with self._session_lock:
+                    session = self._sessions.get(key) if self._closing else None
+                if session is not None:
+                    with session.lock:
+                        self._close(key, session)
+            finally:
+                self._finish_command(payload.request_id)
+
+    def _cancel_command(self, request_id: str) -> None:
+        with self._session_lock:
+            event = self._commands.get(request_id)
+            if event is not None:
+                event.set()
+
+    def _shutdown_sessions(self) -> None:
+        with self._session_lock:
+            self._closing = True
+            for event in self._commands.values():
+                event.set()
+            sessions = list(self._sessions.items())
+        errors = []
+        for key, session in sessions:
+            if session.lock.acquire(blocking=False):
+                try:
+                    self._close(key, session)
+                except Exception as exc:
+                    errors.append(exc)
+                finally:
+                    session.lock.release()
+        if errors:
+            raise RuntimeError("session shutdown cleanup failed") from errors[0]
+
+    def _close(self, key, session) -> None:
+        if session.state is not None:
+            self.hooks.close(session.state)
+            session.state = None
+        with self._session_lock:
+            self._sessions.pop(key, None)
+
+    def _update_usage(self, session: _StageSession) -> None:
+        usage = self.hooks.usage(session.state)
+        with self._session_lock:
+            session.usage = usage
+            if (
+                sum(s.usage.bytes for s in self._sessions.values())
+                > self.max_state_bytes
+            ):
+                raise QueueFullError()
+
+    def _compute_session(self, payload: StagePayload) -> StagePayload:
+        command = payload.request.metadata[SESSION_METADATA_KEY]
+        ref = SessionRef(**command["ref"])
+        key = (ref.session_id, ref.incarnation)
+        op = command["op"]
+        if op not in {"open", "append", "abort", "close"}:
+            raise ValueError("unknown session operation")
+        if op == "open":
+            session = _StageSession(ref, None)
+            session.lock.acquire()
+            with self._session_lock:
+                if self._closing:
+                    session.lock.release()
+                    raise RuntimeError("session scheduler is stopping")
+                if key in self._sessions:
+                    session.lock.release()
+                    raise ValueError("session already opened")
+                if len(self._sessions) >= self.max_sessions:
+                    session.lock.release()
+                    raise QueueFullError()
+                self._sessions[key] = session
+            try:
+                session.state = self.hooks.open(ref, payload.request)
+                self._update_usage(session)
+                if self._closing:
+                    raise RuntimeError("session scheduler is stopping")
+            except BaseException:
+                self._close(key, session)
+                raise
+            finally:
+                session.lock.release()
+            payload.data = {"opened": True}
+            return payload
+
+        with self._session_lock:
+            session = self._sessions.get(key)
+        if session is None:
+            if op == "close":
+                payload.data = {"closed": True}
+                return payload
+            raise ValueError("unknown session incarnation")
+        with session.lock:
+            if op == "close":
+                self._close(key, session)
+                payload.data = {"closed": True}
+                return payload
+            if self._closing:
+                raise RuntimeError("session scheduler is stopping")
+            if op == "abort":
+                if ref.epoch != session.ref.epoch + 1:
+                    raise ValueError("invalid abort epoch")
+                self.hooks.abort(session.state, ref)
+                session.ref = ref
+                payload.data = {"aborted": True}
+                return payload
+            if ref != session.ref:
+                raise ValueError("stale session epoch")
+            event = threading.Event()
+            with self._session_lock:
+                self._commands[payload.request_id] = event
+            with self._abort_lock:
+                if payload.request_id in self._aborted:
+                    event.set()
+
+            emitted_count = emitted_bytes = 0
+
+            def emit(chunk: TimedChunk) -> None:
+                nonlocal emitted_count, emitted_bytes
+                emitted_count += 1
+                emitted_bytes += wire_size(asdict(chunk))
+                limits = command["output_limits"]
+                if emitted_count > limits["chunks"] or emitted_bytes > limits["bytes"]:
+                    raise QueueFullError()
+                if not event.is_set():
+                    self.outbox.put(
+                        OutgoingMessage(
+                            request_id=payload.request_id,
+                            type="stream",
+                            data=asdict(chunk),
+                            metadata={"modality": chunk.modality},
+                        )
+                    )
+
+            try:
+                result = self.hooks.append(
+                    session.state,
+                    TimedChunk(**command["chunk"]),
+                    payload,
+                    SessionContext(ref, event, emit),
+                )
+                self._update_usage(session)
+                return result
+            finally:
+                with self._session_lock:
+                    self._commands.pop(payload.request_id, None)

--- a/sglang_omni/scheduling/session.py
+++ b/sglang_omni/scheduling/session.py
@@ -83,6 +83,7 @@ class SessionScheduler(SimpleScheduler):
         self,
         hooks: SessionHooks,
         *,
+        compute_fn: Callable[[StagePayload], StagePayload] | None = None,
         max_sessions: int = 64,
         max_concurrency: int = 4,
         max_state_bytes: int = 1 << 30,
@@ -90,6 +91,7 @@ class SessionScheduler(SimpleScheduler):
         if max_sessions <= 0 or max_state_bytes <= 0:
             raise ValueError("session capacity must be positive")
         self.hooks = hooks
+        self._ordinary_compute = compute_fn
         self.max_sessions = max_sessions
         self.max_state_bytes = max_state_bytes
         self._sessions: dict[tuple[str, int], _StageSession] = {}
@@ -107,7 +109,10 @@ class SessionScheduler(SimpleScheduler):
         self.inbox = _SessionInbox(self._register_command)
 
     def _register_command(self, message) -> None:
-        ref = message.data.request.metadata[SESSION_METADATA_KEY]["ref"]
+        command = message.data.request.metadata.get(SESSION_METADATA_KEY)
+        if command is None:
+            return
+        ref = command["ref"]
         key = (ref["session_id"], ref["incarnation"])
         with self._session_lock:
             done = threading.Event()
@@ -135,7 +140,12 @@ class SessionScheduler(SimpleScheduler):
         return aborted
 
     def _compute(self, payload: StagePayload) -> StagePayload:
-        ref = payload.request.metadata[SESSION_METADATA_KEY]["ref"]
+        command = payload.request.metadata.get(SESSION_METADATA_KEY)
+        if command is None:
+            if self._ordinary_compute is None:
+                raise ValueError("this stage has no compute_fn for ordinary requests")
+            return self._ordinary_compute(payload)
+        ref = command["ref"]
         key = (ref["session_id"], ref["incarnation"])
         with self._session_lock:
             ticket = self._tickets.get(payload.request_id)

--- a/sglang_omni/scheduling/session.py
+++ b/sglang_omni/scheduling/session.py
@@ -1,5 +1,5 @@
 # SPDX-License-Identifier: Apache-2.0
-"""Persistent stage state using the existing scheduler inbox/outbox contract."""
+"""Persistent state for session-aware pipeline stages."""
 from __future__ import annotations
 
 import queue
@@ -148,9 +148,9 @@ class SessionScheduler(SimpleScheduler):
         ref = command["ref"]
         key = (ref["session_id"], ref["incarnation"])
         with self._session_lock:
-            ticket = self._tickets.get(payload.request_id)
+            ticket = self._tickets[payload.request_id]
         try:
-            predecessor = ticket[1] if ticket is not None else None
+            predecessor = ticket[1]
             while predecessor is not None:
                 predecessor[2].wait()
                 predecessor = predecessor[1]

--- a/tests/README.md
+++ b/tests/README.md
@@ -851,3 +851,22 @@ that happened to contain an older version of the test.
   `config.json` for tests that need a record the SGLang resolution pipeline can
   resolve end to end. Single-test helpers should stay local until a second
   test needs them.
+
+- `unit_test/pipeline/test_session_flow.py`: Ordered units, concurrent input/output,
+  EOS receipts, configured routes, replica ownership, and input-clear accounting.
+- `unit_test/pipeline/test_session_cancel.py`: Output epoch fencing, retained
+  pending input and completion receipts, and finishing active units on cancel.
+- `unit_test/pipeline/test_session_lifecycle.py`: Input/output limits, sequence
+  rejection, partial open, failed cancellation, timeout quarantine, worker failure,
+  and scoped shutdown.
+  These use `unit_test/fixtures/session_pipeline.py` for real spawned Stage workers,
+  ZMQ control messages and shared-memory tensor relay. Only model hooks are synthetic;
+  they do not establish native-model or accelerator correctness.
+- `unit_test/scheduling/test_session.py`: Session value validation, stage usage
+  accounting and state cleanup without worker processes. Run the session suite with
+  `python -m pytest tests/unit_test/pipeline/test_session_*.py tests/unit_test/scheduling/test_session.py -q`.
+
+- `unit_test/pipeline/test_session_shutdown.py`: Deterministic thread and trace
+  fences cover shutdown during abort/append hooks and the open/append window
+  between the final hook check and owner unlock, requiring exactly-once cleanup
+  after native work returns without blocking shutdown.

--- a/tests/README.md
+++ b/tests/README.md
@@ -863,7 +863,7 @@ that happened to contain an older version of the test.
   ZMQ control messages and shared-memory tensor relay. Only model hooks are synthetic;
   they do not establish native-model or accelerator correctness.
 - `unit_test/scheduling/test_session.py`: Session value validation, stage usage
-  accounting and state cleanup without worker processes. Run the session suite with
+  accounting, exact binary chunk wire sizes and state cleanup without worker processes. Run the session suite with
   `python -m pytest tests/unit_test/pipeline/test_session_*.py tests/unit_test/scheduling/test_session.py -q`.
 
 - `unit_test/pipeline/test_session_shutdown.py`: Deterministic thread and trace

--- a/tests/unit_test/fixtures/session_pipeline.py
+++ b/tests/unit_test/fixtures/session_pipeline.py
@@ -1,5 +1,5 @@
 # SPDX-License-Identifier: Apache-2.0
-"""Real multiprocess session lifecycle; only the model hooks are synthetic."""
+"""Multiprocess stage fixture with synthetic session hooks."""
 from __future__ import annotations
 
 import asyncio
@@ -187,3 +187,12 @@ def block_async_call(monkeypatch, obj, name):
 
     monkeypatch.setattr(obj, name, blocked)
     return entered, release, completed
+
+
+def compute_registered(scheduler, payload):
+    """Run one session command on an unstarted scheduler through its inbox registration."""
+    from sglang_omni.scheduling.messages import IncomingMessage
+
+    scheduler.inbox.put(IncomingMessage(payload.request_id, "new_request", payload))
+    message = scheduler.inbox.get_nowait()
+    return scheduler._compute(message.data)

--- a/tests/unit_test/fixtures/session_pipeline.py
+++ b/tests/unit_test/fixtures/session_pipeline.py
@@ -1,0 +1,174 @@
+# SPDX-License-Identifier: Apache-2.0
+"""Real multiprocess session lifecycle; only the model hooks are synthetic."""
+from __future__ import annotations
+
+import asyncio
+import multiprocessing
+import time
+from contextlib import asynccontextmanager
+
+from sglang_omni.pipeline.coordinator import Coordinator
+from sglang_omni.proto.session import ResourceUsage, TimedChunk
+from sglang_omni.scheduling.session import SessionHooks, SessionScheduler
+
+
+class Hooks(SessionHooks):
+    def __init__(self, name, events):
+        self.name, self.events = name, events
+
+    def open(self, ref, request):
+        self.events.put(("open", self.name, ref.session_id))
+        time.sleep(request.params.get("open_delay", 0))
+        if request.params.get("fail_open") == self.name:
+            raise RuntimeError("open failed")
+        return {"id": ref.session_id, "n": 0, "params": request.params}
+
+    def append(self, state, chunk, payload, context):
+        import torch
+
+        self.events.put(("append", self.name, state["id"], chunk.seq))
+        state["n"] += 1
+        if self.name == "source":
+            payload.data = {"tensor": torch.tensor([state["n"]])}
+        elif self.name.split("@r")[0] == "middle":
+            assert payload.data["tensor"].item() == state["n"]
+        else:
+            assert payload.data["tensor"].item() == state["n"]
+            if state["n"] % state["params"].get("emit_every", 1) and not chunk.eos:
+                payload.data = {"count": state["n"]}
+                return payload
+            cadence = state["params"].get("cadence", 1)
+            for i in range(cadence):
+                if state["params"].get("ignore_cancel"):
+                    time.sleep(state["params"].get("delay", 0))
+                    self.events.put(("finished", self.name, state["id"]))
+                elif context.cancelled.wait(state["params"].get("delay", 0)):
+                    self.events.put(("cancelled", self.name, state["id"]))
+                    break
+                context.emit(
+                    TimedChunk(
+                        "text",
+                        chunk.t_start_ms,
+                        0,
+                        i,
+                        [state["n"], i],
+                        eos=chunk.eos and i == cadence - 1,
+                    )
+                )
+            payload.data = {"count": state["n"]}
+        return payload
+
+    def abort(self, state, ref):
+        self.events.put(("abort", self.name, state["id"]))
+        if state["params"].get("cannot_abort"):
+            raise RuntimeError("state cannot be retained")
+
+    def close(self, state):
+        self.events.put(("close", self.name, state["id"]))
+
+    def usage(self, state):
+        return ResourceUsage(bytes=state["n"])
+
+
+def make_session_scheduler(name, events):
+    return SessionScheduler(Hooks(name, events))
+
+
+def worker(spec, ready):
+    import logging
+
+    from sglang_omni.pipeline.stage_workers import _construct_stage
+
+    async def run():
+        stage = _construct_stage(spec, logging.getLogger(__name__))
+        await stage.start()
+        ready.set()
+        await stage.run()
+        assert not stage.scheduler._sessions
+
+    asyncio.run(run())
+
+
+@asynccontextmanager
+async def pipeline(tmp_path, *, stage_count=2, replicated=False, list_next=False):
+    from sglang_omni.config.schema import PipelineConfig, ProcessConfig, StageConfig
+    from sglang_omni.config.topology import compile_logical_processes
+    from sglang_omni.pipeline.replicas import expand_replica_stages
+    from sglang_omni.pipeline.stage_workers import StageLaunchConfig
+
+    ctx = multiprocessing.get_context("spawn")
+    names = ["source", "middle", "sink"] if stage_count == 3 else ["source", "sink"]
+    stages = []
+    for index, name in enumerate(names):
+        target = names[index + 1] if index + 1 < len(names) else None
+        stages.append(
+            StageConfig(
+                name=name,
+                process=name,
+                terminal=target is None,
+                next=[target] if list_next and target else target,
+                factory_path=f"{__name__}.make_session_scheduler",
+            )
+        )
+    config = PipelineConfig(
+        model_path="mock",
+        entry_stage="source",
+        stages=stages,
+        processes={"sink": ProcessConfig(num_replicas=2)} if replicated else {},
+    )
+    plan, stages = compile_logical_processes(config)
+    expanded, topology = expand_replica_stages(stages, plan)
+    endpoints = {stage.name: f"ipc://{tmp_path}/{stage.name}" for stage in expanded}
+    completion, abort = f"ipc://{tmp_path}/done", f"ipc://{tmp_path}/abort"
+    coordinator = Coordinator(
+        completion,
+        abort,
+        "source",
+        ["sink"],
+        max_sessions=3,
+        logical_process_plan=plan,
+        replica_topology=topology,
+    )
+    events = ctx.Queue()
+    processes = []
+    await coordinator.start()
+    loop = asyncio.create_task(coordinator.run_completion_loop())
+    try:
+        for stage in expanded:
+            ready = ctx.Event()
+            spec = StageLaunchConfig(
+                stage_name=stage.name,
+                factory=stage.factory_path,
+                factory_kwargs={"name": stage.name, "events": events},
+                next_stages=stage.next,
+                is_terminal=stage.terminal,
+                recv_endpoint=endpoints[stage.name],
+                coordinator_endpoint=completion,
+                abort_endpoint=abort,
+                stage_endpoints=endpoints,
+                replica_topology=topology.to_dict(),
+            )
+            process = ctx.Process(target=worker, args=(spec, ready))
+            process.start()
+            processes.append(process)
+            assert await asyncio.to_thread(ready.wait, 30)
+            coordinator.register_stage(stage.name, endpoints[stage.name])
+        # PUB/SUB subscription is asynchronous; work begins after both workers bind.
+        await asyncio.sleep(0.1)
+        yield coordinator, events, processes
+    finally:
+        await coordinator.shutdown_stages()
+        await coordinator.stop()
+        loop.cancel()
+        await asyncio.gather(loop, return_exceptions=True)
+        for process in processes:
+            await asyncio.to_thread(process.join, 10)
+            if process.is_alive():
+                process.kill()
+                process.join()
+            assert process.exitcode == getattr(process, "expected_exitcode", 0)
+        events.close()
+
+
+def chunk(seq, eos=False):
+    return TimedChunk("audio", seq * 20, 20, seq, b"pcm", eos=eos)

--- a/tests/unit_test/fixtures/session_pipeline.py
+++ b/tests/unit_test/fixtures/session_pipeline.py
@@ -65,6 +65,9 @@ class Hooks(SessionHooks):
 
     def close(self, state):
         self.events.put(("close", self.name, state["id"]))
+        if state["params"].get("fail_close_once") == self.name:
+            state["params"]["fail_close_once"] = None
+            raise RuntimeError("close rejected")
 
     def usage(self, state):
         return ResourceUsage(bytes=state["n"])

--- a/tests/unit_test/fixtures/session_pipeline.py
+++ b/tests/unit_test/fixtures/session_pipeline.py
@@ -172,3 +172,18 @@ async def pipeline(tmp_path, *, stage_count=2, replicated=False, list_next=False
 
 def chunk(seq, eos=False):
     return TimedChunk("audio", seq * 20, 20, seq, b"pcm", eos=eos)
+
+
+def block_async_call(monkeypatch, obj, name):
+    entered, release, completed = (asyncio.Event() for _ in range(3))
+    original = getattr(obj, name)
+
+    async def blocked(*args, **kwargs):
+        entered.set()
+        await release.wait()
+        result = await original(*args, **kwargs)
+        completed.set()
+        return result
+
+    monkeypatch.setattr(obj, name, blocked)
+    return entered, release, completed

--- a/tests/unit_test/pipeline/test_session_cancel.py
+++ b/tests/unit_test/pipeline/test_session_cancel.py
@@ -6,7 +6,7 @@ import asyncio
 import pytest
 
 from sglang_omni.proto import OmniRequest
-from tests.unit_test.fixtures.session_pipeline import chunk, pipeline
+from tests.unit_test.fixtures.session_pipeline import block_async_call, chunk, pipeline
 
 
 @pytest.mark.asyncio
@@ -105,3 +105,31 @@ async def test_abort_preserves_pending_input_and_completion_receipt(tmp_path):
         assert resumed.input_seq == 1 and resumed.ref == new_ref
         assert resumed.payload[0] == 2
         await output.aclose()
+
+
+@pytest.mark.asyncio
+async def test_close_previous_epoch_after_cancelled_abort_waiter(tmp_path, monkeypatch):
+    async with pipeline(tmp_path) as (coordinator, _, _):
+        ref = await coordinator.open_session(
+            OmniRequest(None), stages=["source", "sink"], session_id="reused"
+        )
+        entered, release, completed = block_async_call(
+            monkeypatch, coordinator, "_abort_session"
+        )
+        waiter = asyncio.create_task(coordinator.abort_session(ref))
+        try:
+            await asyncio.wait_for(entered.wait(), 5)
+            waiter.cancel()
+            with pytest.raises(asyncio.CancelledError):
+                await waiter
+        finally:
+            release.set()
+        await asyncio.wait_for(completed.wait(), 5)
+        await coordinator.close_session(ref)
+        current = await coordinator.open_session(
+            OmniRequest(None), stages=["source", "sink"], session_id="reused"
+        )
+        with pytest.raises(ValueError, match="stale"):
+            await coordinator.close_session(ref)
+        await coordinator.append_session(current, chunk(0))
+        await coordinator.close_session(current)

--- a/tests/unit_test/pipeline/test_session_cancel.py
+++ b/tests/unit_test/pipeline/test_session_cancel.py
@@ -89,25 +89,6 @@ async def test_cancel_finishes_active_unit_and_preserves_consumption(tmp_path):
 
 
 @pytest.mark.asyncio
-async def test_abort_preserves_pending_input_and_completion_receipt(tmp_path):
-    async with pipeline(tmp_path) as (coordinator, events, processes):
-        ref = await coordinator.open_session(
-            OmniRequest(None, {"cadence": 2, "delay": 0.1}), stages=["source", "sink"]
-        )
-        output = coordinator.session_outputs(ref)
-        await coordinator.append_session(ref, chunk(0))
-        await asyncio.wait_for(anext(output), 5)
-        await coordinator.append_session(ref, chunk(1))
-        new_ref = await coordinator.abort_session(ref)
-        receipt = await asyncio.wait_for(anext(output), 5)
-        assert receipt.kind == "input_done" and receipt.input_seq == 0
-        resumed = await asyncio.wait_for(anext(output), 5)
-        assert resumed.input_seq == 1 and resumed.ref == new_ref
-        assert resumed.payload[0] == 2
-        await output.aclose()
-
-
-@pytest.mark.asyncio
 async def test_close_previous_epoch_after_cancelled_abort_waiter(tmp_path, monkeypatch):
     async with pipeline(tmp_path) as (coordinator, _, _):
         ref = await coordinator.open_session(

--- a/tests/unit_test/pipeline/test_session_cancel.py
+++ b/tests/unit_test/pipeline/test_session_cancel.py
@@ -1,0 +1,107 @@
+# SPDX-License-Identifier: Apache-2.0
+from __future__ import annotations
+
+import asyncio
+
+import pytest
+
+from sglang_omni.proto import OmniRequest
+from tests.unit_test.fixtures.session_pipeline import chunk, pipeline
+
+
+@pytest.mark.asyncio
+async def test_abort_epoch_suppression_and_reuse(tmp_path):
+    async with pipeline(tmp_path) as (coordinator, events, processes):
+        ref = await coordinator.open_session(
+            OmniRequest(None, {"cadence": 5, "delay": 0.05}),
+            stages=["source", "sink"],
+            session_id="reusable",
+        )
+        output = coordinator.session_outputs(ref)
+        await coordinator.append_session(ref, chunk(0))
+        assert (await asyncio.wait_for(anext(output), 5)).ref == ref
+        new_ref = await coordinator.abort_session(ref)
+        assert new_ref.epoch == ref.epoch + 1
+        with pytest.raises(ValueError, match="stale"):
+            await coordinator.append_session(ref, chunk(0))
+        await coordinator.append_session(new_ref, chunk(1, eos=True))
+        receipt = await asyncio.wait_for(anext(output), 5)
+        assert receipt.kind == "input_done" and receipt.input_seq == 0
+        result = await asyncio.wait_for(anext(output), 5)
+        assert result.ref == new_ref and result.seq >= 1
+        await output.aclose()
+        reused = await coordinator.open_session(
+            OmniRequest(None), stages=["source", "sink"], session_id="reusable"
+        )
+        assert reused.incarnation != ref.incarnation
+        await coordinator.close_session(reused)
+
+
+@pytest.mark.asyncio
+async def test_abort_keeps_queued_completion_receipt_but_drops_old_data(tmp_path):
+    async with pipeline(tmp_path) as (coordinator, events, processes):
+        ref = await coordinator.open_session(
+            OmniRequest(None), stages=["source", "sink"]
+        )
+        output = coordinator.session_outputs(ref)
+        await coordinator.append_session(ref, chunk(0))
+        assert (await asyncio.wait_for(anext(output), 5)).kind == "data"
+        assert (await asyncio.wait_for(anext(output), 5)).kind == "input_done"
+        await coordinator.append_session(ref, chunk(1))
+        session = coordinator._sessions[ref.session_id]
+        async with asyncio.timeout(5):
+            while session.pending_count:
+                await asyncio.sleep(0.01)
+        assert [item.kind for item, _ in session.outputs] == ["data", "input_done"]
+        new_ref = await coordinator.abort_session(ref)
+        receipt = await asyncio.wait_for(anext(output), 5)
+        assert receipt.kind == "input_done" and receipt.input_seq == 1
+        assert receipt.ref == ref
+        await coordinator.append_session(new_ref, chunk(2))
+        data = await asyncio.wait_for(anext(output), 5)
+        assert data.kind == "data" and data.ref == new_ref and data.input_seq == 2
+        await output.aclose()
+
+
+@pytest.mark.asyncio
+async def test_cancel_finishes_active_unit_and_preserves_consumption(tmp_path):
+    async with pipeline(tmp_path) as (coordinator, events, processes):
+        ref = await coordinator.open_session(
+            OmniRequest(None, {"cadence": 3, "delay": 0.08}),
+            stages=["source", "sink"],
+        )
+        output = coordinator.session_outputs(ref)
+        await coordinator.append_session(ref, chunk(0))
+        assert (await asyncio.wait_for(anext(output), 5)).kind == "data"
+        await coordinator.append_session(ref, chunk(1, eos=True))
+        new_ref = await coordinator.abort_session(ref)
+        receipt = await asyncio.wait_for(anext(output), 5)
+        assert receipt.kind == "input_done" and receipt.input_seq == 0
+        assert receipt.ref == ref
+        later = await asyncio.wait_for(anext(output), 5)
+        assert later.kind == "data" and later.input_seq == 1
+        assert later.ref == new_ref and later.payload[0] == 2
+        await output.aclose()
+        log = []
+        while not events.empty():
+            log.append(events.get(timeout=1))
+        assert not any(e[0] == "cancelled" for e in log)
+
+
+@pytest.mark.asyncio
+async def test_abort_preserves_pending_input_and_completion_receipt(tmp_path):
+    async with pipeline(tmp_path) as (coordinator, events, processes):
+        ref = await coordinator.open_session(
+            OmniRequest(None, {"cadence": 2, "delay": 0.1}), stages=["source", "sink"]
+        )
+        output = coordinator.session_outputs(ref)
+        await coordinator.append_session(ref, chunk(0))
+        await asyncio.wait_for(anext(output), 5)
+        await coordinator.append_session(ref, chunk(1))
+        new_ref = await coordinator.abort_session(ref)
+        receipt = await asyncio.wait_for(anext(output), 5)
+        assert receipt.kind == "input_done" and receipt.input_seq == 0
+        resumed = await asyncio.wait_for(anext(output), 5)
+        assert resumed.input_seq == 1 and resumed.ref == new_ref
+        assert resumed.payload[0] == 2
+        await output.aclose()

--- a/tests/unit_test/pipeline/test_session_flow.py
+++ b/tests/unit_test/pipeline/test_session_flow.py
@@ -1,0 +1,136 @@
+# SPDX-License-Identifier: Apache-2.0
+from __future__ import annotations
+
+import asyncio
+
+import pytest
+
+from sglang_omni.proto import OmniRequest
+from sglang_omni.proto.session import TimedChunk
+from tests.unit_test.fixtures.session_pipeline import chunk, pipeline
+
+
+@pytest.mark.asyncio
+async def test_interleaved_cadences_input_during_output_eos_and_disconnect(tmp_path):
+    async with pipeline(tmp_path) as (coordinator, events, processes):
+        a = await coordinator.open_session(
+            OmniRequest(None, {"cadence": 3, "delay": 0.05}), stages=["source", "sink"]
+        )
+        b = await coordinator.open_session(
+            OmniRequest(None, {"emit_every": 2}), stages=["source", "sink"]
+        )
+        output_a = coordinator.session_outputs(a)
+        output_b = coordinator.session_outputs(b)
+        await coordinator.append_session(a, chunk(0))
+        first = await asyncio.wait_for(anext(output_a), 5)
+        assert first.payload == [1, 0]
+        # Accept while unit zero still emits its remaining two outputs.
+        await coordinator.append_session(a, chunk(1, eos=True))
+        await coordinator.append_session(b, chunk(0))
+        receipt = await asyncio.wait_for(anext(output_b), 5)
+        assert receipt.kind == "input_done"
+        await coordinator.append_session(b, chunk(1, eos=True))
+        other = await asyncio.wait_for(anext(output_b), 5)
+        assert other.payload == [2, 0] and other.eos
+        rest = [await asyncio.wait_for(anext(output_a), 5) for _ in range(7)]
+        assert [item.seq for item in [first, *rest]] == list(range(8))
+        assert [item.input_seq for item in rest] == [0, 0, 0, 1, 1, 1, 1]
+        assert rest[-1].eos
+        with pytest.raises(ValueError, match="EOS"):
+            await coordinator.append_session(a, chunk(2))
+        await output_a.aclose()
+        await output_b.aclose()
+        assert not coordinator._sessions
+        assert not coordinator._requests
+
+
+@pytest.mark.asyncio
+async def test_configured_singleton_list_route_with_three_stages(tmp_path):
+    async with pipeline(tmp_path, stage_count=3, list_next=True) as (
+        coordinator,
+        events,
+        processes,
+    ):
+        ref = await coordinator.open_session(
+            OmniRequest(None), stages=["source", "middle", "sink"]
+        )
+        output = coordinator.session_outputs(ref)
+        await coordinator.append_session(ref, chunk(0, eos=True))
+        data = await asyncio.wait_for(anext(output), 5)
+        assert data.kind == "data" and data.payload == [1, 0]
+        receipt = await asyncio.wait_for(anext(output), 5)
+        assert receipt.kind == "input_done" and receipt.eos
+        await output.aclose()
+
+
+@pytest.mark.asyncio
+async def test_replica_owner_survives_units_abort_and_scoped_shutdown(tmp_path):
+    async with pipeline(tmp_path, replicated=True) as (coordinator, events, processes):
+        first = await coordinator.open_session(
+            OmniRequest(None), stages=["source", "sink"], session_id="first"
+        )
+        second = await coordinator.open_session(
+            OmniRequest(None), stages=["source", "sink"], session_id="second"
+        )
+        first_output = coordinator.session_outputs(first)
+        second_output = coordinator.session_outputs(second)
+
+        async def unit(ref, output, seq):
+            await coordinator.append_session(ref, chunk(seq))
+            data = await asyncio.wait_for(anext(output), 5)
+            receipt = await asyncio.wait_for(anext(output), 5)
+            assert data.kind == "data" and receipt.kind == "input_done"
+            assert receipt.input_seq == seq
+
+        await unit(first, first_output, 0)
+        await unit(second, second_output, 0)
+        first = await coordinator.abort_session(first)
+        await unit(first, first_output, 1)
+        await unit(second, second_output, 1)
+        await coordinator.shutdown_stages(["sink@r0"])
+        assert processes[0].is_alive() and processes[2].is_alive()
+        await unit(second, second_output, 2)
+        await first_output.aclose()
+        await second_output.aclose()
+        log = []
+        while not events.empty():
+            log.append(events.get(timeout=1))
+        first_owners = {
+            event[1] for event in log if event[0] == "append" and event[2] == "first"
+        }
+        second_owners = {
+            event[1] for event in log if event[0] == "append" and event[2] == "second"
+        }
+        assert first_owners == {"source", "sink@r0"}
+        assert second_owners == {"source", "sink@r1"}
+        assert ("abort", "sink@r0", "first") in log
+        assert ("abort", "sink@r1", "first") not in log
+
+
+@pytest.mark.asyncio
+async def test_clear_preserves_input_clock_and_copies_discarded_payload(tmp_path):
+    async with pipeline(tmp_path) as (coordinator, events, processes):
+        ref = await coordinator.open_session(
+            OmniRequest(None, {"cadence": 2, "delay": 0.1}), stages=["source", "sink"]
+        )
+        output = coordinator.session_outputs(ref)
+        await coordinator.append_session(ref, chunk(0))
+        await asyncio.wait_for(anext(output), 5)
+        payload = {"values": [1]}
+        await coordinator.append_session(ref, TimedChunk("audio", 20, 20, 1, payload))
+        payload["values"].append(2)
+        discarded = await coordinator.clear_session_input(ref)
+        assert [c.seq for c in discarded] == [1]
+        assert discarded[0].payload == {"values": [1]}
+        assert sum(c.duration_ms for c in discarded) == 20
+        with pytest.raises(ValueError, match="contiguous"):
+            await coordinator.append_session(ref, chunk(1))
+        await coordinator.append_session(ref, chunk(2, eos=True))
+        receipts = []
+        while len(receipts) < 2:
+            item = await asyncio.wait_for(anext(output), 5)
+            if item.kind == "input_done":
+                receipts.append(item)
+        assert [r.input_seq for r in receipts] == [0, 2]
+        assert receipts[-1].eos
+        await output.aclose()

--- a/tests/unit_test/pipeline/test_session_flow.py
+++ b/tests/unit_test/pipeline/test_session_flow.py
@@ -24,7 +24,6 @@ async def test_interleaved_cadences_input_during_output_eos_and_disconnect(tmp_p
         await coordinator.append_session(a, chunk(0))
         first = await asyncio.wait_for(anext(output_a), 5)
         assert first.payload == [1, 0]
-        # Accept while unit zero still emits its remaining two outputs.
         await coordinator.append_session(a, chunk(1, eos=True))
         await coordinator.append_session(b, chunk(0))
         receipt = await asyncio.wait_for(anext(output_b), 5)
@@ -108,32 +107,36 @@ async def test_replica_owner_survives_units_abort_and_scoped_shutdown(tmp_path):
 
 
 @pytest.mark.asyncio
-async def test_clear_preserves_input_clock_and_copies_discarded_payload(tmp_path):
-    async with pipeline(tmp_path) as (coordinator, events, processes):
+async def test_accepted_input_snapshots_mutable_payload(tmp_path, monkeypatch):
+    async with pipeline(tmp_path) as (coordinator, _, _):
+        submitted = []
+        original = coordinator.control_plane.submit_to_stage
+
+        async def submit(stage, endpoint, message):
+            command = message.data.request.metadata.get("omni_session", {})
+            if command.get("op") == "append":
+                submitted.append(command["chunk"]["payload"])
+            return await original(stage, endpoint, message)
+
+        monkeypatch.setattr(coordinator.control_plane, "submit_to_stage", submit)
         ref = await coordinator.open_session(
-            OmniRequest(None, {"cadence": 2, "delay": 0.1}), stages=["source", "sink"]
+            OmniRequest(None), stages=["source", "sink"]
         )
-        output = coordinator.session_outputs(ref)
-        await coordinator.append_session(ref, chunk(0))
-        await asyncio.wait_for(anext(output), 5)
+        outputs = coordinator.session_outputs(ref)
         payload = {"values": [1]}
-        await coordinator.append_session(ref, TimedChunk("audio", 20, 20, 1, payload))
-        payload["values"].append(2)
-        discarded = await coordinator.clear_session_input(ref)
-        assert [c.seq for c in discarded] == [1]
-        assert discarded[0].payload == {"values": [1]}
-        assert sum(c.duration_ms for c in discarded) == 20
-        with pytest.raises(ValueError, match="contiguous"):
-            await coordinator.append_session(ref, chunk(1))
-        await coordinator.append_session(ref, chunk(2, eos=True))
-        receipts = []
-        while len(receipts) < 2:
-            item = await asyncio.wait_for(anext(output), 5)
-            if item.kind == "input_done":
-                receipts.append(item)
-        assert [r.input_seq for r in receipts] == [0, 2]
-        assert receipts[-1].eos
-        await output.aclose()
+        try:
+            await coordinator.append_session(
+                ref, TimedChunk("audio", 0, 20, 0, payload, eos=True)
+            )
+            payload["values"].append(2)
+            async with asyncio.timeout(5):
+                async for output in outputs:
+                    if output.kind == "input_done":
+                        break
+            assert submitted and all(value == {"values": [1]} for value in submitted)
+        finally:
+            await outputs.aclose()
+            await coordinator.close_session(ref)
 
 
 @pytest.mark.asyncio

--- a/tests/unit_test/pipeline/test_session_flow.py
+++ b/tests/unit_test/pipeline/test_session_flow.py
@@ -134,3 +134,50 @@ async def test_clear_preserves_input_clock_and_copies_discarded_payload(tmp_path
         assert [r.input_seq for r in receipts] == [0, 2]
         assert receipts[-1].eos
         await output.aclose()
+
+
+@pytest.mark.asyncio
+async def test_open_inputs_are_not_relayed_by_later_commands(tmp_path, monkeypatch):
+    from dataclasses import asdict
+
+    import msgpack
+
+    from sglang_omni.admission import QueueFullError
+    from sglang_omni.proto.session import SESSION_METADATA_KEY, SessionLimits
+
+    async with pipeline(tmp_path) as (coordinator, events, processes):
+        submitted = []
+        submit = coordinator._submit_request
+
+        async def record(request_id, request, **kwargs):
+            submitted.append(
+                (request.metadata[SESSION_METADATA_KEY]["op"], request.inputs)
+            )
+            return await submit(request_id, request, **kwargs)
+
+        monkeypatch.setattr(coordinator, "_submit_request", record)
+        request = OmniRequest(b"initial audio")
+        unit = TimedChunk("audio", 0, 80, 0, b"unit")
+        limit = len(msgpack.packb(asdict(unit), use_bin_type=True))
+        ref = await coordinator.open_session(
+            request,
+            stages=["source", "sink"],
+            limits=SessionLimits(max_chunk_bytes=limit),
+        )
+        output = coordinator.session_outputs(ref)
+        with pytest.raises(QueueFullError):
+            await coordinator.append_session(
+                ref, TimedChunk("audio", 0, 80, 0, b"units")
+            )
+        await coordinator.append_session(ref, unit)
+        assert (await asyncio.wait_for(anext(output), 5)).kind == "data"
+        assert (await asyncio.wait_for(anext(output), 5)).kind == "input_done"
+        ref = await coordinator.abort_session(ref)
+        await output.aclose()
+        assert [value for op, value in submitted if op == "open"] == [
+            request.inputs
+        ] * 2
+        later = [(op, value) for op, value in submitted if op != "open"]
+        assert {op for op, _ in later} == {"append", "abort", "close"}
+        assert all(value is None for _, value in later)
+        assert request.inputs == b"initial audio"

--- a/tests/unit_test/pipeline/test_session_lifecycle.py
+++ b/tests/unit_test/pipeline/test_session_lifecycle.py
@@ -8,7 +8,7 @@ import pytest
 from sglang_omni.admission import QueueFullError
 from sglang_omni.proto import OmniRequest
 from sglang_omni.proto.session import SessionLimits, TimedChunk
-from tests.unit_test.fixtures.session_pipeline import chunk, pipeline
+from tests.unit_test.fixtures.session_pipeline import block_async_call, chunk, pipeline
 
 
 @pytest.mark.asyncio
@@ -205,3 +205,31 @@ async def test_cross_modality_order_and_rejected_input_retry(tmp_path):
         with pytest.raises(ValueError, match="EOS"):
             await coordinator.append_session(ref, chunk(2))
         await output.aclose()
+
+
+@pytest.mark.asyncio
+@pytest.mark.parametrize("trigger", ["close", "shutdown", "idle"])
+async def test_closing_rejects_input_before_cleanup(tmp_path, monkeypatch, trigger):
+    async with pipeline(tmp_path) as (coordinator, _, _):
+        ref = await coordinator.open_session(
+            OmniRequest(None),
+            stages=["source", "sink"],
+            limits=SessionLimits(idle_timeout_s=0.2 if trigger == "idle" else 300),
+        )
+        entered, release, _ = block_async_call(
+            monkeypatch, coordinator, "_cleanup_session"
+        )
+        task = None
+        if trigger == "close":
+            task = asyncio.create_task(coordinator.close_session(ref))
+        elif trigger == "shutdown":
+            task = asyncio.create_task(coordinator.shutdown_stages(["sink"]))
+        try:
+            await asyncio.wait_for(entered.wait(), 5)
+            with pytest.raises(RuntimeError, match="closing"):
+                await coordinator.append_session(ref, chunk(0))
+        finally:
+            release.set()
+            await asyncio.wait_for(
+                task if task is not None else coordinator.close_session(ref), 5
+            )

--- a/tests/unit_test/pipeline/test_session_lifecycle.py
+++ b/tests/unit_test/pipeline/test_session_lifecycle.py
@@ -11,6 +11,13 @@ from sglang_omni.proto.session import SessionLimits, TimedChunk
 from tests.unit_test.fixtures.session_pipeline import block_async_call, chunk, pipeline
 
 
+def drain(events):
+    log = []
+    while not events.empty():
+        log.append(events.get(timeout=1))
+    return log
+
+
 @pytest.mark.asyncio
 async def test_timeout_cancel_noop_waits_before_close(tmp_path):
     async with pipeline(tmp_path) as (coordinator, events, processes):
@@ -53,6 +60,43 @@ async def test_open_timeout_quarantines_and_worker_shutdown_releases(tmp_path):
         await asyncio.sleep(0.4)
         with pytest.raises(RuntimeError, match="capacity remains reserved"):
             await coordinator.close_session(coordinator._sessions["slow-open"].ref)
+
+
+@pytest.mark.asyncio
+@pytest.mark.parametrize("reason", ["close_rejected", "pump_unresponsive"])
+async def test_unconfirmed_owner_release_blocks_new_sessions(tmp_path, reason):
+    async with pipeline(tmp_path) as (coordinator, events, processes):
+        params = {"fail_close_once": "source"}
+        if reason == "pump_unresponsive":
+            params = {"ignore_cancel": True, "delay": 0.3}
+        ref = await coordinator.open_session(
+            OmniRequest(None, params), stages=["source", "sink"], session_id="held"
+        )
+        if reason == "pump_unresponsive":
+            coordinator._sessions["held"].limits = SessionLimits(command_timeout_s=0.1)
+            output = coordinator.session_outputs(ref)
+            await coordinator.append_session(ref, chunk(0))
+            with pytest.raises(TimeoutError):
+                await asyncio.wait_for(anext(output), 5)
+            await output.aclose()
+        else:
+            with pytest.raises(RuntimeError, match="cleanup incomplete"):
+                await coordinator.close_session(ref)
+        assert coordinator._sessions["held"].cleanup_error is not None
+        with pytest.raises(ValueError, match="unavailable owner"):
+            await coordinator.open_session(OmniRequest(None), stages=["source", "sink"])
+        with pytest.raises(ValueError, match="already reserved"):
+            await coordinator.open_session(
+                OmniRequest(None), stages=["source", "sink"], session_id="held"
+            )
+        with pytest.raises(RuntimeError, match="capacity remains reserved"):
+            await coordinator.close_session(ref)
+        if reason == "close_rejected":
+            # Note (Junnan Li): Only the owner whose close was rejected, and owners upstream of
+            # it, stay unconfirmed; the downstream owner acknowledged its close.
+            closed = [e[1] for e in drain(events) if e[0] == "close"]
+            assert closed == ["sink", "source"]
+        await asyncio.sleep(0.4)
 
 
 @pytest.mark.asyncio

--- a/tests/unit_test/pipeline/test_session_lifecycle.py
+++ b/tests/unit_test/pipeline/test_session_lifecycle.py
@@ -1,0 +1,180 @@
+# SPDX-License-Identifier: Apache-2.0
+from __future__ import annotations
+
+import asyncio
+
+import pytest
+
+from sglang_omni.admission import QueueFullError
+from sglang_omni.proto import OmniRequest
+from sglang_omni.proto.session import SessionLimits
+from tests.unit_test.fixtures.session_pipeline import chunk, pipeline
+
+
+@pytest.mark.asyncio
+async def test_timeout_cancel_noop_waits_before_close(tmp_path):
+    async with pipeline(tmp_path) as (coordinator, events, processes):
+        ref = await coordinator.open_session(
+            OmniRequest(None, {"ignore_cancel": True, "delay": 0.3}),
+            stages=["source", "sink"],
+        )
+        coordinator._sessions[ref.session_id].limits = SessionLimits(
+            command_timeout_s=0.1
+        )
+        output = coordinator.session_outputs(ref)
+        await coordinator.append_session(ref, chunk(0))
+        with pytest.raises(TimeoutError):
+            await asyncio.wait_for(anext(output), 5)
+        # The close timeout quarantines ownership until process teardown; late
+        # non-preemptible work may finish, but capacity is not falsely returned.
+        assert coordinator._sessions[ref.session_id].cleanup_error is not None
+        await asyncio.sleep(0.4)
+        log = []
+        while not events.empty():
+            log.append(events.get(timeout=1))
+        finished = next(i for i, e in enumerate(log) if e[:2] == ("finished", "sink"))
+        # A timed-out queued close may be dropped by request abort. If it ran,
+        # it must follow completion; otherwise scheduler.stop owns reclamation.
+        close_positions = [i for i, e in enumerate(log) if e[:2] == ("close", "sink")]
+        assert all(i > finished for i in close_positions)
+        assert not any(e[:2] == ("close", "source") for e in log)
+
+
+@pytest.mark.asyncio
+async def test_open_timeout_quarantines_and_worker_shutdown_releases(tmp_path):
+    async with pipeline(tmp_path) as (coordinator, events, processes):
+        with pytest.raises(TimeoutError):
+            await coordinator.open_session(
+                OmniRequest(None, {"open_delay": 0.3}),
+                stages=["source", "sink"],
+                session_id="slow-open",
+                limits=SessionLimits(command_timeout_s=0.08),
+            )
+        assert coordinator._sessions["slow-open"].cleanup_error is not None
+        await asyncio.sleep(0.4)
+        with pytest.raises(RuntimeError, match="capacity remains reserved"):
+            await coordinator.close_session(coordinator._sessions["slow-open"].ref)
+
+
+@pytest.mark.asyncio
+async def test_worker_failure_wakes_output_and_fails_session(tmp_path):
+    async with pipeline(tmp_path) as (coordinator, events, processes):
+        ref = await coordinator.open_session(
+            OmniRequest(None), stages=["source", "sink"]
+        )
+        output = coordinator.session_outputs(ref)
+        waiting = asyncio.create_task(anext(output))
+        await asyncio.sleep(0)
+        processes[-1].kill()
+        processes[-1].expected_exitcode = -9
+        await asyncio.to_thread(processes[-1].join, 5)
+        await coordinator.fail_pending_requests("session worker exited")
+        with pytest.raises(RuntimeError, match="worker exited"):
+            await asyncio.wait_for(waiting, 5)
+        with pytest.raises(RuntimeError, match="worker exited"):
+            await coordinator.open_session(OmniRequest(None), stages=["source", "sink"])
+
+
+@pytest.mark.asyncio
+async def test_public_subset_shutdown_closes_owners_despite_full_admission(tmp_path):
+    async with pipeline(tmp_path) as (coordinator, events, processes):
+        refs = [
+            await coordinator.open_session(OmniRequest(None), stages=["source", "sink"])
+            for _ in range(3)
+        ]
+        with pytest.raises(QueueFullError):
+            await coordinator.open_session(OmniRequest(None), stages=["source", "sink"])
+        await coordinator.shutdown_stages([])
+        assert len(coordinator._sessions) == 3
+        coordinator.max_in_flight = 0
+        await coordinator.shutdown_stages(["sink"])
+        assert not coordinator._sessions
+        assert processes[0].is_alive()
+        await asyncio.to_thread(processes[1].join, 5)
+        assert processes[1].exitcode == 0
+        with pytest.raises(ValueError, match="unregistered owner"):
+            await coordinator.open_session(OmniRequest(None), stages=["source", "sink"])
+        for ref in refs:
+            await coordinator.close_session(ref)
+
+
+@pytest.mark.asyncio
+async def test_partial_open_releases_previously_opened_owner(tmp_path):
+    async with pipeline(tmp_path) as (coordinator, events, processes):
+        with pytest.raises(RuntimeError, match="open failed"):
+            await coordinator.open_session(
+                OmniRequest(None, {"fail_open": "sink"}), stages=["source", "sink"]
+            )
+        assert not coordinator._sessions
+        log = [await asyncio.to_thread(events.get, True, 1) for _ in range(3)]
+        assert [entry[1] for entry in log if entry[0] == "close"] == ["source"]
+
+
+@pytest.mark.asyncio
+async def test_cancel_failure_closes_owners_in_reverse_order(tmp_path):
+    async with pipeline(tmp_path) as (coordinator, events, processes):
+        ref = await coordinator.open_session(
+            OmniRequest(None, {"cannot_abort": True}), stages=["source", "sink"]
+        )
+        with pytest.raises(RuntimeError, match="cannot be retained"):
+            await coordinator.abort_session(ref)
+        assert not coordinator._sessions
+        log = [await asyncio.to_thread(events.get, True, 1) for _ in range(5)]
+        assert [entry[1] for entry in log if entry[0] == "close"] == ["sink", "source"]
+
+
+@pytest.mark.asyncio
+async def test_pending_input_limit_rejects_extra_unit(tmp_path):
+    async with pipeline(tmp_path) as (coordinator, events, processes):
+        ref = await coordinator.open_session(
+            OmniRequest(None),
+            stages=["source", "sink"],
+            limits=SessionLimits(max_pending_chunks=1),
+        )
+        await coordinator.append_session(ref, chunk(0))
+        with pytest.raises(QueueFullError):
+            await coordinator.append_session(ref, chunk(1))
+        await coordinator.close_session(ref)
+
+
+@pytest.mark.asyncio
+async def test_input_sequence_rejects_a_gap(tmp_path):
+    async with pipeline(tmp_path) as (coordinator, events, processes):
+        ref = await coordinator.open_session(
+            OmniRequest(None), stages=["source", "sink"]
+        )
+        await coordinator.append_session(ref, chunk(0))
+        with pytest.raises(ValueError, match="contiguous"):
+            await coordinator.append_session(ref, chunk(2))
+        await coordinator.append_session(ref, chunk(1, eos=True))
+        await coordinator.close_session(ref)
+
+
+@pytest.mark.asyncio
+async def test_output_overflow_closes_session(tmp_path):
+    async with pipeline(tmp_path) as (coordinator, events, processes):
+        ref = await coordinator.open_session(
+            OmniRequest(None, {"cadence": 3}),
+            stages=["source", "sink"],
+            limits=SessionLimits(max_output_chunks=1),
+        )
+        state = coordinator._sessions[ref.session_id]
+        await coordinator.append_session(ref, chunk(0))
+        async with asyncio.timeout(5):
+            while ref.session_id in coordinator._sessions:
+                await asyncio.sleep(0.01)
+        assert isinstance(state.error, QueueFullError)
+
+
+@pytest.mark.asyncio
+async def test_idle_timeout_closes_session_and_wakes_reader(tmp_path):
+    async with pipeline(tmp_path) as (coordinator, events, processes):
+        ref = await coordinator.open_session(
+            OmniRequest(None),
+            stages=["source", "sink"],
+            limits=SessionLimits(idle_timeout_s=0.3),
+        )
+        output = coordinator.session_outputs(ref)
+        with pytest.raises(TimeoutError):
+            await asyncio.wait_for(anext(output), 5)
+        assert ref.session_id not in coordinator._sessions

--- a/tests/unit_test/pipeline/test_session_lifecycle.py
+++ b/tests/unit_test/pipeline/test_session_lifecycle.py
@@ -25,15 +25,14 @@ async def test_timeout_cancel_noop_waits_before_close(tmp_path):
         await coordinator.append_session(ref, chunk(0))
         with pytest.raises(TimeoutError):
             await asyncio.wait_for(anext(output), 5)
-        # The close timeout quarantines ownership until process teardown; late
-        # non-preemptible work may finish, but capacity is not falsely returned.
+        # Note (Junnan Li): A failed close retains the session reservation until worker teardown.
         assert coordinator._sessions[ref.session_id].cleanup_error is not None
         await asyncio.sleep(0.4)
         log = []
         while not events.empty():
             log.append(events.get(timeout=1))
         finished = next(i for i, e in enumerate(log) if e[:2] == ("finished", "sink"))
-        # A timed-out queued close may be dropped by request abort. If it ran,
+        # Note (Junnan Li): A timed-out queued close may be dropped by request abort. If it ran,
         # it must follow completion; otherwise scheduler.stop owns reclamation.
         close_positions = [i for i, e in enumerate(log) if e[:2] == ("close", "sink")]
         assert all(i > finished for i in close_positions)
@@ -103,24 +102,34 @@ async def test_partial_open_releases_previously_opened_owner(tmp_path):
     async with pipeline(tmp_path) as (coordinator, events, processes):
         with pytest.raises(RuntimeError, match="open failed"):
             await coordinator.open_session(
-                OmniRequest(None, {"fail_open": "sink"}), stages=["source", "sink"]
+                OmniRequest(None, {"fail_open": "sink"}),
+                stages=["source", "sink"],
+                session_id="reused",
             )
-        assert not coordinator._sessions
         log = [await asyncio.to_thread(events.get, True, 1) for _ in range(3)]
         assert [entry[1] for entry in log if entry[0] == "close"] == ["source"]
+        reopened = await coordinator.open_session(
+            OmniRequest(None), stages=["source", "sink"], session_id="reused"
+        )
+        await coordinator.close_session(reopened)
 
 
 @pytest.mark.asyncio
 async def test_cancel_failure_closes_owners_in_reverse_order(tmp_path):
     async with pipeline(tmp_path) as (coordinator, events, processes):
         ref = await coordinator.open_session(
-            OmniRequest(None, {"cannot_abort": True}), stages=["source", "sink"]
+            OmniRequest(None, {"cannot_abort": True}),
+            stages=["source", "sink"],
+            session_id="reused",
         )
         with pytest.raises(RuntimeError, match="cannot be retained"):
             await coordinator.abort_session(ref)
-        assert not coordinator._sessions
         log = [await asyncio.to_thread(events.get, True, 1) for _ in range(5)]
         assert [entry[1] for entry in log if entry[0] == "close"] == ["sink", "source"]
+        reopened = await coordinator.open_session(
+            OmniRequest(None), stages=["source", "sink"], session_id="reused"
+        )
+        await coordinator.close_session(reopened)
 
 
 @pytest.mark.asyncio
@@ -173,11 +182,15 @@ async def test_idle_timeout_closes_session_and_wakes_reader(tmp_path):
             OmniRequest(None),
             stages=["source", "sink"],
             limits=SessionLimits(idle_timeout_s=0.3),
+            session_id="reused",
         )
         output = coordinator.session_outputs(ref)
         with pytest.raises(TimeoutError):
             await asyncio.wait_for(anext(output), 5)
-        assert ref.session_id not in coordinator._sessions
+        reopened = await coordinator.open_session(
+            OmniRequest(None), stages=["source", "sink"], session_id="reused"
+        )
+        await coordinator.close_session(reopened)
 
 
 @pytest.mark.asyncio

--- a/tests/unit_test/pipeline/test_session_lifecycle.py
+++ b/tests/unit_test/pipeline/test_session_lifecycle.py
@@ -7,7 +7,7 @@ import pytest
 
 from sglang_omni.admission import QueueFullError
 from sglang_omni.proto import OmniRequest
-from sglang_omni.proto.session import SessionLimits
+from sglang_omni.proto.session import SessionLimits, TimedChunk
 from tests.unit_test.fixtures.session_pipeline import chunk, pipeline
 
 
@@ -178,3 +178,30 @@ async def test_idle_timeout_closes_session_and_wakes_reader(tmp_path):
         with pytest.raises(TimeoutError):
             await asyncio.wait_for(anext(output), 5)
         assert ref.session_id not in coordinator._sessions
+
+
+@pytest.mark.asyncio
+async def test_cross_modality_order_and_rejected_input_retry(tmp_path):
+    async with pipeline(tmp_path) as (coordinator, events, processes):
+        ref = await coordinator.open_session(
+            OmniRequest(None),
+            stages=["source", "sink"],
+            limits=SessionLimits(max_pending_chunks=1),
+        )
+        output = coordinator.session_outputs(ref)
+        await coordinator.append_session(ref, chunk(0, eos=True))
+        text = TimedChunk("text", 0, 0, 1, "hello", eos=True)
+        with pytest.raises(QueueFullError):
+            await coordinator.append_session(ref, text)
+        for kind in ("data", "input_done"):
+            result = await asyncio.wait_for(anext(output), 5)
+            assert (result.kind, result.input_seq) == (kind, 0)
+        assert await coordinator.append_session(ref, text) == 1
+        with pytest.raises(ValueError, match="contiguous"):
+            await coordinator.append_session(ref, text)
+        for kind in ("data", "input_done"):
+            result = await asyncio.wait_for(anext(output), 5)
+            assert (result.kind, result.input_seq) == (kind, 1)
+        with pytest.raises(ValueError, match="EOS"):
+            await coordinator.append_session(ref, chunk(2))
+        await output.aclose()

--- a/tests/unit_test/pipeline/test_session_lifecycle.py
+++ b/tests/unit_test/pipeline/test_session_lifecycle.py
@@ -100,18 +100,35 @@ async def test_unconfirmed_owner_release_blocks_new_sessions(tmp_path, reason):
 
 
 @pytest.mark.asyncio
-async def test_worker_failure_wakes_output_and_fails_session(tmp_path):
+async def test_worker_failure_wakes_output_and_fails_session(tmp_path, monkeypatch):
     async with pipeline(tmp_path) as (coordinator, events, processes):
         ref = await coordinator.open_session(
-            OmniRequest(None), stages=["source", "sink"]
+            OmniRequest(None, {"delay": 30}), stages=["source", "sink"]
         )
         output = coordinator.session_outputs(ref)
         waiting = asyncio.create_task(anext(output))
-        await asyncio.sleep(0)
+        await coordinator.append_session(ref, chunk(0))
+        for _ in range(100):
+            if any(e[:2] == ("append", "sink") for e in drain(events)):
+                break
+            await asyncio.sleep(0.05)
         processes[-1].kill()
         processes[-1].expected_exitcode = -9
         await asyncio.to_thread(processes[-1].join, 5)
-        await coordinator.fail_pending_requests("session worker exited")
+        futures = list(coordinator._completion_futures.values())
+        assert futures and not any(future.done() for future in futures)
+        # Note (Junnan Li): The pump is parked on the unit's completion future; cleanup waits
+        # for the pump, so request waiters must be failed before cleanup is entered.
+        entered, release, _ = block_async_call(
+            monkeypatch, coordinator, "_cleanup_session"
+        )
+        failing = asyncio.create_task(
+            coordinator.fail_pending_requests("session worker exited")
+        )
+        await asyncio.wait_for(entered.wait(), 5)
+        assert all(future.done() for future in futures)
+        release.set()
+        await asyncio.wait_for(failing, 5)
         with pytest.raises(RuntimeError, match="worker exited"):
             await asyncio.wait_for(waiting, 5)
         with pytest.raises(RuntimeError, match="worker exited"):
@@ -265,28 +282,46 @@ async def test_cross_modality_order_and_rejected_input_retry(tmp_path):
 
 
 @pytest.mark.asyncio
-@pytest.mark.parametrize("trigger", ["close", "shutdown", "idle"])
+@pytest.mark.parametrize("trigger", ["close", "shutdown", "idle", "command_timeout"])
 async def test_closing_rejects_input_before_cleanup(tmp_path, monkeypatch, trigger):
     async with pipeline(tmp_path) as (coordinator, _, _):
+        params = (
+            {"ignore_cancel": True, "delay": 0.3}
+            if trigger == "command_timeout"
+            else {}
+        )
         ref = await coordinator.open_session(
-            OmniRequest(None),
+            OmniRequest(None, params),
             stages=["source", "sink"],
-            limits=SessionLimits(idle_timeout_s=0.2 if trigger == "idle" else 300),
+            limits=SessionLimits(
+                idle_timeout_s=0.2 if trigger == "idle" else 300,
+                command_timeout_s=0.1 if trigger == "command_timeout" else 30,
+            ),
         )
-        entered, release, _ = block_async_call(
-            monkeypatch, coordinator, "_cleanup_session"
-        )
+        # Note (Junnan Li): A failed command finalizes through request abort before the
+        # pump can start cleanup; admission must already be closed at that seam.
+        seam = "abort" if trigger == "command_timeout" else "_cleanup_session"
+        entered, release, _ = block_async_call(monkeypatch, coordinator, seam)
         task = None
         if trigger == "close":
             task = asyncio.create_task(coordinator.close_session(ref))
         elif trigger == "shutdown":
             task = asyncio.create_task(coordinator.shutdown_stages(["sink"]))
+        elif trigger == "command_timeout":
+            await coordinator.append_session(ref, chunk(0))
         try:
             await asyncio.wait_for(entered.wait(), 5)
             with pytest.raises(RuntimeError, match="closing"):
-                await coordinator.append_session(ref, chunk(0))
+                await coordinator.append_session(ref, chunk(1))
         finally:
             release.set()
-            await asyncio.wait_for(
-                task if task is not None else coordinator.close_session(ref), 5
-            )
+            if task is not None:
+                await asyncio.wait_for(task, 5)
+            elif trigger == "command_timeout":
+                # Note (Junnan Li): The non-preemptible hook outlives the command timeout, so
+                # this close reports an incomplete cleanup; wait for the hook before teardown.
+                with pytest.raises(RuntimeError, match="capacity remains reserved"):
+                    await asyncio.wait_for(coordinator.close_session(ref), 5)
+                await asyncio.sleep(0.4)
+            else:
+                await asyncio.wait_for(coordinator.close_session(ref), 5)

--- a/tests/unit_test/pipeline/test_session_shutdown.py
+++ b/tests/unit_test/pipeline/test_session_shutdown.py
@@ -1,5 +1,5 @@
 # SPDX-License-Identifier: Apache-2.0
-"""Deterministic shutdown handoff tests without model or accelerator dependencies."""
+"""Shutdown handoff at hook completion and owner unlock."""
 from __future__ import annotations
 
 import inspect
@@ -12,6 +12,7 @@ import pytest
 from sglang_omni.proto import OmniRequest, StagePayload
 from sglang_omni.proto.session import SESSION_METADATA_KEY, SessionRef, TimedChunk
 from sglang_omni.scheduling.session import SessionHooks, SessionScheduler
+from tests.unit_test.fixtures.session_pipeline import compute_registered
 
 
 def command(op):
@@ -59,7 +60,7 @@ def run_command(scheduler, op, trace=None):
         if trace is not None:
             sys.settrace(trace)
         try:
-            scheduler._compute(command(op))
+            compute_registered(scheduler, command(op))
         except BaseException as exc:
             errors.append(exc)
         finally:
@@ -74,7 +75,7 @@ def run_command(scheduler, op, trace=None):
 def test_stop_hands_cleanup_to_active_hook_completion(op):
     hooks = Hooks(block=op)
     scheduler = SessionScheduler(hooks)
-    scheduler._compute(command("open"))
+    compute_registered(scheduler, command("open"))
     thread, errors = run_command(scheduler, op)
     try:
         assert hooks.entered.wait(5)
@@ -95,7 +96,7 @@ def test_stop_after_last_hook_check_before_owner_unlock(op):
     hooks = Hooks()
     scheduler = SessionScheduler(hooks)
     if op != "open":
-        scheduler._compute(command("open"))
+        compute_registered(scheduler, command("open"))
     lines, first_line = inspect.getsourcelines(scheduler._compute_session)
     if op == "open":
         pause_line = max(

--- a/tests/unit_test/pipeline/test_session_shutdown.py
+++ b/tests/unit_test/pipeline/test_session_shutdown.py
@@ -1,0 +1,137 @@
+# SPDX-License-Identifier: Apache-2.0
+"""Deterministic shutdown handoff tests without model or accelerator dependencies."""
+from __future__ import annotations
+
+import inspect
+import sys
+import threading
+from dataclasses import asdict
+
+import pytest
+
+from sglang_omni.proto import OmniRequest, StagePayload
+from sglang_omni.proto.session import SESSION_METADATA_KEY, SessionRef, TimedChunk
+from sglang_omni.scheduling.session import SessionHooks, SessionScheduler
+
+
+def command(op):
+    data = {
+        "op": op,
+        "ref": asdict(SessionRef("session", epoch=int(op == "abort"))),
+        "chunk": asdict(TimedChunk("audio", 0, 20, 0, b"pcm")),
+        "output_limits": {"chunks": 4, "bytes": 1024},
+    }
+    return StagePayload(
+        op, OmniRequest(None, metadata={SESSION_METADATA_KEY: data}), {}
+    )
+
+
+class Hooks(SessionHooks):
+    def __init__(self, block=None):
+        self.block = block
+        self.entered = threading.Event()
+        self.release = threading.Event()
+        self.closed = []
+
+    def open(self, ref, request):
+        return object()
+
+    def append(self, state, chunk, payload, context):
+        self.pause("append")
+        return payload
+
+    def abort(self, state, ref):
+        self.pause("abort")
+
+    def pause(self, op):
+        if self.block == op:
+            self.entered.set()
+            assert self.release.wait(5)
+
+    def close(self, state):
+        self.closed.append(state)
+
+
+def run_command(scheduler, op, trace=None):
+    errors = []
+
+    def run():
+        if trace is not None:
+            sys.settrace(trace)
+        try:
+            scheduler._compute(command(op))
+        except BaseException as exc:
+            errors.append(exc)
+        finally:
+            sys.settrace(None)
+
+    thread = threading.Thread(target=run)
+    thread.start()
+    return thread, errors
+
+
+@pytest.mark.parametrize("op", ["abort", "append"])
+def test_stop_hands_cleanup_to_active_hook_completion(op):
+    hooks = Hooks(block=op)
+    scheduler = SessionScheduler(hooks)
+    scheduler._compute(command("open"))
+    thread, errors = run_command(scheduler, op)
+    try:
+        assert hooks.entered.wait(5)
+        scheduler.stop()
+        assert not hooks.closed
+    finally:
+        hooks.release.set()
+        thread.join(5)
+    assert not thread.is_alive() and not errors
+    assert len(hooks.closed) == 1
+    assert not scheduler._sessions
+    scheduler.stop()
+    assert len(hooks.closed) == 1
+
+
+@pytest.mark.parametrize("op", ["open", "append"])
+def test_stop_after_last_hook_check_before_owner_unlock(op):
+    hooks = Hooks()
+    scheduler = SessionScheduler(hooks)
+    if op != "open":
+        scheduler._compute(command("open"))
+    lines, first_line = inspect.getsourcelines(scheduler._compute_session)
+    if op == "open":
+        pause_line = max(
+            first_line + i
+            for i, line in enumerate(lines)
+            if line.strip() == "session.lock.release()"
+        )
+    else:
+        pause_line = next(
+            first_line + i
+            for i, line in enumerate(lines)
+            if line.strip() == "with session.lock:"
+        )
+    paused, release = threading.Event(), threading.Event()
+
+    def trace(frame, event, arg):
+        if (
+            event == "line"
+            and frame.f_code is scheduler._compute_session.__func__.__code__
+            and frame.f_lineno == pause_line
+            and (op == "open" or "result" in frame.f_locals)
+        ):
+            paused.set()
+            assert release.wait(5)
+        return trace
+
+    thread, errors = run_command(scheduler, op, trace)
+    try:
+        assert paused.wait(5)
+        scheduler.stop()
+        assert not hooks.closed
+    finally:
+        release.set()
+        thread.join(5)
+    assert not thread.is_alive() and not errors
+    assert len(hooks.closed) == 1
+    assert not scheduler._sessions
+    scheduler.stop()
+    assert len(hooks.closed) == 1

--- a/tests/unit_test/scheduling/test_session.py
+++ b/tests/unit_test/scheduling/test_session.py
@@ -1,0 +1,89 @@
+# SPDX-License-Identifier: Apache-2.0
+"""Session value validation and stage state ownership without worker processes."""
+from dataclasses import asdict
+
+import pytest
+
+from sglang_omni.admission import QueueFullError
+from sglang_omni.proto import OmniRequest
+from sglang_omni.proto.session import (
+    ResourceUsage,
+    SessionLimits,
+    SessionRef,
+    TimedChunk,
+)
+from sglang_omni.scheduling.session import SessionHooks, SessionScheduler
+
+
+class Hooks(SessionHooks):
+    def __init__(self, name, events):
+        self.name, self.events = name, events
+
+    def open(self, ref, request):
+        self.events.put(("open", self.name, ref.session_id))
+        return {"id": ref.session_id}
+
+    def close(self, state):
+        self.events.put(("close", self.name, state["id"]))
+
+
+def test_timing_and_capacity_validation():
+    for bad in [-1, float("inf"), float("nan")]:
+        with pytest.raises(ValueError):
+            TimedChunk("audio", bad, 1, 0, b"")
+    with pytest.raises(ValueError):
+        SessionLimits(max_pending_chunks=0)
+
+
+def test_open_usage_failure_releases_state():
+    import queue
+
+    from sglang_omni.proto import StagePayload
+    from sglang_omni.proto.session import SESSION_METADATA_KEY
+
+    class BrokenUsage(Hooks):
+        def usage(self, state):
+            raise RuntimeError("usage failed")
+
+    events = queue.Queue()
+    scheduler = SessionScheduler(BrokenUsage("source", events))
+    request = OmniRequest(
+        None,
+        metadata={
+            SESSION_METADATA_KEY: {"op": "open", "ref": asdict(SessionRef("one"))}
+        },
+    )
+    with pytest.raises(RuntimeError, match="usage failed"):
+        scheduler._compute(StagePayload("one-open", request, {}))
+    assert not scheduler._sessions
+    assert events.get_nowait()[0] == "open"
+    assert events.get_nowait()[0] == "close"
+
+
+def test_stage_capacity_is_aggregate_and_unknown_commands_fail():
+    import queue
+
+    from sglang_omni.proto import StagePayload
+    from sglang_omni.proto.session import SESSION_METADATA_KEY
+
+    class SizedHooks(Hooks):
+        def usage(self, state):
+            return ResourceUsage(bytes=2)
+
+    scheduler = SessionScheduler(SizedHooks("source", queue.Queue()), max_state_bytes=3)
+
+    def invoke(sid, op):
+        request = OmniRequest(
+            None,
+            metadata={SESSION_METADATA_KEY: {"op": op, "ref": asdict(SessionRef(sid))}},
+        )
+        return scheduler._compute(StagePayload(sid + op, request, {}))
+
+    invoke("one", "open")
+    with pytest.raises(QueueFullError):
+        invoke("two", "open")
+    assert list(scheduler._sessions) == [("one", 1)]
+    with pytest.raises(ValueError, match="unknown session operation"):
+        invoke("one", "invalid")
+    scheduler.stop()
+    assert not scheduler._sessions

--- a/tests/unit_test/scheduling/test_session.py
+++ b/tests/unit_test/scheduling/test_session.py
@@ -87,3 +87,50 @@ def test_stage_capacity_is_aggregate_and_unknown_commands_fail():
         invoke("one", "invalid")
     scheduler.stop()
     assert not scheduler._sessions
+
+
+@pytest.mark.parametrize("configured", [False, True])
+def test_ordinary_request_uses_handler_or_reports_scoped_error(configured):
+    import queue
+    import threading
+
+    from sglang_omni.proto import StagePayload
+    from sglang_omni.scheduling.messages import IncomingMessage
+
+    def compute(payload):
+        payload.data = {"ordinary": True}
+        return payload
+
+    kwargs = {"compute_fn": compute} if configured else {}
+    scheduler = SessionScheduler(Hooks("source", queue.Queue()), **kwargs)
+    worker = threading.Thread(target=scheduler.start)
+    worker.start()
+    try:
+        payload = StagePayload("ordinary", OmniRequest(None), {})
+        scheduler.inbox.put(IncomingMessage("ordinary", "new_request", payload))
+        output = scheduler.outbox.get(timeout=5)
+        assert output.request_id == "ordinary"
+        if configured:
+            assert output.type == "result"
+            assert output.data.data == {"ordinary": True}
+        else:
+            assert output.type == "error"
+            assert isinstance(output.data, ValueError)
+            assert "ordinary requests" in str(output.data)
+        request = OmniRequest(
+            None,
+            metadata={
+                "omni_session": {
+                    "op": "open",
+                    "ref": asdict(SessionRef("after-ordinary")),
+                }
+            },
+        )
+        scheduler.inbox.put(
+            IncomingMessage("open", "new_request", StagePayload("open", request, {}))
+        )
+        assert scheduler.outbox.get(timeout=5).type == "result"
+    finally:
+        scheduler.stop()
+        worker.join(timeout=5)
+    assert not worker.is_alive()

--- a/tests/unit_test/scheduling/test_session.py
+++ b/tests/unit_test/scheduling/test_session.py
@@ -13,6 +13,7 @@ from sglang_omni.proto.session import (
     TimedChunk,
 )
 from sglang_omni.scheduling.session import SessionHooks, SessionScheduler
+from tests.unit_test.fixtures.session_pipeline import compute_registered
 
 
 class Hooks(SessionHooks):
@@ -54,7 +55,7 @@ def test_open_usage_failure_releases_state():
         },
     )
     with pytest.raises(RuntimeError, match="usage failed"):
-        scheduler._compute(StagePayload("one-open", request, {}))
+        compute_registered(scheduler, StagePayload("one-open", request, {}))
     assert not scheduler._sessions
     assert events.get_nowait()[0] == "open"
     assert events.get_nowait()[0] == "close"
@@ -77,7 +78,7 @@ def test_stage_capacity_is_aggregate_and_unknown_commands_fail():
             None,
             metadata={SESSION_METADATA_KEY: {"op": op, "ref": asdict(SessionRef(sid))}},
         )
-        return scheduler._compute(StagePayload(sid + op, request, {}))
+        return compute_registered(scheduler, StagePayload(sid + op, request, {}))
 
     invoke("one", "open")
     with pytest.raises(QueueFullError):

--- a/tests/unit_test/scheduling/test_session.py
+++ b/tests/unit_test/scheduling/test_session.py
@@ -134,3 +134,39 @@ def test_ordinary_request_uses_handler_or_reports_scoped_error(configured):
         scheduler.stop()
         worker.join(timeout=5)
     assert not worker.is_alive()
+
+
+@pytest.mark.parametrize("size", [0, 255, 256, 65535, 65536])
+def test_binary_chunk_wire_size_matches_msgpack(size, monkeypatch):
+    import msgpack
+
+    from sglang_omni.proto.session import OutputChunk, wire_size
+
+    chunk = TimedChunk("audio", 0, 80, 0, b"x" * size, format="pcm16")
+    output = OutputChunk(
+        SessionRef("session"),
+        0,
+        0,
+        **{key: value for key, value in asdict(chunk).items() if key != "seq"},
+    )
+    pack = msgpack.packb
+    values = [asdict(chunk), asdict(output)]
+    expected = [len(pack(value, use_bin_type=True)) for value in values]
+    encoded_payloads = []
+
+    def record(value, **kwargs):
+        encoded_payloads.append(len(value["payload"]))
+        return pack(value, **kwargs)
+
+    monkeypatch.setattr(msgpack, "packb", record)
+    assert [wire_size(value) for value in values] == expected
+    assert all(size == 0 for size in encoded_payloads)
+
+
+def test_structured_chunk_wire_size_matches_msgpack():
+    import msgpack
+
+    from sglang_omni.proto.session import wire_size
+
+    value = asdict(TimedChunk("text", 0, 0, 0, {"tokens": [1, 2]}))
+    assert wire_size(value) == len(msgpack.packb(value, use_bin_type=True))


### PR DESCRIPTION
## Motivation

Add a session lifecycle to the Omni pipeline so stateful stages can retain context across short requests. In continuous audio processing, finishing one input chunk should finish that unit of work while leaving the stage's streaming state available for the next chunk.

A session ID alone does not define where that state lives or when it is safe to update or release it. Successive requests must reach the same stage owners, advance state in order, and distinguish cancelling current work from closing the conversation. This PR establishes those rules at the pipeline and non-AR scheduler layers.

## Modifications

### Session identity and execution

- Add `SessionRef`, `TimedChunk`, `OutputChunk`, `SessionLimits`, and `ResourceUsage` in `proto/session.py`. Session incarnation identifies a lifetime; output epoch fences cancelled work. Chunks carry modality, sequence, timestamps, duration, and EOS.
- Add `CoordinatorSessions` in `pipeline/sessions.py`. Opening a session pins one physical owner for each stage on a fixed linear route. Appending submits short pipeline requests through the existing dispatch and payload-relay paths, with one in-flight unit per session. Input acceptance and output consumption remain independent while the unit executes; different sessions can run concurrently.
- Keep lifecycle integration in `pipeline/coordinator.py`: initialization, shutdown, worker-failure propagation, directed commands, fixed replica bindings, and session output dispatch. The session module reuses the coordinator's request tracking and completion machinery.

For example, U1 updates the state held by the selected encoder and decoder. U1 completion produces an `input_done` receipt, and U2 then runs against those same owners with the next input. A unit can complete without producing model output. Its receipt describes pipeline completion; the model adapter defines the relationship between that unit and consumed media.

### Stage integration and cleanup

- Update `pipeline/stage/runtime.py` so open/abort/close commands complete at their addressed owner. Append results continue through ordinary payload relay after validating the fixed route.
- Add `SessionScheduler` and `SessionHooks` in `scheduling/session.py` for non-AR stage implementations. Hooks provide open, append, abort, close, and resource reporting. Per-session ordering and cooperative cancellation keep close from freeing state still used by a running hook.
- Preserve ordinary request handling in session-enabled stages. Requests without session metadata use the configured ordinary handler or receive a request-scoped error.
- On session cancellation, advance the output epoch immediately and discard old queued data. Let the in-flight unit finish and preserve its consumption receipt; only then send stage epoch-transition commands and dispatch the next unit. Accepted pending input remains queued. This avoids request abort releasing a streaming session's KV. If a stage cannot retain a usable context, close the session.
- Bound accepted input, buffered output, session count, and reported stage-state bytes. Input clocks remain monotonic across cancellation. Timeout, failed open, worker failure, and shutdown enter the cleanup path. Close owners downstream to upstream; unacknowledged cleanup retains ownership and capacity instead of reporting resources as released.

### Payload accounting

- Compute binary payload wire size without serializing the full media payload. Reuse immutable byte inputs while preserving snapshots for structured inputs.
- Clear initial media from the retained session request after all stage owners open, so later lifecycle commands do not resend it.

The SGLang AR bridge and public realtime adapters are separate dependent PRs. This PR supplies their shared lifecycle; it does not enable a production duplex model.

## Related Issues

- Related to [Full Duplex roadmap #1909](https://github.com/sgl-project/sglang-omni/issues/1909), Phase 1 #2052: session lifecycle, stage ownership, ordered timed input, bounded queues, and mock validation.

- Related to [#2003](https://github.com/sgl-project/sglang-omni/pull/2003), which adds AR streaming-session hosting. Both introduce coordinator session entry points; this PR manages cross-stage ownership and non-AR stage lifecycle.

## Accuracy Test

Pass all current session unit tests.

## Benchmark & Profiling

N/A

## Checklist

- [x] Format your code according with pre-commit.
- [x] Add unit tests.
- [x] Update documentation / docstrings / example tutorials as needed.
- [ ] Provide throughput / latency benchmark results and accuracy evaluation results as needed.
- [ ] For reviewers: If you haven't made any contributions to this PR and are only assisting with merging the main branch, please remove yourself as a co-author when merging the PR.

## CI

CI runs on self-hosted GPU runners and requires a maintainer to add the
`run-ci` label. Once labeled, every subsequent push re-triggers CI as
long as the label remains. Use `/tag-and-rerun-ci higgs` or
`/tag-and-rerun-ci moss` or `/tag-and-rerun-ci qwen3-tts` to select a TTS CI
model, and
`/tag-and-rerun-ci fun-asr`, `/tag-and-rerun-ci qwen3-asr` or
`/tag-and-rerun-ci whisper-asr` to select an ASR CI model. One selector from
each family can be combined, for example `/tag-and-rerun-ci moss fun-asr`.
Draft PRs are skipped even if labeled.

