### PR TITLE
[Qwen3-TTS] Order vocoder reads behind the talker's write for cross-process stream chunks

### DIFF
--- a/sglang_omni/models/qwen3_tts/streaming_vocoder.py
+++ b/sglang_omni/models/qwen3_tts/streaming_vocoder.py
@@ -1111,8 +1111,8 @@ class Qwen3TTSStreamingVocoderScheduler(
             return
 
         metadata: Mapping[str, Any] = source
-        # note (luojiaxuan): absent for chunks that crossed a process boundary;
-        # ingest records the readiness those chunks need, see there.
+        # note (luojiaxuan): absent for chunks that crossed a process boundary,
+        # ingest records the readiness those chunks need.
         state.pending_codes_ready = metadata.get("codes_ready_event")
         if "num_quantizers" not in metadata and state.num_quantizers is None:
             raise RuntimeError(
@@ -1224,12 +1224,10 @@ class Qwen3TTSStreamingVocoderScheduler(
         codes_ready = state.pending_codes_ready
         state.pending_codes_ready = None
         if codes_ready is None and codes.is_cuda:
-            # note(ratish): a chunk that crossed a process boundary was made
-            # complete on this thread's stream only, by the CUDA IPC import. The
-            # decode workers run on their own streams, so they need an event
-            # recorded here, after that import, to order their reads behind it.
+            # note(ratish): raw CUDA IPC orders only the receiver's default
+            # stream after the producer; the decode workers read on their own.
             codes_ready = torch.cuda.Event()
-            codes_ready.record()
+            codes_ready.record(torch.cuda.current_stream(codes.device))
         state.codes_ready = codes_ready
         state.total_frames += int(codes.shape[0])
 

--- a/sglang_omni/models/qwen3_tts/streaming_vocoder.py
+++ b/sglang_omni/models/qwen3_tts/streaming_vocoder.py
@@ -1227,7 +1227,7 @@ class Qwen3TTSStreamingVocoderScheduler(
             # note(ratish): raw CUDA IPC orders only the receiver's default
             # stream after the producer; the decode workers read on their own.
             codes_ready = torch.cuda.Event()
-            codes_ready.record(torch.cuda.current_stream(codes.device))
+            codes_ready.record()
         state.codes_ready = codes_ready
         state.total_frames += int(codes.shape[0])
 

--- a/sglang_omni/models/qwen3_tts/streaming_vocoder.py
+++ b/sglang_omni/models/qwen3_tts/streaming_vocoder.py
@@ -1226,6 +1226,9 @@ class Qwen3TTSStreamingVocoderScheduler(
         if codes_ready is None and codes.is_cuda:
             # note(ratish): raw CUDA IPC orders only the receiver's default
             # stream after the producer; the decode workers read on their own.
+            # note (luojiaxuan): so `record` has to land on that same default
+            # stream. It does because nothing on the ingest path switches
+            # streams; the workers' `set_stream` calls stay in their threads.
             codes_ready = torch.cuda.Event()
             codes_ready.record()
         state.codes_ready = codes_ready

--- a/sglang_omni/models/qwen3_tts/streaming_vocoder.py
+++ b/sglang_omni/models/qwen3_tts/streaming_vocoder.py
@@ -1112,7 +1112,7 @@ class Qwen3TTSStreamingVocoderScheduler(
 
         metadata: Mapping[str, Any] = source
         # note (luojiaxuan): absent for chunks that crossed a process boundary;
-        # the transport made those complete before handing them over.
+        # ingest records the readiness those chunks need, see there.
         state.pending_codes_ready = metadata.get("codes_ready_event")
         if "num_quantizers" not in metadata and state.num_quantizers is None:
             raise RuntimeError(
@@ -1221,8 +1221,16 @@ class Qwen3TTSStreamingVocoderScheduler(
         state.code_chunks.append(codes)
         # note (luojiaxuan): chunks arrive in production order on one talker
         # stream, so the newest chunk's event also covers every older one.
-        state.codes_ready = state.pending_codes_ready
+        codes_ready = state.pending_codes_ready
         state.pending_codes_ready = None
+        if codes_ready is None and codes.is_cuda:
+            # note(ratish): a chunk that crossed a process boundary was made
+            # complete on this thread's stream only, by the CUDA IPC import. The
+            # decode workers run on their own streams, so they need an event
+            # recorded here, after that import, to order their reads behind it.
+            codes_ready = torch.cuda.Event()
+            codes_ready.record()
+        state.codes_ready = codes_ready
         state.total_frames += int(codes.shape[0])
 
     def should_decode(self, state: _Qwen3TTSStreamState, *, is_final: bool) -> bool:

--- a/tests/unit_test/qwen3_tts/test_pipeline.py
+++ b/tests/unit_test/qwen3_tts/test_pipeline.py
@@ -2729,6 +2729,34 @@ def test_qwen3_tts_ingest_keeps_the_newest_chunk_event() -> None:
     assert state.codes_ready is None
 
 
+@pytest.mark.skipif(not torch.cuda.is_available(), reason="requires CUDA")
+def test_qwen3_tts_ingest_records_readiness_for_a_device_chunk_without_an_event() -> (
+    None
+):
+    scheduler = Qwen3TTSStreamingVocoderScheduler(
+        _FakeQwen3TTSTokenizer(),
+        device="cpu",
+    )
+    state = scheduler.create_stream_state("request")
+    state.num_quantizers = 2
+    scheduler.latch_stream_contract(
+        "request", state, {"num_quantizers": 2}, origin="stream metadata"
+    )
+    producer = torch.cuda.Stream()
+    with torch.cuda.stream(producer):
+        codes = torch.ones((1, 2), dtype=torch.long, device="cuda")
+    torch.cuda.current_stream().wait_stream(producer)
+
+    scheduler.ingest("request", state, codes)
+
+    assert isinstance(state.codes_ready, torch.cuda.Event)
+    worker = torch.cuda.Stream()
+    worker.wait_event(state.codes_ready)
+    worker.synchronize()
+    assert state.codes_ready.query()
+    assert state.code_chunks == [codes]
+
+
 def test_qwen3_tts_pageable_fallback_syncs_with_empty_delta(
     monkeypatch: pytest.MonkeyPatch,
 ) -> None:

--- a/tests/unit_test/qwen3_tts/test_pipeline.py
+++ b/tests/unit_test/qwen3_tts/test_pipeline.py
@@ -2757,6 +2757,43 @@ def test_qwen3_tts_ingest_records_readiness_for_a_device_chunk_without_an_event(
     assert state.code_chunks == [codes]
 
 
+@pytest.mark.skipif(not torch.cuda.is_available(), reason="requires CUDA")
+def test_qwen3_tts_worker_plan_reads_a_device_chunk_after_the_producer_wrote_it() -> (
+    None
+):
+    """A worker stream must see the producer's finished write, not the memory it
+    found before that write landed. The producer's write is held back on its own
+    stream, the ingesting stream is ordered after the producer the way the CUDA
+    IPC import orders it, and the plan is built on a separate worker stream."""
+    scheduler = Qwen3TTSStreamingVocoderScheduler(
+        _FakeQwen3TTSTokenizer(),
+        device="cuda",
+        enable_stateful_codec_decoder=False,
+    )
+    state = scheduler.create_stream_state("request")
+    state.num_quantizers = 2
+    scheduler.latch_stream_contract(
+        "request", state, {"num_quantizers": 2}, origin="stream metadata"
+    )
+    codes = torch.full((4, 2), 4095, dtype=torch.long, device="cuda")
+    torch.cuda.synchronize()
+    producer = torch.cuda.Stream()
+    with torch.cuda.stream(producer):
+        torch.cuda._sleep(400_000_000)
+        codes.fill_(7)
+    torch.cuda.current_stream().wait_stream(producer)
+
+    scheduler.ingest("request", state, codes)
+    worker = torch.cuda.Stream()
+    with torch.cuda.stream(worker):
+        plan = scheduler._build_decode_plan(state, is_final=True)
+    worker.synchronize()
+
+    assert plan is not None
+    assert plan.decoder_input.shape == (1, 2, 4)
+    assert plan.decoder_input.eq(7).all().item()
+
+
 def test_qwen3_tts_pageable_fallback_syncs_with_empty_delta(
     monkeypatch: pytest.MonkeyPatch,
 ) -> None:


### PR DESCRIPTION
## Summary

Qwen3-TTS streaming behind the Omni router with the vocoder in its own process intermittently drops a request mid-stream. The client gets HTTP 200 and the first audio chunk, then the chunked body ends without its terminator, and the TTS CI streaming stage fails on "All routed requests should succeed", 1 to 5 requests per 1088 at c16, retries included. Reproduced on upstream main 53239c285 with the worker traceback:

```
RuntimeError: Qwen3-TTS decoder input contains codec ids outside [0, 2048) in rows [0]
```

The failing frame, dumped before the vocoder's clamp, held garbage across ten codebooks, values such as 360777252969 and 8528369376115806908. Nothing the talker can sample looks like that: codebooks 1 to 15 come from a 2048-wide predictor head, codebook 0 is masked to codec ids plus EOS, and the EOS frame is gated out before emission. The vocoder was reading the chunk's memory before the talker had written it.

How that happens in the separate-process layout, which is the CI layout: the code chunk crosses to the vocoder process as a raw CUDA IPC handle. Torch's import makes the importing thread's stream wait on the talker's write, and only that stream, the device's default stream. Since #1997 the decode workers run on their own streams and their `_wait_codes_ready` does nothing when the chunk carries no event, on the assumption that the transport had made the chunk complete. Before #1997 the workers planned on the default stream and fenced the decode stream behind it, which carried the import's wait through. With the workers on their own streams no read is ordered behind the import, so under load a worker reads stale memory, the range screen flags the row, and the stream is failed for that request.

Fix: when `ingest` receives a device chunk that carries no readiness event, it records one on the ingesting thread's stream, which is the same default stream the import already ordered behind the talker's write. The workers' existing wait then orders their reads behind it. In-process chunks already carry the talker's event and are unchanged. CPU chunks need no ordering and are unchanged.

Changes:

- `streaming_vocoder.py` `ingest`: record a readiness event on the current stream of the chunk's device when a device chunk arrives without one, and correct the comment on the cross-process case.
- Two CUDA-gated contract tests. One checks that a device chunk ingested without an event yields a recorded event a separate stream can wait on. The other holds the producer's write back on its own stream, orders the ingesting stream after the producer the way the CUDA IPC import does, builds the real decode plan on a separate worker stream, and asserts the plan holds the written values. On the parent commit the worker reads the memory before the write lands and the assertion fails.

CI history: every Qwen3-TTS streaming run since Aug 28 passed until Sep 8, when the first two failures appeared. Both ran merge commits of their PR heads into 836cdd778, which is #1997, as the streaming job checkout lines show, so all recorded failures contain the change above.

## Testing

Unit, H100 venv: the ingest tests pass, the CUDA ones included.

Streaming validation (H100, Base 1.7B, two workers behind the router, separate vocoder processes, CI caps and fractions, full Seed-TTS EN, 1,088 utterances, c16, warmup 1). The baseline and the two controls carry only a pre-clamp value diagnostic, which adds a host sync per decode, so absolute latencies are not production figures. The fix runs are one boot, three passes.

| Run | Completed | Failed | TTFC mean ms | TTFC p99 ms | ITL p99 ms | req/s |
|---|---:|---:|---:|---:|---:|---:|
| main 53239c285 | 1087/1088 | 1 | 182.1 | 792.6 | 188.1 | 18.858 |
| main, diagnostic pass 1 | 1088/1088 | 0 | 180.3 | 678.9 | 182.1 | 18.871 |
| main, diagnostic pass 2 | 1087/1088 | 1 | 131.9 | 308.3 | 192.2 | 19.606 |
| fix, pass 1 | 1088/1088 | 0 | 188.4 | 784.7 | 188.4 | 18.541 |
| fix, pass 2 | 1088/1088 | 0 | 140.4 | 330.8 | 192.4 | 19.443 |
| fix, pass 3 | 1088/1088 | 0 | 132.8 | 310.8 | 192.7 | 19.713 |

Fix arm: 3,264 of 3,264 requests completed, zero range-screen hits and zero tracebacks in either worker log, router counters routed equal successful on both workers in every pass. Controls: 2 failures in 3,264. Throughput and chunk latencies on the fix arm sit inside the band of the control passes, which is expected since the added wait only orders a read behind a write that has already been issued.
