### PR TITLE
[ASR Feature] Add live MOSS-Transcribe-Diarize realtime transcription

### DIFF
--- a/sglang_omni/models/moss_transcribe_diarize/config.py
+++ b/sglang_omni/models/moss_transcribe_diarize/config.py
@@ -12,10 +12,14 @@ from sglang_omni.config import (
     EngineStageConfig,
     FactoryArgs,
     PipelineConfig,
+    RealtimeTranscriptionConfig,
     StageConfig,
 )
 from sglang_omni.models.moss_transcribe_diarize import (  # noqa: F401
     hf_config as _hf_config,
+)
+from sglang_omni.models.moss_transcribe_diarize.streaming import (
+    MossTranscribeDiarizeStreamingStrategy,
 )
 from sglang_omni.utils.cpu import bounded_intraop_threads
 
@@ -42,6 +46,11 @@ class MossTranscribeDiarizePipelineConfig(PipelineConfig):
 
     architecture: ClassVar[str] = "MossTranscribeDiarizeForConditionalGeneration"
     requires_model_capabilities: ClassVar[bool] = True
+    realtime_transcription: ClassVar[RealtimeTranscriptionConfig] = (
+        RealtimeTranscriptionConfig(
+            strategy_cls=MossTranscribeDiarizeStreamingStrategy,
+        )
+    )
 
     stage_config_types: ClassVar[dict[str, type[StageConfig]]] = {
         "asr": MossTDStageConfig,

--- a/sglang_omni/models/moss_transcribe_diarize/streaming.py
+++ b/sglang_omni/models/moss_transcribe_diarize/streaming.py
@@ -1,0 +1,75 @@
+from __future__ import annotations
+
+from dataclasses import dataclass
+
+from sglang_omni.client import GenerateRequest
+from sglang_omni.serve.speech_to_text import build_speech_to_text_generate_request
+
+
+@dataclass(slots=True)
+class MossTranscribeDiarizeStreamingState:
+    model_name: str
+    language: str | None = None
+    chunk_id: int = 0
+    transcript: str = ""
+
+
+class MossTranscribeDiarizeStreamingStrategy:
+    """Cumulative re-decode strategy for MOSS-TD realtime transcription."""
+
+    def create_state(
+        self, *, model_name: str, language: str | None
+    ) -> MossTranscribeDiarizeStreamingState:
+        return MossTranscribeDiarizeStreamingState(
+            model_name=model_name,
+            language=language,
+        )
+
+    @staticmethod
+    def _state(state: object) -> MossTranscribeDiarizeStreamingState:
+        if not isinstance(state, MossTranscribeDiarizeStreamingState):
+            raise TypeError(
+                "MOSS-Transcribe-Diarize received incompatible streaming state"
+            )
+        return state
+
+    def build_decode_request(
+        self,
+        *,
+        audio: bytes,
+        state: object,
+        is_final: bool,
+        request_id: str,
+    ) -> GenerateRequest:
+        del is_final, request_id
+        moss_state = self._state(state)
+        return build_speech_to_text_generate_request(
+            audio_bytes=audio,
+            filename="realtime-segment.wav",
+            content_type="audio/wav",
+            model=moss_state.model_name,
+            language=moss_state.language,
+            prompt=None,
+            temperature=0.0,
+            stream=False,
+        )
+
+    def update_hypothesis(
+        self,
+        *,
+        generated_text: str,
+        language: str | None,
+        state: object,
+    ) -> str:
+        moss_state = self._state(state)
+        if language:
+            moss_state.language = language
+        moss_state.transcript = generated_text
+        moss_state.chunk_id += 1
+        return generated_text
+
+
+__all__ = [
+    "MossTranscribeDiarizeStreamingState",
+    "MossTranscribeDiarizeStreamingStrategy",
+]

--- a/tests/unit_test/moss_transcribe_diarize/test_pipeline.py
+++ b/tests/unit_test/moss_transcribe_diarize/test_pipeline.py
@@ -20,6 +20,9 @@ from sglang_omni.models.moss_transcribe_diarize.stages import (
     _missing_additional_chat_templates_compat,
     create_sglang_moss_transcribe_diarize_executor,
 )
+from sglang_omni.models.moss_transcribe_diarize.streaming import (
+    MossTranscribeDiarizeStreamingStrategy,
+)
 from sglang_omni.models.registry import PIPELINE_CONFIG_REGISTRY
 from sglang_omni.scheduling.generation_batch_policy import (
     build_default_prefill_cuda_graph_bs,
@@ -86,6 +89,9 @@ def test_moss_transcribe_diarize_config_uses_single_batched_stage() -> None:
         is MossTranscribeDiarizePipelineConfig
     )
     assert MossTranscribeDiarizePipelineConfig.stage_config_cls("asr").engine_stage
+    realtime = MossTranscribeDiarizePipelineConfig.realtime_transcription
+    assert realtime.strategy_cls is MossTranscribeDiarizeStreamingStrategy
+    assert realtime.decode_interval_ms == 2000
 
 
 def test_moss_transcribe_diarize_prefill_backend_policy() -> None:

--- a/tests/unit_test/moss_transcribe_diarize/test_streaming.py
+++ b/tests/unit_test/moss_transcribe_diarize/test_streaming.py
@@ -1,0 +1,70 @@
+# SPDX-License-Identifier: Apache-2.0
+from __future__ import annotations
+
+from sglang_omni.models.moss_transcribe_diarize.streaming import (
+    MossTranscribeDiarizeStreamingStrategy,
+)
+
+
+def test_moss_streaming_builds_cumulative_audio_request() -> None:
+    strategy = MossTranscribeDiarizeStreamingStrategy()
+    state = strategy.create_state(
+        model_name="OpenMOSS-Team/MOSS-Transcribe-Diarize",
+        language="zh",
+    )
+
+    request = strategy.build_decode_request(
+        audio=b"wav-refresh",
+        state=state,
+        is_final=False,
+        request_id="session:0:1",
+    )
+
+    assert request.model == "OpenMOSS-Team/MOSS-Transcribe-Diarize"
+    assert request.prompt == {
+        "audio_bytes": b"wav-refresh",
+        "filename": "realtime-segment.wav",
+        "content_type": "audio/wav",
+    }
+    assert request.extra_params == {"task": "transcribe", "language": "zh"}
+    assert request.stream is False
+    assert request.output_modalities == ["text"]
+
+
+def test_moss_streaming_updates_language_and_hypothesis() -> None:
+    strategy = MossTranscribeDiarizeStreamingStrategy()
+    state = strategy.create_state(model_name="moss", language=None)
+
+    first = strategy.update_hypothesis(
+        generated_text="[0.00][S01] 你好[1.20]",
+        language="Chinese",
+        state=state,
+    )
+    second = strategy.update_hypothesis(
+        generated_text="[0.00][S01] 你好，世界。[2.10]",
+        language=None,
+        state=state,
+    )
+
+    assert first == "[0.00][S01] 你好[1.20]"
+    assert second == "[0.00][S01] 你好，世界。[2.10]"
+    assert state.transcript == second
+    assert state.language == "Chinese"
+    assert state.chunk_id == 2
+
+
+def test_moss_streaming_states_are_isolated() -> None:
+    strategy = MossTranscribeDiarizeStreamingStrategy()
+    first = strategy.create_state(model_name="moss", language="en")
+    second = strategy.create_state(model_name="moss", language="zh")
+
+    strategy.update_hypothesis(
+        generated_text="first",
+        language="English",
+        state=first,
+    )
+
+    assert first.transcript == "first"
+    assert first.language == "English"
+    assert second.transcript == ""
+    assert second.language == "zh"


### PR DESCRIPTION
## Motivation

MOSS-Transcribe-Diarize already supports complete uploads through
`/v1/audio/transcriptions`, but its pipeline was not registered for the shared
`/v1/realtime` transcription session. This adds model-specific realtime input
support while preserving MOSS-TD's timestamp and speaker-label output format.

## Modifications

- Add `MossTranscribeDiarizeStreamingStrategy`, using cumulative audio
  re-decodes for revisable partial hypotheses and final segments.
- Register the strategy in `MossTranscribeDiarizePipelineConfig` with the
  existing 2-second realtime refresh interval.
- Add unit coverage for request construction, language propagation, state
  isolation, and pipeline registration.

## Related Issues

Related to #1837.

## Accuracy Test

The following checks pass in the repository virtual environment:

- `23 passed` for MOSS streaming, realtime session, and pipeline unit tests.
- `python -m compileall` for the changed model and test packages.
- Applicable pre-commit hooks for all changed files.

The full `tests/unit_test` run has no failures in the changed MOSS or realtime
tests. Its unrelated environment-dependent failures are documented separately
in the development notes.

## Benchmark & Profiling

Cumulative re-decode intentionally trades additional encoder/prefill work for
correct revisable hypotheses. No benchmark is included because this change
adds model wiring and strategy behavior without changing shared performance
paths.

## Checklist

- [x] Format your code according with pre-commit.
- [x] Add unit tests.
- [x] Update documentation / docstrings / example tutorials as needed.
- [x] Provide throughput / latency benchmark results and accuracy evaluation results as needed.
- [ ] For reviewers: If you haven't made any contributions to this PR and are only assisting with merging the main branch, please remove yourself as a co-author when merging the PR.