### PR TITLE
perf(higgs-tts): fuse sampler row reset

### DIFF
--- a/sglang_omni/models/higgs_tts/reset_kernels.py
+++ b/sglang_omni/models/higgs_tts/reset_kernels.py
@@ -1,0 +1,79 @@
+# SPDX-License-Identifier: Apache-2.0
+"""Optional CUDA kernels for Higgs TTS sampler state."""
+
+from __future__ import annotations
+
+import torch
+
+try:
+    import triton
+    import triton.language as tl
+except ImportError:  # pragma: no cover - depends on runtime image
+    triton = None
+    tl = None
+
+
+if triton is not None:
+
+    @triton.jit
+    def _reset_sampler_row_kernel(
+        delay_count,
+        eoc_countdown,
+        generation_done,
+        last_codes,
+        seeds,
+        step_count,
+        row,
+        no_seed,
+        num_codebooks: tl.constexpr,
+        block_size: tl.constexpr,
+    ):
+        offsets = tl.arange(0, block_size)
+        tl.store(delay_count + row, 0)
+        tl.store(eoc_countdown + row, -1)
+        tl.store(generation_done + row, 0)
+        tl.store(seeds + row, no_seed)
+        tl.store(step_count + row, 0)
+        tl.store(
+            last_codes + row * num_codebooks + offsets,
+            0,
+            mask=offsets < num_codebooks,
+        )
+
+else:
+    _reset_sampler_row_kernel = None
+
+
+def reset_sampler_row(
+    delay_count: torch.Tensor,
+    eoc_countdown: torch.Tensor,
+    generation_done: torch.Tensor,
+    last_codes: torch.Tensor,
+    seeds: torch.Tensor,
+    step_count: torch.Tensor,
+    row: int,
+    no_seed: int,
+) -> bool:
+    """Reset one CUDA state row in one launch, or return ``False``."""
+    if _reset_sampler_row_kernel is None or not delay_count.is_cuda:
+        return False
+
+    num_codebooks = last_codes.shape[1]
+    block_size = triton.next_power_of_2(num_codebooks)
+    _reset_sampler_row_kernel[(1,)](
+        delay_count,
+        eoc_countdown,
+        generation_done,
+        last_codes,
+        seeds,
+        step_count,
+        row,
+        no_seed,
+        num_codebooks,
+        block_size,
+        num_warps=1,
+    )
+    return True
+
+
+__all__ = ["reset_sampler_row"]

--- a/sglang_omni/models/higgs_tts/reset_kernels.py
+++ b/sglang_omni/models/higgs_tts/reset_kernels.py
@@ -15,7 +15,10 @@ except ImportError:  # pragma: no cover - depends on runtime image
 
 if triton is not None:
 
-    @triton.jit
+    # note (Dayuxiaoshui): ``row`` changes with every request. Left to Triton's
+    # default specialization (row == 1, row % 16 == 0) it would JIT three
+    # variants at unpredictable points during serving, each a 40-450 ms stall.
+    @triton.jit(do_not_specialize=["row", "no_seed", "codes_row_stride"])
     def _reset_sampler_row_kernel(
         delay_count,
         eoc_countdown,
@@ -25,6 +28,7 @@ if triton is not None:
         step_count,
         row,
         no_seed,
+        codes_row_stride,
         num_codebooks: tl.constexpr,
         block_size: tl.constexpr,
     ):
@@ -35,7 +39,7 @@ if triton is not None:
         tl.store(seeds + row, no_seed)
         tl.store(step_count + row, 0)
         tl.store(
-            last_codes + row * num_codebooks + offsets,
+            last_codes + row * codes_row_stride + offsets,
             0,
             mask=offsets < num_codebooks,
         )
@@ -69,6 +73,9 @@ def reset_sampler_row(
         step_count,
         row,
         no_seed,
+        # The row stride is passed in so a strided view of ``last_codes`` is
+        # reset in place instead of silently writing past its own row.
+        last_codes.stride(0),
         num_codebooks,
         block_size,
         num_warps=1,

--- a/sglang_omni/models/higgs_tts/reset_kernels.py
+++ b/sglang_omni/models/higgs_tts/reset_kernels.py
@@ -18,6 +18,7 @@ if triton is not None:
     # note (Dayuxiaoshui): ``row`` changes with every request. Left to Triton's
     # default specialization (row == 1, row % 16 == 0) it would JIT three
     # variants at unpredictable points during serving, each a 40-450 ms stall.
+    # Excluding every integer argument leaves one binary per pool.
     @triton.jit(do_not_specialize=["row", "no_seed", "codes_row_stride"])
     def _reset_sampler_row_kernel(
         delay_count,
@@ -58,9 +59,22 @@ def reset_sampler_row(
     row: int,
     no_seed: int,
 ) -> bool:
-    """Reset one CUDA state row in one launch, or return ``False``."""
-    if _reset_sampler_row_kernel is None or not delay_count.is_cuda:
+    """Reset one CUDA state row in one launch, or return ``False``.
+
+    ``False`` means the caller must take its generic path: no Triton, a
+    non-CUDA pool, or a ``last_codes`` layout whose codebooks are not
+    contiguous, which the kernel does not address.
+    """
+    if (
+        _reset_sampler_row_kernel is None
+        or not delay_count.is_cuda
+        or last_codes.stride(1) != 1
+    ):
         return False
+    # The kernel cannot bounds-check; keep the IndexError the tensor
+    # indexing of the generic path would have raised.
+    if not 0 <= row < delay_count.shape[0]:
+        raise IndexError(f"row {row} out of range for {delay_count.shape[0]} rows")
 
     num_codebooks = last_codes.shape[1]
     block_size = triton.next_power_of_2(num_codebooks)
@@ -73,8 +87,8 @@ def reset_sampler_row(
         step_count,
         row,
         no_seed,
-        # The row stride is passed in so a strided view of ``last_codes`` is
-        # reset in place instead of silently writing past its own row.
+        # Row stride rather than ``num_codebooks``: a row-sliced view of
+        # ``last_codes`` is reset in place instead of past its own row.
         last_codes.stride(0),
         num_codebooks,
         block_size,

--- a/sglang_omni/models/higgs_tts/sampler.py
+++ b/sglang_omni/models/higgs_tts/sampler.py
@@ -15,6 +15,7 @@ from dataclasses import dataclass
 import torch
 from sglang.srt.layers.sampler import multinomial_with_seed
 
+from sglang_omni.models.higgs_tts.reset_kernels import reset_sampler_row
 from sglang_omni.models.higgs_tts.utils import BOC_ID, EOC_ID
 from sglang_omni.platforms import current_platform
 
@@ -114,6 +115,17 @@ class HiggsBatchedSamplerState:
 
     def reset_row(self, row: int) -> None:
         """Wipe row ``row`` so the next owner can't read stale state."""
+        if reset_sampler_row(
+            self.delay_count,
+            self.eoc_countdown,
+            self.generation_done,
+            self.last_codes,
+            self.seeds,
+            self.step_count,
+            row,
+            NO_SEED,
+        ):
+            return
         self.delay_count[row] = 0
         self.eoc_countdown[row] = -1
         self.generation_done[row] = False

--- a/sglang_omni/models/higgs_tts/sampler.py
+++ b/sglang_omni/models/higgs_tts/sampler.py
@@ -112,6 +112,10 @@ class HiggsBatchedSamplerState:
         self.step_count = torch.zeros(
             self.max_batch_size, dtype=torch.long, device=self.device
         )
+        # note (Dayuxiaoshui): the fused reset is JIT-compiled on first use
+        # (~0.5 s). Row 0 is already clean, so this call only moves that
+        # compile from the first request to pool construction.
+        self.reset_row(0)
 
     def reset_row(self, row: int) -> None:
         """Wipe row ``row`` so the next owner can't read stale state."""

--- a/tests/unit_test/higgs_tts/test_batched_step.py
+++ b/tests/unit_test/higgs_tts/test_batched_step.py
@@ -13,6 +13,7 @@ import torch
 
 from sglang_omni.models.higgs_tts.sampler import (
     K_MAX,
+    NO_SEED,
     STOP_CODE,
     HiggsBatchedSamplerState,
     batched_step,
@@ -68,6 +69,44 @@ def _assert_pools_equal(a: dict, b: dict) -> None:
         assert torch.equal(
             a[key], b[key]
         ), f"mismatch on {key}\n a={a[key]}\n b={b[key]}"
+
+
+def _fill_sampler_pool(pool: HiggsBatchedSamplerState) -> None:
+    pool.delay_count.fill_(7)
+    pool.eoc_countdown.fill_(5)
+    pool.generation_done.fill_(True)
+    pool.last_codes.copy_(
+        torch.arange(
+            pool.max_batch_size * pool.num_codebooks,
+            device=pool.device,
+        ).view(pool.max_batch_size, pool.num_codebooks)
+    )
+    pool.seeds.fill_(1234)
+    pool.step_count.fill_(99)
+
+
+@pytest.mark.parametrize("row", [0, 4, 8])
+def test_reset_row_clears_selected_row_only(row: int) -> None:
+    pool = HiggsBatchedSamplerState(9, N, device=DEVICE)
+    _fill_sampler_pool(pool)
+    neighbors = {
+        name: tensor.clone()
+        for name, tensor in vars(pool).items()
+        if isinstance(tensor, torch.Tensor)
+    }
+
+    pool.reset_row(row)
+
+    assert pool.delay_count[row].item() == 0
+    assert pool.eoc_countdown[row].item() == -1
+    assert not pool.generation_done[row].item()
+    assert torch.equal(pool.last_codes[row], torch.zeros_like(pool.last_codes[row]))
+    assert pool.seeds[row].item() == NO_SEED
+    assert pool.step_count[row].item() == 0
+    for name, before in neighbors.items():
+        actual = getattr(pool, name)
+        assert torch.equal(actual[:row], before[:row])
+        assert torch.equal(actual[row + 1 :], before[row + 1 :])
 
 
 # ---------------------------------------------------------------------------

--- a/tests/unit_test/higgs_tts/test_batched_step.py
+++ b/tests/unit_test/higgs_tts/test_batched_step.py
@@ -142,6 +142,21 @@ def test_reset_row_compiles_once_and_respects_last_codes_stride() -> None:
     assert torch.equal(wide[:, N:], torch.full_like(wide[:, N:], 3))
     assert torch.equal(strided[4], torch.full_like(strided[4], 3))
 
+    # Codebooks not contiguous: the fused path declines and the generic
+    # path handles it. Out of range: the generic path's IndexError is kept.
+    assert not reset_kernels.reset_sampler_row(
+        pool.delay_count,
+        pool.eoc_countdown,
+        pool.generation_done,
+        wide[:, ::2],
+        pool.seeds,
+        pool.step_count,
+        5,
+        NO_SEED,
+    )
+    with pytest.raises(IndexError):
+        pool.reset_row(pool.max_batch_size)
+
 
 # ---------------------------------------------------------------------------
 # Parity: delay window

--- a/tests/unit_test/higgs_tts/test_batched_step.py
+++ b/tests/unit_test/higgs_tts/test_batched_step.py
@@ -109,6 +109,40 @@ def test_reset_row_clears_selected_row_only(row: int) -> None:
         assert torch.equal(actual[row + 1 :], before[row + 1 :])
 
 
+@pytest.mark.accelerator
+@pytest.mark.skipif(DEVICE != "cuda", reason="fused reset only runs on CUDA")
+def test_reset_row_compiles_once_and_respects_last_codes_stride() -> None:
+    from sglang_omni.models.higgs_tts import reset_kernels
+
+    pool = HiggsBatchedSamplerState(33, N, device=DEVICE)
+    caches = reset_kernels._reset_sampler_row_kernel.device_caches
+
+    def variants() -> int:
+        return sum(len(entry[0]) for entry in caches.values())
+
+    assert variants() == 1  # compiled by the constructor
+
+    for row in (1, 16, 32):  # the values Triton would otherwise specialize on
+        pool.reset_row(row)
+    assert variants() == 1
+
+    wide = torch.full((33, 2 * N), 3, dtype=torch.long, device=DEVICE)
+    strided = wide[:, :N]
+    assert reset_kernels.reset_sampler_row(
+        pool.delay_count,
+        pool.eoc_countdown,
+        pool.generation_done,
+        strided,
+        pool.seeds,
+        pool.step_count,
+        5,
+        NO_SEED,
+    )
+    assert torch.equal(strided[5], torch.zeros(N, dtype=torch.long, device=DEVICE))
+    assert torch.equal(wide[:, N:], torch.full_like(wide[:, N:], 3))
+    assert torch.equal(strided[4], torch.full_like(strided[4], 3))
+
+
 # ---------------------------------------------------------------------------
 # Parity: delay window
 # ---------------------------------------------------------------------------


### PR DESCRIPTION
## Summary

- replace Higgs TTS sampler-row CUDA resets with one Triton kernel instead of six separate PyTorch mutations
- keep the existing PyTorch path as the fallback for CPU, NPU, and runtimes without Triton
- verify every state tensor is reset and neighboring rows remain unchanged

## Related Issues
#1798 

## Motivation and results

H100 profiling in #2011 identified `HiggsBatchedSamplerState.reset_row` among the top three scheduler leaves in all six independent on-CPU captures. The fused kernel reduced its scheduler leaf share from 18.2–20.6% to 0%.

Under the matched concurrency-64 A/B protocol:

- non-streaming throughput improved 2.79% versus a 0.82% baseline A/A difference
- non-streaming mean latency and p95 improved 2.52% and 3.49%
- streaming changed by only +0.43%, below its 1.82% A/A difference, so no streaming speedup is claimed

A dedicated maximum-length regression completed 72/72 requests with valid audio on both baseline and variant. See #2011 for the complete environment fingerprint, raw headline numbers, and evidence grades.

## Validation

- `pytest tests/unit_test/higgs_tts/test_batched_step.py -q -k reset_row` — 3 passed
- `pytest tests/unit_test/higgs_tts/test_npu_adaptation.py -q` — 9 passed
- Black 24.10.0, isort 5.13.2, Python compileall, and `git diff --check`
- H100 CUDA state-equivalence and neighbor-isolation test across all nine rows
- matched H100 Layer 4 A/A/A-B and Layer 5 long-text functional regression

Refs #2011
