### PR TITLE
fix(ming): load inline and remote audio inputs correctly

### DIFF
--- a/sglang_omni/models/ming_omni/components/preprocessor.py
+++ b/sglang_omni/models/ming_omni/components/preprocessor.py
@@ -16,7 +16,10 @@ from sglang_omni.models.ming_omni.components.common import (
 )
 from sglang_omni.models.ming_omni.io import MingOmniPipelineState, PromptInputs
 from sglang_omni.models.ming_omni.pipeline.next_stage import AUDIO_STAGE, IMAGE_STAGE
-from sglang_omni.preprocessing.audio import compute_audio_cache_key, load_audio_path
+from sglang_omni.preprocessing.audio import (
+    compute_audio_cache_key,
+    ensure_audio_list_async,
+)
 from sglang_omni.preprocessing.image import (
     compute_image_cache_key,
     ensure_image_list_async,
@@ -194,6 +197,44 @@ def _inject_top_level_audios(
         messages[idx] = {**msg, "content": new_content}
         break
     return messages
+
+
+def _extract_audio_inputs(messages: list[dict[str, Any]]) -> list[str]:
+    """Extract audio references from inline multimodal message parts.
+
+    The OpenAI-compatible API accepts both ``audio_url`` parts and raw
+    ``input_audio`` parts.  Normalize the latter to a data URL so all inputs
+    use the same URL/local-file decoder and preserve the message order used by
+    the prompt placeholders.
+    """
+    audio_inputs: list[str] = []
+    for message in messages:
+        content = message.get("content", "")
+        if not isinstance(content, list):
+            continue
+        for item in content:
+            if not isinstance(item, dict):
+                continue
+            item_type = item.get("type")
+            if item_type == "audio_url":
+                audio_url = item.get("audio_url", {})
+                value = (
+                    audio_url.get("url", "")
+                    if isinstance(audio_url, dict)
+                    else str(audio_url)
+                )
+                if value:
+                    audio_inputs.append(value)
+            elif item_type == "input_audio":
+                input_audio = item.get("input_audio", {})
+                if not isinstance(input_audio, dict):
+                    continue
+                data = input_audio.get("data")
+                if not data:
+                    continue
+                audio_format = str(input_audio.get("format") or "wav").lower()
+                audio_inputs.append(f"data:audio/{audio_format};base64,{data}")
+    return audio_inputs
 
 
 def _inject_top_level_videos(
@@ -410,7 +451,10 @@ class MingPreprocessor:
         # different content -> different key so it never falsely aliases image
         # placeholder positions (which share the same generic image_patch_token).
         image_cache_key = compute_image_cache_key(raw_images) if raw_images else None
-        audio_cache_key = compute_audio_cache_key(audio_urls) if audio_urls else None
+        audio_inputs = _extract_audio_inputs(messages)
+        audio_cache_key = (
+            compute_audio_cache_key(audio_inputs) if audio_inputs else None
+        )
         video_cache_key = (
             compute_video_cache_key(
                 raw_videos,
@@ -454,13 +498,13 @@ class MingPreprocessor:
             if raw_videos
             else None
         )
-        audio_coros = (
-            [
-                asyncio.to_thread(load_audio_path, url, target_sr=WHISPER_SAMPLE_RATE)
-                for url in audio_urls
-            ]
-            if audio_urls
-            else []
+        audio_coro = (
+            ensure_audio_list_async(
+                audio_inputs,
+                target_sr=WHISPER_SAMPLE_RATE,
+            )
+            if audio_inputs
+            else None
         )
 
         # Gather all loads concurrently
@@ -469,7 +513,8 @@ class MingPreprocessor:
             all_tasks.append(image_coro)
         if video_coro is not None:
             all_tasks.append(video_coro)
-        all_tasks.extend(audio_coros)
+        if audio_coro is not None:
+            all_tasks.append(audio_coro)
 
         if all_tasks:
             results = await asyncio.gather(*all_tasks, return_exceptions=True)
@@ -495,7 +540,15 @@ class MingPreprocessor:
             else:
                 # ensure_video_list_async returns (videos, sample_fps, audio)
                 videos = vid_result[0] if isinstance(vid_result, tuple) else vid_result
-        audio_results = results[idx:]
+        audio_results: list[Any] = []
+        if audio_coro is not None:
+            audio_result = results[idx]
+            if isinstance(audio_result, BaseException):
+                raise ValueError(
+                    f"Failed to load Ming audio input: {audio_result}"
+                ) from audio_result
+            if isinstance(audio_result, list):
+                audio_results = audio_result
 
         waveforms: list[np.ndarray] = [
             a for a in audio_results if isinstance(a, np.ndarray)

--- a/tests/unit_test/ming_omni/test_thinker.py
+++ b/tests/unit_test/ming_omni/test_thinker.py
@@ -167,7 +167,12 @@ def _load_preprocessor_with_fake_deps(monkeypatch, *, config=None, tokenizer=Non
     )
 
     audio_module = ModuleType("sglang_omni.preprocessing.audio")
-    audio_module.load_audio_path = lambda *args, **kwargs: None
+
+    async def fake_ensure_audio_list_async(audios, **kwargs):
+        del kwargs
+        return [None for _ in audios]
+
+    audio_module.ensure_audio_list_async = fake_ensure_audio_list_async
     audio_module.compute_audio_cache_key = lambda audios: None
     monkeypatch.setitem(sys.modules, "sglang_omni.preprocessing.audio", audio_module)
 
@@ -189,6 +194,141 @@ def _load_preprocessor_with_fake_deps(monkeypatch, *, config=None, tokenizer=Non
     spec.loader.exec_module(module)
     sys.modules.pop(module_name, None)
     return module
+
+
+def test_ming_preprocessor_extracts_inline_audio_urls(monkeypatch) -> None:
+    module = _load_preprocessor_with_fake_deps(monkeypatch)
+
+    messages = [
+        {
+            "role": "user",
+            "content": [
+                {"type": "text", "text": "describe"},
+                {
+                    "type": "audio_url",
+                    "audio_url": {"url": "https://example/audio.wav"},
+                },
+                {"type": "audio_url", "audio_url": "file.wav"},
+            ],
+        }
+    ]
+
+    assert module._extract_audio_inputs(messages) == [
+        "https://example/audio.wav",
+        "file.wav",
+    ]
+
+
+def test_ming_preprocessor_extracts_inline_input_audio_as_data_url(monkeypatch) -> None:
+    module = _load_preprocessor_with_fake_deps(monkeypatch)
+
+    messages = [
+        {
+            "role": "user",
+            "content": [
+                {
+                    "type": "input_audio",
+                    "input_audio": {"data": "YWJj", "format": "WAV"},
+                }
+            ],
+        }
+    ]
+
+    assert module._extract_audio_inputs(messages) == [
+        "data:audio/wav;base64,YWJj",
+    ]
+
+
+@pytest.mark.asyncio
+async def test_ming_preprocessor_loads_inline_audio_inputs(monkeypatch) -> None:
+    module = _load_preprocessor_with_fake_deps(monkeypatch)
+    loaded: list[list[str]] = []
+
+    async def fake_loader(audios, **kwargs):
+        loaded.append(list(audios))
+        assert kwargs == {"target_sr": module.WHISPER_SAMPLE_RATE}
+        return [None for _ in audios]
+
+    monkeypatch.setattr(module, "ensure_audio_list_async", fake_loader)
+
+    class FakeState:
+        def __init__(self, **kwargs):
+            self.kwargs = kwargs
+
+        def to_dict(self):
+            return self.kwargs
+
+    monkeypatch.setattr(module, "MingOmniPipelineState", FakeState)
+
+    class FakePayload:
+        def __init__(self, **kwargs):
+            self.__dict__.update(kwargs)
+
+    monkeypatch.setattr(module, "StagePayload", FakePayload)
+    processor = module.MingPreprocessor.__new__(module.MingPreprocessor)
+    processor._tokenizer = _FakeMingTokenizer()
+    processor._audio_patch_id = 12
+    processor._audio_start_id = 10
+    processor._audio_end_id = 11
+    processor._image_patch_id = 22
+    processor._video_patch_id = 30
+    processor._audio_config = SimpleNamespace()
+
+    payload = SimpleNamespace(
+        request_id="request-1",
+        request=SimpleNamespace(
+            inputs=[
+                {
+                    "role": "user",
+                    "content": [
+                        {"type": "text", "text": "describe"},
+                        {
+                            "type": "audio_url",
+                            "audio_url": {"url": "https://example/audio.wav"},
+                        },
+                    ],
+                }
+            ]
+        ),
+    )
+
+    result = await processor(payload)
+
+    assert loaded == [["https://example/audio.wav"]]
+    assert result.data["prompt"]["input_ids"].tolist()[0].count(12) == 1
+
+
+@pytest.mark.asyncio
+async def test_ming_preprocessor_reports_audio_load_errors(monkeypatch) -> None:
+    module = _load_preprocessor_with_fake_deps(monkeypatch)
+
+    async def failing_loader(audios, **kwargs):
+        del audios, kwargs
+        raise RuntimeError("audio backend unavailable")
+
+    monkeypatch.setattr(module, "ensure_audio_list_async", failing_loader)
+    processor = module.MingPreprocessor.__new__(module.MingPreprocessor)
+    processor._tokenizer = _FakeMingTokenizer()
+    processor._audio_patch_id = 12
+    processor._audio_start_id = 10
+    processor._audio_end_id = 11
+    processor._image_patch_id = 22
+    processor._video_patch_id = 30
+
+    payload = SimpleNamespace(
+        request_id="request-1",
+        request=SimpleNamespace(
+            inputs=[
+                {
+                    "role": "user",
+                    "content": [{"type": "audio_url", "audio_url": "audio://1"}],
+                }
+            ]
+        ),
+    )
+
+    with pytest.raises(ValueError, match="Failed to load Ming audio input"):
+        await processor(payload)
 
 
 class _FakeMingTokenizer:


### PR DESCRIPTION
## Motivation

Ming-Omni currently sends audio inputs through the local file loader. Remote
audio URLs therefore fail, while inline `audio_url` and `input_audio` message
parts are not included in the loading path. Failed loads can also be silently
dropped, leaving audio placeholders without corresponding features.

## Modifications

- Load Ming audio through `ensure_audio_list_async`, covering remote URLs,
  local paths, and data URLs.
- Extract inline `audio_url` and `input_audio` parts in message order.
- Normalize `input_audio` payloads to audio data URLs before decoding.
- Include all normalized audio inputs in the audio cache key.
- Raise a request error when audio loading fails instead of silently dropping
  the input.
- Add unit tests for inline extraction, loading, and error handling.

## Related Issues

None.

## Accuracy Test

Not applicable. This change only fixes audio input preprocessing and does not
modify model weights or inference kernels.

## Benchmark & Profiling

Not applicable. The change uses the shared asynchronous audio loader and fixes
input handling; no model-side performance behavior is intentionally changed.

## Checklist

- [x] Format your code according with pre-commit.
- [x] Add unit tests.
- [x] Update documentation / docstrings / example tutorials as needed.
- [ ] Provide throughput / latency benchmark results and accuracy evaluation results as needed.
