### PR TITLE
[WIP][S2-Pro] One-step async decode lookahead with device-owned sampling history

### DIFF
--- a/sglang_omni/models/fishaudio_s2_pro/config.py
+++ b/sglang_omni/models/fishaudio_s2_pro/config.py
@@ -39,6 +39,7 @@ class S2ProPipelineConfig(PipelineConfig):
             factory_path=f"{_PKG}.stages.create_sglang_tts_engine_executor",
             factory=FactoryArgs(
                 max_new_tokens=2048,
+                enable_async_decode=False,
             ),
             gpu=0,
             next="vocoder",

--- a/sglang_omni/models/fishaudio_s2_pro/engine_builder.py
+++ b/sglang_omni/models/fishaudio_s2_pro/engine_builder.py
@@ -62,9 +62,11 @@ class FishS2ProEngineBuilder(TtsEngineBuilder):
         *,
         max_new_tokens: int,
         ras_window: int,
+        enable_async_decode: bool = False,
     ) -> None:
         self.max_new_tokens = max_new_tokens
         self.ras_window = ras_window
+        self.enable_async_decode = enable_async_decode
         self.adapter: Any | None = None
         self.tokenizer: Any | None = None
 
@@ -195,4 +197,7 @@ class FishS2ProEngineBuilder(TtsEngineBuilder):
         return request_builder, result_adapter
 
     def extra_scheduler_kwargs(self) -> dict[str, Any]:
-        return {"stream_output_builder": self._stream_output_builder}
+        return {
+            "stream_output_builder": self._stream_output_builder,
+            "enable_async_decode": self.enable_async_decode,
+        }

--- a/sglang_omni/models/fishaudio_s2_pro/model_runner.py
+++ b/sglang_omni/models/fishaudio_s2_pro/model_runner.py
@@ -20,35 +20,45 @@ def collect_s2pro_step_outputs(
     output_semantic_ids: torch.Tensor,
     im_end_token_id: int,
     rep_history_len: int | None = None,
+    skip_rows: tuple[bool, ...] | None = None,
+    clone_codes: bool = True,
 ) -> None:
     batch_size = len(requests)
     if batch_size == 0:
         return
 
     result.next_token_ids = output_semantic_ids[:batch_size].clone()
+    # note (Junnan Li): host bookkeeping only; decode state advances inside the graph.
     semantic_tokens = output_semantic_ids[:batch_size].tolist()
 
     for row_idx, sched_req in enumerate(requests):
         data = sched_req.data
-        if data.req.inflight_middle_chunks > 0:
+        if (skip_rows is not None and skip_rows[row_idx]) or _skip_request(data.req):
             continue
 
         semantic_token = semantic_tokens[row_idx]
         if semantic_token == im_end_token_id:
             continue
 
-        codes = output_codes[row_idx].unsqueeze(-1).clone()
-        data.last_codebook_values = codes[1:, 0].clone()
+        codes = output_codes[row_idx].unsqueeze(-1)
+        if clone_codes:
+            codes = codes.clone()
+        last_codes = codes[1:, 0]
+        data.last_codebook_values = last_codes.clone() if clone_codes else last_codes
         data.previous_semantic_tokens.append(semantic_token)
         if rep_history_len is not None:
             _append_semantic_history(
-                data, output_semantic_ids[row_idx], rep_history_len
+                data,
+                torch.tensor(semantic_token, dtype=torch.long, device="cpu"),
+                rep_history_len,
             )
         data.output_codes.append(codes)
         data.latest_stream_code_chunk = codes
 
 
 def _append_semantic_history(data: Any, token: torch.Tensor, history_len: int) -> None:
+    """Keep the chronological CPU checkpoint used only when rebuilding rows."""
+    token = token.cpu()
     history = data.semantic_history_tokens
     if (
         history is None
@@ -68,6 +78,26 @@ def _append_semantic_history(data: Any, token: torch.Tensor, history_len: int) -
     data.semantic_history_count = count + 1
 
 
+def _skip_request(req: Any) -> bool:
+    finished = getattr(req, "finished", None)
+    return bool(
+        req.inflight_middle_chunks > 0
+        or (finished is not None and finished())
+        or getattr(req, "is_retracted", False)
+    )
+
+
+class _StepSnapshot:
+    """Own device codes and a pinned ID slot with launch-time row identities."""
+
+    def __init__(self, host, codes, requests):
+        self.host = host
+        self.codes = codes
+        self.requests = tuple(requests)
+        self.skip_rows = tuple(_skip_request(r.data.req) for r in requests)
+        self.consumed = False
+
+
 class FishS2ProModelRunner(ModelRunner):
     """Fish TTS runner with unified forward-owned decode and persistent buffers."""
 
@@ -76,12 +106,24 @@ class FishS2ProModelRunner(ModelRunner):
         self._semantic_begin_id = int(self.model._semantic_begin_id)
         self._semantic_end_id = int(self.model._semantic_end_id)
         self._im_end_token_id = int(self.model._im_end_token_id)
+        graph = getattr(tp_worker.model_runner, "decode_cuda_graph_runner", None)
+        self._decode_graph_max_bs = max(
+            getattr(graph, "capture_bs", ()) or (), default=0
+        )
+        self._decode_rows: tuple = ()
 
     def lookahead_eligible(self, batch: Any) -> bool:
-        # note (Junnan Li): not supported yet; semantic_history_tokens is
-        # appended at resolve, one step late under lookahead.
-        del batch
-        return False
+        # note (Junnan Li): safe because everything the sampler reads advances inside the graph.
+        reqs = batch.reqs
+        if not reqs or len(reqs) > self._decode_graph_max_bs:
+            return False
+        for req in reqs:
+            data = getattr(req, "_omni_data", None)
+            if req.inflight_middle_chunks > 0 or getattr(req, "return_logprob", False):
+                return False
+            if getattr(data, "return_logprob", False):
+                return False
+        return True
 
     def before_prefill(self, forward_batch, schedule_batch, requests):
         del schedule_batch
@@ -98,28 +140,75 @@ class FishS2ProModelRunner(ModelRunner):
         *,
         is_lookahead: bool = False,
     ):
-        del is_lookahead
         del schedule_batch
+        self._prepare_decode_rows(requests)
         input_ids = forward_batch.input_ids
         batch_size = input_ids.shape[0]
         is_semantic = (input_ids >= self._semantic_begin_id) & (
             input_ids <= self._semantic_end_id
         )
+        if is_lookahead:
+            # note (Junnan Li): an EOS from the previous launch may not have reached host collect yet.
+            is_semantic = is_semantic & ~self.model._generation_done[:batch_size]
         self.model._vq_mask[:batch_size].copy_(is_semantic)
+        self._set_decode_active(requests)
 
-        for row_idx, sched_req in enumerate(requests):
-            data = sched_req.data
-            self._sync_decode_row_state(row_idx, data)
-
-            last_codes = data.last_codebook_values
-            if last_codes is None:
-                continue
-            self.model._vq_codes[row_idx].copy_(
-                last_codes.to(
-                    device=self.model._vq_codes.device,
-                    dtype=self.model._vq_codes.dtype,
-                )
+    def _set_decode_active(self, requests):
+        statuses = tuple(not _skip_request(r.data.req) for r in requests)
+        if statuses == getattr(self, "_decode_active_key", None):
+            return
+        self._decode_active_key = None
+        active = self.model._decode_active
+        # note (Junnan Li): whole buffer, so graph-padding rows past len(requests) stay inactive.
+        active.zero_()
+        active[: len(requests)].copy_(
+            torch.tensor(
+                statuses,
+                dtype=torch.bool,
+                device=active.device,
             )
+        )
+        # note (Junnan Li): nothing else writes this mask, so an unchanged key needs no H2D.
+        self._decode_active_key = statuses
+
+    def _prepare_decode_rows(self, requests):
+        # note (Junnan Li): key by data object, not rid; a surviving row is a step
+        # ahead of its host checkpoint, so remap its device state instead of reseeding.
+        rows = tuple(r.data for r in requests)
+        previous = getattr(self, "_decode_rows", ())
+        if len(rows) == len(previous) and all(a is b for a, b in zip(rows, previous)):
+            return
+        old_indices = {id(data): i for i, data in enumerate(previous)}
+        retained = [
+            (i, old_indices[id(data)])
+            for i, data in enumerate(rows)
+            if id(data) in old_indices
+        ]
+        if retained:
+            device = self.model._prev_tokens.device
+            dest = torch.tensor([i for i, _ in retained], device=device)
+            src = torch.tensor([i for _, i in retained], device=device)
+            for name in (
+                "_prev_tokens",
+                "_prev_token_count",
+                "_prev_token_cursor",
+                "_step_count",
+                "_generation_done",
+                "_vq_codes",
+                "_sampling_temperature",
+                "_sampling_top_p",
+                "_sampling_top_k",
+                "_sampling_rep_penalty",
+                "_ras_temperature",
+                "_ras_top_p",
+                "_sampling_seeds",
+            ):
+                buffer = getattr(self.model, name)
+                buffer.index_copy_(0, dest, buffer.index_select(0, src))
+        for i, data in enumerate(rows):
+            if id(data) not in old_indices:
+                self._sync_decode_row_state(i, data)
+        self._decode_rows = rows
 
     def post_prefill(self, result, forward_batch, schedule_batch, requests):
         del forward_batch, schedule_batch
@@ -129,9 +218,47 @@ class FishS2ProModelRunner(ModelRunner):
         del forward_batch, schedule_batch
         self._collect_step_outputs(result, requests)
 
+    def post_decode_launch(self, result, forward_batch, requests):
+        n = len(requests)
+        if int(forward_batch.batch_size) < n:
+            raise ValueError("forward_batch.batch_size < len(requests)")
+        # note (Junnan Li): detach from the graph output buffers before the next replay.
+        result.next_token_ids = self.model._output_semantic_ids[:n].clone()
+        codes = self.model._output_codes[:n].detach().clone()
+        host = self._pinned_pingpong(
+            "_host_staging_buffers",
+            "_staging_slot",
+            result.next_token_ids.shape,
+            result.next_token_ids.dtype,
+            realloc_on_grow=True,
+        )
+        host[:n].copy_(result.next_token_ids, non_blocking=True)
+        # note (Junnan Li): the base runner records the completion event after this D2H.
+        return _StepSnapshot(host[:n], codes, requests)
+
+    def post_decode_resolve(
+        self, snapshot, result, forward_batch, schedule_batch, requests
+    ):
+        del forward_batch, schedule_batch, requests
+        if snapshot.consumed:
+            return
+        snapshot.consumed = True
+        collect_s2pro_step_outputs(
+            result,
+            snapshot.requests,
+            output_semantic_ids=snapshot.host,
+            output_codes=snapshot.codes,
+            im_end_token_id=self._im_end_token_id,
+            rep_history_len=self.model._rep_history_len,
+            skip_rows=snapshot.skip_rows,
+            clone_codes=False,
+        )
+
     def _sync_decode_state(self, requests: list) -> None:
         for row_idx, sched_req in enumerate(requests):
             self._sync_decode_row_state(row_idx, sched_req.data)
+        self._decode_rows = tuple(r.data for r in requests)
+        self._set_decode_active(requests)
 
     def _sync_decode_row_state(self, row_idx: int, data: Any) -> None:
         self.model._sampling_temperature[row_idx] = data.temperature
@@ -146,7 +273,15 @@ class FishS2ProModelRunner(ModelRunner):
         # semantic_history_count is the uncapped per-request AR step (pre-step).
         self.model._step_count[row_idx] = int(data.semantic_history_count)
 
+        self.model._generation_done[row_idx] = False
         history_len = self.model._rep_history_len
+        # note (Junnan Li): the host checkpoint is chronological, so a full ring restarts at slot 0.
+        self.model._prev_token_cursor[row_idx] = (
+            min(int(data.semantic_history_count), history_len) % history_len
+        )
+        last_codes = data.last_codebook_values
+        if last_codes is not None:
+            self.model._vq_codes[row_idx].copy_(last_codes.to(self.model._vq_codes))
         history = data.semantic_history_tokens
         if history is not None:
             self.model._prev_tokens[row_idx].copy_(

--- a/sglang_omni/models/fishaudio_s2_pro/model_runner.py
+++ b/sglang_omni/models/fishaudio_s2_pro/model_runner.py
@@ -8,6 +8,7 @@ from typing import Any
 import torch
 
 from sglang_omni.model_runner.base import ModelRunner
+from sglang_omni.models.fishaudio_s2_pro.prefill import build_prefill_input_embeds
 from sglang_omni.models.fishaudio_s2_pro.sglang_model import _NO_SEED
 from sglang_omni.sampling.seed import resolve_row_seed
 
@@ -302,60 +303,7 @@ class FishS2ProModelRunner(ModelRunner):
         forward_batch: Any,
         requests: list,
     ) -> torch.Tensor:
-        input_ids = forward_batch.input_ids
-        if not isinstance(input_ids, torch.Tensor):
-            raise TypeError("Fish prefill expects tensor input_ids")
-
-        device = input_ids.device
-        text_embeds = self.model.get_embed_tokens()(input_ids)
-        offset = 0
-
-        for sched_req in requests:
-            data = sched_req.data
-            req = data.req
-            req_len = int(req.extend_range.length)
-
-            if (
-                data.vq_mask_tokens is None
-                or data.vq_parts is None
-                or len(data.vq_parts) == 0
-            ):
-                offset += req_len
-                continue
-
-            vq_mask = data.vq_mask_tokens.to(device=device)
-            if vq_mask.dim() == 2:
-                vq_mask = vq_mask.squeeze(0)
-
-            prefix_len = len(req.prefix_indices)
-            mask_slice = vq_mask[prefix_len : prefix_len + req_len]
-            if not bool(mask_slice.any()):
-                offset += req_len
-                continue
-
-            parts = [
-                part.to(device=device).T for part in data.vq_parts if part.dim() == 2
-            ]
-            vq_parts_flat = torch.cat(parts, dim=0) if parts else None
-            if vq_parts_flat is None:
-                offset += req_len
-                continue
-
-            vq_before = int(vq_mask[:prefix_len].sum().item()) if prefix_len > 0 else 0
-            num_vq_in_slice = int(mask_slice.sum().item())
-            vq_slice = vq_parts_flat[vq_before : vq_before + num_vq_in_slice]
-
-            req_embeds = text_embeds[offset : offset + req_len]
-            vq_embeds = self.model._audio_decoder.embed_text_dim(
-                req_embeds.unsqueeze(0),
-                vq_slice,
-                mask_slice.unsqueeze(0),
-            )
-            mask_indices = mask_slice.nonzero(as_tuple=True)[0] + offset
-            text_embeds[mask_indices] = vq_embeds.to(text_embeds.dtype)
-            offset += req_len
-
-        return text_embeds
+        return build_prefill_input_embeds(self, forward_batch, requests)
 
     def _collect_step_outputs(self, result: Any, requests: list) -> None:
         collect_s2pro_step_outputs(

--- a/sglang_omni/models/fishaudio_s2_pro/prefill.py
+++ b/sglang_omni/models/fishaudio_s2_pro/prefill.py
@@ -1,0 +1,117 @@
+# SPDX-License-Identifier: Apache-2.0
+"""Rebuild Fish prefill VQ inputs from the final committed token prefix."""
+
+from __future__ import annotations
+
+import torch
+
+
+def prefill_vq_inputs(data, *, device, num_codebooks, semantic_begin, semantic_end):
+    """Return an immutable full-prefix mask and VQ rows in token-position order."""
+    raw_mask = data.vq_mask_tokens
+    committed = getattr(data, "output_codes", [])
+    output_ids = list(getattr(data.req, "output_ids", []))
+    if raw_mask is None and not committed and not output_ids:
+        return None, None
+    if raw_mask is None:
+        mask = torch.zeros(
+            len(data.req.origin_input_ids), dtype=torch.bool, device=device
+        )
+    else:
+        mask = torch.as_tensor(raw_mask, device=device, dtype=torch.bool).reshape(-1)
+
+    parts = data.vq_parts or []
+    if any(part.ndim != 2 or part.shape[0] != num_codebooks for part in parts):
+        raise ValueError("Fish reference VQ must have shape [codebooks, frames]")
+    rows = (
+        torch.cat([part.to(device=device) for part in parts], dim=1).T
+        if parts
+        else torch.empty((0, num_codebooks), dtype=torch.long, device=device)
+    )
+    if rows.shape[0] != int(mask.sum()):
+        raise ValueError("Fish prompt VQ mask and reference frames are misaligned")
+    if not committed and not output_ids:
+        return mask, rows
+
+    if mask.numel() != len(data.req.origin_input_ids):
+        raise ValueError("Fish prompt VQ mask does not cover the original prompt")
+    frames = (
+        torch.cat(committed, dim=1).to(device=device)
+        if committed
+        else torch.empty((num_codebooks + 1, 0), dtype=torch.long, device=device)
+    )
+    if frames.ndim != 2 or frames.shape[0] != num_codebooks + 1:
+        raise ValueError("Fish committed codec frames must include semantic IDs")
+
+    # Prefill runs after drain. Validate against scheduler-accepted token IDs,
+    # not device lookahead buffers or the bounded repetition-history window.
+    frame_tokens = frames[0].tolist()
+    cursor = 0
+    tail_mask, tail_rows = [], []
+    for token in output_ids:
+        needs_vq = semantic_begin <= token <= semantic_end
+        has_frame = cursor < len(frame_tokens) and frame_tokens[cursor] == token
+        if needs_vq and not has_frame:
+            raise ValueError(
+                "Fish committed semantic token has no matching codec frame"
+            )
+        tail_mask.append(needs_vq)
+        if has_frame:
+            if needs_vq:
+                tail_rows.append(frames[1:, cursor])
+            cursor += 1
+    if cursor != len(frame_tokens):
+        raise ValueError(
+            "Fish codec frames extend beyond or disagree with committed tokens"
+        )
+    mask = torch.cat((mask, torch.tensor(tail_mask, dtype=torch.bool, device=device)))
+    if tail_rows:
+        rows = torch.cat((rows, torch.stack(tail_rows)))
+    return mask, rows
+
+
+def build_prefill_input_embeds(runner, forward_batch, requests):
+    input_ids = forward_batch.input_ids
+    if not isinstance(input_ids, torch.Tensor):
+        raise TypeError("Fish prefill expects tensor input_ids")
+    model = runner.model
+    embeds = model.get_embed_tokens()(input_ids)
+    offset = 0
+    for request in requests:
+        data = request.data
+        length = int(data.req.extend_range.length)
+        if (
+            data.vq_mask_tokens is None
+            and not getattr(data, "output_codes", [])
+            and not getattr(data.req, "output_ids", [])
+        ):
+            offset += length
+            continue
+        mask, rows = prefill_vq_inputs(
+            data,
+            device=input_ids.device,
+            num_codebooks=model._vq_codes.shape[1],
+            semantic_begin=runner._semantic_begin_id,
+            semantic_end=runner._semantic_end_id,
+        )
+        if mask is not None:
+            start = len(data.req.prefix_indices)
+            end = start + length
+            if end > mask.numel():
+                raise ValueError("Fish prefill extends beyond the committed VQ input")
+            selected = mask[start:end]
+            if bool(selected.any()):
+                first = int(mask[:start].sum())
+                count = int(selected.sum())
+                injected = model._audio_decoder.embed_text_dim(
+                    embeds[offset : offset + length].unsqueeze(0),
+                    rows[first : first + count],
+                    selected.unsqueeze(0),
+                )
+                embeds[selected.nonzero(as_tuple=True)[0] + offset] = injected.to(
+                    embeds.dtype
+                )
+        offset += length
+    if offset != input_ids.numel():
+        raise ValueError("Fish prefill request lengths do not cover input IDs")
+    return embeds

--- a/sglang_omni/models/fishaudio_s2_pro/sglang_model.py
+++ b/sglang_omni/models/fishaudio_s2_pro/sglang_model.py
@@ -267,7 +267,7 @@ class S2ProSGLangTextModel(nn.Module):
         self._vq_codebook_offsets = audio_decoder.codebook_offsets.to(device)
         self._vq_scale = 1.0 / math.sqrt(num_codebooks + 1)
 
-        # Input buffers: VQ codes from previous step (updated by ModelRunner)
+        # note (Junnan Li): seeded by the runner, advanced inside the decode stream.
         self._vq_codes = torch.zeros(
             max_batch_size, num_codebooks, dtype=torch.long, device=device
         )
@@ -315,6 +315,15 @@ class S2ProSGLangTextModel(nn.Module):
         )
         self._prev_token_count = torch.zeros(
             max_batch_size, dtype=torch.long, device=device
+        )
+        self._prev_token_cursor = torch.zeros(
+            max_batch_size, dtype=torch.long, device=device
+        )
+        self._decode_active = torch.ones(
+            max_batch_size, dtype=torch.bool, device=device
+        )
+        self._generation_done = torch.zeros(
+            max_batch_size, dtype=torch.bool, device=device
         )
         self._rep_history_len = rep_history_len
         self._rep_positions = torch.arange(rep_history_len, device=device)
@@ -400,9 +409,16 @@ class S2ProSGLangTextModel(nn.Module):
         biased_logits = biased_logits.to(torch.bfloat16).to(torch.float32)
 
         count = self._prev_token_count[:bs]
+        cursor = self._prev_token_cursor[:bs]
+        # note (Junnan Li): storage is circular, the window is chronological
+        # (zero-padded until full), so RAS and the penalty see the same inputs.
+        history_indices = (
+            cursor.unsqueeze(1) - count.unsqueeze(1) + self._rep_positions.unsqueeze(0)
+        ) % self._rep_history_len
+        prev = self._prev_tokens[:bs].gather(1, history_indices)
         idx_base = count.unsqueeze(1) - self._ras_range.unsqueeze(0)
         idx_base = idx_base.clamp(min=0)
-        last4 = torch.gather(self._prev_tokens[:bs], 1, idx_base)
+        last4 = torch.gather(prev, 1, idx_base)
         sorted_last4 = torch.sort(last4, dim=-1).values
         has_dup = (sorted_last4[:, 1:] == sorted_last4[:, :-1]).any(dim=-1)
         use_ras = has_dup & (count >= 4)
@@ -414,7 +430,6 @@ class S2ProSGLangTextModel(nn.Module):
             use_ras, self._ras_top_p[:bs], self._sampling_top_p[:bs]
         ).unsqueeze(1)
 
-        prev = self._prev_tokens[:bs]
         scores = torch.gather(biased_logits, dim=-1, index=prev)
         rep_penalty = self._sampling_rep_penalty[:bs].unsqueeze(1)
         penalized = torch.where(scores < 0, scores * rep_penalty, scores / rep_penalty)
@@ -451,6 +466,10 @@ class S2ProSGLangTextModel(nn.Module):
         )
         choice = torch.where((seeds >= 0).unsqueeze(-1), seeded_choice, unseeded_choice)
         semantic_token = top_k_indices.gather(-1, choice).squeeze(-1)
+        active = self._decode_active[:bs] & ~self._generation_done[:bs]
+        semantic_token = torch.where(
+            self._generation_done[:bs], self._im_end_token_id, semantic_token
+        )
 
         # Batched codebook loop
         self._audio_decoder.reset_caches()
@@ -479,6 +498,25 @@ class S2ProSGLangTextModel(nn.Module):
             self._output_codes[:bs, cb_idx + 1] = cb_token
 
         self._output_semantic_ids[:bs] = semantic_token
+
+        # note (Junnan Li): in-place so step N+1 sees step N without a host
+        # resolve; chunked, finished and EOS rows do not advance.
+        advance = active & ~is_eos
+        write_index = cursor.unsqueeze(1)
+        old_token = self._prev_tokens[:bs].gather(1, write_index)
+        write_token = torch.where(
+            advance.unsqueeze(1), semantic_token.unsqueeze(1), old_token
+        )
+        self._prev_tokens[:bs].scatter_(1, write_index, write_token)
+        cursor.copy_((cursor + advance.long()) % self._rep_history_len)
+        count.copy_((count + advance.long()).clamp(max=self._rep_history_len))
+        self._vq_codes[:bs].copy_(
+            torch.where(
+                advance.unsqueeze(1), self._output_codes[:bs, 1:], self._vq_codes[:bs]
+            )
+        )
+        self._step_count[:bs].add_(advance.long())
+        self._generation_done[:bs].logical_or_(active & is_eos)
 
     def get_embed_tokens(self):
         return self.embed_tokens

--- a/sglang_omni/models/fishaudio_s2_pro/stages.py
+++ b/sglang_omni/models/fishaudio_s2_pro/stages.py
@@ -373,6 +373,7 @@ def create_sglang_tts_engine_executor(
     max_new_tokens: int = 2048,
     top_k: int = 30,
     ras_window: int = 16,
+    enable_async_decode: bool = False,
     server_args_overrides: dict[str, Any] | None = None,
 ):
     """Returns OmniScheduler for the Fish TTS AR engine."""
@@ -384,6 +385,7 @@ def create_sglang_tts_engine_executor(
     return FishS2ProEngineBuilder(
         max_new_tokens=max_new_tokens,
         ras_window=ras_window,
+        enable_async_decode=enable_async_decode,
     ).build(
         model_path,
         device=device,

--- a/tests/unit_test/fishaudio_s2_pro/test_reprefill.py
+++ b/tests/unit_test/fishaudio_s2_pro/test_reprefill.py
@@ -1,0 +1,160 @@
+# SPDX-License-Identifier: Apache-2.0
+from __future__ import annotations
+
+import math
+import types
+from types import SimpleNamespace
+
+import pytest
+import torch
+
+from sglang_omni.models.fishaudio_s2_pro.fish_speech.models.text2semantic.audio_decoder import (
+    FishQwen3AudioDecoder,
+)
+from sglang_omni.models.fishaudio_s2_pro.model_runner import FishS2ProModelRunner
+from sglang_omni.models.fishaudio_s2_pro.prefill import prefill_vq_inputs
+
+
+def fixture(reference=True, generated=7):
+    model = SimpleNamespace(_vq_codes=torch.zeros((1, 2), dtype=torch.long))
+    model.get_embed_tokens = lambda: lambda ids: ids.float().unsqueeze(1).repeat(1, 3)
+    decoder = SimpleNamespace(
+        codebook_offsets=torch.tensor([0, 100]),
+        codebook_embeddings=torch.nn.Embedding.from_pretrained(
+            torch.arange(600).float().reshape(200, 3)
+        ),
+        config=SimpleNamespace(num_codebooks=2),
+    )
+    decoder.embed_text_dim = types.MethodType(
+        FishQwen3AudioDecoder.embed_text_dim, decoder
+    )
+    model._audio_decoder = decoder
+    runner = object.__new__(FishS2ProModelRunner)
+    runner.model = model
+    runner._semantic_begin_id, runner._semantic_end_id = 100, 199
+    prompt = [10] * 155
+    mask = torch.zeros(155, dtype=torch.bool) if reference else None
+    if reference:
+        mask[1] = True
+    output = [100 + i for i in range(generated)]
+    frames = [torch.tensor([[token], [i], [i + 1]]) for i, token in enumerate(output)]
+    data = SimpleNamespace(
+        req=SimpleNamespace(
+            origin_input_ids=prompt,
+            output_ids=output,
+            prefix_indices=[],
+            extend_range=SimpleNamespace(length=155 + generated),
+        ),
+        vq_mask_tokens=mask,
+        vq_parts=[torch.tensor([[3], [7]])] if reference else None,
+        output_codes=frames,
+        semantic_history_tokens=torch.tensor(output[-4:]),
+        semantic_history_count=generated,
+    )
+    return runner, data
+
+
+def expected(runner, data):
+    tokens = data.req.origin_input_ids + data.req.output_ids
+    result = runner.model.get_embed_tokens()(torch.tensor(tokens))
+    rows = {}
+    if data.vq_parts:
+        rows[1] = data.vq_parts[0][:, 0]
+    frame_by_token = {int(f[0, 0]): f[1:, 0] for f in data.output_codes}
+    for i, token in enumerate(data.req.output_ids):
+        if 100 <= token <= 199:
+            rows[155 + i] = frame_by_token[token]
+    decoder = runner.model._audio_decoder
+    for index, codes in rows.items():
+        result[index] = (
+            result[index]
+            + decoder.codebook_embeddings(codes + decoder.codebook_offsets).sum(0)
+        ) / math.sqrt(3)
+    return result
+
+
+@pytest.mark.parametrize("reference", [True, False])
+@pytest.mark.parametrize("generated", [7, 40])
+@pytest.mark.parametrize("start", [0, 2, 154, 156])
+def test_rebuild_and_partial_cached_prefix(reference, generated, start):
+    runner, data = fixture(reference, generated)
+    original = None if data.vq_mask_tokens is None else data.vq_mask_tokens.clone()
+    want = expected(runner, data)
+    # Separate extends can end inside the prompt or generated tail.
+    for end in sorted(set([max(start + 1, 155), len(want)])):
+        data.req.prefix_indices = list(range(start))
+        data.req.extend_range.length = end - start
+        batch = SimpleNamespace(
+            input_ids=torch.tensor(
+                (data.req.origin_input_ids + data.req.output_ids)[start:end]
+            )
+        )
+        for _ in range(2):
+            got = runner._build_prefill_input_embeds(
+                batch, [SimpleNamespace(data=data)]
+            )
+            assert torch.equal(got, want[start:end])
+        assert data.semantic_history_count == generated
+        assert len(data.output_codes) == generated
+        assert original is None or torch.equal(data.vq_mask_tokens, original)
+
+
+def test_two_retractions_rederive_instead_of_appending():
+    runner, data = fixture()
+    for generated in (7, 12):
+        while len(data.output_codes) < generated:
+            i = len(data.output_codes)
+            data.req.output_ids.append(100 + i)
+            data.output_codes.append(torch.tensor([[100 + i], [i], [i + 1]]))
+        data.req.extend_range.length = 155 + generated
+        batch = SimpleNamespace(
+            input_ids=torch.tensor(data.req.origin_input_ids + data.req.output_ids)
+        )
+        assert torch.equal(
+            runner._build_prefill_input_embeds(batch, [SimpleNamespace(data=data)]),
+            expected(runner, data),
+        )
+        assert len(data.vq_mask_tokens) == 155
+        assert data.vq_parts[0].shape == (2, 1)
+
+
+def test_control_and_eos_positions_do_not_consume_vq_rows():
+    runner, data = fixture(False, 2)
+    data.req.output_ids = [100, 9, 101, 2]
+    data.req.extend_range.length = 159
+    batch = SimpleNamespace(
+        input_ids=torch.tensor(data.req.origin_input_ids + data.req.output_ids)
+    )
+    assert torch.equal(
+        runner._build_prefill_input_embeds(batch, [SimpleNamespace(data=data)]),
+        expected(runner, data),
+    )
+
+
+@pytest.mark.parametrize("fault", ["missing", "wrong_token", "overrun", "all_missing"])
+def test_reject_uncommitted_or_misaligned_frames(fault):
+    runner, data = fixture(False, 2)
+    if fault == "missing":
+        data.output_codes.pop()
+    elif fault == "wrong_token":
+        data.output_codes[0][0] = 199
+    elif fault == "overrun":
+        data.output_codes.append(torch.tensor([[102], [2], [3]]))
+    else:
+        data.output_codes.clear()
+    with pytest.raises(ValueError, match="committed|codec"):
+        prefill_vq_inputs(
+            data, device="cpu", num_codebooks=2, semantic_begin=100, semantic_end=199
+        )
+
+
+def test_155_plus_7_rebuild_includes_generated_vq_embeddings():
+    runner, data = fixture()
+    batch = SimpleNamespace(
+        input_ids=torch.tensor(data.req.origin_input_ids + data.req.output_ids)
+    )
+    got = runner._build_prefill_input_embeds(batch, [SimpleNamespace(data=data)])
+    assert got.shape == (162, 3)
+    assert torch.equal(got, expected(runner, data))
+    text_only = runner.model.get_embed_tokens()(batch.input_ids)
+    assert not torch.equal(got[155:], text_only[155:])

--- a/tests/unit_test/fishaudio_s2_pro/test_tts.py
+++ b/tests/unit_test/fishaudio_s2_pro/test_tts.py
@@ -187,6 +187,9 @@ def test_fish_s2pro_before_decode_uses_gpu_history_buffer() -> None:
         _ras_top_p=torch.zeros(1),
         _prev_tokens=torch.zeros(1, 4, dtype=torch.long),
         _prev_token_count=torch.zeros(1, dtype=torch.long),
+        _prev_token_cursor=torch.zeros(1, dtype=torch.long),
+        _generation_done=torch.zeros(1, dtype=torch.bool),
+        _decode_active=torch.ones(1, dtype=torch.bool),
         _vq_codes=torch.zeros(1, 2, dtype=torch.long),
     )
     forward_batch = SimpleNamespace(input_ids=torch.tensor([SEMANTIC_TOKEN_ID]))
@@ -257,6 +260,9 @@ def test_fish_s2pro_before_prefill_syncs_decode_state() -> None:
         _ras_top_p=torch.zeros(2),
         _prev_tokens=torch.full((2, 4), 999, dtype=torch.long),
         _prev_token_count=torch.full((2,), 99, dtype=torch.long),
+        _prev_token_cursor=torch.zeros(2, dtype=torch.long),
+        _generation_done=torch.zeros(2, dtype=torch.bool),
+        _decode_active=torch.ones(2, dtype=torch.bool),
     )
     forward_batch = SimpleNamespace(input_ids=torch.tensor([10, 11]))
 
@@ -377,6 +383,9 @@ def test_fish_s2pro_decode_codebooks_keeps_eos_out_of_audio_embedding(
     model = SimpleNamespace(
         _semantic_bias=torch.full((40,), -float("inf")),
         _prev_token_count=torch.zeros(1, dtype=torch.long),
+        _prev_token_cursor=torch.zeros(1, dtype=torch.long),
+        _generation_done=torch.zeros(1, dtype=torch.bool),
+        _decode_active=torch.ones(1, dtype=torch.bool),
         _ras_range=torch.arange(4, 0, -1),
         _prev_tokens=torch.zeros(1, 4, dtype=torch.long),
         _ras_temperature=torch.ones(1),
@@ -396,6 +405,8 @@ def test_fish_s2pro_decode_codebooks_keeps_eos_out_of_audio_embedding(
         _codebook_size=8,
         _num_codebooks=2,
         _output_codes=torch.zeros(1, 3, dtype=torch.long),
+        _vq_codes=torch.zeros(1, 2, dtype=torch.long),
+        _rep_history_len=4,
         _output_semantic_ids=torch.zeros(1, dtype=torch.long),
     )
     model._semantic_bias[10:18] = 0.0
@@ -456,6 +467,11 @@ def test_fish_s2pro_seeded_sampler_preserves_probability_distribution() -> None:
     model = SimpleNamespace(
         _semantic_bias=semantic_bias,
         _prev_token_count=torch.zeros(batch, dtype=torch.long, device=device),
+        _prev_token_cursor=torch.zeros(batch, dtype=torch.long, device=device),
+        _generation_done=torch.zeros(batch, dtype=torch.bool, device=device),
+        _decode_active=torch.ones(batch, dtype=torch.bool, device=device),
+        _vq_codes=torch.zeros(batch, 1, dtype=torch.long, device=device),
+        _rep_history_len=4,
         _ras_range=torch.arange(4, 0, -1, device=device),
         _prev_tokens=torch.zeros(batch, 4, dtype=torch.long, device=device),
         _ras_temperature=torch.ones(batch, device=device),
@@ -720,17 +736,26 @@ def test_fish_tts_stream_output_builder_gates_and_clears_chunks() -> None:
     assert stream_output_builder("non-stream", non_stream_data, None) == []
 
 
-def test_lookahead_is_never_eligible_for_fish():
-    """The in-model sampler reads semantic history, so lookahead must stay off
-    even though the SamplingParams the base gate inspects are history-free."""
+@pytest.mark.parametrize(
+    "chunked,over_graph_cap,logprob,expected",
+    [
+        (False, False, False, True),
+        (True, False, False, False),
+        (False, True, False, False),
+        (False, False, True, False),
+    ],
+)
+def test_lookahead_is_conditionally_eligible_for_fish(
+    chunked, over_graph_cap, logprob, expected
+):
     runner = object.__new__(FishS2ProModelRunner)
-    req = SimpleNamespace(
-        sampling_params=SimpleNamespace(
-            repetition_penalty=1.0,
-            frequency_penalty=0.0,
-            presence_penalty=0.0,
-            min_new_tokens=0,
-        ),
-        custom_logit_processor=None,
+    runner._decode_graph_max_bs = 2
+    req = SimpleNamespace(inflight_middle_chunks=int(chunked), return_logprob=False)
+    if logprob:
+        req._omni_data = SimpleNamespace(return_omni_rollout=True, return_logprob=True)
+    assert (
+        runner.lookahead_eligible(
+            SimpleNamespace(reqs=[req] * (3 if over_graph_cap else 1))
+        )
+        is expected
     )
-    assert runner.lookahead_eligible(SimpleNamespace(reqs=[req])) is False


### PR DESCRIPTION
## Motivation

Fish S2-Pro's in-model sampler reads the semantic-token history that the runner appended only at resolve, so the shared one-step async decode lookahead could not be enabled for it (#2005 keeps it explicitly off). Own the history on the device stream so the lookahead can hide the per-step host collect.

## Modifications

- **`sglang_omni/models/fishaudio_s2_pro/sglang_model.py`: the decode graph owns the sampling feedback.** The 16-token history becomes a device ring with a cursor; the chronological gather keeps the same window, RAS trigger and penalty math; the sampled token, VQ feedback, step count and done flag advance in-place inside the captured step (chunked, finished and EOS rows do not advance).
- **`sglang_omni/models/fishaudio_s2_pro/model_runner.py`: launch/resolve split.** `post_decode_launch` copies the semantic ids into a pinned ping-pong buffer and keeps the codebook codes in a GPU clone; `post_decode_resolve` consumes both once for host bookkeeping and streaming without moving codes to the host, skipping chunked/done/retracted rows; device state follows request identity across row compaction and reordering, and rows new to the batch are reseeded from the host checkpoint (prefill and retraction). `lookahead_eligible()` is true when the batch fits the captured graph, has no chunked rows and captures no logprobs.
- **`sglang_omni/models/fishaudio_s2_pro/{config,engine_builder,stages}.py`**: `enable_async_decode` reaches the Fish factory the same way as Higgs (`--tts_engine.factory.enable_async_decode true`); default off.
- **`tests/unit_test/fishaudio_s2_pro/test_tts.py`**: the lookahead-eligibility assertion becomes conditional (eligible unless chunked rows, a batch above the captured graph size, or logprob capture).

## Related Issues

Follows #2005 (merged) and the Higgs async decode design (#590).

## Accuracy Test

In progress.

## Benchmark & Profiling

In progress.

## Checklist

- [x] Format your code according with pre-commit.
- [ ] Add unit tests.
- [ ] Update documentation / docstrings / example tutorials as needed.
- [ ] Provide throughput / latency benchmark results and accuracy evaluation results as needed.
- [ ] For reviewers: If you haven't made any contributions to this PR and are only assisting with merging the main branch, please remove yourself as a co-author when merging the PR.

## CI

CI runs on self-hosted GPU runners and requires a maintainer to add the
`run-ci` label. Once labeled, every subsequent push re-triggers CI as
long as the label remains. Use `/tag-and-rerun-ci higgs` or
`/tag-and-rerun-ci moss` or `/tag-and-rerun-ci qwen3-tts` to select a TTS CI
model, and
`/tag-and-rerun-ci fun-asr`, `/tag-and-rerun-ci qwen3-asr` or
`/tag-and-rerun-ci whisper-asr` to select an ASR CI model. One selector from
each family can be combined, for example `/tag-and-rerun-ci moss fun-asr`.
Draft PRs are skipped even if labeled.







