### PR TITLE
[Perf][MOSS-TTS] Fuse streaming KV cache updates in MOSS-Audio-Tokenizer

### DIFF
--- a/sglang_omni/models/moss_tts/attention.py
+++ b/sglang_omni/models/moss_tts/attention.py
@@ -18,6 +18,9 @@ from torch import nn
 
 from sglang_omni.models.moss_tts.vocoder_kernels import (
     apply_exact_interleaved_rope_inplace,
+    can_fuse_streaming_kv,
+    commit_streaming_kv_,
+    gather_streaming_kv,
 )
 
 # note (Zhang Yiyang): Bound SDPA fallback memory with query chunks.
@@ -1074,6 +1077,47 @@ class MossAudioTokenizerAttention(MossAudioTokenizerStreamingModule):
             self.get_backend_dtype(x),
         )
         old_offsets = state.offset.index_select(0, slots)
+        if (
+            self.context is not None
+            and cached_keys.shape[2] == self.context
+            and can_fuse_streaming_kv(
+                cached_keys,
+                cached_values,
+                cached_positions,
+                state.offset,
+                slots,
+                valid_rows,
+            )
+        ):
+            q, current_k, current_v, query_positions = self._project_streaming_qkv(
+                x, old_offsets
+            )
+            all_k, all_v, key_positions = gather_streaming_kv(
+                cached_keys,
+                cached_values,
+                cached_positions,
+                current_k,
+                current_v,
+                query_positions,
+                slots,
+            )
+            output = self._streaming_attention(
+                q, all_k, all_v, query_positions, key_positions
+            )
+            output = self.out_proj(output)
+            commit_streaming_kv_(
+                cached_keys,
+                cached_values,
+                cached_positions,
+                state.offset,
+                all_k,
+                all_v,
+                key_positions,
+                slots,
+                valid_rows,
+            )
+            return output.masked_fill(~valid_rows.view(-1, 1, 1), 0)
+
         old_row_keys = cached_keys.index_select(0, slots)
         old_row_values = cached_values.index_select(0, slots)
         old_row_positions = cached_positions.index_select(0, slots)
@@ -1090,7 +1134,12 @@ class MossAudioTokenizerAttention(MossAudioTokenizerStreamingModule):
             row_state.exec_mask.fill_(True)
         output = self._forward_streaming_sdpa(x, row_state)
 
-        next_offsets = torch.where(valid_rows, row_state.offset, old_offsets)
+        # note (Zhang Yiyang): Finite-context SDPA preserves inactive rows and
+        # offsets. Unbounded attention advances every execution row while its
+        # cache grows, so only that path needs the outer validity guards.
+        next_offsets = row_state.offset
+        if self.context is None:
+            next_offsets = torch.where(valid_rows, next_offsets, old_offsets)
         state.offset.index_copy_(0, slots, next_offsets)
         if self.context is None:
             old_length = int(cached_keys.shape[2])
@@ -1120,39 +1169,26 @@ class MossAudioTokenizerAttention(MossAudioTokenizerStreamingModule):
             state.cached_keys = expanded_keys
             state.cached_values = expanded_values
             state.cached_positions = expanded_positions
-        else:
-            old_row_keys_expanded = old_row_keys
-            old_row_values_expanded = old_row_values
-            old_row_positions_expanded = old_row_positions
-
-        valid_cache_rows = valid_rows.view(-1, 1, 1, 1)
-        state.cached_keys.index_copy_(
-            0,
-            slots,
-            torch.where(
-                valid_cache_rows,
-                row_state.cached_keys,
-                old_row_keys_expanded,
-            ),
-        )
-        state.cached_values.index_copy_(
-            0,
-            slots,
-            torch.where(
-                valid_cache_rows,
-                row_state.cached_values,
-                old_row_values_expanded,
-            ),
-        )
-        state.cached_positions.index_copy_(
-            0,
-            slots,
-            torch.where(
+            valid_cache_rows = valid_rows.view(-1, 1, 1, 1)
+            next_row_keys = torch.where(
+                valid_cache_rows, row_state.cached_keys, old_row_keys_expanded
+            )
+            next_row_values = torch.where(
+                valid_cache_rows, row_state.cached_values, old_row_values_expanded
+            )
+            next_row_positions = torch.where(
                 valid_rows.view(-1, 1),
                 row_state.cached_positions,
                 old_row_positions_expanded,
-            ),
-        )
+            )
+        else:
+            next_row_keys = row_state.cached_keys
+            next_row_values = row_state.cached_values
+            next_row_positions = row_state.cached_positions
+
+        state.cached_keys.index_copy_(0, slots, next_row_keys)
+        state.cached_values.index_copy_(0, slots, next_row_values)
+        state.cached_positions.index_copy_(0, slots, next_row_positions)
         return output.masked_fill(~valid_rows.view(-1, 1, 1), 0)
 
     def _ensure_streaming_cache(
@@ -1242,6 +1278,21 @@ class MossAudioTokenizerAttention(MossAudioTokenizerStreamingModule):
             cached_pos,
         )
 
+    def _project_streaming_qkv(
+        self,
+        x: torch.Tensor,
+        offsets: torch.Tensor,
+    ) -> tuple[torch.Tensor, torch.Tensor, torch.Tensor, torch.Tensor]:
+        q, current_k, current_v = self._project_qkv(x)
+        if self.rope is not None:
+            q, current_k = _apply_cached_streaming_rope(
+                q, current_k, offsets, cache=self._packed_rope_cache
+            )
+        query_positions = offsets.view(-1, 1) + torch.arange(
+            x.shape[1], device=x.device, dtype=torch.long
+        ).view(1, -1)
+        return q, current_k, current_v, query_positions
+
     def _streaming_qkv(
         self,
         x: torch.Tensor,
@@ -1256,23 +1307,12 @@ class MossAudioTokenizerAttention(MossAudioTokenizerStreamingModule):
         torch.Tensor,
         torch.Tensor,
     ]:
-        batch_size, chunk_length, _ = x.shape
-        q, current_k, current_v = self._project_qkv(x)
-        if self.rope is not None:
-            q, current_k = _apply_cached_streaming_rope(
-                q,
-                current_k,
-                state.offset,
-                cache=self._packed_rope_cache,
-            )
-        query_positions = state.offset.view(-1, 1) + torch.arange(
-            chunk_length,
-            device=x.device,
-            dtype=torch.long,
-        ).view(1, -1)
+        q, current_k, current_v, query_positions = self._project_streaming_qkv(
+            x, state.offset
+        )
         cached_k, cached_v, cached_pos = self._ensure_streaming_cache(
             state,
-            batch_size,
+            x.shape[0],
             current_k.device,
             current_k.dtype,
         )
@@ -1331,7 +1371,7 @@ class MossAudioTokenizerAttention(MossAudioTokenizerStreamingModule):
         x: torch.Tensor,
         state: _AttentionStreamingState,
     ) -> torch.Tensor:
-        batch_size, chunk_length, _ = x.shape
+        chunk_length = x.shape[1]
         if chunk_length == 0:
             return self.out_proj(x)
         (
@@ -1344,21 +1384,8 @@ class MossAudioTokenizerAttention(MossAudioTokenizerStreamingModule):
             cached_v,
             cached_pos,
         ) = self._streaming_qkv(x, state)
-        delta = query_positions[:, :, None] - key_positions[:, None, :]
-        attention_mask = (key_positions[:, None, :] >= 0) & (delta >= 0)
-        if self.context is not None:
-            attention_mask &= delta < self.context
-        output = F.scaled_dot_product_attention(
-            q,
-            all_k,
-            all_v,
-            attn_mask=attention_mask[:, None, :, :],
-            dropout_p=0.0,
-        )
-        output = output.transpose(1, 2).reshape(
-            batch_size,
-            chunk_length,
-            self.embed_dim,
+        output = self._streaming_attention(
+            q, all_k, all_v, query_positions, key_positions
         )
         return self._finish_streaming_attention(
             output,
@@ -1370,6 +1397,25 @@ class MossAudioTokenizerAttention(MossAudioTokenizerStreamingModule):
             all_k=all_k,
             all_v=all_v,
             key_positions=key_positions,
+        )
+
+    def _streaming_attention(
+        self,
+        q: torch.Tensor,
+        all_k: torch.Tensor,
+        all_v: torch.Tensor,
+        query_positions: torch.Tensor,
+        key_positions: torch.Tensor,
+    ) -> torch.Tensor:
+        delta = query_positions[:, :, None] - key_positions[:, None, :]
+        attention_mask = (key_positions[:, None, :] >= 0) & (delta >= 0)
+        if self.context is not None:
+            attention_mask &= delta < self.context
+        output = F.scaled_dot_product_attention(
+            q, all_k, all_v, attn_mask=attention_mask[:, None, :, :], dropout_p=0.0
+        )
+        return output.transpose(1, 2).reshape(
+            query_positions.shape[0], query_positions.shape[1], self.embed_dim
         )
 
     def _project_qkv(

--- a/sglang_omni/models/moss_tts/vocoder_kernels.py
+++ b/sglang_omni/models/moss_tts/vocoder_kernels.py
@@ -15,6 +15,7 @@ except ImportError:  # pragma: no cover - depends on runtime image
 
 _EXACT_ROPE_BLOCK_SIZE = 256
 _EXACT_ROPE_NUM_WARPS = 4
+_STREAMING_KV_BLOCK_SIZE = 512
 
 
 if triton is not None and hasattr(tl, "inline_asm_elementwise"):
@@ -152,4 +153,312 @@ def apply_exact_interleaved_rope_inplace(
     return True
 
 
-__all__ = ["apply_exact_interleaved_rope_inplace"]
+if triton is not None:
+
+    @triton.jit
+    def _streaming_kv_gather_kernel(
+        cached_k,
+        cached_v,
+        cached_positions,
+        current_k,
+        current_v,
+        query_positions,
+        slots,
+        all_k,
+        all_v,
+        key_positions,
+        cached_k_strides: tl.constexpr,
+        cached_v_strides: tl.constexpr,
+        current_k_strides: tl.constexpr,
+        current_v_strides: tl.constexpr,
+        num_heads: tl.constexpr,
+        context: tl.constexpr,
+        chunk_length: tl.constexpr,
+        head_dim: tl.constexpr,
+        block_size: tl.constexpr,
+    ):
+        row = tl.program_id(0)
+        index = tl.program_id(1) * block_size + tl.arange(0, block_size)
+        length: tl.constexpr = context + chunk_length
+        mask = index < num_heads * length * head_dim
+        head = index // (length * head_dim)
+        position = (index // head_dim) % length
+        dim = index % head_dim
+        old = position < context
+        slot = tl.load(slots + row)
+        old_k = tl.load(
+            cached_k
+            + slot * cached_k_strides[0]
+            + head * cached_k_strides[1]
+            + position * cached_k_strides[2]
+            + dim * cached_k_strides[3],
+            mask & old,
+            other=0,
+        )
+        old_v = tl.load(
+            cached_v
+            + slot * cached_v_strides[0]
+            + head * cached_v_strides[1]
+            + position * cached_v_strides[2]
+            + dim * cached_v_strides[3],
+            mask & old,
+            other=0,
+        )
+        new_k = tl.load(
+            current_k
+            + row * current_k_strides[0]
+            + head * current_k_strides[1]
+            + (position - context) * current_k_strides[2]
+            + dim * current_k_strides[3],
+            mask & ~old,
+            other=0,
+        )
+        new_v = tl.load(
+            current_v
+            + row * current_v_strides[0]
+            + head * current_v_strides[1]
+            + (position - context) * current_v_strides[2]
+            + dim * current_v_strides[3],
+            mask & ~old,
+            other=0,
+        )
+        output_index = row * num_heads * length * head_dim + index
+        tl.store(all_k + output_index, tl.where(old, old_k, new_k), mask)
+        tl.store(all_v + output_index, tl.where(old, old_v, new_v), mask)
+
+        position_mask = mask & (head == 0) & (dim == 0)
+        old_position = tl.load(
+            cached_positions + slot * context + position,
+            position_mask & old,
+            other=-1,
+        )
+        new_position = tl.load(
+            query_positions + row * chunk_length + position - context,
+            position_mask & ~old,
+            other=0,
+        )
+        tl.store(
+            key_positions + row * length + position,
+            tl.where(old, old_position, new_position),
+            position_mask,
+        )
+
+    @triton.jit
+    def _streaming_kv_commit_kernel(
+        cached_k,
+        cached_v,
+        cached_positions,
+        offsets,
+        all_k,
+        all_v,
+        key_positions,
+        slots,
+        valid_rows,
+        cached_k_strides: tl.constexpr,
+        cached_v_strides: tl.constexpr,
+        num_heads: tl.constexpr,
+        context: tl.constexpr,
+        chunk_length: tl.constexpr,
+        head_dim: tl.constexpr,
+        block_size: tl.constexpr,
+    ):
+        row = tl.program_id(0)
+        index = tl.program_id(1) * block_size + tl.arange(0, block_size)
+        valid = tl.load(valid_rows + row)
+        slot = tl.load(slots + row)
+        mask = (index < num_heads * context * head_dim) & valid
+        head = index // (context * head_dim)
+        position = (index // head_dim) % context
+        dim = index % head_dim
+        # note (Zhang Yiyang): Read the separate gather output to avoid races
+        # from shifting persistent rows in place. The suffix starts at T,
+        # including T >= C.
+        source = (
+            (row * num_heads + head) * (context + chunk_length)
+            + position
+            + chunk_length
+        ) * head_dim + dim
+        k = tl.load(all_k + source, mask, other=0)
+        v = tl.load(all_v + source, mask, other=0)
+        tl.store(
+            cached_k
+            + slot * cached_k_strides[0]
+            + head * cached_k_strides[1]
+            + position * cached_k_strides[2]
+            + dim * cached_k_strides[3],
+            k,
+            mask,
+        )
+        tl.store(
+            cached_v
+            + slot * cached_v_strides[0]
+            + head * cached_v_strides[1]
+            + position * cached_v_strides[2]
+            + dim * cached_v_strides[3],
+            v,
+            mask,
+        )
+        position_mask = mask & (head == 0) & (dim == 0)
+        next_position = tl.load(
+            key_positions + row * (context + chunk_length) + position + chunk_length,
+            position_mask,
+            other=-1,
+        )
+        tl.store(
+            cached_positions + slot * context + position, next_position, position_mask
+        )
+        if tl.program_id(1) == 0:
+            offset = tl.load(offsets + slot, valid, other=0)
+            tl.store(offsets + slot, offset + chunk_length, valid)
+
+else:
+    _streaming_kv_gather_kernel = None
+    _streaming_kv_commit_kernel = None
+
+
+def can_fuse_streaming_kv(
+    cached_k: torch.Tensor,
+    cached_v: torch.Tensor,
+    cached_positions: torch.Tensor,
+    offsets: torch.Tensor,
+    slots: torch.Tensor,
+    valid_rows: torch.Tensor,
+) -> bool:
+    """Check the inference/layout boundary, independently of execution B and T."""
+    if (
+        _streaming_kv_gather_kernel is None
+        or torch.version.hip is not None
+        or torch.is_grad_enabled()
+        or cached_k.device.type != "cuda"
+        or cached_k.dtype not in (torch.float16, torch.bfloat16, torch.float32)
+        or cached_v.dtype != cached_k.dtype
+        or cached_k.ndim != 4
+        or cached_v.shape != cached_k.shape
+        or any(size <= 0 for size in cached_k.shape)
+        or any(stride <= 0 for stride in (*cached_k.stride(), *cached_v.stride()))
+        or slots.ndim != 1
+        or slots.numel() == 0
+    ):
+        return False
+    capacity, _, context, _ = cached_k.shape
+    return (
+        all(
+            t.device == cached_k.device
+            for t in (cached_v, cached_positions, offsets, slots, valid_rows)
+        )
+        and cached_positions.dtype == offsets.dtype == slots.dtype == torch.long
+        and valid_rows.dtype == torch.bool
+        and cached_positions.shape == (capacity, context)
+        and offsets.shape == (capacity,)
+        and valid_rows.shape == slots.shape
+        and cached_positions.is_contiguous()
+        and offsets.stride() == slots.stride() == valid_rows.stride() == (1,)
+    )
+
+
+def gather_streaming_kv(
+    cached_k: torch.Tensor,
+    cached_v: torch.Tensor,
+    cached_positions: torch.Tensor,
+    current_k: torch.Tensor,
+    current_v: torch.Tensor,
+    query_positions: torch.Tensor,
+    slots: torch.Tensor,
+) -> tuple[torch.Tensor, torch.Tensor, torch.Tensor]:
+    """Gather and append chronological K/V for eligible indexed inference.
+
+    The caller checks ``can_fuse_streaming_kv`` first. Current K/V must match
+    the cache dtype/head shape; query_positions is contiguous [B, T]. K/V may
+    be strided. The returned tensors own separate contiguous storage.
+    """
+    batch_size, num_heads, chunk_length, head_dim = current_k.shape
+    context = cached_k.shape[2]
+    shape = (batch_size, num_heads, context + chunk_length, head_dim)
+    all_k = current_k.new_empty(shape)
+    all_v = torch.empty_like(all_k)
+    key_positions = query_positions.new_empty((batch_size, context + chunk_length))
+    block_size = _STREAMING_KV_BLOCK_SIZE
+    with torch.cuda.device(current_k.device):
+        _streaming_kv_gather_kernel[
+            (
+                batch_size,
+                triton.cdiv(
+                    num_heads * (context + chunk_length) * head_dim, block_size
+                ),
+            )
+        ](
+            cached_k,
+            cached_v,
+            cached_positions,
+            current_k,
+            current_v,
+            query_positions,
+            slots,
+            all_k,
+            all_v,
+            key_positions,
+            cached_k.stride(),
+            cached_v.stride(),
+            current_k.stride(),
+            current_v.stride(),
+            num_heads,
+            context,
+            chunk_length,
+            head_dim,
+            block_size,
+            num_warps=4,
+        )
+    return all_k, all_v, key_positions
+
+
+def commit_streaming_kv_(
+    cached_k: torch.Tensor,
+    cached_v: torch.Tensor,
+    cached_positions: torch.Tensor,
+    offsets: torch.Tensor,
+    all_k: torch.Tensor,
+    all_v: torch.Tensor,
+    key_positions: torch.Tensor,
+    slots: torch.Tensor,
+    valid_rows: torch.Tensor,
+) -> None:
+    """Commit a gather result to unique valid slots, preserving inactive rows.
+
+    Inputs follow ``can_fuse_streaming_kv`` and ``gather_streaming_kv``. Run
+    gather and commit in order on the same stream; the gather outputs must not
+    alias the persistent cache. Invalid rows never access persistent offsets.
+    """
+    batch_size, num_heads, length, head_dim = all_k.shape
+    context = cached_k.shape[2]
+    chunk_length = length - context
+    block_size = _STREAMING_KV_BLOCK_SIZE
+    with torch.cuda.device(all_k.device):
+        _streaming_kv_commit_kernel[
+            (batch_size, triton.cdiv(num_heads * context * head_dim, block_size))
+        ](
+            cached_k,
+            cached_v,
+            cached_positions,
+            offsets,
+            all_k,
+            all_v,
+            key_positions,
+            slots,
+            valid_rows,
+            cached_k.stride(),
+            cached_v.stride(),
+            num_heads,
+            context,
+            chunk_length,
+            head_dim,
+            block_size,
+            num_warps=4,
+        )
+
+
+__all__ = [
+    "apply_exact_interleaved_rope_inplace",
+    "can_fuse_streaming_kv",
+    "commit_streaming_kv_",
+    "gather_streaming_kv",
+]

--- a/tests/unit_test/moss_tts/test_audio_tokenizer.py
+++ b/tests/unit_test/moss_tts/test_audio_tokenizer.py
@@ -1327,6 +1327,83 @@ def test_streaming_attention_matches_dense_reference() -> None:
             torch.testing.assert_close(attention(chunk), expected, rtol=1e-5, atol=1e-6)
 
 
+@pytest.mark.parametrize("context", [4, None])
+def test_indexed_attention_preserves_inactive_slots(context: int | None) -> None:
+    torch.manual_seed(29)
+    reference = _ReferenceAttention(8)
+    reference.context = context
+    reference.rope = _RotaryEmbedding(10000.0)
+    attention = MossAudioTokenizerAttention.from_module(
+        reference,
+        attention_backend="sdpa",
+        packed_rope_cache=attention_impl.MossPackedRopeCache(
+            max_period=10000.0, streaming_max_positions=64
+        ),
+    )
+    history = {slot: [] for slot in range(4)}
+    steps = [
+        ([2, 0], [True, True], 2),
+        ([0, 2], [False, True], 5),
+        ([2, 0], [False, False], 1),
+        ([3, 0], [True, True], 7),
+        ([2, 0], [True, True], 3),
+        ([2, 3], [True, False], 2),
+    ]
+    with attention.streaming(4), torch.no_grad():
+        state = attention._streaming_state
+        for step, (slots, valid, length) in enumerate(steps):
+            if step == len(steps) - 1:
+                state.reset_slots(torch.tensor([2]))
+                history[2].clear()
+            inactive = sorted(
+                set(range(4)) - {s for s, live in zip(slots, valid) if live}
+            )
+            before = {
+                name: value.clone()
+                for name in (
+                    "offset",
+                    "cached_keys",
+                    "cached_values",
+                    "cached_positions",
+                )
+                if (value := getattr(state, name)) is not None
+            }
+            chunk = torch.randn(len(slots), length, 8)
+            actual = attention(
+                chunk,
+                execution_context=attention_impl.StreamingExecutionContext(
+                    torch.tensor(slots), torch.tensor(valid)
+                ),
+            )
+            for row, (slot, live) in enumerate(zip(slots, valid)):
+                if not live:
+                    assert torch.count_nonzero(actual[row]) == 0
+                    continue
+                history[slot].append(chunk[row])
+                full_input = torch.cat(history[slot]).unsqueeze(0)
+                expected = reference(
+                    full_input, input_lengths=torch.tensor([full_input.shape[1]])
+                )[0, -length:]
+                torch.testing.assert_close(actual[row], expected, rtol=1e-5, atol=1e-6)
+
+            # note (Zhang Yiyang): Inactive real slots retain history to resume.
+            # Unbounded caches may grow, but their old prefix must stay intact.
+            for name, old in before.items():
+                current = getattr(state, name)
+                if name == "offset":
+                    assert torch.equal(current[inactive], old[inactive])
+                elif name == "cached_positions":
+                    assert torch.equal(current[inactive, : old.shape[1]], old[inactive])
+                    assert torch.all(current[inactive, old.shape[1] :] == -1)
+                else:
+                    assert torch.equal(
+                        current[inactive, :, : old.shape[2]], old[inactive]
+                    )
+                    assert (
+                        torch.count_nonzero(current[inactive, :, old.shape[2] :]) == 0
+                    )
+
+
 def test_transformer_layer_uses_source_modules_for_primitive_ops() -> None:
     source = _CountingLayer(hidden_size=6)
     wrapper = MossAudioTokenizerTransformerLayer.from_module(source)

--- a/tests/unit_test/moss_tts/test_vocoder_kernels.py
+++ b/tests/unit_test/moss_tts/test_vocoder_kernels.py
@@ -1,0 +1,326 @@
+# SPDX-License-Identifier: Apache-2.0
+"""Chronological streaming cache fusion, mutation, and fallback coverage."""
+
+from __future__ import annotations
+
+import copy
+
+import pytest
+import torch
+
+from sglang_omni.models.moss_tts import attention as attention_impl
+from sglang_omni.models.moss_tts import vocoder_kernels as kernels
+
+requires_cuda = pytest.mark.skipif(
+    not torch.cuda.is_available() or torch.version.hip is not None,
+    reason="NVIDIA CUDA is required",
+)
+
+
+def _assert_bytes_equal(actual: torch.Tensor, expected: torch.Tensor) -> None:
+    assert actual.shape == expected.shape
+    assert actual.dtype == expected.dtype
+    assert torch.equal(
+        actual.contiguous().view(torch.uint8),
+        expected.contiguous().view(torch.uint8),
+    )
+
+
+def _inputs(batch, heads, context, length, dim, dtype, *, device="cuda"):
+    capacity = batch + 4
+    # note (Zhang Yiyang): Exercise sliced cache rows and packed-QKV layout.
+    cached_k = torch.randn(
+        capacity, heads, context, dim * 2, device=device, dtype=dtype
+    )[..., ::2]
+    cached_v = torch.randn(
+        capacity, context, heads, dim, device=device, dtype=dtype
+    ).permute(0, 2, 1, 3)
+    offsets = torch.arange(capacity, device=device) + context + 3
+    positions = (
+        offsets[:, None] - context + torch.arange(context, device=device)[None, :]
+    )
+    slots = torch.randperm(capacity, device=device)[:batch]
+    valid = torch.arange(batch, device=device) % 3 != 1
+    packed = torch.randn(batch, length, 3, heads, dim, device=device, dtype=dtype)
+    current_k, current_v = packed[:, :, 1].transpose(1, 2), packed[:, :, 2].transpose(
+        1, 2
+    )
+    query_positions = (
+        offsets[slots, None] + torch.arange(length, device=device)[None, :]
+    )
+    return (
+        cached_k,
+        cached_v,
+        positions,
+        offsets,
+        slots,
+        valid,
+        current_k,
+        current_v,
+        query_positions,
+    )
+
+
+def _reference(inputs):
+    ck, cv, cp, offsets, slots, valid, k, v, qp = inputs
+    context = ck.shape[2]
+    all_k = torch.cat((ck.index_select(0, slots), k), dim=2)
+    all_v = torch.cat((cv.index_select(0, slots), v), dim=2)
+    positions = torch.cat((cp.index_select(0, slots), qp), dim=1)
+    next_state = [x.clone() for x in (ck, cv, cp, offsets)]
+    # note (Zhang Yiyang): Invalid rows can refer to inactive real slots.
+    live_slots = slots[valid]
+    next_state[0].index_copy_(0, live_slots, all_k[valid, :, -context:, :])
+    next_state[1].index_copy_(0, live_slots, all_v[valid, :, -context:, :])
+    next_state[2].index_copy_(0, live_slots, positions[valid, -context:])
+    next_state[3][live_slots] += k.shape[2]
+    return (all_k, all_v, positions), next_state
+
+
+def _fused(inputs):
+    ck, cv, cp, offsets, slots, valid, k, v, qp = inputs
+    all_k, all_v, positions = kernels.gather_streaming_kv(ck, cv, cp, k, v, qp, slots)
+    kernels.commit_streaming_kv_(
+        ck, cv, cp, offsets, all_k, all_v, positions, slots, valid
+    )
+    return all_k, all_v, positions
+
+
+@pytest.mark.accelerator
+@requires_cuda
+@pytest.mark.parametrize("dtype", [torch.float16, torch.bfloat16, torch.float32])
+@pytest.mark.parametrize(
+    "shape",
+    [
+        (1, 2, 1, 1, 8),
+        (3, 3, 17, 1, 7),
+        (3, 3, 17, 17, 7),
+        (3, 3, 17, 21, 7),
+        (2, 20, 125, 5, 64),
+        (16, 12, 400, 160, 64),
+        (4, 12, 400, 800, 64),
+    ],
+)
+@torch.no_grad()
+def test_streaming_kv_matches_chronological_reference(shape, dtype):
+    inputs = _inputs(*shape, dtype)
+    assert kernels.can_fuse_streaming_kv(*inputs[:6])
+    expected, expected_state = _reference(inputs)
+    actual = _fused(inputs)
+    for got, want in zip(actual, expected):
+        _assert_bytes_equal(got, want)
+    for got, want in zip(inputs[:4], expected_state):
+        _assert_bytes_equal(got, want)
+
+
+@pytest.mark.accelerator
+@requires_cuda
+@torch.no_grad()
+def test_streaming_kv_graph_replays_dynamic_slots_and_valid_rows():
+    inputs = _inputs(4, 3, 17, 5, 8, torch.bfloat16)
+    initial = [t.clone() for t in inputs[:4]]
+    stream = torch.cuda.Stream()
+    stream.wait_stream(torch.cuda.current_stream())
+    with torch.cuda.stream(stream):
+        _fused(inputs)
+    torch.cuda.current_stream().wait_stream(stream)
+    graph = torch.cuda.CUDAGraph()
+    with torch.cuda.graph(graph):
+        actual = _fused(inputs)
+    for tensor, value in zip(inputs[:4], initial):
+        tensor.copy_(value)
+    for step in range(6):
+        inputs[4].copy_(inputs[4].roll(1))
+        inputs[5].copy_(
+            torch.tensor([step % 2 == 0, False, True, step % 3 == 0], device="cuda")
+        )
+        inputs[8].copy_(inputs[3][inputs[4], None] + torch.arange(5, device="cuda"))
+        expected, expected_state = _reference(inputs)
+        graph.replay()
+        for got, want in zip(actual, expected):
+            _assert_bytes_equal(got, want)
+        for got, want in zip(inputs[:4], expected_state):
+            _assert_bytes_equal(got, want)
+
+
+@pytest.mark.accelerator
+@requires_cuda
+@torch.no_grad()
+def test_streaming_kv_preserves_inactive_nan_and_signed_zero_bytes():
+    inputs = _inputs(3, 2, 4, 5, 8, torch.bfloat16)
+    # note (Zhang Yiyang): Invalid real slots retain stale/nonfinite bytes.
+    # Cached values need no arithmetic, even when their positions are invalid.
+    inputs[0].fill_(float("nan"))
+    inputs[1].fill_(-0.0)
+    inputs[2].fill_(-1)
+    inputs[5].zero_()
+    expected, expected_state = _reference(inputs)
+    actual = _fused(inputs)
+    for got, want in zip(actual, expected):
+        _assert_bytes_equal(got, want)
+    for got, want in zip(inputs[:4], expected_state):
+        _assert_bytes_equal(got, want)
+
+
+@pytest.mark.accelerator
+@requires_cuda
+@pytest.mark.parametrize(
+    "layout", ["slots", "valid", "offsets", "positions", "broadcast_cache"]
+)
+@torch.no_grad()
+def test_streaming_kv_rejects_unsupported_metadata_or_writable_layout(layout):
+    inputs = list(_inputs(3, 2, 4, 5, 8, torch.bfloat16))
+    assert kernels.can_fuse_streaming_kv(*inputs[:6])
+    index = {"slots": 4, "valid": 5, "offsets": 3, "positions": 2}.get(layout)
+    if layout == "broadcast_cache":
+        inputs[0] = inputs[0][:1].expand_as(inputs[0])
+    else:
+        original = inputs[index]
+        backing = original.new_empty((*original.shape[:-1], original.shape[-1] * 2))
+        backing[..., ::2].copy_(original)
+        inputs[index] = backing[..., ::2]
+    assert not kernels.can_fuse_streaming_kv(*inputs[:6])
+
+
+@torch.no_grad()
+def test_streaming_kv_cpu_uses_torch_fallback():
+    inputs = _inputs(3, 2, 4, 5, 8, torch.float32, device="cpu")
+    assert not kernels.can_fuse_streaming_kv(*inputs[:6])
+
+
+@pytest.mark.accelerator
+@requires_cuda
+def test_streaming_kv_grad_and_missing_triton_use_fallback(monkeypatch):
+    inputs = _inputs(3, 2, 4, 5, 8, torch.bfloat16)
+    assert not kernels.can_fuse_streaming_kv(*inputs[:6])
+    with torch.no_grad():
+        assert kernels.can_fuse_streaming_kv(*inputs[:6])
+        monkeypatch.setattr(kernels, "_streaming_kv_gather_kernel", None)
+        assert not kernels.can_fuse_streaming_kv(*inputs[:6])
+
+
+@pytest.mark.accelerator
+@requires_cuda
+@pytest.mark.parametrize(
+    "context,strided_metadata", [(17, False), (17, True), (None, False)]
+)
+@torch.no_grad()
+def test_indexed_attention_fusion_and_fallback_match_torch(
+    monkeypatch, context, strided_metadata
+):
+    model = attention_impl.MossAudioTokenizerAttention(
+        in_proj=torch.nn.Linear(
+            48, 144, bias=False, device="cuda", dtype=torch.bfloat16
+        ),
+        out_proj=torch.nn.Linear(
+            48, 48, bias=False, device="cuda", dtype=torch.bfloat16
+        ),
+        embed_dim=48,
+        num_heads=3,
+        causal=True,
+        context=context,
+        rope=None,
+    ).eval()
+    reference = copy.deepcopy(model)
+    can_fuse = attention_impl.can_fuse_streaming_kv
+    used = []
+    gather = attention_impl.gather_streaming_kv
+
+    def record_gather(*args):
+        used.append(True)
+        return gather(*args)
+
+    monkeypatch.setattr(attention_impl, "gather_streaming_kv", record_gather)
+    with model.streaming(8), reference.streaming(8):
+        for step, length in enumerate([1, 17, 21, 2, 5]):
+            slots = torch.tensor([6, 1, 3], device="cuda").roll(step)
+            valid = torch.tensor([True, False, step % 2 == 0], device="cuda")
+            if strided_metadata:
+                backing = torch.zeros(6, device="cuda", dtype=torch.long)
+                backing[::2].copy_(slots)
+                slots = backing[::2]
+            if step == 3:
+                for m in (model, reference):
+                    m._streaming_state.reset_slots(torch.tensor([3], device="cuda"))
+            chunk = torch.randn(3, length, 48, device="cuda", dtype=torch.bfloat16)
+            execution = attention_impl.StreamingExecutionContext(slots, valid)
+            with monkeypatch.context() as patch:
+                patch.setattr(
+                    attention_impl, "can_fuse_streaming_kv", lambda *args: False
+                )
+                expected = reference(chunk, execution_context=execution)
+            assert attention_impl.can_fuse_streaming_kv is can_fuse
+            actual = model(chunk, execution_context=execution)
+            _assert_bytes_equal(actual, expected)
+            for name in [
+                "offset",
+                "cached_keys",
+                "cached_values",
+                "cached_positions",
+                "exec_mask",
+            ]:
+                _assert_bytes_equal(
+                    getattr(model._streaming_state, name),
+                    getattr(reference._streaming_state, name),
+                )
+        # note (Zhang Yiyang): Empty chunks retain output and state behavior.
+        empty = chunk[:, :0]
+        _assert_bytes_equal(
+            model(empty, execution_context=execution),
+            reference(empty, execution_context=execution),
+        )
+    assert bool(used) == (context is not None and not strided_metadata)
+
+
+@pytest.mark.accelerator
+@requires_cuda
+@torch.no_grad()
+def test_indexed_attention_commits_only_after_output_projection(monkeypatch):
+    model = attention_impl.MossAudioTokenizerAttention(
+        in_proj=torch.nn.Linear(
+            48, 144, bias=False, device="cuda", dtype=torch.bfloat16
+        ),
+        out_proj=torch.nn.Linear(
+            48, 48, bias=False, device="cuda", dtype=torch.bfloat16
+        ),
+        embed_dim=48,
+        num_heads=3,
+        causal=True,
+        context=17,
+        rope=None,
+    )
+
+    def fail_projection(x):
+        raise RuntimeError("projection failed")
+
+    monkeypatch.setattr(model.out_proj, "forward", fail_projection)
+    with model.streaming(4):
+        state = model._streaming_state
+        model._ensure_streaming_cache(state, 4, torch.device("cuda"), torch.bfloat16)
+        names = ["offset", "cached_keys", "cached_values", "cached_positions"]
+        before = {name: getattr(state, name).clone() for name in names}
+        with pytest.raises(RuntimeError, match="projection failed"):
+            model(
+                torch.randn(2, 5, 48, device="cuda", dtype=torch.bfloat16),
+                execution_context=attention_impl.StreamingExecutionContext(
+                    torch.tensor([2, 0], device="cuda"),
+                    torch.tensor([True, False], device="cuda"),
+                ),
+            )
+        for name in names:
+            _assert_bytes_equal(getattr(state, name), before[name])
+
+
+@pytest.mark.accelerator
+@requires_cuda
+@torch.no_grad()
+def test_streaming_kv_fullgraph_tracks_cache_mutations():
+    inputs = _inputs(3, 2, 17, 5, 8, torch.bfloat16)
+    compiled = torch.compile(_fused, fullgraph=True)
+    for _ in range(3):
+        expected, expected_state = _reference(inputs)
+        actual = compiled(inputs)
+        for got, want in zip(actual, expected):
+            _assert_bytes_equal(got, want)
+        for got, want in zip(inputs[:4], expected_state):
+            _assert_bytes_equal(got, want)


### PR DESCRIPTION
## Motivation

For each streaming chunk, MOSS-Audio-Tokenizer gathers a request's cached K/V and positions, appends the current chunk, and writes the retained context back to its state pool. These separate tensor operations add memory traffic and kernel launches even when decoding runs inside CUDA graphs.

This PR fuses the cache preparation and writeback for indexed streaming attention. On Seed-TTS-Eval EN at concurrency 16, the five-round mean throughput increases from **10.9182 to 12.7288 requests/s (+16.58%)**, and mean time to first audio decreases from **359.76 to 308.02 ms (-14.38%)**.

## Modifications

- Add two Triton kernels for finite-context streaming attention: one gathers slot histories and appends the current K/V and positions; the other writes the chronological context tail and advances offsets for active slots.
- Commit persistent state after the output projection succeeds, preserving inactive slots for later continuation.
- Remove redundant outer validity guards from the finite-context PyTorch path. Retain the guards needed when an unbounded cache grows, and use the PyTorch fallback for unsupported devices/layouts or gradient-enabled execution.
- Share QKV/RoPE preparation and SDPA attention math between the fused and fallback paths. The kernels copy existing K/V values; they do not change decoder precision or replace attention computation.
- Add coverage for changing slot mappings, inactive slots, release/reuse, chunk lengths relative to the context window, strided tensors, CUDA graph replay, and cache mutation under `torch.compile`.

## Related Issues

#1233 

## Accuracy Test

### Kernel and streaming-state tests

Post-rebase validation on NVIDIA H200: **552 passed, 0 skipped** across `tests/unit_test/moss_tts/` and `tests/unit_test/moss_tts_local/`, using SGLang 0.5.19 and FlashInfer 0.6.18. Pre-commit checks passed.

The tests compare cache contents and positions against a chronological PyTorch reference for FP16, BF16 and FP32, compare fused/fallback attention outputs, and check inactive-state preservation and dynamic slot changes during graph replay. These are scoped numerical and state checks, not a claim of bit-identical end-to-end AR generation.

### Seed-TTS-Eval EN

**1,088 samples per round, five rounds per side; all samples and rounds retained.** WER uses Qwen3-ASR-1.7B and corpus-level aggregation. Speaker similarity uses the evaluator's original score scale, and UTMOS uses the same scorer on both sides. Generation has no fixed seed. Each metric evaluates all **10,880 generated samples**, with no skipped samples.

`Base` = `e168a3dc133cc8710f35d3a544a3d0d9d7cfcc15`; `Current` = this PR's patch on that base. Raw cells show `Base / Current`. All summaries use arithmetic means across the five rounds. Confidence intervals use paired round-index differences, `Current − Base`, with Student t (df=4). WER is in percent; WER differences are in percentage points (pp).

| Round | Corpus WER (%) | Speaker similarity | UTMOS |
| ---: | ---: | ---: | ---: |
| 1 | 2.3445 / 2.2691 | 65.2270 / 65.3757 | 3.9606 / 3.9575 |
| 2 | 2.1435 / 2.3528 | 65.3527 / 65.3355 | 3.9634 / 3.9619 |
| 3 | 2.0095 / 2.2440 | 65.4294 / 65.2130 | 3.9620 / 3.9651 |
| 4 | 2.2524 / 2.1100 | 65.4662 / 65.2830 | 3.9465 / 3.9689 |
| 5 | 2.4449 / 2.2691 | 65.3375 / 65.1466 | 3.9671 / 3.9652 |

| Metric | Base mean | Current mean | Change | Current − Base paired 95% CI |
| --- | ---: | ---: | ---: | --- |
| Corpus WER (%) | 2.2390 | 2.2490 | +0.45% | `[-0.2345, +0.2546]` pp |
| Speaker similarity | 65.3626 | 65.2707 | -0.14% | `[-0.2853, +0.1016]` |
| UTMOS | 3.9599 | 3.9637 | +0.10% | `[-0.0094, +0.0170]` |

Corpus WER increases by **0.0100 pp** in these runs. The paired intervals for WER, speaker similarity and UTMOS all include zero; these five rounds do not establish quality equivalence.

## Benchmark & Profiling

### Setup

- **Model/workload:** MOSS-TTS-Local-Transformer-v1.5, streaming speech with reference audio and text, Seed-TTS-Eval EN (`zhaochenyang20/seed-tts-eval-arrow`), 1,088 requests per round, concurrency 16.
- **Hardware:** one NVIDIA H200, shared by serial Base/Current runs on the same host; CPU quota is 1/8 of the host's logical CPUs.
- **Server:** Local pipeline configuration, AR `max_running_requests=64` and `cuda_graph_max_bs=64`; vocoder CUDA graphs enabled for `T=1..25`. Both server logs report BF16 decoder and compute dtypes.
- **Requests:** `max_new_tokens=2048`, `token_count=auto`, `ref_format=references`, PCM streaming, no fixed seed.
- **Lifecycle:** a fresh server for every measured round on both sides. Each round waits for readiness, sends 16 untimed warmup requests, measures 1,088 requests, then shuts the server down and waits for teardown before the next launch. All five rounds are retained.

The intervals use five round-index pairs from ten server lifetimes; they do not capture all variation on a shared host. Every measured round completed **1,088/1,088 requests with zero failures**.

### Throughput and latency

| Round | Requests/s | Audio seconds/s | Mean latency (s) | Mean first audio (ms) | P95 first audio (ms) | Mean RTF |
| ---: | ---: | ---: | ---: | ---: | ---: | ---: |
| 1 | 10.925 / 12.853 | 48.078 / 56.565 | 1.456 / 1.238 | 359.60 / 302.80 | 509.50 / 455.50 | 0.3348 / 0.2846 |
| 2 | 10.932 / 12.773 | 48.115 / 56.216 | 1.454 / 1.245 | 363.00 / 310.30 | 526.30 / 443.70 | 0.3347 / 0.2866 |
| 3 | 11.055 / 12.654 | 48.654 / 55.698 | 1.440 / 1.258 | 363.60 / 309.70 | 510.10 / 453.20 | 0.3317 / 0.2898 |
| 4 | 10.843 / 12.720 | 47.706 / 55.981 | 1.468 / 1.251 | 354.60 / 307.30 | 493.80 / 452.50 | 0.3382 / 0.2879 |
| 5 | 10.836 / 12.644 | 47.692 / 55.641 | 1.469 / 1.259 | 358.00 / 310.00 | 502.50 / 453.70 | 0.3380 / 0.2899 |

| Metric | Base mean | Current mean | Change | Current − Base paired 95% CI |
| --- | ---: | ---: | ---: | --- |
| Requests/s | 10.9182 | 12.7288 | +16.58% | `[+1.6537, +1.9675]` req/s |
| Audio seconds/s | 48.0490 | 56.0202 | +16.59% | `[+7.2812, +8.6612]` s/s |
| Mean latency (s) | 1.4574 | 1.2502 | -14.22% | `[-0.2254, -0.1890]` s |
| Mean first audio (ms) | 359.76 | 308.02 | -14.38% | `[-56.74, -46.74]` ms |
| P95 first audio (ms) | 508.44 | 451.72 | -11.16% | `[-76.13, -37.31]` ms |
| Mean RTF | 0.3355 | 0.2878 | -14.22% | `[-0.0520, -0.0435]` |

The latency and RTF entries summarize each round's client-observed metrics.

### Playback continuity

For each request, the evaluator records its maximum playback underrun. C50 and C100 are the percentages of requests with maximum underrun at most 50 ms and 100 ms. All 1,088 requests in every round have multiple audio chunks and are included in the continuity metrics.

| Round | Mean maximum underrun (ms) | P99 maximum underrun (ms) | C50 (%) | C100 (%) |
| ---: | ---: | ---: | ---: | ---: |
| 1 | 0.70 / 0.20 | 24.30 / 0.00 | 99.36 / 99.82 | 100.00 / 100.00 |
| 2 | 0.40 / 0.70 | 9.70 / 0.00 | 99.63 / 99.63 | 100.00 / 99.63 |
| 3 | 0.90 / 0.10 | 23.10 / 0.00 | 99.36 / 100.00 | 99.72 / 100.00 |
| 4 | 0.90 / 0.20 | 38.40 / 0.00 | 99.45 / 99.82 | 99.91 / 100.00 |
| 5 | 0.90 / 0.10 | 25.40 / 0.00 | 99.17 / 99.91 | 99.72 / 100.00 |

| Metric | Base mean | Current mean | Change | Current − Base paired 95% CI |
| --- | ---: | ---: | ---: | --- |
| Mean maximum underrun (ms) | 0.760 | 0.260 | -65.79% | `[-1.076, +0.076]` ms |
| P99 maximum underrun (ms) | 24.180 | 0.000 | -100.00% | `[-36.820, -11.540]` ms |
| C50 (%) | 99.394 | 99.836 | +0.44% | `[+0.086, +0.798]` pp |
| C100 (%) | 99.870 | 99.926 | +0.06% | `[-0.276, +0.388]` pp |

P95 maximum underrun is zero in every round on both sides. C200 is 100% in all Base rounds; Current records 99.82% in round 2 and 100% in the other rounds. Mean maximum underrun is already below 1 ms on both sides; its interval includes zero, so the point estimate should not be interpreted as a demonstrated continuity improvement. Underrun summaries use the precision retained in the source JSON.

## Checklist

- [x] Format your code according with pre-commit.
- [x] Add unit tests.
- [x] Update documentation / docstrings / example tutorials as needed.
- [x] Provide throughput / latency benchmark results and accuracy evaluation results as needed.
- [ ] For reviewers: If you haven't made any contributions to this PR and are only assisting with merging the main branch, please remove yourself as a co-author when merging the PR.

## CI

CI runs on self-hosted GPU runners and requires a maintainer to add the
`run-ci` label. Once labeled, every subsequent push re-triggers CI as
long as the label remains. Use `/tag-and-rerun-ci higgs` or
`/tag-and-rerun-ci moss` or `/tag-and-rerun-ci qwen3-tts` to select a TTS CI
model, and
`/tag-and-rerun-ci fun-asr`, `/tag-and-rerun-ci qwen3-asr` or
`/tag-and-rerun-ci whisper-asr` to select an ASR CI model. One selector from
each family can be combined, for example `/tag-and-rerun-ci moss fun-asr`.
Draft PRs are skipped even if labeled.
