### PR TITLE
[Config] Validate shared selectors and explicit null blocks

### DIFF
--- a/docs/developer_reference/config.md
+++ b/docs/developer_reference/config.md
@@ -146,7 +146,8 @@ shared:
 
 The entry expands to one patch per matched stage before resolution. An
 explicit per-stage entry (under `stages:` or as a dotted flag) overrides the
-expansion; two `shared` entries writing one leaf conflict.
+expansion; two `shared` entries writing one leaf conflict. `engine: true`
+selects engine stages, while `engine: false` selects non-engine stages.
 
 **Broadcast flag** — `--mem-fraction-static 0.7` fans one value out to every
 SGLang engine stage's `engine.mem_fraction_static`. It is the one convenience

--- a/sglang_omni/config/sources.py
+++ b/sglang_omni/config/sources.py
@@ -109,6 +109,8 @@ _STAGES_LIST_GUIDANCE = (
     "key:\n\n    stages:\n      thinker:\n        tp_size: 2"
 )
 
+_MISSING = object()
+
 
 def patches_from_dotted_cli(
     extra_args: Mapping[str, Any] | Iterable[tuple[str, Any]],
@@ -202,7 +204,7 @@ def patches_from_shared_block(
     being a conflict. Selectors:
 
     * ``stages`` -- explicit stage names (each must exist);
-    * ``engine`` -- ``true`` matches every SGLang engine stage;
+    * ``engine`` -- ``true`` matches engine stages, ``false`` non-engine stages;
     * ``exclude`` -- removes stages after the positive selectors matched.
 
     The expansion happens before duplicate checking and validation; resolved
@@ -279,13 +281,12 @@ def _select_stages(
             raise ValueError(
                 f"{label}.select.engine must be true or false, got {engine!r}"
             )
-        if engine:
-            matched = [
-                name
-                for name in matched
-                if config_cls.stage_config_cls(name).engine_stage
-            ]
-    excluded = select.get("exclude") or []
+        matched = [
+            name
+            for name in matched
+            if config_cls.stage_config_cls(name).engine_stage == engine
+        ]
+    excluded = select.get("exclude", [])
     if not isinstance(excluded, list) or not all(
         isinstance(name, str) for name in excluded
     ):
@@ -394,8 +395,8 @@ def sources_from_config_file(
             f"Config file {file_path!r} must name its pipeline class in " "config_cls"
         )
     config_cls = PIPELINE_CONFIG_REGISTRY.get_config_cls_by_name(data["config_cls"])
-    stages_block = data.pop("stages", None)
-    shared_block = data.pop("shared", None)
+    stages_block = data.pop("stages", _MISSING)
+    shared_block = data.pop("shared", _MISSING)
     overrides = {key: value for key, value in data.items() if key != "config_cls"}
 
     # The baseline is built from the class's own defaults plus only the keys
@@ -430,7 +431,7 @@ def sources_from_config_file(
                 )
         else:
             patches.add(ConfigPatch.create(key, value, source, root=config_cls))
-    if stages_block is not None:
+    if stages_block is not _MISSING:
         patches = patches.merge(
             patches_from_stages_mapping(
                 stages_block,
@@ -439,7 +440,7 @@ def sources_from_config_file(
                 origin=str(file_path),
             )
         )
-    if shared_block is not None:
+    if shared_block is not _MISSING:
         # Expanded against the settled stage list, so a selector can reach a
         # stage this same file added.
         patches = patches.merge(

--- a/tests/unit_test/config/test_cli_config.py
+++ b/tests/unit_test/config/test_cli_config.py
@@ -104,6 +104,28 @@ def plain_config_file(tmp_path, base_config):
 
 
 class TestResolve:
+    @pytest.mark.parametrize(
+        ("block", "message"),
+        [("stages", "must be a mapping"), ("shared", "must be a list")],
+    )
+    def test_an_explicit_null_block_is_not_treated_as_absent(
+        self, tmp_path, base_config, block, message
+    ):
+        path = tmp_path / "null-block.yaml"
+        path.write_text(
+            yaml.safe_dump(
+                {
+                    "config_cls": base_config.config_cls,
+                    "model_path": "dummy",
+                    block: None,
+                },
+                sort_keys=False,
+            )
+        )
+
+        with pytest.raises(ValueError, match=message):
+            ConfigManager.from_file(str(path))
+
     def test_prints_the_config_a_launch_would_use(self, runner, config_file):
         """The whole point: this is what `serve` with these arguments builds."""
         result = runner.invoke(config_app, ["resolve", "--config", str(config_file)])

--- a/tests/unit_test/config/test_config_set.py
+++ b/tests/unit_test/config/test_config_set.py
@@ -275,6 +275,18 @@ class TestStageDefaults:
             "stages.thinker.engine.mem_fraction_static"
         ]
 
+    def test_the_false_engine_selector_matches_non_engine_stages_only(
+        self, pipeline_config
+    ):
+        patches = patches_from_shared_block(
+            [{"select": {"engine": False}, "factory": {"max_seq_len": 4096}}],
+            type(pipeline_config),
+            ["preprocessing", "thinker"],
+        )
+        assert [patch.path.raw for patch in patches.ordered()] == [
+            "stages.preprocessing.factory.max_seq_len"
+        ]
+
     def test_exclude_removes_matched_stages(self, pipeline_config):
         patches = patches_from_shared_block(
             [
@@ -346,6 +358,23 @@ class TestStageDefaults:
                     {
                         "select": {"capability": "sglang"},
                         "engine": {"mem_fraction_static": 0.5},
+                    }
+                ],
+                type(pipeline_config),
+                ["preprocessing", "thinker"],
+            )
+
+    @pytest.mark.parametrize("exclude", [False, 0, "", None])
+    def test_a_falsy_non_list_exclusion_is_refused(
+        self, pipeline_config, exclude
+    ) -> None:
+        """A mistyped exclusion must not silently select every stage."""
+        with pytest.raises(ValueError, match="exclude must be a list"):
+            patches_from_shared_block(
+                [
+                    {
+                        "select": {"exclude": exclude},
+                        "factory": {"max_seq_len": 4096},
                     }
                 ],
                 type(pipeline_config),


### PR DESCRIPTION
## Motivation

Three configuration inputs currently bypass their intended selection or validation:

- `shared.select.engine: false` leaves engine stages selected.
- Non-list `exclude` values such as `false`, `0`, `""`, and `null` behave like an empty exclusion list.
- Explicit `stages: null` and `shared: null` blocks are treated as absent.

## Modifications

- Make `engine: false` select only non-engine stages, while retaining stage-name and exclusion filters.
- Validate `exclude` whenever it is supplied, including falsy values.
- Use a missing-value sentinel so explicit null blocks reach the existing type validation.
- Document the boolean selector behavior and add seven regression cases. All seven fail with the upstream implementation.

## Related Issues

N/A.

## Accuracy Test

Behavior comparison from the original regression validation (`836cdd7` before, implementation `cd4b6c7` after):

| Configuration input | Before | After | Regression cases passing, before → after |
|---|---|---|---|
| `shared.select.engine: false` | Engine stages remain selected | Selects non-engine stages, respecting name/exclusion filters | 0/1 → 1/1 |
| `exclude: false`, `0`, `""`, or `null` | Invalid values silently behave as an empty exclusion list | Each value raises the existing list-type validation error | 0/4 → 4/4 |
| Explicit `stages: null` or `shared: null` | Null blocks are treated as absent | Raises the corresponding mapping/list type error | 0/2 → 2/2 |
| Total targeted regression cases | The original behavior fails all seven cases | The corrected behavior passes all seven | 0/7 → 7/7 |

These are functional parsing/selection results, not model-quality or performance measurements. They show that mistyped configuration no longer silently selects unintended stages or bypasses validation. The before run loads the upstream configuration module with the same regression cases; the after cases are included in the validated test suite below. This table summarizes the original validation, not a new full-suite run on current main.

Model accuracy evaluation is not applicable to this configuration parsing change.

Validation of commit `cd4b6c7`, based on upstream `836cdd778392a7280afb8c0f04b466e2138284b7`:

- `pytest tests/ -m "not benchmark and not accelerator"`: **6294 passed, 4 skipped, 362 deselected**.
- Full repository pre-commit checks, Test Layout, 13 realtime playback tests, and `git diff --check`: passed.
- Sphinx HTML build: passed with 22 existing documentation warnings.

Environment: Linux/WSL, Python 3.11, `CUDA_VISIBLE_DEVICES=`, `NUMA_NODE=0`, and FFmpeg shared libraries available. No additional pytest exclusions were used.

## Benchmark & Profiling

This PR changes setup-time configuration validation; it does not change model execution.

| Measurement | Before | After | Evidence boundary |
|---|---|---|---|
| Configuration parsing latency | Not measured | Not measured | No speedup claim |
| Model throughput / accuracy | Not evaluated | Not evaluated | No model execution change; functional results are reported above |

## Checklist

- [x] Format your code according with pre-commit.
- [x] Add unit tests.
- [x] Update documentation / docstrings / example tutorials as needed.
- [x] Provide throughput / latency benchmark results and accuracy evaluation results as needed. N/A for configuration parsing and validation.
- [ ] For reviewers: If you haven't made any contributions to this PR and are only assisting with merging the main branch, please remove yourself as a co-author when merging the PR.

## CI

The self-hosted GPU suite requires a maintainer to add `run-ci`.

AI tools (Codex) assisted with code, tests, and this description.
