### PR TITLE
[Runtime] Turn NCCL NVLS off for TP stage processes

### DIFF
--- a/sglang_omni/platforms/cuda.py
+++ b/sglang_omni/platforms/cuda.py
@@ -77,11 +77,19 @@ class CUDAOmniPlatform(CudaDeviceMixin, OmniPlatform):
         else:
             mapped_gpu = str(spec.gpu_id)
 
-        return {
+        env_updates = {
             "CUDA_VISIBLE_DEVICES": mapped_gpu,
             "SGLANG_ONE_VISIBLE_DEVICE_PER_PROCESS": "true",
             "SGLANG_ENABLE_TP_MEMORY_INBALANCE_CHECK": "false",
         }
+        # note (ratish): NVLS multicast binding is not available on every host,
+        # and NCCL 2.29 fails communicator init instead of falling back. A
+        # value from the shell or the stage configuration stands.
+        if "NCCL_NVLS_ENABLE" not in source_env and (
+            "NCCL_NVLS_ENABLE" not in spec.env_defaults
+        ):
+            env_updates["NCCL_NVLS_ENABLE"] = "0"
+        return env_updates
 
     def get_intra_node_transport(self) -> TransportKind:
         from sglang_omni.comm.data_ref import TransportKind

--- a/sglang_omni/scheduling/sglang_backend/server_args_builder.py
+++ b/sglang_omni/scheduling/sglang_backend/server_args_builder.py
@@ -90,6 +90,14 @@ def build_sglang_server_args(
     # chunked prefill stays allowed (the bridge handles it natively).
     if server_args.enable_dp_attention:
         raise ValueError("sglang-omni does not support enable_dp_attention")
+    # note (ratish): NVLS is controlled through the process environment and
+    # symmetric memory is never set up, so either flag would run without effect.
+    if server_args.enable_nccl_nvls or server_args.enable_symm_mem:
+        raise ValueError(
+            "enable_nccl_nvls and enable_symm_mem are not supported; remove them. "
+            "NVLS is enabled with NCCL_NVLS_ENABLE=1 in the shell or the stage "
+            "env. Symmetric memory is not available."
+        )
     # Overlapped startup weight load leaves sentinel weights until the scheduler
     # calls finalize_startup_weight_load after capture; omni's bootstrap never
     # does, so profiling, weight sharing and capture would run on the sentinels.

--- a/tests/unit_test/pipeline/test_stage_process_env.py
+++ b/tests/unit_test/pipeline/test_stage_process_env.py
@@ -61,6 +61,53 @@ def test_tp_process_env_maps_logical_gpu_through_visible_devices() -> None:
     assert env["SGLANG_ONE_VISIBLE_DEVICE_PER_PROCESS"] == "true"
 
 
+def test_tp_process_env_turns_nccl_nvls_off() -> None:
+    env = cuda_platform.get_stage_process_env(_tp_spec(gpu_id=0), {})
+
+    assert env["NCCL_NVLS_ENABLE"] == "0"
+
+
+def test_tp_process_env_leaves_an_operator_nvls_value_alone() -> None:
+    env = cuda_platform.get_stage_process_env(
+        _tp_spec(gpu_id=0), {"NCCL_NVLS_ENABLE": "1"}
+    )
+
+    assert "NCCL_NVLS_ENABLE" not in env
+
+
+def test_spawn_env_maps_the_planned_gpu_even_with_a_configured_visibility(
+    monkeypatch,
+) -> None:
+    monkeypatch.delenv("CUDA_VISIBLE_DEVICES", raising=False)
+    monkeypatch.setattr(stage_workers, "current_platform", cuda_platform)
+    stage_spec = _tp_spec(gpu_id=1)
+    stage_spec.env_defaults = {"CUDA_VISIBLE_DEVICES": "2,3"}
+
+    with _patched_spawn_env(_worker_spec(stage_spec)):
+        assert os.environ["CUDA_VISIBLE_DEVICES"] == "1"
+
+    assert "CUDA_VISIBLE_DEVICES" not in os.environ
+
+
+def test_spawn_env_keeps_a_configured_stage_nvls_value(monkeypatch) -> None:
+    monkeypatch.delenv("NCCL_NVLS_ENABLE", raising=False)
+    monkeypatch.setenv("CUDA_VISIBLE_DEVICES", "3,4")
+    monkeypatch.setattr(stage_workers, "current_platform", cuda_platform)
+    stage_spec = _tp_spec(gpu_id=1)
+    stage_spec.env_defaults = {"NCCL_NVLS_ENABLE": "1"}
+
+    with _patched_spawn_env(_worker_spec(stage_spec)):
+        assert os.environ["NCCL_NVLS_ENABLE"] == "1"
+
+    assert "NCCL_NVLS_ENABLE" not in os.environ
+
+
+def test_non_tp_stage_gets_no_cuda_process_env() -> None:
+    spec = StageLaunchConfig(stage_name="thinker", tp_size=1, gpu_id=0)
+
+    assert cuda_platform.get_stage_process_env(spec, {}) == {}
+
+
 def test_tp_process_env_rejects_single_visible_device_for_second_gpu() -> None:
     with pytest.raises(ValueError, match="CUDA_VISIBLE_DEVICES only exposes"):
         cuda_platform.get_stage_process_env(

--- a/tests/unit_test/scheduling/test_server_args_builder_device.py
+++ b/tests/unit_test/scheduling/test_server_args_builder_device.py
@@ -19,6 +19,8 @@ class _CapturedServerArgs:
     def __init__(self, **kwargs: Any) -> None:
         self.kwargs = kwargs
         self.enable_dp_attention = False
+        self.enable_nccl_nvls = kwargs.get("enable_nccl_nvls", False)
+        self.enable_symm_mem = kwargs.get("enable_symm_mem", False)
         self.startup_weight_load_mode = kwargs.get("startup_weight_load_mode", "serial")
 
 
@@ -54,6 +56,15 @@ def test_overlapped_startup_weight_load_is_rejected(monkeypatch) -> None:
 
     with pytest.raises(ValueError, match="startup_weight_load_mode"):
         _build(monkeypatch, startup_weight_load_mode="overlap")
+
+
+def test_nvls_and_symmetric_memory_engine_flags_are_rejected(monkeypatch) -> None:
+    import pytest
+
+    with pytest.raises(ValueError, match="enable_nccl_nvls"):
+        _build(monkeypatch, enable_nccl_nvls=True)
+    with pytest.raises(ValueError, match="enable_symm_mem"):
+        _build(monkeypatch, enable_symm_mem=True)
 
 
 def _drive_build(monkeypatch, *, overrides, gpu_id=0):

--- a/tests/unit_test/test_platforms.py
+++ b/tests/unit_test/test_platforms.py
@@ -13,6 +13,7 @@ from sglang.srt.platforms.xpu import XpuSRTPlatform
 
 import sglang_omni.platforms as platforms
 import sglang_omni.platforms.xpu as xpu_platform
+from sglang_omni.pipeline.stage_workers import StageLaunchConfig
 from sglang_omni.platforms.cpu import CPUOmniPlatform
 from sglang_omni.platforms.cuda import CUDAOmniPlatform
 from sglang_omni.platforms.interface import OmniPlatform
@@ -46,6 +47,21 @@ def test_cpu_platform_needs_no_stage_process_env() -> None:
     spec = SimpleNamespace(stage_name="cpu", tp_size=2, gpu_id=None)
 
     assert CPUOmniPlatform().get_stage_process_env(spec, {}) == {}
+
+
+def test_cuda_tp_stage_env_is_the_narrowing_plus_nvls_off() -> None:
+    spec = StageLaunchConfig(stage_name="thinker", tp_size=2, gpu_id=1)
+
+    env = CUDAOmniPlatform().get_stage_process_env(
+        spec, {"CUDA_VISIBLE_DEVICES": "3,4"}
+    )
+
+    assert env == {
+        "CUDA_VISIBLE_DEVICES": "4",
+        "SGLANG_ONE_VISIBLE_DEVICE_PER_PROCESS": "true",
+        "SGLANG_ENABLE_TP_MEMORY_INBALANCE_CHECK": "false",
+        "NCCL_NVLS_ENABLE": "0",
+    }
 
 
 def test_rocm_platform_keeps_cuda_compatible_tp_mapping() -> None:


### PR DESCRIPTION
## Summary

NCCL 2.29 (torch 2.13's pin) fails communicator initialization when the NVLS multicast bind fails, where 2.28 logged it and fell back to plain NVLink transport (NVIDIA/nccl#2077). The bind fails on hosts whose driver cannot create multicast objects, which includes the CI runners and the H100 dev host (CUDA error 401), so every TP>=2 engine died in `ncclCommInitRank` unless the operator exported `NCCL_NVLS_ENABLE=0` by hand. The Qwen3-Omni workflow already does that; this makes the TP stage launch do it.

- `CUDAOmniPlatform.get_stage_process_env` sets `NCCL_NVLS_ENABLE=0` for a CUDA TP stage process unless the shell or the stage configuration (`env:`) already carries the variable. The device mapping keeps reading the shell only, so a configured visibility value cannot move a rank away from the GPU the placement planner budgeted. This default applies only to CUDA stages with `tp_size > 1`; TP1 stages and the ROCm and XPU platforms never reach it.
- `build_sglang_server_args` rejects `enable_nccl_nvls` and `enable_symm_mem`, next to the existing DP-attention rejection, for every engine configuration on every platform: NVLS is controlled through the environment and symmetric memory is never set up, so either flag would run without effect. Both flags default to false and no shipped configuration sets them, so default behavior is unchanged everywhere; a configuration that sets one now fails at startup with the remedy in the message.

## Testing

Unit: `tests/unit_test/pipeline/test_stage_process_env.py`, `tests/unit_test/test_platforms.py`, `tests/unit_test/scheduling/test_server_args_builder_device.py`: the default on a TP stage; a shell value left alone; a configured stage value surviving the real spawn boundary; a configured visibility value not changing the planned device mapping; the two engine flags rejected; a non-TP stage returning nothing.

H100, on `7b2251a86` (the earlier head of this branch, which set the same `NCCL_NVLS_ENABLE=0` for TP stages; the later revisions changed only precedence, the flag rejection and tests): two TP2 Qwen3-Omni FP8 thinker boots with every `NCCL_*` variable removed from the launch shell reached readiness with `NCCL_NVLS_ENABLE=0` in the live worker environment; 20,000 MMSU requests at c16 across the two boots, zero failures.
