### PR TITLE
[AMD][ROCm] Update Docker base to SGLang v0.5.19

### DIFF
--- a/docker/rocm.Dockerfile
+++ b/docker/rocm.Dockerfile
@@ -1,7 +1,7 @@
 # syntax=docker/dockerfile:1.7
 
 # Build on the validated SGLang ROCm stack without replacing GPU-coupled components.
-ARG SGLANG_IMAGE=lmsysorg/sglang:v0.5.18-rocm720-mi35x@sha256:6d68cd19206716cb3f1e31e2ad89cd0852d7ae614a792773c30a4277f8955c72
+ARG SGLANG_IMAGE=lmsysorg/sglang:v0.5.19-rocm720-mi35x@sha256:f4b6260f7cd2fe46e09f0eb4cbdf2f6a13f4023ebd9dde91144cb97b10c3def0
 
 FROM ${SGLANG_IMAGE} AS runtime
 


### PR DESCRIPTION
## Motivation

SGLang-Omni now pins SGLang v0.5.19, while the ROCm development image still inherits the v0.5.18 SGLang ROCm image.

## Modifications

- Update the gfx950 ROCm 7.2 base image from SGLang v0.5.18 to v0.5.19.
- Pin the v0.5.19 image by its immutable manifest digest.

## Validation

- `git diff --check` and pre-commit pass.
- Docker BuildKit `--check` passes without warnings.
- A no-cache image build from the exact PR commit succeeds.
- The final image preserves the base Torch, torchvision, torchaudio, SGLang, Triton, AITER, NIXL, and protobuf versions.
- A gfx950 runtime smoke passes for ROCm PyTorch execution, AITER and NIXL imports, UCX ROCm transports, and NIXL VRAM registration.
- The installed SGLang-Omni metadata contains no CUDA requirements and adds no new `pip check` errors relative to the base image.

## Checklist

- [x] Format your code according with pre-commit.
- [x] Add unit tests or provide scoped validation.
- [x] Update documentation / docstrings / example tutorials as needed.
- [x] Provide throughput / latency benchmark results and accuracy evaluation results as needed.
- [ ] For reviewers: If you haven't made any contributions to this PR and are only assisting with merging the main branch, please remove yourself as a co-author when merging the PR.
