### PR TITLE
[Apple] Keep the profiler import working under SGLang's Metal profiler patch

### DIFF
--- a/sglang_omni/profiler/torch_profiler.py
+++ b/sglang_omni/profiler/torch_profiler.py
@@ -3,6 +3,8 @@
 # Original files:
 # - https://github.com/vllm-project/vllm-omni/blob/main/vllm_omni/diffusion/profiler/torch_profiler.py
 
+from __future__ import annotations
+
 import logging
 import os
 import subprocess

--- a/tests/unit_test/profiler/test_torch_profiler_import.py
+++ b/tests/unit_test/profiler/test_torch_profiler_import.py
@@ -1,0 +1,22 @@
+# SPDX-License-Identifier: Apache-2.0
+"""Keep profiler imports safe after SGLang installs its Metal wrapper."""
+
+import subprocess
+import sys
+
+
+def test_torch_profiler_import_after_function_wrapper():
+    result = subprocess.run(
+        [
+            sys.executable,
+            "-c",
+            "import torch.profiler; "
+            "torch.profiler.profile = lambda *args, **kwargs: None; "
+            "from sglang_omni.profiler.torch_profiler import TorchProfiler; "
+            "assert TorchProfiler._profiler is None",
+        ],
+        capture_output=True,
+        text=True,
+        timeout=60,
+    )
+    assert result.returncode == 0, result.stderr


### PR DESCRIPTION
> **Draft / temporary** — opened for review of the diagnosis. Branch is based on an
> older `main`; the diff is the single commit below.

## Problem

On Apple Silicon, importing `sglang.srt.managers.scheduler` runs SGLang's
`apply_metal_profiler_patches()`, which rebinds `torch.profiler.profile` from a class to a
function. Any *later* import of `sglang_omni.profiler.torch_profiler` then evaluates the
class-body annotation `_profiler: profile | None` against that function:

```
TypeError: unsupported operand type(s) for |: 'function' and 'NoneType'
```

The unit suite hits exactly that order. `tests/unit_test/qwen3_asr/test_pipeline.py` imports
`sglang_omni.scheduling.omni_scheduler`, which imports the SGLang scheduler, so collecting the
Qwen3-ASR tests alongside the pipeline tests aborts collection of 10 pipeline modules:

```
$ pytest tests/unit_test/qwen3_asr tests/unit_test/pipeline --co -q
!!!!!! Interrupted: 10 errors during collection !!!!!!
1019 tests collected, 10 errors
```

pytest exits without running any of them, so there is no way to get a green unit run on macOS.

## Scope — serving is *not* affected

Verified on unmodified `main`: `serve.launcher` imports the profiler before anything reaches
the SGLang scheduler, so `profile` is still a class at that point. Both Qwen3-ASR servers start
clean without this change (`/health` 200):

| Path | Result |
|---|---|
| MLX (`SGLANG_USE_MLX=1`, `Qwen3-ASR-0.6B-4bit`) | starts clean |
| Torch-MPS (`SGLANG_USE_MLX=0`, `Qwen3-ASR-0.6B`) | starts clean |

The breakage is purely a function of import order, so this defers the annotation with
`from __future__ import annotations` rather than depending on which module lands first.

## Verification

A/B on current `main` (`4562a7ef`), macOS arm64:

| | Result |
|---|---|
| without the fix | `Interrupted: 10 errors during collection` |
| with the fix | `1199 tests collected` |

The regression test asserts the import in a subprocess with `torch.profiler.profile` rebound to
a function, so it reproduces on machines without the Metal build.

## Notes

This is pre-existing, not a regression — it reproduces on `main` at `53f0599c` with the
pre-0.5.19 SGLang pin. It surfaced while validating the 0.5.19 bump in
sgl-project/sglang-omni#2040 on macOS, where the unit suite could not be run without it.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
