### PR TITLE
[Bug][AuK] Honor the conditioning dtype configuration

### DIFF
--- a/sglang_omni/models/auk/config.py
+++ b/sglang_omni/models/auk/config.py
@@ -33,7 +33,10 @@ class AuKPipelineConfig(PipelineConfig):
             factory_path=f"{_PKG}.stages.create_conditioning_executor",
             factory=FactoryArgs(
                 device=current_platform.device_type,
-                dtype="bfloat16",
+                # Keep the conditioner in FP32 by default for parity with the
+                # reference implementation.  BF16 remains available as an
+                # explicit stage-factory override.
+                dtype="float32",
                 text_encoder_path=C.DEFAULT_TEXT_ENCODER,
                 max_batch_size=8,
                 max_batch_wait_ms=10,

--- a/sglang_omni/models/auk/reference_encode.py
+++ b/sglang_omni/models/auk/reference_encode.py
@@ -66,7 +66,7 @@ class AuKConditionEncoder:
         model.lm_head = torch.nn.Identity()
         model.requires_grad_(False)
         model.eval()
-        self.model = model.to(device=self.device, dtype=torch.float32)
+        self.model = model.to(device=self.device, dtype=dtype)
 
     @property
     def num_hidden_layers(self) -> int:

--- a/sglang_omni/models/auk/stages.py
+++ b/sglang_omni/models/auk/stages.py
@@ -157,7 +157,7 @@ def create_conditioning_executor(
     *,
     device: str | None = None,
     gpu_id: int | None = None,
-    dtype: str = "bfloat16",
+    dtype: str = "float32",
     text_encoder_path: str = C.DEFAULT_TEXT_ENCODER,
     max_batch_size: int = 8,
     max_batch_wait_ms: int = 10,

--- a/tests/unit_test/auk/test_config.py
+++ b/tests/unit_test/auk/test_config.py
@@ -33,6 +33,7 @@ def test_registered_pipeline_is_connected(architecture):
     assert conditioning.next == engine.name == ENGINE_STAGE
     assert engine.next == decode.name == DECODE_STAGE
     assert config.terminal_stages == [decode.name]
+    assert conditioning.factory.dtype == "float32"
     for stage in config.stages:
         module, name = stage.factory_path.rsplit(".", 1)
         assert callable(getattr(importlib.import_module(module), name))

--- a/tests/unit_test/auk/test_reference_encode.py
+++ b/tests/unit_test/auk/test_reference_encode.py
@@ -1,0 +1,50 @@
+# SPDX-License-Identifier: Apache-2.0
+"""Conditioner construction and dtype handling for AuK."""
+
+from types import SimpleNamespace
+
+import torch
+
+
+def test_conditioner_honors_requested_dtype(monkeypatch):
+    import sys
+
+    from sglang_omni.models.auk.reference_encode import AuKConditionEncoder
+
+    class FakeProcessor:
+        @classmethod
+        def from_pretrained(cls, path):
+            return cls()
+
+    class FakeModel(torch.nn.Module):
+        _keys_to_ignore_on_load_unexpected = None
+
+        @classmethod
+        def from_pretrained(cls, path, torch_dtype):
+            model = cls()
+            model.loaded_dtype = torch_dtype
+            return model
+
+        def __init__(self):
+            super().__init__()
+            self.weight = torch.nn.Parameter(torch.ones(2, 2))
+            self.config = SimpleNamespace(
+                text_config=SimpleNamespace(num_hidden_layers=1)
+            )
+            self.visual = object()
+            self.lm_head = object()
+
+    monkeypatch.setitem(
+        sys.modules,
+        "transformers",
+        SimpleNamespace(
+            Qwen2_5OmniProcessor=FakeProcessor,
+            Qwen2_5OmniThinkerForConditionalGeneration=FakeModel,
+        ),
+    )
+
+    encoder = AuKConditionEncoder("stub", dtype=torch.bfloat16)
+
+    assert encoder.dtype is torch.bfloat16
+    assert encoder.model.loaded_dtype is torch.bfloat16
+    assert next(encoder.model.parameters()).dtype is torch.bfloat16


### PR DESCRIPTION
## Motivation

The AuK conditioning stage exposes a `dtype` setting, but
`AuKConditionEncoder` always converted the Qwen2.5-Omni-3B conditioner to
FP32 after loading. This made the configured dtype ineffective and could not
be overridden by users.

## Modifications

Make `AuKConditionEncoder` retain the dtype passed by the conditioning stage.
Keep FP32 as the default conditioning dtype to preserve the current output behavior and upstream parity.
Allow an explicit BF16 override through the existing stage factory configuration.
Add a unit test that verifies the requested dtype reaches model loading and parameter storage.

## Related Issues

None.

## Accuracy Test

- The local Qwen2.5-Omni-3B checkpoint loaded successfully with both FP32 and
  explicit BF16 conditioner dtypes.
- Both modes produced finite hidden states with shape `(37, 47, 2048)`.
- The default remains FP32, so existing AuK parity behavior is unchanged.

Explicit BF16 compared with FP32:

| Output | Relative L2 difference |
| --- | ---: |
| Hidden states | 1.05% |
| Fused AuK conditioning | 0.83% |
| Generated latent | 0.93% |

## Benchmark & Profiling

The default FP32 path is unchanged.
Environment: RTX 5090, 32 GB VRAM, production BF16 autocast context

Explicit BF16 compared with FP32:

| Metric | FP32 | BF16 | Change |
| --- | ---: | ---: | ---: |
| Qwen conditioner memory | 13.97 GiB | 6.97 GiB | 7.00 GiB lower |
| Single-request encoding latency | 18.98 ms | 14.41 ms | 24.1% lower |

The BF16 path is opt-in through the existing conditioning stage `dtype`
setting, so deployments can trade numerical difference for lower memory use
without changing the default.

## Checklist

- [x] Format your code according with pre-commit.
- [x] Add unit tests.
- [ ] Update documentation / docstrings / example tutorials as needed.
- [x] Provide throughput / latency benchmark results and accuracy evaluation results as needed.
- [ ] CI