### PR TITLE
[Qwen3-TTS] Build resident stages before the KV pool is sized

### DIFF
--- a/sglang_omni/models/qwen3_tts/config.py
+++ b/sglang_omni/models/qwen3_tts/config.py
@@ -62,15 +62,8 @@ class Qwen3TTSPipelineConfig(PipelineConfig):
             # split frontend passes --preprocessing.gpu with its own fraction.
             next="tts_engine",
         ),
-        EngineStageConfig(
-            name="tts_engine",
-            process="pipeline",
-            factory_path=f"{_PKG}.stages.create_sglang_tts_engine_executor",
-            factory=FactoryArgs(dtype="bfloat16"),
-            gpu=0,
-            next="vocoder",
-            stream_to=["vocoder"],
-        ),
+        # note(ratish): stages are built in list order. The vocoder comes before
+        # the engine so its weights and graphs are resident when the KV pool is sized.
         StageConfig(
             name="vocoder",
             process="pipeline",
@@ -79,6 +72,15 @@ class Qwen3TTSPipelineConfig(PipelineConfig):
             gpu=0,
             terminal=True,
             can_accept_stream_before_payload=True,
+        ),
+        EngineStageConfig(
+            name="tts_engine",
+            process="pipeline",
+            factory_path=f"{_PKG}.stages.create_sglang_tts_engine_executor",
+            factory=FactoryArgs(dtype="bfloat16"),
+            gpu=0,
+            next="vocoder",
+            stream_to=["vocoder"],
         ),
     ]
 

--- a/sglang_omni/models/qwen3_tts/engine_builder.py
+++ b/sglang_omni/models/qwen3_tts/engine_builder.py
@@ -4,6 +4,7 @@
 from __future__ import annotations
 
 import importlib
+import logging
 from typing import Any
 
 import torch
@@ -16,6 +17,8 @@ from sglang_omni.scheduling.generation_batch_policy import (
     CudaGraphBackend,
     build_default_prefill_cuda_graph_bs,
 )
+
+logger = logging.getLogger(__name__)
 
 
 def _is_truthy(value: Any) -> bool:
@@ -176,6 +179,24 @@ class Qwen3TtsEngineBuilder(TtsEngineBuilder):
     def adjust_overrides(self, overrides: dict[str, Any]) -> None:
         if _is_truthy(overrides.get("enable_torch_compile", False)):
             raise ValueError("Qwen3-TTS torch.compile is not supported")
+
+    def post_scheduler_setup(self, scheduler: Any, model_runner: Any) -> None:
+        del model_runner
+        server_args = scheduler.server_args
+        running = int(server_args.max_running_requests)
+        context = int(server_args.context_length)
+        pool = scheduler.tp_worker.model_runner.token_to_kv_pool
+        k_bytes, v_bytes = pool.get_kv_size_bytes()
+        logger.info(
+            "Qwen3-TTS KV pool holds %d tokens, %.2f GiB, against an admission "
+            "bound of %d (%d running x %d context), mem_fraction_static %.3f",
+            int(scheduler.max_total_num_tokens),
+            (int(k_bytes) + int(v_bytes)) / float(1 << 30),
+            running * context,
+            running,
+            context,
+            float(server_args.mem_fraction_static),
+        )
 
     def make_model_runner(self, model_worker: Any, output_proc: Any) -> Any:
         model_runner_mod = importlib.import_module(

--- a/sglang_omni/models/qwen3_tts/engine_builder.py
+++ b/sglang_omni/models/qwen3_tts/engine_builder.py
@@ -149,7 +149,6 @@ class Qwen3TtsEngineBuilder(TtsEngineBuilder):
             model=model,
             wrapper=self.wrapper,
             device=torch.device(device),
-            context_length=int(server_args.context_length),
         )
         if bool(server_args.disable_cuda_graph):
             return

--- a/sglang_omni/models/qwen3_tts/engine_builder.py
+++ b/sglang_omni/models/qwen3_tts/engine_builder.py
@@ -108,7 +108,7 @@ class Qwen3TtsEngineBuilder(TtsEngineBuilder):
             defaults["cuda_graph_bs_prefill"] = list(QWEN3_TTS_PREFILL_CUDA_GRAPH_BS)
         return defaults
 
-    def setup_model(
+    def before_memory_pool(
         self,
         *,
         model_worker: Any,
@@ -117,10 +117,12 @@ class Qwen3TtsEngineBuilder(TtsEngineBuilder):
         gpu_id: int,
         server_args: Any,
     ) -> None:
-        del gpu_id, server_args
+        del gpu_id
         from qwen_tts import Qwen3TTSModel
         from transformers import AutoProcessor
 
+        # note(ratish): the tokenizer and the predictor graphs live for the whole
+        # process, so they are attached before sglang reads free memory for the pool.
         model = model_worker.model_runner.model
         speech_tokenizer = qwen3_stages._load_qwen3_tts_tokenizer(
             checkpoint_dir,
@@ -145,20 +147,7 @@ class Qwen3TtsEngineBuilder(TtsEngineBuilder):
             wrapper=self.wrapper,
             device=torch.device(device),
         )
-
-    def adjust_overrides(self, overrides: dict[str, Any]) -> None:
-        if _is_truthy(overrides.get("enable_torch_compile", False)):
-            raise ValueError("Qwen3-TTS torch.compile is not supported")
-
-    def setup_model_resources(
-        self,
-        model: Any,
-        server_args: Any,
-        *,
-        generation_cuda_graph_enabled: bool,
-    ) -> None:
-        del server_args
-        if not generation_cuda_graph_enabled:
+        if bool(server_args.disable_cuda_graph):
             return
         # note(ratish): the bucket warmups also build cuDNN's attention plans,
         # which otherwise land inside the first serving step of each batch size.
@@ -170,6 +159,23 @@ class Qwen3TtsEngineBuilder(TtsEngineBuilder):
             top_k=subtalker.top_k,
             top_p=subtalker.top_p,
         )
+
+    def setup_model(
+        self,
+        *,
+        model_worker: Any,
+        checkpoint_dir: str,
+        device: str,
+        gpu_id: int,
+        server_args: Any,
+    ) -> None:
+        # note(ratish): everything Qwen3-TTS attaches stays resident, so it all
+        # runs in before_memory_pool and nothing is left for after the pool.
+        del model_worker, checkpoint_dir, device, gpu_id, server_args
+
+    def adjust_overrides(self, overrides: dict[str, Any]) -> None:
+        if _is_truthy(overrides.get("enable_torch_compile", False)):
+            raise ValueError("Qwen3-TTS torch.compile is not supported")
 
     def make_model_runner(self, model_worker: Any, output_proc: Any) -> Any:
         model_runner_mod = importlib.import_module(

--- a/sglang_omni/models/qwen3_tts/engine_builder.py
+++ b/sglang_omni/models/qwen3_tts/engine_builder.py
@@ -189,8 +189,8 @@ class Qwen3TtsEngineBuilder(TtsEngineBuilder):
         pool = scheduler.tp_worker.model_runner.token_to_kv_pool
         k_bytes, v_bytes = pool.get_kv_size_bytes()
         logger.info(
-            "Qwen3-TTS KV pool holds %d tokens, %.2f GiB, against an admission "
-            "bound of %d (%d running x %d context), mem_fraction_static %.3f",
+            "Qwen3-TTS KV pool holds %d tokens, %.2f GiB, against a configured "
+            "maximum demand of %d (%d running x %d context), mem_fraction_static %.3f",
             int(scheduler.max_total_num_tokens),
             (int(k_bytes) + int(v_bytes)) / float(1 << 30),
             running * context,

--- a/sglang_omni/models/qwen3_tts/engine_builder.py
+++ b/sglang_omni/models/qwen3_tts/engine_builder.py
@@ -149,6 +149,7 @@ class Qwen3TtsEngineBuilder(TtsEngineBuilder):
             model=model,
             wrapper=self.wrapper,
             device=torch.device(device),
+            context_length=int(server_args.context_length),
         )
         if bool(server_args.disable_cuda_graph):
             return

--- a/sglang_omni/models/qwen3_tts/request_builders.py
+++ b/sglang_omni/models/qwen3_tts/request_builders.py
@@ -186,12 +186,15 @@ def set_qwen3_tts_preprocessing_context(
     wrapper: Any,
     standalone: bool = False,
     device: torch.device | None = None,
+    context_length: int | None = None,
 ) -> None:
     """Register model objects used by the preprocessing stage."""
 
     global _PREPROCESSING_CONTEXT
     with _PREPARED_REQUESTS_LOCK:
-        _get_qwen3_tts_adhoc_reference_service_locked(model, wrapper)
+        _get_qwen3_tts_adhoc_reference_service_locked(
+            model, wrapper, context_length=context_length
+        )
         _PREPROCESSING_CONTEXT = Qwen3TTSPreprocessingContext(
             model=model,
             wrapper=wrapper,
@@ -910,9 +913,21 @@ class _Qwen3TTSAdhocReferenceHook(
     encoder_id = "qwen3_tts_voice_clone_prompt"
     artifact_kind = "qwen3_tts_voice_clone_prompt_adhoc"
 
-    def __init__(self, *, model: Any, wrapper: Any) -> None:
+    def __init__(
+        self, *, model: Any, wrapper: Any, context_length: int | None = None
+    ) -> None:
         self._model = model
         self._wrapper = wrapper
+        # note(ratish): the engine's context bounds the ICL prompt. A standalone
+        # preprocessing process has no engine and leaves the check to it.
+        self._icl_frame_rule: tuple[int, int, int] | None = None
+        if context_length is not None:
+            tokenizer = model.speech_tokenizer
+            self._icl_frame_rule = (
+                int(context_length),
+                int(tokenizer.feature_extractor.sampling_rate),
+                int(tokenizer.get_encode_downsample_rate()),
+            )
         # note (luojiaxuan): the engine builder loads the speech tokenizer on
         # the same device as the talker model, so model.device selects the
         # dedicated reference-code encode stream for that device.
@@ -962,7 +977,12 @@ class _Qwen3TTSAdhocReferenceHook(
             if len(normalized) != 1:
                 raise ValueError("Qwen3-TTS expects exactly one reference audio")
             waveform, sample_rate = normalized[0]
-            ref_code_future = self._ref_code_batcher.submit(waveform, sample_rate)
+            # note(ratish): the codes are only consumed in ICL mode, so x vector
+            # mode runs the speaker encoder alone.
+            ref_code_future = None
+            if not item.x_vector_only_mode:
+                self._check_icl_reference_fits(waveform, sample_rate)
+                ref_code_future = self._ref_code_batcher.submit(waveform, sample_rate)
             speaker_waveform = waveform
             speaker_sample_rate = self._model.speaker_encoder_sample_rate
             if sample_rate != speaker_sample_rate:
@@ -977,16 +997,39 @@ class _Qwen3TTSAdhocReferenceHook(
                 audio=speaker_waveform,
                 sr=speaker_sample_rate,
             )
-            ref_code = _record_ref_code_consumer_stream(
-                ref_code_future.result(timeout=130.0)
+            ref_code = (
+                _record_ref_code_consumer_stream(ref_code_future.result(timeout=130.0))
+                if ref_code_future is not None
+                else None
             )
         voice_clone_prompt = {
-            "ref_code": [None if item.x_vector_only_mode else ref_code],
+            "ref_code": [ref_code],
             "ref_spk_embedding": [speaker_embedding],
             "x_vector_only_mode": [item.x_vector_only_mode],
             "icl_mode": [not item.x_vector_only_mode],
         }
         return voice_clone_prompt, item.ref_text
+
+    def _check_icl_reference_fits(self, waveform: Any, sample_rate: int) -> None:
+        """Refuse an ICL reference the engine cannot admit before it is encoded.
+
+        The tokenizer resamples the clip to its feature extractor rate and
+        keeps one frame per encode_downsample_rate samples, rounded up. The
+        prompt carries one position per frame plus the text, and the engine
+        refuses any input at or above its context, so a clip whose frames alone
+        reach the context is refused here, before any device work.
+        """
+        if self._icl_frame_rule is None:
+            return
+        context_length, tokenizer_rate, downsample_rate = self._icl_frame_rule
+        samples = -(-len(waveform) * tokenizer_rate // int(sample_rate))
+        frames = -(-samples // downsample_rate)
+        if frames >= context_length:
+            raise ValueError(
+                f"Qwen3-TTS ICL reference holds {frames} codec frames, the engine "
+                f"context holds {context_length}; use a shorter reference or "
+                "x_vector_only_mode"
+            )
 
     def store_artifact(self, artifact: tuple[dict[str, Any], str | None]) -> dict:
         voice_clone_prompt, ref_text = artifact
@@ -1048,6 +1091,8 @@ def _qwen3_tts_encoder_config_hash(model: Any, wrapper: Any) -> str:
 def _get_qwen3_tts_adhoc_reference_service_locked(
     model: Any,
     wrapper: Any,
+    *,
+    context_length: int | None = None,
 ) -> ReferenceEncodeService:
     global _ADHOC_REFERENCE_SERVICE_ENTRY
     owner = (id(model), id(wrapper))
@@ -1056,7 +1101,9 @@ def _get_qwen3_tts_adhoc_reference_service_locked(
         if entry is not None:
             entry[1].close()
         service = ReferenceEncodeService(
-            _Qwen3TTSAdhocReferenceHook(model=model, wrapper=wrapper),
+            _Qwen3TTSAdhocReferenceHook(
+                model=model, wrapper=wrapper, context_length=context_length
+            ),
             max_items=256,
             max_bytes=64 * 1024 * 1024,
             timeout_s=130.0,
@@ -1133,16 +1180,10 @@ def _prepare_qwen3_tts_base_request(
             desc="Qwen3-TTS ad-hoc reference",
         )
     else:
-        with torch.no_grad():
-            prompt_items = wrapper.create_voice_clone_prompt(
-                ref_audio=state.ref_audio,
-                ref_text=state.ref_text,
-                x_vector_only_mode=state.x_vector_only_mode,
-            )
-        if len(prompt_items) != 1:
-            raise ValueError("Qwen3-TTS expects exactly one voice-clone prompt")
-        voice_clone_prompt = wrapper._prompt_items_to_voice_clone_prompt(prompt_items)
-        ref_text = prompt_items[0].ref_text
+        # note(ratish): the hook is the one caller of the tokenizer encoder and
+        # the speaker encoder, so an uploaded miss takes the same path as an ad hoc clip.
+        hook = _get_qwen3_tts_adhoc_reference_service(model, wrapper).hook
+        voice_clone_prompt, ref_text = hook.encode_one(hook.normalize_input(state))
         speaker_cache.put(
             cache_key,
             _cacheable_qwen3_tts_voice_prompt(

--- a/sglang_omni/models/qwen3_tts/request_builders.py
+++ b/sglang_omni/models/qwen3_tts/request_builders.py
@@ -1180,8 +1180,6 @@ def _prepare_qwen3_tts_base_request(
             desc="Qwen3-TTS ad-hoc reference",
         )
     else:
-        # note(ratish): the hook is the one caller of the tokenizer encoder and
-        # the speaker encoder, so an uploaded miss takes the same path as an ad hoc clip.
         hook = _get_qwen3_tts_adhoc_reference_service(model, wrapper).hook
         voice_clone_prompt, ref_text = hook.encode_one(hook.normalize_input(state))
         speaker_cache.put(

--- a/sglang_omni/models/qwen3_tts/request_builders.py
+++ b/sglang_omni/models/qwen3_tts/request_builders.py
@@ -186,15 +186,12 @@ def set_qwen3_tts_preprocessing_context(
     wrapper: Any,
     standalone: bool = False,
     device: torch.device | None = None,
-    context_length: int | None = None,
 ) -> None:
     """Register model objects used by the preprocessing stage."""
 
     global _PREPROCESSING_CONTEXT
     with _PREPARED_REQUESTS_LOCK:
-        _get_qwen3_tts_adhoc_reference_service_locked(
-            model, wrapper, context_length=context_length
-        )
+        _get_qwen3_tts_adhoc_reference_service_locked(model, wrapper)
         _PREPROCESSING_CONTEXT = Qwen3TTSPreprocessingContext(
             model=model,
             wrapper=wrapper,
@@ -913,21 +910,9 @@ class _Qwen3TTSAdhocReferenceHook(
     encoder_id = "qwen3_tts_voice_clone_prompt"
     artifact_kind = "qwen3_tts_voice_clone_prompt_adhoc"
 
-    def __init__(
-        self, *, model: Any, wrapper: Any, context_length: int | None = None
-    ) -> None:
+    def __init__(self, *, model: Any, wrapper: Any) -> None:
         self._model = model
         self._wrapper = wrapper
-        # note(ratish): the engine's context bounds the ICL prompt. A standalone
-        # preprocessing process has no engine and leaves the check to it.
-        self._icl_frame_rule: tuple[int, int, int] | None = None
-        if context_length is not None:
-            tokenizer = model.speech_tokenizer
-            self._icl_frame_rule = (
-                int(context_length),
-                int(tokenizer.feature_extractor.sampling_rate),
-                int(tokenizer.get_encode_downsample_rate()),
-            )
         # note (luojiaxuan): the engine builder loads the speech tokenizer on
         # the same device as the talker model, so model.device selects the
         # dedicated reference-code encode stream for that device.
@@ -981,7 +966,6 @@ class _Qwen3TTSAdhocReferenceHook(
             # mode runs the speaker encoder alone.
             ref_code_future = None
             if not item.x_vector_only_mode:
-                self._check_icl_reference_fits(waveform, sample_rate)
                 ref_code_future = self._ref_code_batcher.submit(waveform, sample_rate)
             speaker_waveform = waveform
             speaker_sample_rate = self._model.speaker_encoder_sample_rate
@@ -1009,27 +993,6 @@ class _Qwen3TTSAdhocReferenceHook(
             "icl_mode": [not item.x_vector_only_mode],
         }
         return voice_clone_prompt, item.ref_text
-
-    def _check_icl_reference_fits(self, waveform: Any, sample_rate: int) -> None:
-        """Refuse an ICL reference the engine cannot admit before it is encoded.
-
-        The tokenizer resamples the clip to its feature extractor rate and
-        keeps one frame per encode_downsample_rate samples, rounded up. The
-        prompt carries one position per frame plus the text, and the engine
-        refuses any input at or above its context, so a clip whose frames alone
-        reach the context is refused here, before any device work.
-        """
-        if self._icl_frame_rule is None:
-            return
-        context_length, tokenizer_rate, downsample_rate = self._icl_frame_rule
-        samples = -(-len(waveform) * tokenizer_rate // int(sample_rate))
-        frames = -(-samples // downsample_rate)
-        if frames >= context_length:
-            raise ValueError(
-                f"Qwen3-TTS ICL reference holds {frames} codec frames, the engine "
-                f"context holds {context_length}; use a shorter reference or "
-                "x_vector_only_mode"
-            )
 
     def store_artifact(self, artifact: tuple[dict[str, Any], str | None]) -> dict:
         voice_clone_prompt, ref_text = artifact
@@ -1089,10 +1052,7 @@ def _qwen3_tts_encoder_config_hash(model: Any, wrapper: Any) -> str:
 
 
 def _get_qwen3_tts_adhoc_reference_service_locked(
-    model: Any,
-    wrapper: Any,
-    *,
-    context_length: int | None = None,
+    model: Any, wrapper: Any
 ) -> ReferenceEncodeService:
     global _ADHOC_REFERENCE_SERVICE_ENTRY
     owner = (id(model), id(wrapper))
@@ -1101,9 +1061,7 @@ def _get_qwen3_tts_adhoc_reference_service_locked(
         if entry is not None:
             entry[1].close()
         service = ReferenceEncodeService(
-            _Qwen3TTSAdhocReferenceHook(
-                model=model, wrapper=wrapper, context_length=context_length
-            ),
+            _Qwen3TTSAdhocReferenceHook(model=model, wrapper=wrapper),
             max_items=256,
             max_bytes=64 * 1024 * 1024,
             timeout_s=130.0,

--- a/sglang_omni/models/qwen3_tts/sglang_model.py
+++ b/sglang_omni/models/qwen3_tts/sglang_model.py
@@ -951,8 +951,8 @@ class Qwen3TTSTalker(Qwen3TTSPromptBuilderMixin, nn.Module):
         )
         self._predictor_graphs: dict[tuple, _PredictorDecodeGraph] = {}
         self._predictor_graph_disabled: set[tuple] = set()
-        # note(ratish): None until the startup capture or the first decode
-        # resolves it, after the bootstrap has built sglang's graphs.
+        # note(ratish): None until the startup capture, which runs before the
+        # KV pool is sized, or the first decode resolves it.
         self._predictor_graph_enabled: bool | None = None
         self._predictor_graph_failure_count = 0
         self._predictor_graph_capacity_fallback_count = 0

--- a/sglang_omni/models/qwen3_tts/stages.py
+++ b/sglang_omni/models/qwen3_tts/stages.py
@@ -6,6 +6,7 @@ from __future__ import annotations
 import functools
 import logging
 import os
+import threading
 from collections.abc import Sequence
 from typing import Any
 
@@ -31,6 +32,9 @@ from sglang_omni.utils.checkpoint import resolve_checkpoint as _resolve_checkpoi
 from sglang_omni.utils.device import resolve_device_spec
 
 logger = logging.getLogger(__name__)
+
+_SPEECH_TOKENIZERS: dict[tuple[str, str, str, str | None], Any] = {}
+_SPEECH_TOKENIZERS_LOCK = threading.Lock()
 
 _QWEN_TTS_INSTALL_HINT = (
     "Qwen3-TTS support requires the official `qwen-tts` package:\n"
@@ -59,15 +63,29 @@ def _load_qwen3_tts_tokenizer(
     checkpoint_dir = _resolve_checkpoint(model_path)
     tokenizer_path = os.path.join(checkpoint_dir, "speech_tokenizer")
     torch_dtype = getattr(torch, dtype) if isinstance(dtype, str) else dtype
-    kwargs: dict[str, Any] = {
-        "device_map": device,
-        "dtype": torch_dtype,
-    }
-    if attn_implementation is not None:
-        kwargs["attn_implementation"] = attn_implementation
+    # note(ratish): one copy per process. The vocoder loads it first and the
+    # engine attaches the same object, so it is resident before the KV pool is sized.
+    key = (tokenizer_path, str(device), str(torch_dtype), attn_implementation)
+    with _SPEECH_TOKENIZERS_LOCK:
+        tokenizer = _SPEECH_TOKENIZERS.get(key)
+        if tokenizer is not None:
+            logger.info(
+                f"Reusing the Qwen3-TTS speech tokenizer from {tokenizer_path} on {device}"
+            )
+            return tokenizer
+        kwargs: dict[str, Any] = {
+            "device_map": device,
+            "dtype": torch_dtype,
+        }
+        if attn_implementation is not None:
+            kwargs["attn_implementation"] = attn_implementation
 
-    logger.info(f"Loading Qwen3-TTS speech tokenizer from {tokenizer_path} on {device}")
-    return Qwen3TTSTokenizer.from_pretrained(tokenizer_path, **kwargs)
+        logger.info(
+            f"Loading Qwen3-TTS speech tokenizer from {tokenizer_path} on {device}"
+        )
+        tokenizer = Qwen3TTSTokenizer.from_pretrained(tokenizer_path, **kwargs)
+        _SPEECH_TOKENIZERS[key] = tokenizer
+        return tokenizer
 
 
 def _register_qwen3_tts_hf_config() -> None:

--- a/sglang_omni/scheduling/bootstrap.py
+++ b/sglang_omni/scheduling/bootstrap.py
@@ -4,6 +4,7 @@
 from __future__ import annotations
 
 import logging
+from collections.abc import Callable
 from typing import Any, Protocol
 
 from sglang_omni.utils.gpu_compat import (
@@ -107,8 +108,14 @@ def create_sglang_infrastructure(
     total_gpu_memory_fraction: float | None = None,
     defer_cuda_graph_capture: bool = False,
     enable_prefill_input_embeds: bool = False,
+    before_memory_pool: Callable[[Any], None] | None = None,
 ):
-    """Create SGLang worker, memory pools, and tree cache."""
+    """Create SGLang worker, memory pools, and tree cache.
+
+    ``before_memory_pool`` runs with the model worker after the weights are
+    loaded and before the KV pool is sized, for resources the stage keeps for
+    the life of the process.
+    """
     # ModelRunner.__init__ publishes server_args as the process-wide runtime
     # context; publishing again would silently reconfigure whatever already runs
     # here, so an engine is only built where the context is unpublished. A
@@ -174,6 +181,11 @@ def create_sglang_infrastructure(
             capture_hidden_layers,
             max_tokens=_hidden_capture_max_tokens(server_args),
         )
+
+    if before_memory_pool is not None:
+        # note(ratish): sglang sizes the pool from free memory at this point, so
+        # whatever the stage keeps resident has to exist before the reading.
+        before_memory_pool(model_worker)
 
     # Phase order follows upstream Scheduler.init_model_worker().
     model_runner = model_worker.model_runner

--- a/sglang_omni/scheduling/bootstrap.py
+++ b/sglang_omni/scheduling/bootstrap.py
@@ -112,9 +112,9 @@ def create_sglang_infrastructure(
 ):
     """Create SGLang worker, memory pools, and tree cache.
 
-    ``before_memory_pool`` runs with the model worker after the weights are
-    loaded and before the KV pool is sized, for resources the stage keeps for
-    the life of the process.
+    before_memory_pool runs with the model worker after the weights are loaded
+    and before the KV pool is sized, for resources the stage keeps for the life
+    of the process.
     """
     # ModelRunner.__init__ publishes server_args as the process-wide runtime
     # context; publishing again would silently reconfigure whatever already runs

--- a/sglang_omni/scheduling/engine_factory.py
+++ b/sglang_omni/scheduling/engine_factory.py
@@ -175,6 +175,17 @@ class SGLangGenerationEngineBuilder(ABC):
         infra_kwargs = dict(self.infra_kwargs())
         if self.model_arch_override is not None:
             infra_kwargs.setdefault("model_arch_override", self.model_arch_override)
+
+        def before_memory_pool(model_worker: Any) -> None:
+            self.before_memory_pool(
+                model_worker=model_worker,
+                checkpoint_dir=checkpoint_dir,
+                device=device,
+                gpu_id=gpu_id,
+                server_args=server_args,
+            )
+
+        infra_kwargs["before_memory_pool"] = before_memory_pool
         prefill_graph_backend = get_prefill_cuda_graph_backend(server_args)
         if (
             prefill_graph_backend != CudaGraphBackend.DISABLED
@@ -299,6 +310,18 @@ class SGLangGenerationEngineBuilder(ABC):
 
     def infra_kwargs(self) -> dict[str, Any]:
         return {}
+
+    def before_memory_pool(
+        self,
+        *,
+        model_worker: Any,
+        checkpoint_dir: str,
+        device: str,
+        gpu_id: int,
+        server_args: Any,
+    ) -> None:
+        """Attach what the stage keeps resident, before the KV pool is sized."""
+        del model_worker, checkpoint_dir, device, gpu_id, server_args
 
     def setup_model(
         self,

--- a/sglang_omni/scheduling/reference_encoder.py
+++ b/sglang_omni/scheduling/reference_encoder.py
@@ -185,6 +185,10 @@ class ReferenceEncodeService(Generic[InputT, ArtifactT, StoredT]):
             self._batch_thread.start()
 
     @property
+    def hook(self) -> ReferenceEncodeHook[InputT, ArtifactT, StoredT]:
+        return self._hook
+
+    @property
     def batching_enabled(self) -> bool:
         return self._batching
 

--- a/tests/unit_test/fishaudio_s2_pro/test_pipeline.py
+++ b/tests/unit_test/fishaudio_s2_pro/test_pipeline.py
@@ -959,11 +959,15 @@ def _run_s2pro_engine_with_fake_buffers(
         gpu_id: int,
         *,
         defer_cuda_graph_capture: bool = False,
+        before_memory_pool=None,
     ) -> tuple[object, object, object, object, object]:
         assert gpu_id == 0
         infrastructure_saw_deferred_capture.append(defer_cuda_graph_capture)
+        worker = _FakeWorker(server_args)
+        if before_memory_pool is not None:
+            before_memory_pool(worker)
         return (
-            _FakeWorker(server_args),
+            worker,
             object(),
             object(),
             object(),
@@ -979,10 +983,14 @@ def _run_s2pro_engine_with_fake_buffers(
     def fake_create_sglang_infrastructure_defer_cuda_graph(
         server_args: SimpleNamespace,
         gpu_id: int,
+        **kwargs,
     ) -> tuple[bool, tuple[object, object, object, object, object]]:
         want_cuda_graph = not bool(server_args.disable_cuda_graph)
         infrastructure = fake_create_sglang_infrastructure(
-            server_args, gpu_id, defer_cuda_graph_capture=want_cuda_graph
+            server_args,
+            gpu_id,
+            defer_cuda_graph_capture=want_cuda_graph,
+            **kwargs,
         )
         return want_cuda_graph, infrastructure
 

--- a/tests/unit_test/moss_tts/test_pipeline.py
+++ b/tests/unit_test/moss_tts/test_pipeline.py
@@ -615,6 +615,7 @@ def test_moss_tts_engine_uses_auto_mem_fraction_by_default(monkeypatch) -> None:
         *,
         model_arch_override=None,
         defer_cuda_graph_capture=False,
+        before_memory_pool=None,
     ):
         captured["gpu_id"] = gpu_id
         captured["model_arch_override"] = model_arch_override
@@ -643,6 +644,8 @@ def test_moss_tts_engine_uses_auto_mem_fraction_by_default(monkeypatch) -> None:
             model_runner=model_runner,
             enable_prefill_input_embeds=False,
         )
+        if before_memory_pool is not None:
+            before_memory_pool(model_worker)
         return (
             model_worker,
             object(),

--- a/tests/unit_test/qwen3_tts/test_config.py
+++ b/tests/unit_test/qwen3_tts/test_config.py
@@ -25,7 +25,8 @@ def test_custom_voice_config_uses_engine_checkpoint_metadata(
     download = Mock(side_effect=AssertionError("Local checkpoint must not use HF"))
     monkeypatch.setattr("huggingface_hub.hf_hub_download", download)
     config = Qwen3TTSPipelineConfig(model_path=str(root))
-    config.stages[1].factory = config.stages[1].factory.model_copy(
+    engine_stage = config.stage_named("tts_engine")
+    engine_stage.factory = engine_stage.factory.model_copy(
         update={"model_path": str(engine)}
     )
     monkeypatch.setattr(

--- a/tests/unit_test/qwen3_tts/test_pipeline.py
+++ b/tests/unit_test/qwen3_tts/test_pipeline.py
@@ -821,24 +821,22 @@ def test_qwen3_tts_uploaded_voice_clone_prompt_uses_shared_cache(
 ) -> None:
     cache = get_speaker_artifact_cache()
     cache.clear()
+    qwen3_request_builders.clear_qwen3_tts_preprocessing_context()
     calls = 0
 
-    class FakePrompt:
-        ref_text = "reference"
-
-    class FakeWrapper:
-        def create_voice_clone_prompt(self, **kwargs):
+    class FakeSpeechTokenizer:
+        def encode(self, waveforms, *, sr):
             nonlocal calls
             calls += 1
-            return [FakePrompt()]
+            assert sr == 24000
+            return SimpleNamespace(
+                audio_codes=[torch.ones((1, 2), dtype=torch.long) for _ in waveforms]
+            )
 
-        def _prompt_items_to_voice_clone_prompt(self, prompt_items):
-            del prompt_items
-            return {
-                "ref_code": [torch.ones((1, 2), dtype=torch.long)],
-                "ref_spk_embedding": [torch.ones(4)],
-                "icl_mode": [True],
-            }
+    class FakeWrapper:
+        def _normalize_audio_inputs(self, ref_audio):
+            assert ref_audio == ["voice.wav"]
+            return [(np.zeros(32, dtype=np.float32), 24000)]
 
         def _tokenize_texts(self, texts):
             return [torch.arange(len(texts[0]), dtype=torch.long).unsqueeze(0)]
@@ -856,6 +854,13 @@ def test_qwen3_tts_uploaded_voice_clone_prompt_uses_shared_cache(
         device = torch.device("cpu")
         root_config = SimpleNamespace(tts_pad_token_id=0)
         model = SimpleNamespace(_feedback_buffer=torch.empty((1, 4)))
+        speech_tokenizer = FakeSpeechTokenizer()
+        speaker_encoder_sample_rate = 24000
+
+        def extract_speaker_embedding(self, *, audio, sr):
+            assert audio.shape == (32,)
+            assert sr == 24000
+            return torch.ones(4)
 
         def build_voice_clone_inputs(self, **kwargs):
             assert kwargs["voice_clone_prompt"]["icl_mode"] == [True]
@@ -877,6 +882,8 @@ def test_qwen3_tts_uploaded_voice_clone_prompt_uses_shared_cache(
         "_build_qwen3_tts_pad_embed",
         lambda model: torch.zeros(4),
     )
+    model = FakeModel()
+    wrapper = FakeWrapper()
 
     def make_uploaded_payload(created_at: int) -> StagePayload:
         return make_payload(
@@ -891,35 +898,38 @@ def test_qwen3_tts_uploaded_voice_clone_prompt_uses_shared_cache(
 
     qwen3_request_builders._prepare_qwen3_tts_request(
         make_uploaded_payload(7),
-        model=FakeModel(),
-        wrapper=FakeWrapper(),
+        model=model,
+        wrapper=wrapper,
     )
     cached = cache.get(
         SpeakerCacheKey("qwen3_tts_icl", "guide", 7, "voice_clone_prompt")
     )
     assert isinstance(cached, dict)
     assert cached["artifact_type"] == "qwen3_tts_voice_clone_prompt"
+    assert cached["ref_text"] == "reference"
     assert cached["ref_spk_embedding"][0].device.type == "cpu"
     assert cached["ref_code"][0].device.type == "cpu"
+    assert cached["ref_code"][0].shape == (1, 2)
 
     qwen3_request_builders._prepare_qwen3_tts_request(
         make_uploaded_payload(7),
-        model=FakeModel(),
-        wrapper=FakeWrapper(),
+        model=model,
+        wrapper=wrapper,
     )
     qwen3_request_builders._prepare_qwen3_tts_request(
         make_uploaded_payload(8),
-        model=FakeModel(),
-        wrapper=FakeWrapper(),
+        model=model,
+        wrapper=wrapper,
     )
     cache.clear_voice("guide")
     qwen3_request_builders._prepare_qwen3_tts_request(
         make_uploaded_payload(8),
-        model=FakeModel(),
-        wrapper=FakeWrapper(),
+        model=model,
+        wrapper=wrapper,
     )
 
     assert calls == 3
+    qwen3_request_builders.clear_qwen3_tts_preprocessing_context()
 
 
 def test_qwen3_tts_adhoc_voice_clone_prompt_uses_reference_service(
@@ -1018,12 +1028,13 @@ def test_qwen3_tts_adhoc_voice_clone_prompt_uses_reference_service(
         model=model,
         wrapper=wrapper,
     )
+    assert calls == 2
     qwen3_request_builders._prepare_qwen3_tts_request(
         make_adhoc_payload(x_vector_only_mode=True),
         model=model,
         wrapper=wrapper,
     )
-    assert calls == 3
+    assert calls == 2
     qwen3_request_builders.clear_qwen3_tts_preprocessing_context()
 
 
@@ -1242,6 +1253,111 @@ def test_qwen3_tts_reference_code_overlaps_speaker_embedding() -> None:
     assert prompt["icl_mode"] == [True]
 
 
+@pytest.mark.parametrize(
+    "samples, frames, refused",
+    [(126_720, 99, False), (126_721, 100, True)],
+)
+def test_qwen3_tts_icl_reference_is_refused_at_the_context_before_encoding(
+    samples: int, frames: int, refused: bool
+) -> None:
+    encoded_lengths: list[int] = []
+
+    class FakeSpeechTokenizer:
+        feature_extractor = SimpleNamespace(sampling_rate=24000)
+
+        def get_encode_downsample_rate(self):
+            return 1920
+
+        def encode(self, waveforms, *, sr):
+            encoded_lengths.append(len(waveforms[0]))
+            return SimpleNamespace(
+                audio_codes=[torch.ones((frames, 2), dtype=torch.long)]
+            )
+
+    class FakeWrapper:
+        def _normalize_audio_inputs(self, ref_audio):
+            return [(np.zeros(samples, dtype=np.float32), 16000)]
+
+    class FakeModel:
+        device = torch.device("cpu")
+        speech_tokenizer = FakeSpeechTokenizer()
+        speaker_encoder_sample_rate = 16000
+
+        def extract_speaker_embedding(self, *, audio, sr):
+            return torch.ones(4)
+
+    hook = qwen3_request_builders._Qwen3TTSAdhocReferenceHook(
+        model=FakeModel(),
+        wrapper=FakeWrapper(),
+        context_length=100,
+    )
+    item = qwen3_request_builders._Qwen3TTSAdhocReferenceInput(
+        ref_audio="voice.wav",
+        ref_text="reference",
+        x_vector_only_mode=False,
+    )
+    try:
+        if refused:
+            with pytest.raises(ValueError, match=f"{frames} codec frames"):
+                hook.encode_one(item)
+            assert encoded_lengths == []
+        else:
+            prompt, ref_text = hook.encode_one(item)
+            assert encoded_lengths == [samples]
+            assert prompt["ref_code"][0].shape == (frames, 2)
+            assert prompt["icl_mode"] == [True]
+            assert ref_text == "reference"
+    finally:
+        hook.close()
+
+
+def test_qwen3_tts_x_vector_reference_runs_only_the_speaker_encoder() -> None:
+    speaker_inputs: list[tuple[int, int]] = []
+
+    class FakeSpeechTokenizer:
+        feature_extractor = SimpleNamespace(sampling_rate=24000)
+
+        def get_encode_downsample_rate(self):
+            return 1920
+
+        def encode(self, waveforms, *, sr):
+            raise AssertionError("x vector only mode must not encode the clip")
+
+    class FakeWrapper:
+        def _normalize_audio_inputs(self, ref_audio):
+            return [(np.zeros(1_000_000, dtype=np.float32), 24000)]
+
+    class FakeModel:
+        device = torch.device("cpu")
+        speech_tokenizer = FakeSpeechTokenizer()
+        speaker_encoder_sample_rate = 24000
+
+        def extract_speaker_embedding(self, *, audio, sr):
+            speaker_inputs.append((len(audio), sr))
+            return torch.ones(4)
+
+    hook = qwen3_request_builders._Qwen3TTSAdhocReferenceHook(
+        model=FakeModel(),
+        wrapper=FakeWrapper(),
+        context_length=100,
+    )
+    item = qwen3_request_builders._Qwen3TTSAdhocReferenceInput(
+        ref_audio="voice.wav",
+        ref_text=None,
+        x_vector_only_mode=True,
+    )
+    try:
+        prompt, ref_text = hook.encode_one(item)
+    finally:
+        hook.close()
+
+    assert speaker_inputs == [(1_000_000, 24000)]
+    assert prompt["ref_code"] == [None]
+    assert prompt["icl_mode"] == [False]
+    assert prompt["x_vector_only_mode"] == [True]
+    assert ref_text is None
+
+
 def test_qwen3_tts_reference_code_batcher_synchronizes_cuda_results(
     monkeypatch: pytest.MonkeyPatch,
 ) -> None:
@@ -1329,25 +1445,17 @@ def test_qwen3_tts_uploaded_voice_x_vector_cache_omits_ref_code(
 ) -> None:
     cache = get_speaker_artifact_cache()
     cache.clear()
+    qwen3_request_builders.clear_qwen3_tts_preprocessing_context()
     calls = 0
 
-    class FakePrompt:
-        ref_text = None
+    class FakeSpeechTokenizer:
+        def encode(self, waveforms, *, sr):
+            raise AssertionError("x vector only mode must not encode the clip")
 
     class FakeWrapper:
-        def create_voice_clone_prompt(self, **kwargs):
-            nonlocal calls
-            calls += 1
-            assert kwargs["x_vector_only_mode"] is True
-            return [FakePrompt()]
-
-        def _prompt_items_to_voice_clone_prompt(self, prompt_items):
-            del prompt_items
-            return {
-                "ref_code": [None],
-                "ref_spk_embedding": [torch.ones(4)],
-                "icl_mode": [False],
-            }
+        def _normalize_audio_inputs(self, ref_audio):
+            assert ref_audio == ["voice.wav"]
+            return [(np.zeros(32, dtype=np.float32), 24000)]
 
         def _tokenize_texts(self, texts):
             return [torch.arange(len(texts[0]), dtype=torch.long).unsqueeze(0)]
@@ -1362,6 +1470,13 @@ def test_qwen3_tts_uploaded_voice_x_vector_cache_omits_ref_code(
         device = torch.device("cpu")
         root_config = SimpleNamespace(tts_pad_token_id=0)
         model = SimpleNamespace(_feedback_buffer=torch.empty((1, 4)))
+        speech_tokenizer = FakeSpeechTokenizer()
+        speaker_encoder_sample_rate = 24000
+
+        def extract_speaker_embedding(self, *, audio, sr):
+            nonlocal calls
+            calls += 1
+            return torch.ones(4)
 
         def build_voice_clone_inputs(self, **kwargs):
             assert kwargs["voice_clone_prompt"]["icl_mode"] == [False]
@@ -1395,24 +1510,28 @@ def test_qwen3_tts_uploaded_voice_x_vector_cache_omits_ref_code(
         },
     )
 
+    model = FakeModel()
+    wrapper = FakeWrapper()
     qwen3_request_builders._prepare_qwen3_tts_request(
         payload,
-        model=FakeModel(),
-        wrapper=FakeWrapper(),
+        model=model,
+        wrapper=wrapper,
     )
     cached = cache.get(
         SpeakerCacheKey("qwen3_tts_xvec", "guide", 9, "voice_clone_prompt")
     )
     assert isinstance(cached, dict)
     assert "ref_code" not in cached
+    assert cached["icl_mode"] == (False,)
 
     qwen3_request_builders._prepare_qwen3_tts_request(
         payload,
-        model=FakeModel(),
-        wrapper=FakeWrapper(),
+        model=model,
+        wrapper=wrapper,
     )
 
     assert calls == 1
+    qwen3_request_builders.clear_qwen3_tts_preprocessing_context()
 
 
 def test_qwen3_tts_public_seed_derivation_is_stable() -> None:
@@ -6236,7 +6355,10 @@ def test_qwen3_tts_engine_accepts_64_batch_policy_and_enables_cuda_graph(
     monkeypatch.setattr(
         stages,
         "_load_qwen3_tts_tokenizer",
-        lambda *args, **kwargs: object(),
+        lambda *args, **kwargs: SimpleNamespace(
+            feature_extractor=SimpleNamespace(sampling_rate=24000),
+            get_encode_downsample_rate=lambda: 1920,
+        ),
     )
     monkeypatch.setattr(
         AutoProcessor,

--- a/tests/unit_test/qwen3_tts/test_pipeline.py
+++ b/tests/unit_test/qwen3_tts/test_pipeline.py
@@ -268,22 +268,78 @@ def test_qwen3_tts_config_and_registry_contracts() -> None:
     config = Qwen3TTSPipelineConfig(model_path="model")
     assert [stage.name for stage in config.stages] == [
         "preprocessing",
-        "tts_engine",
         "vocoder",
+        "tts_engine",
     ]
-    assert config.stages[1].factory_path.endswith("create_sglang_tts_engine_executor")
+    stages = {stage.name: stage for stage in config.stages}
+    assert config.resolved_entry_stage == "preprocessing"
+    assert stages["preprocessing"].next == "tts_engine"
+    assert stages["tts_engine"].next == "vocoder"
+    assert stages["tts_engine"].factory_path.endswith(
+        "create_sglang_tts_engine_executor"
+    )
     assert config.terminal_stages == ["vocoder"]
     assert config.gpu_placement == {"tts_engine": 0, "vocoder": 0}
-    assert config.stages[1].factory.device is None
-    assert config.stages[2].factory.device is None
+    assert stages["tts_engine"].factory.device is None
+    assert stages["vocoder"].factory.device is None
     assert {stage.process for stage in config.stages} == {"pipeline"}
-    assert config.stages[1].stream_to == ["vocoder"]
-    assert config.stages[2].can_accept_stream_before_payload is True
+    assert stages["tts_engine"].stream_to == ["vocoder"]
+    assert stages["vocoder"].can_accept_stream_before_payload is True
     assert Qwen3TTSPipelineConfig.stage_config_cls("tts_engine").engine_stage
     assert (
         PIPELINE_CONFIG_REGISTRY.get_config("Qwen3TTSForConditionalGeneration")
         is Qwen3TTSPipelineConfig
     )
+
+
+def test_qwen3_tts_speech_tokenizer_is_loaded_once_per_process_key(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    loads: list[tuple[str, dict[str, object]]] = []
+
+    class FakeQwen3TTSTokenizer:
+        @classmethod
+        def from_pretrained(cls, path, **kwargs):
+            loads.append((path, kwargs))
+            return cls()
+
+    qwen_tts_module = types.ModuleType("qwen_tts")
+    qwen_tts_module.Qwen3TTSTokenizer = FakeQwen3TTSTokenizer
+    monkeypatch.setitem(sys.modules, "qwen_tts", qwen_tts_module)
+    monkeypatch.setattr(
+        qwen3_stages, "apply_qwen_tts_transformers_compatibility_patches", lambda: None
+    )
+    monkeypatch.setattr(qwen3_stages, "_resolve_checkpoint", lambda path: path)
+    monkeypatch.setattr(qwen3_stages, "_SPEECH_TOKENIZERS", {})
+
+    vocoder_copy = qwen3_stages._load_qwen3_tts_tokenizer(
+        "/ckpt", device="cuda:0", dtype="bfloat16", attn_implementation=None
+    )
+    engine_copy = qwen3_stages._load_qwen3_tts_tokenizer(
+        "/ckpt", device="cuda:0", dtype="bfloat16", attn_implementation=None
+    )
+    other_device = qwen3_stages._load_qwen3_tts_tokenizer(
+        "/ckpt", device="cuda:1", dtype="bfloat16", attn_implementation=None
+    )
+    other_attention = qwen3_stages._load_qwen3_tts_tokenizer(
+        "/ckpt", device="cuda:0", dtype="bfloat16", attn_implementation="sdpa"
+    )
+
+    assert engine_copy is vocoder_copy
+    assert other_device is not vocoder_copy
+    assert other_attention is not vocoder_copy
+    assert loads == [
+        ("/ckpt/speech_tokenizer", {"device_map": "cuda:0", "dtype": torch.bfloat16}),
+        ("/ckpt/speech_tokenizer", {"device_map": "cuda:1", "dtype": torch.bfloat16}),
+        (
+            "/ckpt/speech_tokenizer",
+            {
+                "device_map": "cuda:0",
+                "dtype": torch.bfloat16,
+                "attn_implementation": "sdpa",
+            },
+        ),
+    ]
 
 
 def test_qwen3_tts_deterministic_inference_configures_pipeline() -> None:
@@ -6822,11 +6878,12 @@ def test_qwen3_tts_config_loads_frontend_only_outside_engine_process() -> None:
 
     split = config.model_copy(deep=True)
     # A split frontend declares its own gpu, the way the documented recipe does.
-    split.stages[0] = split.stages[0].model_copy(
-        update={"process": "tts_frontend", "gpu": 0, "gpu_memory_fraction": 0.05}
-    )
-    split.stages[1] = split.stages[1].model_copy(update={"gpu_memory_fraction": 0.75})
-    split.stages[2] = split.stages[2].model_copy(update={"gpu_memory_fraction": 0.12})
+    fractions = {"preprocessing": 0.05, "tts_engine": 0.75, "vocoder": 0.12}
+    for index, stage in enumerate(split.stages):
+        update = {"gpu_memory_fraction": fractions[stage.name]}
+        if stage.name == "preprocessing":
+            update.update({"process": "tts_frontend", "gpu": 0})
+        split.stages[index] = stage.model_copy(update=update)
     assert split.preprocessing_in_own_process() is True
     assert split.stage_factory_kwargs("preprocessing") == {"load_frontend": True}
     assert split.stage_factory_kwargs("tts_engine") == {}
@@ -6859,7 +6916,14 @@ def test_qwen3_tts_shared_gpu_layout_demands_no_preprocessing_fraction() -> None
 
     config = Qwen3TTSPipelineConfig(model_path="model")
     shared = config.model_copy(deep=True)
-    shared.stages[2] = shared.stages[2].model_copy(update={"process": "vocoder"})
+    shared.stages = [
+        (
+            stage.model_copy(update={"process": "vocoder"})
+            if stage.name == "vocoder"
+            else stage
+        )
+        for stage in shared.stages
+    ]
 
     placement = build_stage_placement_plan(shared)
     assert placement.gpus[0].missing_fraction_stage_names == ("tts_engine", "vocoder")

--- a/tests/unit_test/qwen3_tts/test_pipeline.py
+++ b/tests/unit_test/qwen3_tts/test_pipeline.py
@@ -6063,6 +6063,46 @@ def test_qwen3_tts_engine_accepts_disabled_torch_compile(value) -> None:
     Qwen3TtsEngineBuilder().adjust_overrides({"enable_torch_compile": value})
 
 
+@pytest.mark.parametrize(
+    "pool_tokens, max_running_requests, context_length",
+    [(131072, 16, 8192), (589142, 128, 8192)],
+)
+def test_qwen3_tts_engine_reports_the_pool_against_the_admission_bound(
+    pool_tokens: int,
+    max_running_requests: int,
+    context_length: int,
+    caplog: pytest.LogCaptureFixture,
+) -> None:
+    from sglang_omni.models.qwen3_tts.engine_builder import Qwen3TtsEngineBuilder
+
+    class FakePool:
+        def get_kv_size_bytes(self):
+            return pool_tokens * 1024, pool_tokens * 1024
+
+    scheduler = SimpleNamespace(
+        max_total_num_tokens=pool_tokens,
+        server_args=SimpleNamespace(
+            max_running_requests=max_running_requests,
+            context_length=context_length,
+            mem_fraction_static=0.875,
+        ),
+        tp_worker=SimpleNamespace(
+            model_runner=SimpleNamespace(token_to_kv_pool=FakePool())
+        ),
+    )
+
+    with caplog.at_level("INFO", logger="sglang_omni.models.qwen3_tts.engine_builder"):
+        Qwen3TtsEngineBuilder().post_scheduler_setup(scheduler, model_runner=None)
+
+    assert caplog.messages == [
+        f"Qwen3-TTS KV pool holds {pool_tokens} tokens, "
+        f"{pool_tokens * 2048 / 2**30:.2f} GiB, against an admission bound of "
+        f"{max_running_requests * context_length} "
+        f"({max_running_requests} running x {context_length} context), "
+        "mem_fraction_static 0.875"
+    ]
+
+
 def test_qwen3_tts_engine_accepts_64_batch_policy_and_enables_cuda_graph(
     monkeypatch: pytest.MonkeyPatch,
 ) -> None:
@@ -6123,10 +6163,15 @@ def test_qwen3_tts_engine_accepts_64_batch_policy_and_enables_cuda_graph(
             predictor_captures.append((do_sample, top_k, top_p))
             return 6
 
+    class FakePool:
+        def get_kv_size_bytes(self):
+            return 64 * 8192 * 1024, 64 * 8192 * 1024
+
     class FakeSGLangRunner:
         def __init__(self, server_args) -> None:
             self.server_args = server_args
             self.model = FakeModel()
+            self.token_to_kv_pool = FakePool()
 
         def init_cuda_graphs(self) -> None:
             assert self.server_args.enable_torch_compile is False
@@ -6209,9 +6254,11 @@ def test_qwen3_tts_engine_accepts_64_batch_policy_and_enables_cuda_graph(
     )
 
     def fake_build_sglang_server_args(model_path, context_length, **kwargs):
-        del model_path, context_length
+        del model_path
         build_kwargs.update(kwargs)
         return SimpleNamespace(
+            context_length=context_length,
+            mem_fraction_static=kwargs["mem_fraction_static"],
             cuda_graph_bs=kwargs["cuda_graph_bs"],
             cuda_graph_max_bs=kwargs["cuda_graph_max_bs"],
             cuda_graph_config=SimpleNamespace(
@@ -6273,7 +6320,7 @@ def test_qwen3_tts_engine_accepts_64_batch_policy_and_enables_cuda_graph(
     monkeypatch.setattr(
         scheduler_mod,
         "OmniScheduler",
-        lambda **kwargs: SimpleNamespace(**kwargs),
+        lambda **kwargs: SimpleNamespace(max_total_num_tokens=579894, **kwargs),
     )
 
     scheduler = stages.create_sglang_tts_engine_executor(
@@ -6835,7 +6882,7 @@ def test_qwen3_tts_standalone_preprocessing_ships_tensors_without_registry(
     monkeypatch.setattr(
         qwen3_request_builders,
         "_get_qwen3_tts_adhoc_reference_service_locked",
-        lambda model, wrapper: None,
+        lambda model, wrapper, *, context_length=None: None,
     )
     monkeypatch.setattr(
         qwen3_request_builders,

--- a/tests/unit_test/qwen3_tts/test_pipeline.py
+++ b/tests/unit_test/qwen3_tts/test_pipeline.py
@@ -6325,7 +6325,7 @@ def test_qwen3_tts_engine_reports_the_pool_against_the_admission_bound(
 
     assert caplog.messages == [
         f"Qwen3-TTS KV pool holds {pool_tokens} tokens, "
-        f"{pool_tokens * 2048 / 2**30:.2f} GiB, against an admission bound of "
+        f"{pool_tokens * 2048 / 2**30:.2f} GiB, against a configured maximum demand of "
         f"{max_running_requests * context_length} "
         f"({max_running_requests} running x {context_length} context), "
         "mem_fraction_static 0.875"

--- a/tests/unit_test/qwen3_tts/test_pipeline.py
+++ b/tests/unit_test/qwen3_tts/test_pipeline.py
@@ -324,10 +324,13 @@ def test_qwen3_tts_speech_tokenizer_is_loaded_once_per_process_key(
     other_attention = qwen3_stages._load_qwen3_tts_tokenizer(
         "/ckpt", device="cuda:0", dtype="bfloat16", attn_implementation="sdpa"
     )
+    other_checkpoint = qwen3_stages._load_qwen3_tts_tokenizer(
+        "/other", device="cuda:0", dtype="bfloat16", attn_implementation=None
+    )
 
     assert engine_copy is vocoder_copy
-    assert other_device is not vocoder_copy
-    assert other_attention is not vocoder_copy
+    assert len({id(vocoder_copy), id(other_device), id(other_attention)}) == 3
+    assert other_checkpoint is not vocoder_copy
     assert loads == [
         ("/ckpt/speech_tokenizer", {"device_map": "cuda:0", "dtype": torch.bfloat16}),
         ("/ckpt/speech_tokenizer", {"device_map": "cuda:1", "dtype": torch.bfloat16}),
@@ -339,7 +342,108 @@ def test_qwen3_tts_speech_tokenizer_is_loaded_once_per_process_key(
                 "attn_implementation": "sdpa",
             },
         ),
+        ("/other/speech_tokenizer", {"device_map": "cuda:0", "dtype": torch.bfloat16}),
     ]
+
+
+@pytest.mark.parametrize("disable_cuda_graph", [False, True])
+def test_qwen3_tts_engine_attaches_the_vocoder_speech_tokenizer_before_the_pool(
+    monkeypatch: pytest.MonkeyPatch, disable_cuda_graph: bool
+) -> None:
+    from transformers import AutoProcessor
+
+    from sglang_omni.models.qwen3_tts.engine_builder import Qwen3TtsEngineBuilder
+
+    loads: list[str] = []
+    predictor_captures: list[tuple] = []
+
+    class FakeQwen3TTSTokenizer:
+        feature_extractor = SimpleNamespace(sampling_rate=24000)
+
+        @classmethod
+        def from_pretrained(cls, path, **kwargs):
+            del kwargs
+            loads.append(path)
+            return cls()
+
+        def get_encode_downsample_rate(self):
+            return 1920
+
+    class FakeQwen3TTSModel:
+        def __init__(self, **kwargs) -> None:
+            self.kwargs = kwargs
+
+        def _merge_generate_kwargs(self, **kwargs):
+            return {**self.kwargs["generate_defaults"], **kwargs}
+
+    class FakeScheduler:
+        def __init__(self, tokenizer, **kwargs) -> None:
+            del kwargs
+            self.tokenizer = tokenizer
+
+        def warmup_now(self) -> None:
+            pass
+
+    class FakeTalker:
+        device = torch.device("cpu")
+        speech_tokenizer = None
+
+        def load_speech_tokenizer(self, tokenizer) -> None:
+            self.speech_tokenizer = tokenizer
+
+        def capture_predictor_graphs(
+            self, *, do_sample: bool, top_k: int, top_p: float
+        ) -> int:
+            predictor_captures.append((do_sample, top_k, top_p))
+            return 6
+
+    qwen_tts_module = types.ModuleType("qwen_tts")
+    qwen_tts_module.Qwen3TTSTokenizer = FakeQwen3TTSTokenizer
+    qwen_tts_module.Qwen3TTSModel = FakeQwen3TTSModel
+    monkeypatch.setitem(sys.modules, "qwen_tts", qwen_tts_module)
+    monkeypatch.setattr(
+        qwen3_stages, "apply_qwen_tts_transformers_compatibility_patches", lambda: None
+    )
+    monkeypatch.setattr(qwen3_stages, "_resolve_checkpoint", lambda path: path)
+    monkeypatch.setattr(
+        qwen3_stages, "_load_qwen3_tts_generate_defaults", lambda path: {}
+    )
+    monkeypatch.setattr(qwen3_stages, "_SPEECH_TOKENIZERS", {})
+    monkeypatch.setattr(
+        qwen3_stages, "Qwen3TTSStreamingVocoderScheduler", FakeScheduler
+    )
+    monkeypatch.setattr(
+        AutoProcessor,
+        "from_pretrained",
+        staticmethod(lambda *args, **kwargs: object()),
+    )
+    qwen3_request_builders.clear_qwen3_tts_preprocessing_context()
+
+    vocoder = qwen3_stages.create_vocoder_executor("/ckpt", device="cpu")
+    talker = FakeTalker()
+    builder = Qwen3TtsEngineBuilder()
+    builder.dtype = "bfloat16"
+    try:
+        builder.before_memory_pool(
+            model_worker=SimpleNamespace(model_runner=SimpleNamespace(model=talker)),
+            checkpoint_dir="/ckpt",
+            device="cpu",
+            gpu_id=0,
+            server_args=SimpleNamespace(
+                context_length=8192, disable_cuda_graph=disable_cuda_graph
+            ),
+        )
+    finally:
+        qwen3_request_builders.clear_qwen3_tts_preprocessing_context()
+
+    assert talker.speech_tokenizer is vocoder.tokenizer
+    assert loads == ["/ckpt/speech_tokenizer"]
+    expected = qwen3_request_builders.resolve_subtalker_sampling({})
+    assert predictor_captures == (
+        []
+        if disable_cuda_graph
+        else [(expected.do_sample, expected.top_k, expected.top_p)]
+    )
 
 
 def test_qwen3_tts_deterministic_inference_configures_pipeline() -> None:
@@ -1254,11 +1358,16 @@ def test_qwen3_tts_reference_code_overlaps_speaker_embedding() -> None:
 
 
 @pytest.mark.parametrize(
-    "samples, frames, refused",
-    [(126_720, 99, False), (126_721, 100, True)],
+    "samples, sample_rate, frames, refused",
+    [
+        (126_720, 16000, 99, False),
+        (126_721, 16000, 100, True),
+        (190_080, 24000, 99, False),
+        (190_081, 24000, 100, True),
+    ],
 )
 def test_qwen3_tts_icl_reference_is_refused_at_the_context_before_encoding(
-    samples: int, frames: int, refused: bool
+    samples: int, sample_rate: int, frames: int, refused: bool
 ) -> None:
     encoded_lengths: list[int] = []
 
@@ -1269,6 +1378,7 @@ def test_qwen3_tts_icl_reference_is_refused_at_the_context_before_encoding(
             return 1920
 
         def encode(self, waveforms, *, sr):
+            assert sr == sample_rate
             encoded_lengths.append(len(waveforms[0]))
             return SimpleNamespace(
                 audio_codes=[torch.ones((frames, 2), dtype=torch.long)]
@@ -1276,12 +1386,12 @@ def test_qwen3_tts_icl_reference_is_refused_at_the_context_before_encoding(
 
     class FakeWrapper:
         def _normalize_audio_inputs(self, ref_audio):
-            return [(np.zeros(samples, dtype=np.float32), 16000)]
+            return [(np.zeros(samples, dtype=np.float32), sample_rate)]
 
     class FakeModel:
         device = torch.device("cpu")
         speech_tokenizer = FakeSpeechTokenizer()
-        speaker_encoder_sample_rate = 16000
+        speaker_encoder_sample_rate = sample_rate
 
         def extract_speaker_embedding(self, *, audio, sr):
             return torch.ones(4)

--- a/tests/unit_test/qwen3_tts/test_pipeline.py
+++ b/tests/unit_test/qwen3_tts/test_pipeline.py
@@ -429,9 +429,7 @@ def test_qwen3_tts_engine_attaches_the_vocoder_speech_tokenizer_before_the_pool(
             checkpoint_dir="/ckpt",
             device="cpu",
             gpu_id=0,
-            server_args=SimpleNamespace(
-                context_length=8192, disable_cuda_graph=disable_cuda_graph
-            ),
+            server_args=SimpleNamespace(disable_cuda_graph=disable_cuda_graph),
         )
     finally:
         qwen3_request_builders.clear_qwen3_tts_preprocessing_context()
@@ -1357,79 +1355,10 @@ def test_qwen3_tts_reference_code_overlaps_speaker_embedding() -> None:
     assert prompt["icl_mode"] == [True]
 
 
-@pytest.mark.parametrize(
-    "samples, sample_rate, frames, refused",
-    [
-        (126_720, 16000, 99, False),
-        (126_721, 16000, 100, True),
-        (190_080, 24000, 99, False),
-        (190_081, 24000, 100, True),
-    ],
-)
-def test_qwen3_tts_icl_reference_is_refused_at_the_context_before_encoding(
-    samples: int, sample_rate: int, frames: int, refused: bool
-) -> None:
-    encoded_lengths: list[int] = []
-
-    class FakeSpeechTokenizer:
-        feature_extractor = SimpleNamespace(sampling_rate=24000)
-
-        def get_encode_downsample_rate(self):
-            return 1920
-
-        def encode(self, waveforms, *, sr):
-            assert sr == sample_rate
-            encoded_lengths.append(len(waveforms[0]))
-            return SimpleNamespace(
-                audio_codes=[torch.ones((frames, 2), dtype=torch.long)]
-            )
-
-    class FakeWrapper:
-        def _normalize_audio_inputs(self, ref_audio):
-            return [(np.zeros(samples, dtype=np.float32), sample_rate)]
-
-    class FakeModel:
-        device = torch.device("cpu")
-        speech_tokenizer = FakeSpeechTokenizer()
-        speaker_encoder_sample_rate = sample_rate
-
-        def extract_speaker_embedding(self, *, audio, sr):
-            return torch.ones(4)
-
-    hook = qwen3_request_builders._Qwen3TTSAdhocReferenceHook(
-        model=FakeModel(),
-        wrapper=FakeWrapper(),
-        context_length=100,
-    )
-    item = qwen3_request_builders._Qwen3TTSAdhocReferenceInput(
-        ref_audio="voice.wav",
-        ref_text="reference",
-        x_vector_only_mode=False,
-    )
-    try:
-        if refused:
-            with pytest.raises(ValueError, match=f"{frames} codec frames"):
-                hook.encode_one(item)
-            assert encoded_lengths == []
-        else:
-            prompt, ref_text = hook.encode_one(item)
-            assert encoded_lengths == [samples]
-            assert prompt["ref_code"][0].shape == (frames, 2)
-            assert prompt["icl_mode"] == [True]
-            assert ref_text == "reference"
-    finally:
-        hook.close()
-
-
 def test_qwen3_tts_x_vector_reference_runs_only_the_speaker_encoder() -> None:
     speaker_inputs: list[tuple[int, int]] = []
 
     class FakeSpeechTokenizer:
-        feature_extractor = SimpleNamespace(sampling_rate=24000)
-
-        def get_encode_downsample_rate(self):
-            return 1920
-
         def encode(self, waveforms, *, sr):
             raise AssertionError("x vector only mode must not encode the clip")
 
@@ -1449,7 +1378,6 @@ def test_qwen3_tts_x_vector_reference_runs_only_the_speaker_encoder() -> None:
     hook = qwen3_request_builders._Qwen3TTSAdhocReferenceHook(
         model=FakeModel(),
         wrapper=FakeWrapper(),
-        context_length=100,
     )
     item = qwen3_request_builders._Qwen3TTSAdhocReferenceInput(
         ref_audio="voice.wav",
@@ -7114,7 +7042,7 @@ def test_qwen3_tts_standalone_preprocessing_ships_tensors_without_registry(
     monkeypatch.setattr(
         qwen3_request_builders,
         "_get_qwen3_tts_adhoc_reference_service_locked",
-        lambda model, wrapper, *, context_length=None: None,
+        lambda model, wrapper: None,
     )
     monkeypatch.setattr(
         qwen3_request_builders,

--- a/tests/unit_test/qwen3_tts/test_pipeline.py
+++ b/tests/unit_test/qwen3_tts/test_pipeline.py
@@ -6110,6 +6110,7 @@ def test_qwen3_tts_engine_accepts_64_batch_policy_and_enables_cuda_graph(
     infrastructure_saw_deferred_capture: list[bool] = []
     init_graph_calls: list[bool] = []
     predictor_captures: list[tuple] = []
+    events: list[str] = []
 
     class FakeModel:
         def load_speech_tokenizer(self, tokenizer) -> None:
@@ -6118,6 +6119,7 @@ def test_qwen3_tts_engine_accepts_64_batch_policy_and_enables_cuda_graph(
         def capture_predictor_graphs(
             self, *, do_sample: bool, top_k: int, top_p: float
         ) -> int:
+            events.append("predictor_capture")
             predictor_captures.append((do_sample, top_k, top_p))
             return 6
 
@@ -6129,6 +6131,7 @@ def test_qwen3_tts_engine_accepts_64_batch_policy_and_enables_cuda_graph(
         def init_cuda_graphs(self) -> None:
             assert self.server_args.enable_torch_compile is False
             assert self.server_args.torch_compile_max_bs == 64
+            events.append("init_graphs")
             init_graph_calls.append(True)
 
     class FakeWorker:
@@ -6236,8 +6239,11 @@ def test_qwen3_tts_engine_accepts_64_batch_policy_and_enables_cuda_graph(
         infrastructure_saw_deferred_capture.append(
             bool(kwargs.get("defer_cuda_graph_capture"))
         )
+        worker = FakeWorker(server_args)
+        kwargs["before_memory_pool"](worker)
+        events.append("memory_pool")
         return (
-            FakeWorker(server_args),
+            worker,
             object(),
             object(),
             object(),
@@ -6323,6 +6329,7 @@ def test_qwen3_tts_engine_accepts_64_batch_policy_and_enables_cuda_graph(
     assert infrastructure_saw_deferred_capture == [True]
     assert init_graph_calls == [True]
     assert predictor_captures == [(True, 50, 1.0)]
+    assert events == ["predictor_capture", "memory_pool", "init_graphs"]
     assert scheduler.server_args.cuda_graph_bs == expected_cuda_graph_bs
     assert scheduler.server_args.cuda_graph_max_bs == 64
     assert scheduler.server_args.disable_cuda_graph is False

--- a/tests/unit_test/scheduling/test_engine_factory.py
+++ b/tests/unit_test/scheduling/test_engine_factory.py
@@ -201,12 +201,15 @@ def test_tts_engine_builder_phase_order_and_override_contract(monkeypatch) -> No
     ) -> tuple[Any, ...]:
         events.append("infrastructure")
         assert gpu_id == 2
+        before_memory_pool = kwargs.pop("before_memory_pool")
         assert kwargs == {
             "defer_cuda_graph_capture": True,
             "model_arch_override": "TestArch",
         }
+        worker = FakeWorker(server_args)
+        before_memory_pool(worker)
         return (
-            FakeWorker(server_args),
+            worker,
             "tree_cache",
             "req_pool",
             "kv_pool",
@@ -295,6 +298,22 @@ def test_tts_engine_builder_phase_order_and_override_contract(monkeypatch) -> No
         def customize_server_args(self, server_args: Any) -> None:
             events.append("customize_server_args")
             assert server_args.context_length == 123
+
+        def before_memory_pool(
+            self,
+            *,
+            model_worker: Any,
+            checkpoint_dir: str,
+            device: str,
+            gpu_id: int,
+            server_args: Any,
+        ) -> None:
+            events.append("before_memory_pool")
+            assert isinstance(model_worker.model_runner.model, FakeModel)
+            assert checkpoint_dir == "model-resolved"
+            assert device == "cuda:2"
+            assert gpu_id == 2
+            assert server_args.disable_cuda_graph is False
 
         def setup_model(
             self,
@@ -397,6 +416,7 @@ def test_tts_engine_builder_phase_order_and_override_contract(monkeypatch) -> No
         "build_server_args",
         "customize_server_args",
         "infrastructure",
+        "before_memory_pool",
         "setup_model",
         "get_model_buffer_bs",
         "compile_model",

--- a/tests/unit_test/serve/test_sglang_bootstrap.py
+++ b/tests/unit_test/serve/test_sglang_bootstrap.py
@@ -136,6 +136,74 @@ def test_create_sglang_infrastructure_runs_0515_initialization_phases(
     assert infrastructure[0].model_runner.model is FakeRunner.model
 
 
+def test_before_memory_pool_runs_after_the_weights_and_before_the_pool(
+    monkeypatch,
+) -> None:
+    events: list[object] = []
+    monkeypatch.setattr(
+        bootstrap,
+        "_describe_sglang_runtime_configuration",
+        lambda *_args: "runtime configuration",
+    )
+
+    class FakeRunner:
+        model = object()
+
+        def alloc_memory_pool(self) -> None:
+            events.append("alloc_memory_pool")
+
+        def init_attention_backends(self) -> None:
+            events.append("init_attention_backends")
+
+        def init_cuda_graphs(self) -> None:
+            events.append("init_cuda_graphs")
+
+    class FakeWorker:
+        model_config = SimpleNamespace(is_multimodal=False)
+        enable_prefill_input_embeds = False
+
+        def __init__(self, **kwargs) -> None:
+            del kwargs
+            events.append("model_worker")
+            self.model_runner = FakeRunner()
+
+        def get_memory_pool(self):
+            return "req_pool", "kv_pool"
+
+    monkeypatch.setattr(model_worker_module, "ModelWorker", FakeWorker)
+    monkeypatch.setattr(
+        sglang_backend,
+        "create_tree_cache",
+        lambda *args: ("tree_cache", args),
+    )
+    server_args = SimpleNamespace(
+        attention_backend=None,
+        decode_attention_backend=None,
+        prefill_attention_backend=None,
+        sampling_backend=None,
+        page_size=1,
+        disable_overlap_schedule=False,
+        chunked_prefill_size=8,
+        max_prefill_tokens=16,
+    )
+
+    bootstrap.create_sglang_infrastructure(
+        server_args,
+        0,
+        defer_cuda_graph_capture=True,
+        before_memory_pool=lambda worker: events.append(
+            ("before_memory_pool", worker.model_runner.model)
+        ),
+    )
+
+    assert events == [
+        "model_worker",
+        ("before_memory_pool", FakeRunner.model),
+        "alloc_memory_pool",
+        "init_attention_backends",
+    ]
+
+
 def test_an_engine_is_refused_in_a_process_with_a_published_context(
     monkeypatch,
 ) -> None:


### PR DESCRIPTION
## Summary

sglang sizes the Qwen3-TTS KV pool once, from free memory after the talker weights load minus the `mem_fraction_static` slack. On main the process keeps loading things after that reading that live for the whole process: the vocoder's codec state and graphs, the predictor CUDA graphs, and a second copy of the speech tokenizer. They are paid out of the slack that sglang left for request-time work. On the sglang bump this is what failed: an 844 MiB prefill transient found 502 MiB free with 4.5 GiB of graph pools sitting in the slack, and disabling either the predictor capture or the vocoder graphs restored the run.

This PR moves that residency before the reading, so the persistent resources are present when sglang derives the pool budget and the slack stays available for requests. No measurement, no reserve, no new configuration. The vocoder is built before both of sglang's readings, so its residency lowers the budget by the fraction of it, the predictor graphs are captured between the two readings and lower it by their full size, and one tokenizer copy is gone. Peak usage is the same order as before since the pool still fills the card under the fraction rule. What changes is what sits in the request-time headroom.

Changes:

- **Vocoder before the engine.** The Qwen3-TTS stage list builds the vocoder first. Entry stage and routing by name are unchanged, and config order is load order inside one process.
- **One speech tokenizer per process.** `_load_qwen3_tts_tokenizer` keeps a registry keyed by tokenizer path, device, dtype and attention implementation. The vocoder loads, the engine attaches the same object. The engine uses only the encoder half and the vocoder only the decoder.
- **`before_memory_pool`.** `create_sglang_infrastructure` gains an optional callback run between the model worker and `alloc_memory_pool`. The engine factory hands it to a new builder hook, a no-op by default. Qwen3-TTS attaches the tokenizer, builds the wrapper and captures the predictor graphs there. Its `setup_model` and `setup_model_resources` are empty. sglang's own decode and prefill graphs stay after the pool, where its graph reserve is written for them.
- **Reference path.** The uploaded voice miss path goes through the reference hook, so the hook is the one caller of the tokenizer encoder and the speaker encoder, and uploaded ICL misses now use the batcher and its stream handoff like ad hoc clips. In x-vector mode the Mimi encode no longer runs, its codes were never consumed.
- **Startup line.** `post_scheduler_setup` logs the pool in tokens and GiB, the configured maximum demand `running x context`, and the resolved fraction.

Scope: the default shared process with automatic KV sizing. A vocoder in its own process, `engine.kv_cache_bytes`, and a deployment `max_total_tokens` keep their existing contracts. Request-time transients of the non-LLM components are not provisioned by this PR.

## Testing

Unit: the touched files on the H100 venv, 275 passed, 0 failed, plus the Fish, MOSS and Qwen3-TTS config test doubles migrated to the new bootstrap keyword after the first CI run.

Numerics (H100, Base 1.7B, full Seed-TTS EN, 1,088 utterances, c1, fresh server per arm): 1,088 of 1,088 WAVs byte identical to main.

Memory (Base 1.7B, `max_running_requests` 128, `cuda_graph_max_bs` 128, one boot per arm):

| Measurement | main | PR |
|---|---:|---:|
| KV pool tokens | 588721 | 571378 |
| Free memory at ready, MiB | 9525 | 11745 |
| Sampled peak memory, MiB | 77793 | 76393 |
| Tokenizer loads / reuses | 2 / 0 | 1 / 1 |
| Predictor capture before the pool | no | yes |
| Codec graph headroom warning | no | no |

Performance (same setting, c16, warmup 1, four interleaved pairs A B B A on a shared host): arm means 15.94 and 15.90 req/s, two pairs favour each side, within-arm spread 4.5 percent, p99 1.61 s and RTF 0.246 on both arms. No measurable throughput regression in this experiment: the 0.26 percent between the arm means is inside the run-to-run variation, and the per-step work on the benchmarked ad hoc ICL path is unchanged. Configurations near KV pressure, where the smaller pool can change cache retention, are not covered by this run.

