### PR TITLE
[dots.tts] Apple Silicon support (native MLX + Torch/MPS)

### DIFF
--- a/docs/cookbook/dots_tts.md
+++ b/docs/cookbook/dots_tts.md
@@ -78,6 +78,45 @@ On a full GPU the default `16 × 500` layout is intended. On tighter cards, lowe
 
 Incremental / bucketed tail-KV allocation is not implemented yet; capacity is still the eager full-length pool.
 
+## Apple Silicon
+
+dots.tts serves on Apple through two eager single-request paths; continuous batching stays CUDA-only. The engine detects an MPS device and pins `max_running_requests=1`, `torch_native` attention, and an eager backbone automatically, so the SOAR checkpoint is the natural fit — it already runs the single-request flow solver. Both paths read the same checkpoint; no separate converted artifact is required.
+
+The `dots.tts` package is excluded on Apple arm64 (it pulls Pynini, which has no macOS wheel), so install it without dependencies and add the pure-Python `wetext` normalizer the pipeline substitutes for it:
+
+```bash
+./install.sh
+source .venv-apple/bin/activate
+uv pip install --no-deps dots.tts==0.2.1 wetext==0.0.4
+export DYLD_LIBRARY_PATH="$(brew --prefix ffmpeg@7)/lib${DYLD_LIBRARY_PATH:+:$DYLD_LIBRARY_PATH}"
+```
+
+Keep `DYLD_LIBRARY_PATH` set in the shell that starts `sgl-omni` so TorchCodec finds the keg-only FFmpeg libraries.
+
+### MLX
+
+Set `SGLANG_USE_MLX=1` to run the Qwen2 backbone, semantic encoder, and flow-matching DiT with native MLX; the AudioVAE codec and BigVGAN vocoder continue on Torch/MPS.
+
+```bash
+SGLANG_USE_MLX=1 sgl-omni serve \
+  --model-path dots-studio/dots.tts-soar \
+  --config examples/configs/dots_tts_soar.yaml \
+  --allowed-local-media-path docs/_static/audio \
+  --port 8000
+```
+
+### Torch/MPS
+
+Without the MLX opt-in the same pipeline runs the backbone through PyTorch MPS in float32 (Metal aborts on the mixed-dtype matmuls a bfloat16 profile would emit). It is a useful correctness baseline and needs no extra setup beyond the prerequisites above.
+
+```bash
+sgl-omni serve \
+  --model-path dots-studio/dots.tts-soar \
+  --config examples/configs/dots_tts_soar.yaml \
+  --allowed-local-media-path docs/_static/audio \
+  --port 8000
+```
+
 ## Synthesizing Speech
 
 dots.tts needs a reference clip and its transcript. The speaker comes entirely from the reference (x-vector plus prompt latents), so there is no zero-shot `voice` preset. Under the default continuous-batching deployment, a request without `references` is rejected.

--- a/sglang_omni/models/dots_tts/compat.py
+++ b/sglang_omni/models/dots_tts/compat.py
@@ -12,6 +12,56 @@ from types import ModuleType
 _IMPORT_LOCK = threading.Lock()
 
 
+def _install_tn_shim() -> None:
+    """Back tn.chinese / tn.english with wetext when Pynini is absent.
+
+    dots_tts.utils.text imports WeTextProcessing's Normalizers at module
+    scope, and WeTextProcessing depends on Pynini, which ships no macOS
+    wheels — without a substitute the whole dots_tts package fails to import
+    on Apple Silicon. wetext is the pure-Python runtime for the same FSTs,
+    so when the real tn is missing and wetext is installed, register
+    drop-in normalizer modules under the names dots.tts imports.
+    """
+    try:
+        importlib.import_module("tn.chinese.normalizer")
+        return
+    except ImportError:
+        pass
+    try:
+        from wetext import Normalizer as _WetextNormalizer
+    except ImportError:
+        return
+
+    def _make_normalizer_module(package_lang: str, wetext_lang: str) -> ModuleType:
+        module = ModuleType(f"tn.{package_lang}.normalizer")
+
+        class Normalizer:
+            def __init__(self) -> None:
+                self._impl = _WetextNormalizer(lang=wetext_lang, operator="tn")
+
+            def normalize(self, text: str) -> str:
+                return self._impl.normalize(text)
+
+        module.Normalizer = Normalizer
+        return module
+
+    tn = ModuleType("tn")
+    for package_lang, wetext_lang in (("chinese", "zh"), ("english", "en")):
+        package = ModuleType(f"tn.{package_lang}")
+        normalizer = _make_normalizer_module(package_lang, wetext_lang)
+        package.normalizer = normalizer
+        tn.__dict__[package_lang] = package
+        sys.modules[f"tn.{package_lang}"] = package
+        sys.modules[f"tn.{package_lang}.normalizer"] = normalizer
+    sys.modules["tn"] = tn
+
+
+# note (guozhihao-224): installed at module scope because dots_tts submodules
+# can be imported without going through import_dots_tts; a no-op where the
+# real tn exists.
+_install_tn_shim()
+
+
 def import_dots_tts() -> ModuleType:
     """Import the dots_tts package past its torch/torchaudio version check.
 
@@ -46,3 +96,15 @@ def import_dots_tts() -> ModuleType:
             return importlib.import_module("dots_tts")
         finally:
             importlib.metadata.version = reader
+
+
+def import_dots_solver_deps() -> ModuleType:
+    """Import the DiT solver chain on the host default device.
+
+    torchdiffeq materializes its float64 tableau tensors at import time
+    (torchdiffeq/_impl/dopri5.py). SGLang constructs models inside
+    ``torch.device("mps")``, where float64 does not exist, so the chain must
+    be imported before that context opens. Subsequent imports are no-ops.
+    """
+    import_dots_tts()
+    return importlib.import_module("dots_tts.models.dots_tts.core")

--- a/sglang_omni/models/dots_tts/engine_builder.py
+++ b/sglang_omni/models/dots_tts/engine_builder.py
@@ -10,6 +10,8 @@ from sglang_omni.scheduling.engine_factory import TtsEngineBuilder
 
 logger = logging.getLogger(__name__)
 
+_MPS_MEM_FRACTION_FLOOR = 0.78
+
 
 class DotsTTSEngineBuilder(TtsEngineBuilder):
     model_name = "dots.tts"
@@ -34,12 +36,36 @@ class DotsTTSEngineBuilder(TtsEngineBuilder):
             raise ValueError("dots.tts batching limits must be positive")
         self._model_runner: Any | None = None
         self._acoustic_tail: Any | None = None
+        # Filled by SGLangGenerationEngineBuilder.build before the infra is created.
+        self.checkpoint_dir: str | None = None
+        self.device: str | None = None
+
+    def _uses_torch_mps(self) -> bool:
+        # note (guozhihao-224): the Torch/MPS profile is the non-MLX Apple path.
+        return self._on_apple() and not self._use_mlx()
+
+    def _on_apple(self) -> bool:
+        import torch
+
+        return self.device is not None and torch.device(self.device).type == "mps"
+
+    @staticmethod
+    def _use_mlx() -> bool:
+        from sglang.srt.utils.tensor_bridge import use_mlx
+
+        return bool(use_mlx())
 
     def pre_infra_setup(self, checkpoint_dir: str) -> None:
-        del checkpoint_dir
+        from sglang_omni.models.dots_tts.compat import import_dots_solver_deps
         from sglang_omni.models.dots_tts.hf_config import register_dots_tts_hf_config
 
         register_dots_tts_hf_config()
+        if self._on_apple():
+            # note (guozhihao-224): the DiT compile hook and acoustic-tail
+            # graphs are CUDA-only; Apple serves the eager single-request path.
+            self.optimize = False
+            import_dots_solver_deps()
+        del checkpoint_dir
 
     def customize_server_args(self, server_args: Any) -> None:
         # The compiled DiT path only serves max_running_requests=1; the batched
@@ -52,6 +78,31 @@ class DotsTTSEngineBuilder(TtsEngineBuilder):
             _configure_optimized_kernels()
 
     def generation_defaults(self, *, dtype: str) -> dict[str, Any]:
+        if self._on_apple():
+            if self._use_mlx():
+                # note (guozhihao-224): only idle torch weights sit on Metal
+                # under MLX; bf16 halves them.
+                dtype = "bfloat16"
+            else:
+                # note (guozhihao-224): Metal aborts on mixed-dtype matmuls;
+                # the Torch/MPS profile runs one eager fp32 request.
+                dtype = "float32"
+            return {
+                "disable_cuda_graph": True,
+                "disable_overlap_schedule": True,
+                "disable_radix_cache": True,
+                "enable_torch_compile": False,
+                "max_running_requests": 1,
+                "chunked_prefill_size": 0,
+                # note (guozhihao-224): unified memory must also hold the
+                # weights; start at the viability floor, not the canonical
+                # dedicated-card 0.20.
+                "mem_fraction_static": _MPS_MEM_FRACTION_FLOOR,
+                "attention_backend": "torch_native",
+                "sampling_backend": "pytorch",
+                "dtype": dtype,
+                "trust_remote_code": False,
+            }
         return {
             "disable_cuda_graph": True,
             "disable_overlap_schedule": True,
@@ -70,6 +121,22 @@ class DotsTTSEngineBuilder(TtsEngineBuilder):
         requested = int(
             overrides.get("max_running_requests", self.max_running_requests)
         )
+        if self._on_apple():
+            if requested != 1:
+                raise ValueError(
+                    "dots.tts Apple profiles currently require max_running_requests=1"
+                )
+            # note (guozhihao-224): the canonical 0.20 assumes a dedicated
+            # card; unified memory must also hold the weights.
+            requested_fraction = float(overrides.get("mem_fraction_static", 0.20))
+            if requested_fraction < _MPS_MEM_FRACTION_FLOOR:
+                logger.info(
+                    "dots.tts Apple: raising mem_fraction_static from "
+                    "%.2f to %.2f (unified memory must fit weights + KV)",
+                    requested_fraction,
+                    _MPS_MEM_FRACTION_FLOOR,
+                )
+                overrides["mem_fraction_static"] = _MPS_MEM_FRACTION_FLOOR
         if requested <= 0:
             raise ValueError("dots.tts max_running_requests must be positive")
         self.max_running_requests = requested
@@ -80,10 +147,19 @@ class DotsTTSEngineBuilder(TtsEngineBuilder):
                 "dots.tts uses its DiT compile path; SGLang backbone compile is disabled"
             )
         if not bool(overrides.get("disable_cuda_graph", True)):
-            # note (luojiaxuan): the decode graph must be captured with hidden states (FULL);
-            # its can_run gate requires an exact hidden-mode match with the
-            # acoustic tail's per-step request.
-            overrides["enable_return_hidden_states"] = True
+            if self._on_apple():
+                # note (guozhihao-224): no CUDA graph lifecycle on Metal;
+                # degrade loudly so the canonical serving configs still boot.
+                logger.info(
+                    "dots.tts Apple: forcing disable_cuda_graph=True "
+                    "(no CUDA graph lifecycle on Metal)"
+                )
+                overrides["disable_cuda_graph"] = True
+            else:
+                # note (luojiaxuan): the decode graph must be captured with hidden states (FULL);
+                # its can_run gate requires an exact hidden-mode match with the
+                # acoustic tail's per-step request.
+                overrides["enable_return_hidden_states"] = True
 
     def setup_model(
         self,
@@ -94,8 +170,17 @@ class DotsTTSEngineBuilder(TtsEngineBuilder):
         gpu_id: int,
         server_args: Any,
     ) -> None:
-        del checkpoint_dir, device, gpu_id
         model = model_worker.model_runner.model
+        if self._uses_torch_mps():
+            # note (guozhihao-224): SGLang casts input embeddings to bf16,
+            # which the fp32 MPS profile cannot satisfy; own the backbone
+            # forward with the pinned HF Qwen2.
+            from sglang_omni.models.dots_tts.torch_mps_runner import (
+                install_torch_mps_backbone,
+            )
+
+            install_torch_mps_backbone(model, checkpoint_dir)
+        del device, gpu_id
         max_running_requests = int(server_args.max_running_requests)
         if not bool(server_args.disable_cuda_graph):
             from sglang_omni.scheduling.generation_batch_policy import (
@@ -149,6 +234,25 @@ class DotsTTSEngineBuilder(TtsEngineBuilder):
         )
 
     def make_model_runner(self, model_worker: Any, output_proc: Any) -> Any:
+        if self._use_mlx():
+            from sglang_omni.models.dots_tts.mlx.runner import DotsTTSMlxModelRunner
+
+            if self.checkpoint_dir is None:
+                raise RuntimeError(
+                    "dots.tts MLX runner requires checkpoint_dir, which "
+                    "SGLangGenerationEngineBuilder.build sets before infra creation"
+                )
+            self._model_runner = DotsTTSMlxModelRunner(
+                model_worker, output_proc, checkpoint_dir=self.checkpoint_dir
+            )
+            return self._model_runner
+        if self._uses_torch_mps():
+            from sglang_omni.models.dots_tts.torch_mps_runner import (
+                DotsTTSTorchMpsModelRunner,
+            )
+
+            self._model_runner = DotsTTSTorchMpsModelRunner(model_worker, output_proc)
+            return self._model_runner
         from sglang_omni.models.dots_tts.model_runner import DotsTTSModelRunner
 
         self._model_runner = DotsTTSModelRunner(model_worker, output_proc)

--- a/sglang_omni/models/dots_tts/flow_head.py
+++ b/sglang_omni/models/dots_tts/flow_head.py
@@ -765,6 +765,17 @@ class DotsTTSFlowHead(nn.Module):
             yield
             return
         device = state.fm_sequence.device
+        if device.type == "mps":
+            # note (guozhihao-224): fork_rng has no MPS device list; MPS owns
+            # one global generator, so save/restore it around the sampling.
+            previous = torch.mps.get_rng_state()
+            torch.mps.set_rng_state(state.rng_state)
+            try:
+                yield
+            finally:
+                state.rng_state = torch.mps.get_rng_state()
+                torch.mps.set_rng_state(previous)
+            return
         cuda_device = None
         if device.type == "cuda":
             cuda_device = (

--- a/sglang_omni/models/dots_tts/mlx/__init__.py
+++ b/sglang_omni/models/dots_tts/mlx/__init__.py
@@ -1,0 +1,3 @@
+# SPDX-License-Identifier: Apache-2.0
+
+"""Native MLX latent engine for dots.tts on Apple Silicon."""

--- a/sglang_omni/models/dots_tts/mlx/checkpoint.py
+++ b/sglang_omni/models/dots_tts/mlx/checkpoint.py
@@ -1,0 +1,36 @@
+# SPDX-License-Identifier: Apache-2.0
+"""dots.tts MLX model loading via the standard mlx_lm pipeline.
+
+dots splits its config across config.json (flow head) and llm_config.json
+(backbone), so the two files are merged before mlx_lm.utils.load_model —
+which then discovers model*.safetensors, calls the model's sanitize,
+and loads weights, exactly like the other MLX engines in this repo.
+"""
+
+from __future__ import annotations
+
+import json
+from pathlib import Path
+
+from sglang_omni.models.dots_tts.mlx.config import DotsMlxArgs
+from sglang_omni.models.dots_tts.mlx.model import DotsTTSMlxModel
+
+
+def load_dots_mlx_model(checkpoint_dir: str) -> DotsTTSMlxModel:
+    """Load the dots.tts MLX latent engine from a local checkpoint directory."""
+    from mlx_lm.utils import load_model
+
+    root = Path(checkpoint_dir)
+    config = json.loads((root / "config.json").read_text())
+    config.update(json.loads((root / "llm_config.json").read_text()))
+    config["latent_stats_path"] = str(root / "latent_stats.pt")
+    model, _ = load_model(
+        root,
+        get_model_classes=lambda config: (DotsTTSMlxModel, DotsMlxArgs),
+        model_config=config,
+        strict=True,
+    )
+    return model
+
+
+__all__ = ["load_dots_mlx_model"]

--- a/sglang_omni/models/dots_tts/mlx/config.py
+++ b/sglang_omni/models/dots_tts/mlx/config.py
@@ -1,0 +1,151 @@
+# SPDX-License-Identifier: Apache-2.0
+"""dots.tts MLX latent engine configuration.
+
+Parses the dots checkpoint's top-level config.json and llm_config.json
+into the fields the MLX latent engine needs. The torch path keeps the vendor
+ModelConfig object around; the MLX engine re-homes this process and should
+not import dots_tts (which pulls torch imports), so the configs are
+lightweight dataclasses built from the raw JSON.
+"""
+
+from __future__ import annotations
+
+from dataclasses import dataclass
+from typing import Any
+
+
+def _required(mapping: dict[str, Any], key: str) -> Any:
+    if key not in mapping:
+        raise ValueError(f"dots.tts config is missing {key!r}")
+    return mapping[key]
+
+
+@dataclass(frozen=True)
+class TransformerConfig:
+    """A shared attention/FFN config for the semantic encoder or the DiT."""
+
+    hidden_size: int
+    num_layers: int
+    num_heads: int
+    ffn_hidden_size: int
+    qkv_bias: bool = False
+    qk_norm: bool = True
+    rotary_bias: bool = True
+    rotary_theta: float = 10000.0
+    modulation: bool = False
+    norm_layer: str = "RMSNorm"
+
+    def head_dim(self) -> int:
+        return self.hidden_size // self.num_heads
+
+
+@dataclass(frozen=True)
+class BackboneConfig:
+    """Qwen2 backbone decoder fields from llm_config.json."""
+
+    hidden_size: int
+    num_layers: int
+    num_attention_heads: int
+    num_key_value_heads: int
+    head_dim: int
+    vocab_size: int
+    intermediate_size: int
+    rope_theta: float
+    rms_norm_eps: float
+
+    @classmethod
+    def from_json(cls, raw: dict[str, Any]) -> "BackboneConfig":
+        if raw.get("model_type") != "qwen2":
+            raise ValueError(
+                f"dots.tts llm_config must be a qwen2 config, got {raw.get('model_type')!r}"
+            )
+        hidden_size = int(_required(raw, "hidden_size"))
+        num_heads = int(_required(raw, "num_attention_heads"))
+        head_dim = int(raw.get("head_dim") or hidden_size // num_heads)
+        return cls(
+            hidden_size=hidden_size,
+            num_layers=int(_required(raw, "num_hidden_layers")),
+            num_attention_heads=num_heads,
+            num_key_value_heads=int(_required(raw, "num_key_value_heads")),
+            head_dim=head_dim,
+            vocab_size=int(_required(raw, "vocab_size")),
+            intermediate_size=int(_required(raw, "intermediate_size")),
+            rope_theta=float(_required(raw, "rope_theta")),
+            rms_norm_eps=float(_required(raw, "rms_norm_eps")),
+        )
+
+
+@dataclass(frozen=True)
+class FlowHeadConfig:
+    """Continuous-latent flow head fields from config.json."""
+
+    latent_dim: int
+    patch_size: int
+    campplus_embedding_size: int
+    xvec_max_audio_seconds: float
+    patch_encoder: TransformerConfig
+    dit: TransformerConfig
+    flow_matching: bool
+    fm_sigma: float
+
+    @classmethod
+    def from_config(cls, raw: dict[str, Any]) -> "FlowHeadConfig":
+        patch_encoder = _transformer(_required(raw, "PatchEncoder"))
+        dit = _transformer(_required(raw, "DiT"))
+        meanflow = raw.get("meanflow")
+        flow_matching = meanflow is None or not bool(meanflow.get("enabled", False))
+        return cls(
+            latent_dim=int(_required(raw, "latent_dim")),
+            patch_size=int(_required(raw, "patch_size")),
+            campplus_embedding_size=int(_required(raw, "campplus_embedding_size")),
+            xvec_max_audio_seconds=float(_required(raw, "xvec_max_audio_seconds")),
+            patch_encoder=patch_encoder,
+            dit=dit,
+            flow_matching=flow_matching,
+            fm_sigma=float(raw.get("fm_sigma", 0.0)),
+        )
+
+
+def _transformer(mapping: dict[str, Any]) -> TransformerConfig:
+    return TransformerConfig(
+        hidden_size=int(_required(mapping, "hidden_size")),
+        num_layers=int(_required(mapping, "num_layers")),
+        num_heads=int(_required(mapping, "num_heads")),
+        ffn_hidden_size=int(_required(mapping, "ffn_hidden_size")),
+        qkv_bias=bool(mapping.get("qkv_bias", False)),
+        qk_norm=bool(mapping.get("qk_norm", False)),
+        rotary_bias=bool(mapping.get("rotary_bias", False)),
+        rotary_theta=float(mapping.get("rotary_theta", 10000.0)),
+        modulation=bool(mapping.get("modulation", False)),
+        norm_layer=str(mapping.get("norm_layer", "RMSNorm")),
+    )
+
+
+@dataclass(frozen=True)
+class DotsMlxArgs:
+    """Single config object the MLX engine constructs from.
+
+    from_dict consumes the merged checkpoint config (dots config.json
+    fields for the flow head + llm_config.json fields for the backbone),
+    which is what mlx_lm.utils.load_model hands to ModelArgs.from_dict.
+    """
+
+    backbone: BackboneConfig
+    flow: FlowHeadConfig
+    latent_stats_path: str
+
+    @classmethod
+    def from_dict(cls, raw: dict[str, Any]) -> "DotsMlxArgs":
+        return cls(
+            backbone=BackboneConfig.from_json(raw),
+            flow=FlowHeadConfig.from_config(raw),
+            latent_stats_path=str(_required(raw, "latent_stats_path")),
+        )
+
+
+__all__ = [
+    "BackboneConfig",
+    "DotsMlxArgs",
+    "FlowHeadConfig",
+    "TransformerConfig",
+]

--- a/sglang_omni/models/dots_tts/mlx/dit.py
+++ b/sglang_omni/models/dots_tts/mlx/dit.py
@@ -1,0 +1,163 @@
+# SPDX-License-Identifier: Apache-2.0
+"""MLX port of the dots.tts flow-matching DiT.
+
+Mirrors dots_tts.modules.backbone.dit: a modulated transformer whose
+per-layer adaLN shift/scale/gate is produced from the timestep (+ speaker
+condition g_cond), ending in a final normalized projection back to the
+latent space. Used as the velocity field of the flow ODE.
+"""
+
+from __future__ import annotations
+
+import math
+from typing import Optional
+
+import mlx.core as mx
+import mlx.nn as nn
+
+from sglang_omni.models.dots_tts.mlx.config import TransformerConfig
+from sglang_omni.models.dots_tts.mlx.layers import Mlp, MultiHeadAttention
+
+
+class _GroupNormFree(nn.Module):
+    """Layer normalization without affine parameters (elementwise_affine=False)."""
+
+    def __init__(self, dims: int, *, eps: float = 1e-5) -> None:
+        super().__init__()
+        self.dims = dims
+        self.eps = eps
+
+    def __call__(self, x: mx.array) -> mx.array:
+        mean = mx.mean(x, axis=-1, keepdims=True)
+        var = mx.mean(x * x, axis=-1, keepdims=True) - mean * mean
+        return (x - mean) * mx.rsqrt(var + self.eps)
+
+
+def _timestep_embedding(t: mx.array, dim: int, max_period: float = 10000.0) -> mx.array:
+    half = dim // 2
+    freqs = mx.exp(-math.log(max_period) * mx.arange(0, half, dtype=mx.float32) / half)
+    args = t.astype(mx.float32)[:, None] * freqs[None, :]
+    return mx.concatenate([mx.cos(args), mx.sin(args)], axis=-1)
+
+
+class TimestepEmbedder(nn.Module):
+    """Timestep -> hidden-size condition via a small SiLU MLP."""
+
+    def __init__(self, hidden_size: int, frequency_embedding_size: int = 256) -> None:
+        super().__init__()
+        # note (guozhihao-224): a plain list keeps checkpoint parameter names
+        # (nn.Sequential would nest a layers. prefix).
+        self.mlp = [
+            nn.Linear(frequency_embedding_size, hidden_size, bias=True),
+            nn.SiLU(),
+            nn.Linear(hidden_size, hidden_size, bias=True),
+        ]
+        self.frequency_embedding_size = frequency_embedding_size
+
+    def __call__(self, t: mx.array) -> mx.array:
+        x = _timestep_embedding(t, self.frequency_embedding_size)
+        for layer in self.mlp:
+            x = layer(x)
+        return x
+
+
+class FinalLayer(nn.Module):
+    """Modulated normalization then a linear back to the output dim."""
+
+    def __init__(self, hidden_size: int, output_size: int) -> None:
+        super().__init__()
+        self.adaLN_modulation = [
+            nn.SiLU(),
+            nn.Linear(hidden_size, 2 * hidden_size, bias=True),
+        ]
+        self.norm = _GroupNormFree(hidden_size, eps=1e-5)
+        self.linear = nn.Linear(hidden_size, output_size, bias=True)
+
+    def __call__(self, x: mx.array, c: mx.array) -> mx.array:
+        cond = c
+        for layer in self.adaLN_modulation:
+            cond = layer(cond)
+        shift, scale = mx.split(cond, 2, axis=-1)
+        x = x * (1.0 + scale[:, None, :]) + shift[:, None, :]
+        return self.linear(self.norm(x))
+
+
+class DiTBlock(nn.Module):
+    """Modulated transformer block (attention + GELU MLP)."""
+
+    def __init__(self, config: TransformerConfig) -> None:
+        super().__init__()
+        self.norm1 = _GroupNormFree(config.hidden_size, eps=1e-5)
+        self.norm2 = _GroupNormFree(config.hidden_size, eps=1e-5)
+        self.attn = MultiHeadAttention(config)
+        self.ffn = Mlp(config, activation="gelu_tanh")
+        self.adaLN_modulation = [
+            nn.SiLU(),
+            nn.Linear(config.hidden_size, 6 * config.hidden_size, bias=True),
+        ]
+
+    def __call__(
+        self,
+        x: mx.array,
+        c: mx.array,
+        *,
+        mask: Optional[mx.array] = None,
+    ) -> mx.array:
+        cond = c
+        for layer in self.adaLN_modulation:
+            cond = layer(cond)
+        (
+            shift_attn,
+            scale_attn,
+            gate_attn,
+            shift_ffn,
+            scale_ffn,
+            gate_ffn,
+        ) = mx.split(cond, 6, axis=-1)
+        gate_attn = gate_attn[:, None, :]
+        gate_ffn = gate_ffn[:, None, :]
+
+        h = self.norm1(x)
+        h = h * (1.0 + scale_attn[:, None, :]) + shift_attn[:, None, :]
+        x = x + gate_attn * self.attn(h, mask=mask)
+
+        h = self.norm2(x)
+        h = h * (1.0 + scale_ffn[:, None, :]) + shift_ffn[:, None, :]
+        return x + gate_ffn * self.ffn(h)
+
+
+class DiT(nn.Module):
+    """Flow-matching velocity field over latent patches."""
+
+    def __init__(
+        self,
+        in_dim: int,
+        out_dim: int,
+        config: TransformerConfig,
+    ) -> None:
+        super().__init__()
+        if not config.modulation:
+            raise ValueError("dots.tts DiT requires modulation=True")
+        self.input_layer = nn.Linear(in_dim, config.hidden_size, bias=True)
+        self.time_embedder = TimestepEmbedder(config.hidden_size)
+        self.blocks = [DiTBlock(config) for _ in range(config.num_layers)]
+        self.output_layer = FinalLayer(config.hidden_size, out_dim)
+
+    def __call__(
+        self,
+        x: mx.array,
+        timesteps: mx.array,
+        *,
+        g_cond: Optional[mx.array] = None,
+        mask: Optional[mx.array] = None,
+    ) -> mx.array:
+        c = self.time_embedder(timesteps)
+        if g_cond is not None:
+            c = c + g_cond
+        x = self.input_layer(x)
+        for block in self.blocks:
+            x = block(x, c, mask=mask)
+        return self.output_layer(x, c)
+
+
+__all__ = ["DiT", "TimestepEmbedder"]

--- a/sglang_omni/models/dots_tts/mlx/flow.py
+++ b/sglang_omni/models/dots_tts/mlx/flow.py
@@ -1,0 +1,340 @@
+# SPDX-License-Identifier: Apache-2.0
+"""dots.tts MLX flow-matching decode engine.
+
+The flow history is append-only: each step appends the projected hidden row and
+the projected latent patch to two row lists (conditioned / null-conditioned).
+MLX arrays are immutable, so the DiT input is rebuilt from the history each
+step with lazy concatenation — which the full-compute velocity function needs
+anyway.
+
+decode_step mirrors flow_head.decode_next + the dit_inference
+full-compute flow-matching path: one semantic-encoder feedback embedding feeds
+the backbone, its hidden row is appended to the flow history, the DiT ODE with
+classifier-free guidance is integrated t=0..1, and the denormalized latent
+patch, the next feedback row, the EOS flag and the emit flag come back.
+"""
+
+from __future__ import annotations
+
+from typing import Optional
+
+import mlx.core as mx
+
+from sglang_omni.models.dots_tts.mlx.model import DotsTTSFlowState, DotsTTSMlxModel
+
+_MASK_VALUE = -1.0e9
+
+
+def start_request(
+    model: DotsTTSMlxModel,
+    *,
+    prompt_latents: Optional[mx.array],
+    speaker_embedding: Optional[mx.array],
+    speaker_scale: float,
+    seed: Optional[int],
+) -> tuple[DotsTTSFlowState, Optional[mx.array]]:
+    """Initialize request flow state, return semantic prompt LLM embeddings.
+
+    Prompt latents are encoded by the semantic encoder (one LLM-size row per
+    patch) and kept raw in the patch history for the feedback recompute; the
+    normalized patch rows are kept as the FM-history prompt patches. The first
+    decode is the regenerated prompt patch, so its emission and EOS check are
+    suppressed.
+    """
+    state = DotsTTSFlowState()
+    state.backbone_cache = model.backbone.make_cache()
+    if seed is not None:
+        state.rng_key = mx.random.key(seed)
+    if speaker_embedding is not None:
+        state.g_cond = model.speaker_condition(speaker_embedding, speaker_scale)
+
+    if prompt_latents is None or prompt_latents.shape[-2] == 0:
+        return state, None
+
+    embeddings = _semantic_encode(model, prompt_latents)
+    prompt_count = int(prompt_latents.shape[-2] // model.latent_patch_size)
+    if int(embeddings.shape[1]) != prompt_count:
+        raise RuntimeError(
+            "dots.tts MLX prompt embeddings do not match the prompt patch count: "
+            f"{int(embeddings.shape[1])} != {prompt_count}"
+        )
+    state.patch_history.append(prompt_latents)
+    state.prompt_patches = model.normalize(prompt_latents).reshape(
+        1, prompt_count, model.latent_patch_size, model.latent_dim
+    )
+    state.drop_regenerated_prompt_patch = True
+    state.suppress_first_eos_check = True
+    return state, embeddings
+
+
+def build_prefill_embeds(
+    model: DotsTTSMlxModel,
+    schedule_ids: mx.array,
+    *,
+    prompt_span_positions: mx.array,
+    prompt_embeddings: mx.array,
+) -> mx.array:
+    """Token embeddings with semantic rows spliced in at the prompt spans."""
+    token_embeds = model.backbone.embed_tokens(schedule_ids)  # [T, H]
+    rows = []
+    cursor = 0
+    for index in range(int(prompt_span_positions.shape[0])):
+        position = int(prompt_span_positions[index].item())
+        rows.append(token_embeds[cursor:position])
+        rows.append(prompt_embeddings[0, index : index + 1])
+        cursor = position + 1
+    rows.append(token_embeds[cursor:])
+    return mx.concatenate(rows, axis=0)[None, :, :]
+
+
+def _semantic_encode(model: DotsTTSMlxModel, raw_latents: mx.array) -> mx.array:
+    """Causal full-compute semantic encoding of a raw latent block."""
+    tokens = model.patch_encoder.downsample(raw_latents)
+    token_count = int(tokens.shape[1])
+    return model.patch_encoder.in_proj_and_trunk(tokens, mask=_tril_mask(token_count))
+
+
+def initialize_history(
+    model: DotsTTSMlxModel,
+    state: DotsTTSFlowState,
+    *,
+    hidden_states: mx.array,
+    prompt_span_positions: mx.array,
+    generation_schedule: mx.array,
+    audio_span_token_ids: set[int],
+    prefill_end: int,
+    decoded_latent_patches: list[mx.array],
+) -> None:
+    """Append prefill hidden rows and prompt patch rows into the flow history."""
+    prompt_patches = state.prompt_patches
+    positions = (
+        prompt_span_positions[:0] if prompt_patches is None else prompt_span_positions
+    )
+    if (
+        prompt_patches is not None
+        and int(positions.shape[0]) != prompt_patches.shape[1]
+    ):
+        raise RuntimeError("dots.tts MLX prompt spans do not match prompt latents")
+    schedule = generation_schedule
+    cursor = 0
+
+    for prompt_index in range(int(positions.shape[0])):
+        span_position = int(positions[prompt_index].item())
+        if span_position > cursor:
+            _append_hidden(
+                model, state, hidden_states[:, span_position - 1 : span_position]
+            )
+        _append_patch(model, state, prompt_patches[:, prompt_index])
+        next_position = span_position + 1
+        if (next_position < int(schedule.shape[0])) and (
+            int(schedule[next_position].item()) in audio_span_token_ids
+        ):
+            _append_hidden(
+                model, state, hidden_states[:, span_position : span_position + 1]
+            )
+        cursor = next_position
+    if prefill_end > cursor:
+        _append_hidden(model, state, hidden_states[:, prefill_end - 1 : prefill_end])
+
+    for patch in decoded_latent_patches:
+        _append_patch(model, state, model.normalize(patch))
+        _append_hidden(
+            model,
+            state,
+            hidden_states[:, prefill_end : prefill_end + 1],
+        )
+    if decoded_latent_patches:
+        state.drop_regenerated_prompt_patch = False
+        state.suppress_first_eos_check = False
+
+
+def _append_hidden(
+    model: DotsTTSMlxModel, state: DotsTTSFlowState, hidden: mx.array
+) -> None:
+    projected = model.hidden_proj(hidden)
+    # note (guozhihao-224): the null-conditioned branch is hidden_proj(0),
+    # the bias row broadcast over the sequence.
+    null_projected = mx.broadcast_to(
+        model.hidden_proj.bias[None, None, :], projected.shape
+    )
+    state.fm_history.append(projected)
+    state.fm_cfg_history.append(null_projected)
+    state.fm_seq_len += int(projected.shape[1])
+
+
+def _append_patch(
+    model: DotsTTSMlxModel, state: DotsTTSFlowState, patch_rows: mx.array
+) -> None:
+    projected = model.latent_proj(patch_rows)
+    state.fm_history.append(projected)
+    state.fm_cfg_history.append(projected)
+    state.fm_seq_len += int(projected.shape[1])
+
+
+def decode_step(
+    model: DotsTTSMlxModel,
+    state: DotsTTSFlowState,
+    *,
+    hidden_last: mx.array,
+    num_steps: int,
+    ode_method: str,
+    guidance_scale: float,
+    eos_threshold: float,
+    append_hidden: bool = True,
+) -> tuple[mx.array, mx.array, bool, bool]:
+    """One audio patch: EOS check, DiT ODE, history append, next feedback.
+
+    Returns (latent_patch, feedback, finished, emit) — the latent patch is
+    denormalized (data-space), feedback is the semantic embedding feeding
+    the backbone next step. append_hidden=False marks the prefill step,
+    where initialize_history already appended the last prefill hidden row
+    (mirrors the torch runner's append_hidden arg).
+    """
+    if ode_method != "euler":
+        raise ValueError(f"dots.tts MLX currently requires euler, got {ode_method!r}")
+
+    should_check_eos = not (
+        state.suppress_first_eos_check and state.decoded_patches == 0
+    )
+    finished = False
+    if should_check_eos:
+        probabilities = model.eos_probability(hidden_last)
+        finished = bool((probabilities > eos_threshold).any().item())
+
+    if append_hidden:
+        _append_hidden(model, state, hidden_last)
+    normalized_patch = _decode_flow_matching(
+        model, state, nfe=num_steps, guidance=guidance_scale
+    )
+    _append_patch(model, state, normalized_patch)
+    state.decoded_patches += 1
+    emit = not state.drop_regenerated_prompt_patch
+    state.drop_regenerated_prompt_patch = False
+
+    # note (guozhihao-224): the semantic encoder consumes raw data-space
+    # latents, so the decoded patch joins the raw history first.
+    state.patch_history.append(model.denormalize(normalized_patch))
+    feedback = _next_feedback(model, state)
+    return model.denormalize(normalized_patch), feedback, finished, emit
+
+
+def _next_feedback(model: DotsTTSMlxModel, state: DotsTTSFlowState) -> mx.array:
+    """Semantic-encode the full raw history; take the newest patch's row."""
+    if not state.patch_history:
+        raise RuntimeError("dots.tts MLX feedback has no patch history")
+    raw = mx.concatenate(state.patch_history, axis=1)
+    embeddings = _semantic_encode(model, raw)
+    return embeddings[:, -1:, :]
+
+
+def _tril_mask(length: int) -> mx.array:
+    rows = mx.arange(length)[:, None]
+    cols = mx.arange(length)[None, :]
+    valid = cols <= rows
+    return mx.where(
+        valid,
+        mx.zeros((length, length)),
+        mx.full((length, length), _MASK_VALUE),
+    )[None, None, :, :]
+
+
+def _decode_flow_matching(
+    model: DotsTTSMlxModel,
+    state: DotsTTSFlowState,
+    *,
+    nfe: int,
+    guidance: float,
+) -> mx.array:
+    """Integrate the classifier-free-flow ODE from t=0 to 1 on the patch slot."""
+    fm_seq_len = int(state.fm_seq_len)
+    patch_size = int(model.latent_patch_size)
+    total_len = fm_seq_len + patch_size
+    latent_start = fm_seq_len  # patch slot starts right after the history
+
+    input_sequence = _build_input(model, state.fm_history, fm_seq_len, total_len)
+    cfg_sequence = _build_input(model, state.fm_cfg_history, fm_seq_len, total_len)
+    mask = _decode_mask(total_len=total_len, fm_seq_len=fm_seq_len)
+
+    z = _sample_noise(model, state)
+    step_size = 1.0 / nfe
+    for index in range(nfe):
+        t = step_size * index
+        timesteps = mx.full((2,), t)
+        z_proj = model.coordinate_proj(z)
+        x = mx.concatenate(
+            [
+                _splat(input_sequence, z_proj, latent_start),
+                _splat(cfg_sequence, z_proj, latent_start),
+            ],
+            axis=0,
+        )
+        if state.g_cond is not None:
+            g_cond_branches = mx.concatenate(
+                [state.g_cond, mx.zeros_like(state.g_cond)], axis=0
+            )
+        else:
+            g_cond_branches = mx.zeros((2, model.fm_hidden_size))
+        pred = model.velocity_field_predictor(
+            x, timesteps, g_cond=g_cond_branches, mask=mask
+        )[:, latent_start:]
+        cond = pred[:1]
+        uncond = pred[1:]
+        velocity = cond + guidance * (cond - uncond)
+        z = z + step_size * velocity
+    return z
+
+
+def _build_input(
+    model: DotsTTSMlxModel,
+    history: list[mx.array],
+    fm_seq_len: int,
+    total_len: int,
+) -> mx.array:
+    # note (guozhihao-224): history is never empty (prefill seeds it) and the
+    # patch slot always pads; concatenate the rows and the zero patch slot.
+    rows = mx.concatenate(history, axis=1)
+    pad = mx.zeros((1, total_len - fm_seq_len, model.fm_hidden_size))
+    return mx.concatenate([rows, pad], axis=1)
+
+
+def _splat(sequence: mx.array, z_proj: mx.array, latent_start: int) -> mx.array:
+    return mx.concatenate([sequence[:, :latent_start, :], z_proj], axis=1)
+
+
+def _sample_noise(model: DotsTTSMlxModel, state: DotsTTSFlowState) -> mx.array:
+    if state.rng_key is None:
+        return mx.random.normal((1, int(model.latent_patch_size), model.latent_dim))
+    new_key, sample_key = mx.random.split(state.rng_key)
+    state.rng_key = new_key
+    return mx.random.normal(
+        (1, int(model.latent_patch_size), model.latent_dim),
+        key=sample_key,
+    )
+
+
+def _decode_mask(total_len: int, fm_seq_len: int) -> mx.array:
+    """Additive attention bias mirroring _build_decode_mask."""
+    q = mx.arange(total_len)[:, None]
+    k = mx.arange(total_len)[None, :]
+    latent_start = fm_seq_len
+    block_start = max(0, fm_seq_len - 1)
+
+    causal_prefix = (q < block_start) & (k <= q)
+    tail_block = (
+        (q >= block_start) & (q < fm_seq_len) & ((k < fm_seq_len) | (k >= latent_start))
+    )
+    patch_rows = (q >= latent_start) & ((k < fm_seq_len) | (k >= latent_start))
+    ok = causal_prefix | tail_block | patch_rows
+    return mx.where(
+        ok,
+        mx.zeros((total_len, total_len)),
+        mx.full((total_len, total_len), _MASK_VALUE),
+    )[None, None, :, :]
+
+
+__all__ = [
+    "build_prefill_embeds",
+    "decode_step",
+    "initialize_history",
+    "start_request",
+]

--- a/sglang_omni/models/dots_tts/mlx/layers.py
+++ b/sglang_omni/models/dots_tts/mlx/layers.py
@@ -1,0 +1,131 @@
+# SPDX-License-Identifier: Apache-2.0
+"""Shared MLX transformer building blocks for the dots.tts latent engine.
+
+These mirror the torch dots_tts.modules.backbone.layers used by both the
+semantic (patch) encoder and the DiT: multi-head attention with optional QK
+RMSNorm and Qwen-style rotary, and the SiLU/GELU MLP. Dropout is inference-only
+and omitted. The backbone Qwen2 uses its own attention in qwen.py.
+"""
+
+from __future__ import annotations
+
+import math
+from typing import Optional
+
+import mlx.core as mx
+import mlx.nn as nn
+from mlx_lm.models.base import scaled_dot_product_attention
+
+from sglang_omni.models.dots_tts.mlx.config import TransformerConfig
+
+
+class MultiHeadAttention(nn.Module):
+    """Dot-product attention with optional QK norm and rotary."""
+
+    def __init__(
+        self,
+        config: TransformerConfig,
+        *,
+        qk_norm: Optional[bool] = None,
+        rotary_bias: Optional[bool] = None,
+    ) -> None:
+        super().__init__()
+        qk_norm = config.qk_norm if qk_norm is None else qk_norm
+        rotary_bias = config.rotary_bias if rotary_bias is None else rotary_bias
+        self.num_heads = config.num_heads
+        self.head_dim = config.head_dim()
+        self.hidden_size = config.hidden_size
+        self.scale = self.head_dim**-0.5
+
+        self.q_proj = nn.Linear(
+            self.hidden_size, self.hidden_size, bias=config.qkv_bias
+        )
+        self.k_proj = nn.Linear(
+            self.hidden_size, self.hidden_size, bias=config.qkv_bias
+        )
+        self.v_proj = nn.Linear(
+            self.hidden_size, self.hidden_size, bias=config.qkv_bias
+        )
+        self.o_proj = nn.Linear(self.hidden_size, self.hidden_size, bias=True)
+
+        eps = 1e-5 if config.norm_layer == "LayerNorm" else 1e-6
+        if qk_norm:
+            self.q_norm = nn.RMSNorm(self.head_dim, eps=eps)
+            self.k_norm = nn.RMSNorm(self.head_dim, eps=eps)
+        else:
+            self.q_norm = None
+            self.k_norm = None
+        self.rope = (
+            nn.RoPE(self.head_dim, traditional=False, base=config.rotary_theta)
+            if rotary_bias
+            else None
+        )
+
+    def __call__(
+        self,
+        x: mx.array,
+        *,
+        mask: Optional[mx.array] = None,
+        offset: int = 0,
+    ) -> mx.array:
+        bsz, length, _ = x.shape
+
+        queries = self.q_proj(x).reshape(bsz, length, self.num_heads, self.head_dim)
+        keys = self.k_proj(x).reshape(bsz, length, self.num_heads, self.head_dim)
+        values = self.v_proj(x).reshape(bsz, length, self.num_heads, self.head_dim)
+
+        queries = queries.transpose(0, 2, 1, 3)
+        keys = keys.transpose(0, 2, 1, 3)
+        values = values.transpose(0, 2, 1, 3)
+
+        if self.q_norm is not None:
+            queries = self.q_norm(queries)
+            keys = self.k_norm(keys)
+        if self.rope is not None:
+            queries = self.rope(queries, offset=offset)
+            keys = self.rope(keys, offset=offset)
+        queries = queries * self.scale
+
+        # note (guozhihao-224): mx.fast SDPA does not broadcast the batch dim;
+        # expand the (1, 1, L, S) mask for the DiT cond/uncond batch.
+        if mask is not None and mask.shape[:2] != (bsz, self.num_heads):
+            mask = mx.broadcast_to(mask, (bsz, self.num_heads, length, mask.shape[-1]))
+
+        output = scaled_dot_product_attention(
+            queries,
+            keys,
+            values,
+            mask=mask,
+            scale=1.0,
+            cache=None,
+        )
+        output = output.transpose(0, 2, 1, 3).reshape(bsz, length, self.hidden_size)
+        return self.o_proj(output)
+
+
+class Mlp(nn.Module):
+    """Two-layer MLP with GELU-tanh (DiT) or SiLU (semantic encoder) act."""
+
+    def __init__(self, config: TransformerConfig, *, activation: str = "silu") -> None:
+        super().__init__()
+        if activation not in {"silu", "gelu_tanh"}:
+            raise ValueError(f"unsupported MLP activation {activation!r}")
+        self.fc1 = nn.Linear(config.hidden_size, config.ffn_hidden_size, bias=True)
+        self.fc2 = nn.Linear(config.ffn_hidden_size, config.hidden_size, bias=True)
+        self._activation = activation
+
+    @staticmethod
+    def _gelu_tanh(x: mx.array) -> mx.array:
+        inner = x * (2 / math.pi) ** 0.5 * (1.0 + 0.044715 * x * x)
+        return 0.5 * x * (1.0 + mx.tanh(inner))
+
+    def __call__(self, x: mx.array) -> mx.array:
+        h = self.fc1(x)
+        if self._activation == "silu":
+            h = nn.silu(h)
+        else:
+            h = self._gelu_tanh(h)
+        return self.fc2(h)
+
+
+__all__ = ["Mlp", "MultiHeadAttention"]

--- a/sglang_omni/models/dots_tts/mlx/model.py
+++ b/sglang_omni/models/dots_tts/mlx/model.py
@@ -1,0 +1,150 @@
+# SPDX-License-Identifier: Apache-2.0
+"""MLX dots.tts latent engine model and per-request flow state machine.
+
+Ports flow_head.py (the omni torch wrapper) and the flow-matching
+full-compute DiT decode of dots_tts.modules.backbone.dit_inference. One
+scheduler decode step equals one audio patch: the runner feeds the backbone the
+semantic-encoder feedback embedding, runs the DiT ODE over the causally grown
+flow history, and gets back the latent patch, the next feedback embedding, and
+the EOS flag.
+"""
+
+from __future__ import annotations
+
+from dataclasses import dataclass, field
+from typing import Any, Optional
+
+import mlx.core as mx
+import mlx.nn as nn
+
+from sglang_omni.models.dots_tts.mlx.config import DotsMlxArgs
+from sglang_omni.models.dots_tts.mlx.dit import DiT
+from sglang_omni.models.dots_tts.mlx.qwen import Qwen2Model
+from sglang_omni.models.dots_tts.mlx.semantic_encoder import VAESemanticEncoder
+
+
+def _load_latent_stats(path: str) -> tuple[mx.array, mx.array]:
+    """Global latent normalization stats (mean, var) from latent_stats.pt."""
+    import torch
+
+    stats = torch.load(path, map_location="cpu", weights_only=False)
+    return mx.array(stats["mean"]), mx.array(stats["var"])
+
+
+@dataclass
+class DotsTTSFlowState:
+    """Per-request continuous-latent AR state (MLX arrays)."""
+
+    fm_history: list[mx.array] = field(default_factory=list)
+    fm_cfg_history: list[mx.array] = field(default_factory=list)
+    fm_seq_len: int = 0
+    g_cond: Optional[mx.array] = None
+    patch_history: list[mx.array] = field(default_factory=list)
+    prompt_patches: Optional[mx.array] = None
+    backbone_cache: Optional[list] = None
+    rng_key: Optional[Any] = None
+    decoded_patches: int = 0
+    drop_regenerated_prompt_patch: bool = False
+    suppress_first_eos_check: bool = False
+    next_feedback: Optional[mx.array] = None
+
+
+class DotsTTSMlxModel(nn.Module):
+    """Backbone + patch encoder + DiT flow head loaded from the dots checkpoint."""
+
+    def __init__(self, args: DotsMlxArgs) -> None:
+        super().__init__()
+        backbone_config = args.backbone
+        flow_config = args.flow
+        self.fm_hidden_size = flow_config.dit.hidden_size
+        self.latent_patch_size = flow_config.patch_size
+        self.latent_dim = flow_config.latent_dim
+
+        self.backbone = Qwen2Model(backbone_config)
+        self.patch_encoder = VAESemanticEncoder(
+            flow_config, out_dim=backbone_config.hidden_size
+        )
+        self.hidden_proj = nn.Linear(
+            backbone_config.hidden_size, self.fm_hidden_size, bias=True
+        )
+        self.latent_proj = nn.Linear(self.latent_dim, self.fm_hidden_size, bias=True)
+        self.coordinate_proj = nn.Linear(
+            self.latent_dim, self.fm_hidden_size, bias=True
+        )
+        # note (guozhihao-224): a plain list keeps checkpoint parameter names
+        # (nn.Sequential would nest a layers. prefix).
+        self.xvec_proj = [
+            nn.Linear(
+                flow_config.campplus_embedding_size, self.fm_hidden_size, bias=True
+            ),
+            nn.LayerNorm(self.fm_hidden_size),
+        ]
+        self.velocity_field_predictor = DiT(
+            in_dim=self.fm_hidden_size,
+            out_dim=self.latent_dim,
+            config=flow_config.dit,
+        )
+        self.eos_proj = [
+            nn.Linear(
+                backbone_config.hidden_size, backbone_config.hidden_size, bias=True
+            ),
+            nn.SiLU(),
+            nn.Linear(backbone_config.hidden_size, 2, bias=True),
+        ]
+        self._latent_mean, self._latent_var = _load_latent_stats(args.latent_stats_path)
+
+    def sanitize(self, weights: dict[str, mx.array]) -> dict[str, mx.array]:
+        """Map checkpoint names onto this module's parameter tree.
+
+        Follows the mlx_lm convention (mlx_lm.utils.load_model calls it
+        before load_weights): the Qwen2 backbone lives under llm.model.*
+        in the checkpoint and under backbone.* here, and the patch encoder
+        stride-2 conv is stored torch-first [out, in, k] while mlx's Conv1d
+        is channels-last [out, k, in].
+        """
+        sanitized = {}
+        for name, tensor in weights.items():
+            key = (
+                "backbone." + name.removeprefix("llm.model.")
+                if name.startswith("llm.model.")
+                else name
+            )
+            if key == "patch_encoder.ds_proj.weight":
+                tensor = mx.transpose(tensor, (0, 2, 1))
+            sanitized[key] = tensor
+        return sanitized
+
+    def normalize(self, x: mx.array) -> mx.array:
+        return (x - self._latent_mean) / mx.sqrt(self._latent_var)
+
+    def denormalize(self, x: mx.array) -> mx.array:
+        return x * mx.sqrt(self._latent_var) + self._latent_mean
+
+    def __call__(
+        self,
+        embeds: mx.array,
+        *,
+        cache: Optional[list] = None,
+    ) -> mx.array:
+        """Backbone forward over input embeddings (token rows or feedback)."""
+        return self.backbone(inputs_embeds=embeds, cache=cache)
+
+    def speaker_condition(self, embedding: mx.array, scale: float) -> mx.array:
+        """g_cond from the speaker embedding (xvec_proj chain)."""
+        x = embedding * scale
+        for layer in self.xvec_proj:
+            x = layer(x)
+        return x
+
+    def eos_probability(self, hidden_last: mx.array) -> mx.array:
+        """Two-class softmax EOS probability from the final hidden state."""
+        x = hidden_last[:, -1, :]
+        for layer in self.eos_proj:
+            x = layer(x)
+        return mx.softmax(x, axis=-1)[:, 1]
+
+
+Model = DotsTTSMlxModel
+ModelArgs = DotsMlxArgs
+
+__all__ = ["DotsTTSFlowState", "DotsTTSMlxModel", "Model", "ModelArgs"]

--- a/sglang_omni/models/dots_tts/mlx/qwen.py
+++ b/sglang_omni/models/dots_tts/mlx/qwen.py
@@ -1,0 +1,149 @@
+# SPDX-License-Identifier: Apache-2.0
+"""MLX Qwen2 backbone for the dots.tts latent engine.
+
+Ported from the Qwen3 text decoder in qwen3_asr/mlx/model.py (same repo),
+stripped to the Qwen2 configuration: no QK norms, grouped-query attention
+(GQA handled natively by mlx fast SDPA), and the mlx_lm KVCache the runner
+advances one feedback step at a time.
+"""
+
+from __future__ import annotations
+
+from typing import Optional
+
+import mlx.core as mx
+import mlx.nn as nn
+from mlx_lm.models.base import create_attention_mask, scaled_dot_product_attention
+from mlx_lm.models.cache import KVCache
+
+from sglang_omni.models.dots_tts.mlx.config import BackboneConfig
+
+
+class Qwen2Attention(nn.Module):
+    def __init__(self, config: BackboneConfig) -> None:
+        super().__init__()
+        self.num_heads = config.num_attention_heads
+        self.num_kv_heads = config.num_key_value_heads
+        self.head_dim = config.head_dim
+        hidden = config.hidden_size
+        self.scale = self.head_dim**-0.5
+
+        self.q_proj = nn.Linear(hidden, self.num_heads * self.head_dim, bias=True)
+        self.k_proj = nn.Linear(hidden, self.num_kv_heads * self.head_dim, bias=True)
+        self.v_proj = nn.Linear(hidden, self.num_kv_heads * self.head_dim, bias=True)
+        self.o_proj = nn.Linear(self.num_heads * self.head_dim, hidden, bias=False)
+        self.rope = nn.RoPE(self.head_dim, traditional=False, base=config.rope_theta)
+
+    def __call__(
+        self,
+        x: mx.array,
+        *,
+        mask: Optional[mx.array] = None,
+        cache: Optional[KVCache] = None,
+    ) -> mx.array:
+        batch, length, _ = x.shape
+        queries = self.q_proj(x).reshape(batch, length, self.num_heads, self.head_dim)
+        keys = self.k_proj(x).reshape(batch, length, self.num_kv_heads, self.head_dim)
+        values = self.v_proj(x).reshape(batch, length, self.num_kv_heads, self.head_dim)
+        queries = queries.transpose(0, 2, 1, 3)
+        keys = keys.transpose(0, 2, 1, 3)
+        values = values.transpose(0, 2, 1, 3)
+
+        if cache is not None:
+            offset = cache.offset
+            queries = self.rope(queries, offset=offset)
+            keys = self.rope(keys, offset=offset)
+            keys, values = cache.update_and_fetch(keys, values)
+        else:
+            queries = self.rope(queries)
+            keys = self.rope(keys)
+
+        # note (guozhihao-224): mx.fast SDPA handles GQA natively; do not
+        # expand K/V by hand.
+        output = scaled_dot_product_attention(
+            queries,
+            keys,
+            values,
+            cache=cache,
+            scale=self.scale,
+            mask=mask,
+        )
+        output = output.transpose(0, 2, 1, 3).reshape(batch, length, -1)
+        return self.o_proj(output)
+
+
+class Qwen2DecoderLayer(nn.Module):
+    def __init__(self, config: BackboneConfig) -> None:
+        super().__init__()
+        self.self_attn = Qwen2Attention(config)
+        self.mlp = Qwen2Mlp(config)
+        self.input_layernorm = nn.RMSNorm(config.hidden_size, eps=config.rms_norm_eps)
+        self.post_attention_layernorm = nn.RMSNorm(
+            config.hidden_size, eps=config.rms_norm_eps
+        )
+
+    def __call__(
+        self,
+        x: mx.array,
+        *,
+        mask: Optional[mx.array] = None,
+        cache: Optional[KVCache] = None,
+    ) -> mx.array:
+        residual = x
+        h = self.input_layernorm(x)
+        h = self.self_attn(h, mask=mask, cache=cache)
+        x = residual + h
+        residual = x
+        x = residual + self.mlp(self.post_attention_layernorm(x))
+        return x
+
+
+class Qwen2Mlp(nn.Module):
+    def __init__(self, config: BackboneConfig) -> None:
+        super().__init__()
+        self.gate_proj = nn.Linear(
+            config.hidden_size, config.intermediate_size, bias=False
+        )
+        self.up_proj = nn.Linear(
+            config.hidden_size, config.intermediate_size, bias=False
+        )
+        self.down_proj = nn.Linear(
+            config.intermediate_size, config.hidden_size, bias=False
+        )
+
+    def __call__(self, x: mx.array) -> mx.array:
+        return self.down_proj(nn.silu(self.gate_proj(x)) * self.up_proj(x))
+
+
+class Qwen2Model(nn.Module):
+    """Qwen2 decoder over token ids or (feedback) input embeddings."""
+
+    def __init__(self, config: BackboneConfig) -> None:
+        super().__init__()
+        self.embed_tokens = nn.Embedding(config.vocab_size, config.hidden_size)
+        self.layers = [Qwen2DecoderLayer(config) for _ in range(config.num_layers)]
+        self.norm = nn.RMSNorm(config.hidden_size, eps=config.rms_norm_eps)
+
+    def __call__(
+        self,
+        input_ids: Optional[mx.array] = None,
+        inputs_embeds: Optional[mx.array] = None,
+        cache: Optional[list[Optional[KVCache]]] = None,
+    ) -> mx.array:
+        if inputs_embeds is None:
+            inputs_embeds = self.embed_tokens(input_ids)
+
+        if cache is None:
+            cache = [None] * len(self.layers)
+        mask = create_attention_mask(inputs_embeds, cache[0])
+
+        hidden = inputs_embeds
+        for layer, layer_cache in zip(self.layers, cache):
+            hidden = layer(hidden, mask=mask, cache=layer_cache)
+        return self.norm(hidden)
+
+    def make_cache(self) -> list[KVCache]:
+        return [KVCache() for _ in self.layers]
+
+
+__all__ = ["Qwen2Model"]

--- a/sglang_omni/models/dots_tts/mlx/runner.py
+++ b/sglang_omni/models/dots_tts/mlx/runner.py
@@ -1,0 +1,202 @@
+# SPDX-License-Identifier: Apache-2.0
+"""Omni ModelRunner that drives the dots.tts MLX latent engine.
+
+The scheduler keeps its ordinary token loop (one decode step == one audio
+patch); this runner owns the MLX flow state per request and converts patches
+back to Torch at the emission boundary so the omni request-data plumbing
+(latent_patches / latest_latent_patch streaming, apply_latent_result)
+and the Torch-MPS vocoder stage see the usual lower-bound tensors.
+"""
+
+from __future__ import annotations
+
+from typing import Any, Optional
+
+import mlx.core as mx
+import numpy as np
+import torch
+
+from sglang_omni.model_runner.base import ModelRunner
+from sglang_omni.models.dots_tts.mlx import flow as f
+from sglang_omni.models.dots_tts.mlx.model import DotsTTSFlowState
+from sglang_omni.models.dots_tts.request_builders import DotsTTSSGLangRequestData
+
+
+def _to_mx(tensor: Optional[torch.Tensor]) -> Optional[mx.array]:
+    if tensor is None:
+        return None
+    return mx.array(tensor.detach().cpu().numpy())
+
+
+def _to_torch(array: mx.array, device: torch.device) -> torch.Tensor:
+    mx.eval(array)
+    return torch.as_tensor(np.asarray(array), device=device).float()
+
+
+class DotsTTSMlxModelRunner(ModelRunner):
+    """Token loop over the MLX latent engine with omni data plumbing.
+
+    MLX streams are thread-local, while the scheduler runs decode on its own
+    thread (same pattern as the other MLX engine runners): a thread-local
+    stream is created here and every engine step runs under its context, so
+    lazy builds and eager readbacks resolve on the scheduler thread.
+    """
+
+    def __init__(
+        self,
+        tp_worker: Any,
+        output_processor: Any,
+        *,
+        checkpoint_dir: str,
+    ) -> None:
+        super().__init__(tp_worker, output_processor)
+        self._checkpoint_dir = checkpoint_dir
+        self._flow: dict[str, DotsTTSFlowState] = {}
+        self._model: Any = None
+        self._mlx_stream = mx.new_thread_local_stream(mx.gpu)
+
+    def lookahead_eligible(self, batch: Any) -> bool:
+        del batch
+        return False
+
+    def _mlx_model(self) -> Any:
+        if self._model is None:
+            # note (guozhihao-224): build lazily on the scheduler thread under
+            # the stream context; cross-thread array evaluation has no stream.
+            from sglang_omni.models.dots_tts.mlx.checkpoint import load_dots_mlx_model
+
+            self._model = load_dots_mlx_model(self._checkpoint_dir)
+        return self._model
+
+    @staticmethod
+    def _one_request(requests: list) -> Any:
+        if len(requests) != 1:
+            raise RuntimeError("dots.tts MLX currently requires max_running_requests=1")
+        return requests[0]
+
+    def _result(self, data: DotsTTSSGLangRequestData, device: torch.device) -> Any:
+        from sglang.srt.managers.utils import GenerationBatchResult
+
+        return GenerationBatchResult(
+            logits_output=None,
+            next_token_ids=torch.tensor(
+                [data.control_token_id], dtype=torch.long, device=device
+            ),
+            can_run_cuda_graph=False,
+        )
+
+    @torch.inference_mode()
+    def custom_prefill_forward(self, forward_batch, schedule_batch, requests) -> Any:
+        del forward_batch, schedule_batch
+        with mx.stream(self._mlx_stream):
+            return self._prefill_impl(requests)
+
+    def _prefill_impl(self, requests: list) -> Any:
+        request = self._one_request(requests)
+        data: DotsTTSSGLangRequestData = request.data
+        state_data = data.state
+        model = self._mlx_model()
+
+        state, prompt_embeddings = f.start_request(
+            model,
+            prompt_latents=_to_mx(state_data.prompt_latents),
+            speaker_embedding=_to_mx(state_data.speaker_embedding),
+            speaker_scale=float(state_data.speaker_scale),
+            seed=state_data.seed,
+        )
+        self._flow[request.request_id] = state
+
+        prefill_ids = mx.array(data.generation_schedule[0, : data.prefill_end].numpy())
+        prompt_span_positions = mx.array(data.prompt_span_positions.numpy())
+        if prompt_embeddings is None:
+            embeds = model.backbone.embed_tokens(prefill_ids)[None, :, :]
+        else:
+            embeds = f.build_prefill_embeds(
+                model,
+                prefill_ids,
+                prompt_span_positions=prompt_span_positions,
+                prompt_embeddings=prompt_embeddings,
+            )
+        hidden = model(embeds, cache=state.backbone_cache)
+        f.initialize_history(
+            model,
+            state,
+            hidden_states=hidden,
+            prompt_span_positions=prompt_span_positions,
+            generation_schedule=mx.array(data.generation_schedule[0].numpy()),
+            audio_span_token_ids=set(state_data.audio_span_token_ids),
+            prefill_end=int(data.prefill_end),
+            decoded_latent_patches=[
+                _to_mx(patch) for patch in data.decoded_latent_patches
+            ],
+        )
+        # note (guozhihao-224): the last prefill hidden row is already in the
+        # history; the first flow step appends none (torch runner parity).
+        self._run_flow_step(
+            request, data, state, hidden[:, -1:, :], append_hidden=False
+        )
+        return self._result(data, self.device)
+
+    @torch.inference_mode()
+    def custom_decode_forward(self, forward_batch, schedule_batch, requests) -> Any:
+        del forward_batch, schedule_batch
+        with mx.stream(self._mlx_stream):
+            return self._decode_impl(requests)
+
+    def _decode_impl(self, requests: list) -> Any:
+        request = self._one_request(requests)
+        data: DotsTTSSGLangRequestData = request.data
+        state = self._flow.get(request.request_id)
+        if state is None:
+            raise RuntimeError(
+                f"dots.tts MLX decode has no flow state for {request.request_id}"
+            )
+        if state.next_feedback is None:
+            raise RuntimeError("dots.tts MLX decode has no feedback embedding")
+        hidden = self._mlx_model()(state.next_feedback, cache=state.backbone_cache)
+        self._run_flow_step(request, data, state, hidden[:, -1:, :])
+        return self._result(data, self.device)
+
+    def _run_flow_step(
+        self,
+        request: Any,
+        data: DotsTTSSGLangRequestData,
+        state: DotsTTSFlowState,
+        hidden_last: mx.array,
+        *,
+        append_hidden: bool = True,
+    ) -> None:
+        state_data = data.state
+        latent, feedback, finished, emit = f.decode_step(
+            self._mlx_model(),
+            state,
+            hidden_last=hidden_last,
+            num_steps=int(state_data.num_steps),
+            ode_method=str(state_data.ode_method),
+            guidance_scale=float(state_data.guidance_scale),
+            eos_threshold=float(state_data.eos_threshold),
+            append_hidden=append_hidden,
+        )
+        state.next_feedback = feedback
+        if emit:
+            torch_latent = _to_torch(latent, self.device)
+            data.decoded_latent_patches.append(torch_latent)
+            data.latent_patches.append(torch_latent)
+            if bool(state_data.stream):
+                data.latest_latent_patch = torch_latent
+        if finished and request.data.req.finished_reason is None:
+            from sglang.srt.managers.schedule_batch import FINISH_MATCHED_TOKEN
+
+            request.data.req.finished_reason = FINISH_MATCHED_TOKEN(
+                data.control_token_id
+            )
+
+    def on_request_finished(self, request_id: str, req_data: Any) -> None:
+        del req_data
+        self._flow.pop(request_id, None)
+
+    def reset_request(self, request_id: str) -> None:
+        self._flow.pop(request_id, None)
+
+
+__all__ = ["DotsTTSMlxModelRunner"]

--- a/sglang_omni/models/dots_tts/mlx/semantic_encoder.py
+++ b/sglang_omni/models/dots_tts/mlx/semantic_encoder.py
@@ -1,0 +1,127 @@
+# SPDX-License-Identifier: Apache-2.0
+"""MLX port of the dots.tts semantic (patch) encoder.
+
+Mirrors dots_tts.modules.backbone.encoder (VAESemanticEncoder with its
+SuperviseEncoder trunk). The torch path decodes patches incrementally with a KV
+cache; the MLX engine recomputes the causal encoding over the accumulated patch
+history, which yields the identical rows for the newest tokens (the causal mask
+is triangular) at O(n^2) cost until an incremental port lands.
+"""
+
+from __future__ import annotations
+
+from typing import Optional
+
+import mlx.core as mx
+import mlx.nn as nn
+
+from sglang_omni.models.dots_tts.mlx.config import FlowHeadConfig, TransformerConfig
+from sglang_omni.models.dots_tts.mlx.layers import Mlp, MultiHeadAttention
+
+
+class _SuperviseEncoder(nn.Module):
+    """Stack of transformer layers for the patch encoder."""
+
+    def __init__(self, config: TransformerConfig) -> None:
+        super().__init__()
+        self.layers = [_FreedomLayer(config) for _ in range(config.num_layers)]
+
+    def __call__(
+        self,
+        x: mx.array,
+        *,
+        mask: Optional[mx.array] = None,
+    ) -> mx.array:
+        for layer in self.layers:
+            x = layer(x, mask=mask)
+        return x
+
+
+class _FreedomLayer(nn.Module):
+    """Pre-norm transformer layer (attention + SiLU MLP)."""
+
+    def __init__(self, config: TransformerConfig) -> None:
+        super().__init__()
+        eps = 1e-5 if config.norm_layer == "LayerNorm" else 1e-6
+        self.attn_norm = nn.RMSNorm(config.hidden_size, eps=eps)
+        # note (guozhihao-224): the torch semantic encoder uses no qk_norm or
+        # rotary; the checkpoint has no such weights.
+        self.attn = MultiHeadAttention(config, qk_norm=False, rotary_bias=False)
+        self.ffn_norm = nn.RMSNorm(config.hidden_size, eps=eps)
+        self.ffn = Mlp(config, activation="silu")
+
+    def __call__(
+        self,
+        x: mx.array,
+        *,
+        mask: Optional[mx.array] = None,
+    ) -> mx.array:
+        h = self.attn_norm(x)
+        x = x + self.attn(h, mask=mask)
+        h = self.ffn_norm(x)
+        return x + self.ffn(h)
+
+
+class VAESemanticEncoder(nn.Module):
+    """Patch encoder: causal conv downsample, transformer trunk, linear out."""
+
+    def __init__(self, config: FlowHeadConfig, out_dim: int) -> None:
+        super().__init__()
+        patch_encoder = config.patch_encoder
+        in_ds_rate = 2
+        out_ds_rate = config.patch_size // in_ds_rate
+        self.out_ds_rate = out_ds_rate
+        if out_ds_rate != in_ds_rate:
+            raise RuntimeError(
+                "expected patch_size 4 for the MLX semantic encoder, got "
+                f"{config.patch_size}"
+            )
+
+        self.ds_proj = nn.Conv1d(
+            config.latent_dim,
+            config.latent_dim,
+            kernel_size=in_ds_rate,
+            stride=in_ds_rate,
+            bias=True,
+        )
+        self.in_proj = nn.Linear(
+            config.latent_dim, patch_encoder.hidden_size, bias=True
+        )
+        self.encoder = _SuperviseEncoder(patch_encoder)
+        self.out_proj = nn.Linear(
+            patch_encoder.hidden_size * out_ds_rate, out_dim, bias=True
+        )
+
+    def downsample(self, x: mx.array) -> mx.array:
+        """Causal stride-2 conv over the time axis (channels last)."""
+        left_pad = mx.pad(x, ((0, 0), (1, 0), (0, 0)))
+        return self.ds_proj(left_pad)
+
+    def __call__(
+        self,
+        x: mx.array,
+        *,
+        mask: Optional[mx.array] = None,
+    ) -> mx.array:
+        """Encode downsampled patch tokens to LLM-size embeddings."""
+        return self.in_proj_and_trunk(self.downsample(x), mask=mask)
+
+    def in_proj_and_trunk(
+        self,
+        tokens: mx.array,
+        *,
+        mask: Optional[mx.array] = None,
+    ) -> mx.array:
+        """Project + transformer trunk + LLM projection over downsampled tokens."""
+        h = self.in_proj(tokens)
+        h = self.encoder(h, mask=mask)
+        return self._project(h)
+
+    def _project(self, z: mx.array) -> mx.array:
+        bsz, length, hidden = z.shape
+        d = self.out_ds_rate
+        z = z.reshape(bsz, length // d, d * hidden)
+        return self.out_proj(z)
+
+
+__all__ = ["VAESemanticEncoder"]

--- a/sglang_omni/models/dots_tts/stages.py
+++ b/sglang_omni/models/dots_tts/stages.py
@@ -24,14 +24,9 @@ from sglang_omni.scheduling.omni_scheduler import OmniScheduler
 from sglang_omni.scheduling.simple_scheduler import SimpleScheduler
 from sglang_omni.utils.audio_payload import audio_data_uri_from_reference
 from sglang_omni.utils.checkpoint import resolve_checkpoint
+from sglang_omni.utils.device import resolve_device_spec
 
 _DEFAULT_CONTEXT_LENGTH = 2048
-
-
-def _device(device: str | None, gpu_id: int | None) -> str:
-    if device is not None and device != "cuda":
-        return device
-    return f"cuda:{int(gpu_id or 0)}"
 
 
 def _configure_optimized_kernels() -> None:
@@ -392,13 +387,13 @@ def create_preprocessing_executor(
 def create_reference_encode_executor(
     model_path: str,
     *,
-    device: str | None = "cuda",
+    device: str | None = None,
     gpu_id: int | None = None,
     max_concurrency: int = 8,
     max_batch_size: int = 1,
     max_batch_wait_ms: float = 4.0,
 ) -> SimpleScheduler:
-    worker_device = _device(device, gpu_id)
+    worker_device = resolve_device_spec(device, gpu_id)
     codec = load_dots_audio_codec(model_path, device=worker_device)
     encoder = DotsReferenceEncoder(
         codec,
@@ -420,7 +415,7 @@ def create_sglang_latent_engine_executor(
     optimize: bool = True,
     max_generate_length: int = 500,
     num_steps: int = 4,
-    device: str | None = "cuda",
+    device: str | None = None,
     gpu_id: int | None = None,
     server_args_overrides: dict[str, Any] | None = None,
 ) -> OmniScheduler:
@@ -432,7 +427,7 @@ def create_sglang_latent_engine_executor(
         max_audio_patches=max_generate_length,
     ).build(
         model_path,
-        device=device or "cuda",
+        device=device,
         gpu_id=gpu_id,
         dtype=precision,
         server_args_overrides=server_args_overrides,
@@ -442,7 +437,7 @@ def create_sglang_latent_engine_executor(
 def create_vocoder_executor(
     model_path: str,
     *,
-    device: str | None = "cuda",
+    device: str | None = None,
     gpu_id: int | None = None,
     optimize: bool = True,
     vocoder_merge_steps: int = 4,
@@ -450,7 +445,9 @@ def create_vocoder_executor(
     max_batch_wait_ms: int = 2,
     stream_slots: int = 16,
 ) -> DotsTTSStreamingVocoder:
-    codec = load_dots_audio_codec(model_path, device=_device(device, gpu_id))
+    codec = load_dots_audio_codec(
+        model_path, device=resolve_device_spec(device, gpu_id)
+    )
     vocoder = DotsTTSStreamingVocoder(
         codec,
         optimize=optimize,

--- a/sglang_omni/models/dots_tts/torch_mps_runner.py
+++ b/sglang_omni/models/dots_tts/torch_mps_runner.py
@@ -1,0 +1,161 @@
+# SPDX-License-Identifier: Apache-2.0
+"""Torch/MPS runner for dots.tts.
+
+SGLang's eager extend path hardcodes a bfloat16() cast on projected
+input embeddings (ModelRunner._extend_forward_kwargs) that mirrors the
+BF16 models it targets; on MPS with the float32 correctness profile it turns
+every QKV linear into a mixed-dtype matmul, which Metal aborts. Following the
+Qwen3-ASR Torch/MPS pattern, the MPS runner owns the backbone forward instead
+of SGLang's: it swaps the SGLang Qwen2 for the pinned Hugging Face
+implementation (self-contained past_key_values, no SGLang KV pool or
+attention-backend state) and runs prefill/decode through the same
+before_* / post_* hooks as the CUDA path, so the flow head is shared.
+"""
+
+from __future__ import annotations
+
+import gc
+import json
+import logging
+from pathlib import Path
+from typing import Any
+
+import torch
+
+from sglang_omni.models.dots_tts.model_runner import DotsTTSModelRunner
+
+logger = logging.getLogger(__name__)
+
+
+def install_torch_mps_backbone(model: Any, checkpoint_dir: str) -> None:
+    """Replace SGLang's Qwen2 with the pinned HF Torch implementation.
+
+    MPS serves the single-request float32 profile; HF's Qwen2Model keeps its
+    own past_key_values and never touches SGLang's KV pool or eager
+    forward path. The flow head is left as SGLang loaded it (same device and
+    dtype), matching the Qwen3-ASR install_torch_mps_language_model split.
+    """
+    from safetensors import safe_open
+    from transformers import Qwen2Config, Qwen2Model
+
+    root = Path(checkpoint_dir)
+    config = Qwen2Config(**json.loads((root / "llm_config.json").read_text()))
+    old = model.qwen2
+    device = next(old.parameters()).device
+    dtype = next(old.parameters()).dtype
+
+    # note (guozhihao-224): build on CPU, not meta — Qwen2 rotary buffers are
+    # non-persistent, so a meta module would keep them meta and .to would fail.
+    backbone = Qwen2Model(config)
+    expected = set(backbone.state_dict())
+    state_dict: dict[str, torch.Tensor] = {}
+    with safe_open(root / "model.safetensors", framework="pt") as handle:
+        for name in handle.keys():
+            if name.startswith("llm.model."):
+                key = name.removeprefix("llm.model.")
+                if key in expected:
+                    state_dict[key] = handle.get_tensor(name)
+    if not state_dict:
+        raise RuntimeError("dots.tts checkpoint has no llm.model.* backbone weights")
+    missing = expected - state_dict.keys()
+    if missing:
+        raise ValueError(
+            "dots.tts Torch MPS backbone checkpoint is incomplete: "
+            f"{sorted(missing)[:10]}"
+        )
+    backbone.load_state_dict(state_dict, strict=True, assign=True)
+
+    del model.qwen2
+    gc.collect()
+    torch.mps.empty_cache()
+    model.qwen2 = backbone.eval().to(device=device, dtype=dtype)
+    logger.info("Installed dots.tts HF Qwen2 backbone on %s (%s)", device, dtype)
+
+
+class DotsTTSTorchMpsModelRunner(DotsTTSModelRunner):
+    """Shared flow-head recurrence with an HF Qwen2 owned backbone forward."""
+
+    def __init__(self, tp_worker: Any, output_processor: Any) -> None:
+        super().__init__(tp_worker, output_processor)
+        self._past_key_values: dict[str, Any] = {}
+
+    def lookahead_eligible(self, batch: Any) -> bool:
+        del batch
+        return False
+
+    @staticmethod
+    def _one_request(requests: list[Any]) -> Any:
+        if len(requests) != 1:
+            raise RuntimeError(
+                "dots.tts Torch MPS currently requires max_running_requests=1"
+            )
+        return requests[0]
+
+    def _next_result(self, hidden: torch.Tensor) -> Any:
+        from sglang.srt.layers.logits_processor import LogitsProcessorOutput
+        from sglang.srt.managers.utils import GenerationBatchResult
+
+        return GenerationBatchResult(
+            logits_output=LogitsProcessorOutput(
+                next_token_logits=None,
+                hidden_states=hidden,
+            ),
+            next_token_ids=None,
+            can_run_cuda_graph=False,
+        )
+
+    @torch.inference_mode()
+    def custom_prefill_forward(
+        self,
+        forward_batch: Any,
+        schedule_batch: Any,
+        requests: list[Any],
+    ) -> Any:
+        del schedule_batch
+        request = self._one_request(requests)
+        embeds = forward_batch.input_embeds
+        if embeds is None:
+            raise RuntimeError("dots.tts Torch MPS prefill has no input embeddings")
+        output = self.model.qwen2(
+            inputs_embeds=embeds.unsqueeze(0),
+            use_cache=True,
+        )
+        self._past_key_values[request.request_id] = output.past_key_values
+        return self._next_result(output.last_hidden_state)
+
+    @torch.inference_mode()
+    def custom_decode_forward(
+        self,
+        forward_batch: Any,
+        schedule_batch: Any,
+        requests: list[Any],
+    ) -> Any:
+        del schedule_batch
+        request = self._one_request(requests)
+        embeds = forward_batch.input_embeds
+        if embeds is None:
+            raise RuntimeError("dots.tts Torch MPS decode has no input embeddings")
+        try:
+            past_key_values = self._past_key_values[request.request_id]
+        except KeyError as exc:
+            raise RuntimeError(
+                f"dots.tts Torch MPS decode has no cache for {request.request_id}"
+            ) from exc
+        output = self.model.qwen2(
+            inputs_embeds=embeds.unsqueeze(1),
+            past_key_values=past_key_values,
+            use_cache=True,
+        )
+        self._past_key_values[request.request_id] = output.past_key_values
+        return self._next_result(output.last_hidden_state)
+
+    def on_request_finished(self, request_id: str, req_data: Any) -> None:
+        self._past_key_values.pop(request_id, None)
+        super().on_request_finished(request_id, req_data)
+
+    def reset_request(self, request_id: str) -> None:
+        self._past_key_values.pop(request_id, None)
+        super().reset_request(request_id)
+
+
+__all__ = ["DotsTTSTorchMpsModelRunner", "install_torch_mps_backbone"]

--- a/sglang_omni/scheduling/bootstrap.py
+++ b/sglang_omni/scheduling/bootstrap.py
@@ -147,14 +147,35 @@ def create_sglang_infrastructure(
                 "engine.kv_cache_bytes is not supported on the MLX path; "
                 "remove it or run this stage on CUDA"
             )
-        from sglang_omni.model_runner.mlx_model_worker import create_mlx_model_worker
+        if model_arch_override is not None:
+            from sglang_omni.models.dots_tts.hf_config import (
+                DOTS_TTS_MODEL_ARCH_OVERRIDE,
+            )
 
-        model_worker = create_mlx_model_worker(
-            config=worker_config,
-            server_args=server_args,
-            gpu_id=gpu_id,
-            tp_rank=tp_rank,
-        )
+            # note (guozhihao-224): dots.tts' MLX path is not an mlx_lm token
+            # runner; keep the plain worker and run MLX compute in an omni
+            # ModelRunner, preserving the request-data plumbing.
+            is_dots = model_arch_override == DOTS_TTS_MODEL_ARCH_OVERRIDE
+        else:
+            is_dots = False
+        if is_dots:
+            model_worker = ModelWorker(
+                config=worker_config,
+                server_args=server_args,
+                gpu_id=gpu_id,
+                tp_rank=tp_rank,
+            )
+        else:
+            from sglang_omni.model_runner.mlx_model_worker import (
+                create_mlx_model_worker,
+            )
+
+            model_worker = create_mlx_model_worker(
+                config=worker_config,
+                server_args=server_args,
+                gpu_id=gpu_id,
+                tp_rank=tp_rank,
+            )
     else:
         model_worker = ModelWorker(
             config=worker_config,

--- a/tests/unit_test/dots_tts/test_engine_builder.py
+++ b/tests/unit_test/dots_tts/test_engine_builder.py
@@ -53,3 +53,113 @@ def test_extra_scheduler_callbacks_wire_tail_shutdown_logging() -> None:
     callback()
 
     assert calls == [1]
+
+
+def _mps_builder(**kwargs) -> DotsTTSEngineBuilder:
+    builder = DotsTTSEngineBuilder(**kwargs)
+    builder.device = "mps"
+    return builder
+
+
+def test_dots_engine_torch_mps_generation_defaults() -> None:
+    defaults = _mps_builder(optimize=True).generation_defaults(dtype="bfloat16")
+
+    assert defaults["max_running_requests"] == 1
+    assert defaults["disable_cuda_graph"] is True
+    assert defaults["enable_torch_compile"] is False
+    assert defaults["attention_backend"] == "torch_native"
+    assert defaults["sampling_backend"] == "pytorch"
+    assert defaults["dtype"] == "float32"
+
+
+def test_dots_engine_torch_mps_disables_optimize() -> None:
+    builder = _mps_builder(optimize=True)
+    builder.pre_infra_setup("stub")
+
+    assert builder.optimize is False
+
+
+def test_dots_engine_torch_mps_rejects_batched() -> None:
+    with pytest.raises(ValueError, match="max_running_requests=1"):
+        _mps_builder().adjust_overrides({"tp_size": 1, "max_running_requests": 16})
+
+
+def test_dots_engine_torch_mps_degrades_cuda_graph_to_eager() -> None:
+    overrides = {
+        "tp_size": 1,
+        "max_running_requests": 1,
+        "disable_cuda_graph": False,
+    }
+    _mps_builder().adjust_overrides(overrides)
+
+    assert overrides["disable_cuda_graph"] is True
+    assert "enable_return_hidden_states" not in overrides
+
+
+def test_dots_engine_torch_mps_accepts_single_eager_request() -> None:
+    _mps_builder().adjust_overrides(
+        {"tp_size": 1, "max_running_requests": 1, "disable_cuda_graph": True}
+    )
+
+
+def test_dots_engine_torch_mps_floors_mem_fraction() -> None:
+    overrides = {
+        "tp_size": 1,
+        "max_running_requests": 1,
+        "mem_fraction_static": 0.20,
+    }
+    _mps_builder().adjust_overrides(overrides)
+
+    assert overrides["mem_fraction_static"] == 0.78
+
+
+def test_dots_engine_mlx_selects_mlx_runner(monkeypatch) -> None:
+    import sys
+    import types
+
+    stub = types.ModuleType("sglang_omni.models.dots_tts.mlx.runner")
+
+    class FakeMlxRunner:
+        def __init__(
+            self, tp_worker: object, output_proc: object, *, checkpoint_dir: str
+        ) -> None:
+            self.tp_worker = tp_worker
+            self.output_proc = output_proc
+            self.checkpoint_dir = checkpoint_dir
+
+    stub.DotsTTSMlxModelRunner = FakeMlxRunner
+    monkeypatch.setitem(sys.modules, "sglang_omni.models.dots_tts.mlx.runner", stub)
+
+    builder = DotsTTSEngineBuilder()
+    monkeypatch.setattr(builder, "_use_mlx", lambda: True)
+    builder.checkpoint_dir = "/tmp/stub-checkpoint"
+    runner = builder.make_model_runner("worker", "proc")
+
+    assert isinstance(runner, FakeMlxRunner)
+    assert runner.tp_worker == "worker"
+    assert runner.checkpoint_dir == builder.checkpoint_dir
+    assert builder._model_runner is runner
+
+
+def test_dots_engine_torch_mps_selects_mps_runner(monkeypatch) -> None:
+    import sys
+    import types
+
+    stub = types.ModuleType("sglang_omni.models.dots_tts.torch_mps_runner")
+
+    class FakeMpsRunner:
+        def __init__(self, tp_worker: object, output_proc: object) -> None:
+            self.tp_worker = tp_worker
+            self.output_proc = output_proc
+
+    stub.DotsTTSTorchMpsModelRunner = FakeMpsRunner
+    monkeypatch.setitem(
+        sys.modules, "sglang_omni.models.dots_tts.torch_mps_runner", stub
+    )
+
+    builder = _mps_builder()
+    runner = builder.make_model_runner("worker", "proc")
+
+    assert isinstance(runner, FakeMpsRunner)
+    assert runner.tp_worker == "worker"
+    assert builder._model_runner is runner


### PR DESCRIPTION
## Summary

Adds Apple Silicon support for dots.tts (RedNote), the continuous-latent flow-matching TTS model, under #1967. Two eager single-request paths: native **MLX** and a **Torch/MPS** correctness baseline. Both read the stock checkpoint; no separate converted artifact is required.

## Implementation

- **MLX engine** (`sglang_omni/models/dots_tts/mlx/`): the Qwen2 backbone, semantic (patch) encoder, and flow-matching DiT hand-written in the repo's MLX style, loaded through `mlx_lm.utils.load_model` (`sanitize` remaps the  `llm.model.*` backbone prefix and the stride-2 conv layout). A dedicated omni `ModelRunner` owns the per-request flow state (KV cache, FM history, ODE), runs every step under a thread-local MLX stream, and converts the decoded latent patch back to Torch at the emission boundary for the vocoder stage.
- **Torch/MPS backbone** (`torch_mps_runner.py`): SGLang's eager extend path hardcodes a `bfloat16()` cast on input embeddings; on the fp32 MPS profile that becomes a mixed-dtype matmul Metal aborts on. The MPS runner swaps in the pinned HF `Qwen2Model` (self-contained `past_key_values`) and owns the backbone forward, keeping the flow head shared with the CUDA path.
- **Engine wiring** (`engine_builder.py`): auto-detects an MPS device and pins `max_running_requests=1`, `torch_native` attention, eager backbone, and an MPS memory-fraction floor; selects the MLX / Torch-MPS / CUDA runner.
- **Compat** (`compat.py`): a pure-Python `wetext` shim standing in for the`tn.*` normalizers (WeTextProcessing → Pynini has no macOS wheel), plus a`torchdiffeq` float64 preload before the `torch.device("mps")` context.

## Design notes

- **Why an omni ModelRunner, not the MLX token bridge.** The token bridge (qwen3_asr, Fun-CosyVoice3) is a discrete-token-LM abstraction: each decode step samples one token id from vocab logits. dots.tts has no vocabulary — each step runs a DiT ODE producing a continuous latent patch, fed back as a computed semantic embedding. It uses the omni ModelRunner path, matching its own CUDA and Torch/MPS runners and the repo's other continuous omni models (zonos2, ming_tts, moss_tts). CosyVoice3 fits the bridge because its AR emits discrete speech tokens and its flow-matching lives in a separate downstream vocoder; dots fuses AR and flow in one loop.
- **Why `max_running_requests=1` on Apple.** Continuous batching stays CUDA-only across all three Apple ports (qwen3_asr, Fun-CosyVoice3, dots).dots' flow ODE is the AR decode itself, so there is no separately batchable downstream stage; the Apple runners implement the single-request path.

## Validation

Host: M5, 24 GB, macOS.

- **MLX** — `/v1/audio/speech` with `dots.tts-soar` + `male-voice.wav` and its full transcript: HTTP 200, 3.84 s clip, peak amplitude 32767 (full scale).
- **Torch/MPS** — same request: HTTP 200, audible output.
- Reference transcript must match the audio; a truncated transcript yields near-silent output (matches upstream dots.tts behavior, not a code defect).
- Eager single-request path; Apple is a local/dev target, latency is not throughput-optimized.

## Tests

`tests/unit_test/dots_tts/`: 125 passed, 1 skipped. New cases cover the Apple generation defaults, runner selection (MLX / Torch-MPS), the `bs=1` guard, the memory-fraction floor, and CUDA-graph degradation. Cookbook updated with an Apple Silicon section.

Ref #1967