### PR TITLE
[Qwen3-Omni Perf] clip Talker admission new-token estimate to speech length

### DIFF
--- a/sglang_omni/models/qwen3_omni/config.py
+++ b/sglang_omni/models/qwen3_omni/config.py
@@ -182,13 +182,19 @@ def _decode_stage(*, process: str) -> StageConfig:
     )
 
 
+# Note (wenyao): SGLang reserves min(max_new_tokens, this) KV per running request;
+# the 4096 default admitted ~13 of 64 Talker requests at once. 256 is ~20 s at 12.5 Hz.
+TALKER_MAX_NEW_TOKENS_ESTIMATION = "256"
+
+
 def _talker_stage_env() -> dict[str, str]:
-    if not current_platform.is_rocm():
-        return {}
-    # Note (zijiecode): aiter.greedy_sample returns wrong ids for vocab sizes below
-    # 16384 (gfx950, aiter c16d44b9) and the Talker codec head has 3072, so a
-    # greedy Talker request would corrupt its first codec token.
-    return {"SGLANG_DISABLE_AITER_GREEDY_SAMPLE": "1"}
+    env = {"SGLANG_CLIP_MAX_NEW_TOKENS_ESTIMATION": TALKER_MAX_NEW_TOKENS_ESTIMATION}
+    if current_platform.is_rocm():
+        # Note (zijiecode): aiter.greedy_sample returns wrong ids for vocab sizes below
+        # 16384 (gfx950, aiter c16d44b9) and the Talker codec head has 3072, so a
+        # greedy Talker request would corrupt its first codec token.
+        env["SGLANG_DISABLE_AITER_GREEDY_SAMPLE"] = "1"
+    return env
 
 
 def _talker_stage(

--- a/tests/README.md
+++ b/tests/README.md
@@ -101,6 +101,8 @@ tests/
     │   ├── test_sglang_ar_budget.py
     │   ├── test_streaming.py
     │   ├── test_talker.py
+    │   ├── test_talker_admission.py
+    │   ├── test_talker_admission_env.py
     │   ├── test_talker_prefill_embed_cache.py
     │   ├── test_talker_emit_snapshot.py
     │   ├── test_talker_feedback_write.py
@@ -597,6 +599,10 @@ that happened to contain an older version of the test.
   - tokenizer and preprocessing fallback behavior
   - memory flag contracts
   - colocation config and SGLang AR budget contracts
+  - Talker admission estimate: the stage env reaches only the talker process,
+    and the sglang `PrefillAdder` admits 7 of 64 speech requests under the
+    default 4096 clip vs all 64 under the speech-length clip
+    (`test_talker_admission_env.py`, `test_talker_admission.py`)
   - full-model fixture overrides target the preprocessing and thinker context
     limits without leaking thinker-only arguments into the decode stage
   - `Qwen3OmniPipelineState` request builders, including projected payload container

--- a/tests/unit_test/qwen3_omni/test_config_manager.py
+++ b/tests/unit_test/qwen3_omni/test_config_manager.py
@@ -283,14 +283,17 @@ def test_qwen3_omni_gfx950_bf16_config_uses_colocated_budgets() -> None:
     }
 
 
+_TALKER_ADMISSION_ENV = {"SGLANG_CLIP_MAX_NEW_TOKENS_ESTIMATION": "256"}
+
+
 @pytest.mark.parametrize(
     ("is_rocm", "expected_env"),
     [
-        (True, {"SGLANG_DISABLE_AITER_GREEDY_SAMPLE": "1"}),
-        (False, {}),
+        (True, {**_TALKER_ADMISSION_ENV, "SGLANG_DISABLE_AITER_GREEDY_SAMPLE": "1"}),
+        (False, _TALKER_ADMISSION_ENV),
     ],
 )
-def test_qwen3_omni_talker_stage_keeps_greedy_selection_off_aiter_on_rocm(
+def test_qwen3_omni_talker_stage_env_defaults(
     monkeypatch: pytest.MonkeyPatch,
     is_rocm: bool,
     expected_env: dict[str, str],
@@ -307,6 +310,26 @@ def test_qwen3_omni_talker_stage_keeps_greedy_selection_off_aiter_on_rocm(
 
         assert _stage(config, "talker_ar").env == expected_env
         assert _stage(config, "thinker").env == {}
+
+
+def test_qwen3_omni_stage_env_config_overrides_talker_default(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    monkeypatch.setattr(qwen3_omni_config.current_platform, "is_rocm", lambda: False)
+    manager = ConfigManager(Qwen3OmniSpeechColocatedPipelineConfig(model_path="dummy"))
+    config = manager.merge_config(
+        {
+            "talker_ar.env.SGLANG_CLIP_MAX_NEW_TOKENS_ESTIMATION": "512",
+            "thinker.env.SGLANG_CLIP_MAX_NEW_TOKENS_ESTIMATION": "32",
+        }
+    )
+
+    assert _stage(config, "talker_ar").env == {
+        "SGLANG_CLIP_MAX_NEW_TOKENS_ESTIMATION": "512"
+    }
+    assert _stage(config, "thinker").env == {
+        "SGLANG_CLIP_MAX_NEW_TOKENS_ESTIMATION": "32"
+    }
 
 
 def test_qwen3_omni_xpu_b60_example_config_loads_and_plans() -> None:

--- a/tests/unit_test/qwen3_omni/test_talker_admission.py
+++ b/tests/unit_test/qwen3_omni/test_talker_admission.py
@@ -1,0 +1,94 @@
+# SPDX-License-Identifier: Apache-2.0
+from __future__ import annotations
+
+from types import SimpleNamespace
+from unittest.mock import MagicMock
+
+import pytest
+import sglang.srt.managers.schedule_policy as schedule_policy
+from sglang.srt.managers.schedule_batch import Req
+from sglang.srt.managers.schedule_policy import AddReqResult, PrefillAdder
+from sglang.srt.mem_cache.base_prefix_cache import DecLockRefResult, IncLockRefResult
+from sglang.srt.server_args import ServerArgs, set_global_server_args_for_scheduler
+
+from sglang_omni.models.qwen3_omni.config import TALKER_MAX_NEW_TOKENS_ESTIMATION
+
+_TALKER_KV_TOKENS = 33_377
+_CONCURRENCY = 64
+_PROMPT_TOKENS = 128
+_TALKER_MAX_NEW_TOKENS = 4096
+_PAGE_SIZE = 1
+
+
+@pytest.fixture(autouse=True)
+def _scheduler_server_args() -> None:
+    set_global_server_args_for_scheduler(ServerArgs(model_path="dummy"))
+
+
+def _talker_request(rid: int) -> MagicMock:
+    req = MagicMock(spec=Req)
+    req.rid = str(rid)
+    req.prefix_indices = []
+    req.full_untruncated_fill_ids = list(range(_PROMPT_TOKENS))
+    req.output_ids = []
+    req.sampling_params = SimpleNamespace(
+        max_new_tokens=_TALKER_MAX_NEW_TOKENS, ignore_eos=False
+    )
+    req.host_hit_length = 0
+    req.storage_hit_length = 0
+    req.retracted_stain = False
+    req.last_node = MagicMock()
+    req.finished.return_value = False
+    req.needs_host_load_back.return_value = False
+    return req
+
+
+def _admitted_from_empty_pool(clip: int, monkeypatch: pytest.MonkeyPatch) -> int:
+    monkeypatch.setattr(schedule_policy, "CLIP_MAX_NEW_TOKENS", clip)
+    tree_cache = MagicMock()
+    tree_cache.disable = False
+    tree_cache.evictable_size.return_value = 0
+    tree_cache.supports_mamba.return_value = False
+    tree_cache.is_tree_cache.return_value = False
+    tree_cache.inc_lock_ref.return_value = IncLockRefResult()
+    tree_cache.dec_lock_ref.return_value = DecLockRefResult()
+    allocator = MagicMock()
+    allocator.available_size.return_value = _TALKER_KV_TOKENS
+    running_batch = MagicMock()
+    running_batch.reqs = []
+
+    adder = PrefillAdder(
+        page_size=_PAGE_SIZE,
+        tree_cache=tree_cache,
+        token_to_kv_pool_allocator=allocator,
+        running_batch=running_batch,
+        new_token_ratio=1.0,
+        rem_input_tokens=1_000_000,
+        rem_chunk_tokens=None,
+    )
+    for rid in range(_CONCURRENCY):
+        result = adder.add_one_req(
+            _talker_request(rid), has_chunked_req=False, truncation_align_size=None
+        )
+        if result == AddReqResult.NO_TOKEN:
+            break
+    return len(adder.can_run_list)
+
+
+def test_sglang_default_clip_admits_a_fraction_of_the_talker_batch(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    admitted = _admitted_from_empty_pool(4096, monkeypatch)
+
+    assert admitted == _TALKER_KV_TOKENS // (
+        _PROMPT_TOKENS + _TALKER_MAX_NEW_TOKENS + _PAGE_SIZE
+    )
+    assert admitted < _CONCURRENCY
+
+
+def test_speech_length_clip_admits_the_whole_talker_batch(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    clip = int(TALKER_MAX_NEW_TOKENS_ESTIMATION)
+
+    assert _admitted_from_empty_pool(clip, monkeypatch) == _CONCURRENCY

--- a/tests/unit_test/qwen3_omni/test_talker_admission.py
+++ b/tests/unit_test/qwen3_omni/test_talker_admission.py
@@ -1,6 +1,7 @@
 # SPDX-License-Identifier: Apache-2.0
 from __future__ import annotations
 
+from collections.abc import Iterator
 from types import SimpleNamespace
 from unittest.mock import MagicMock
 
@@ -9,7 +10,7 @@ import sglang.srt.managers.schedule_policy as schedule_policy
 from sglang.srt.managers.schedule_batch import Req
 from sglang.srt.managers.schedule_policy import AddReqResult, PrefillAdder
 from sglang.srt.mem_cache.base_prefix_cache import DecLockRefResult, IncLockRefResult
-from sglang.srt.server_args import ServerArgs, set_global_server_args_for_scheduler
+from sglang.srt.runtime_context import get_context
 
 from sglang_omni.models.qwen3_omni.config import TALKER_MAX_NEW_TOKENS_ESTIMATION
 
@@ -21,8 +22,10 @@ _PAGE_SIZE = 1
 
 
 @pytest.fixture(autouse=True)
-def _scheduler_server_args() -> None:
-    set_global_server_args_for_scheduler(ServerArgs(model_path="dummy"))
+def _scheduler_server_args() -> Iterator[None]:
+    # Restore the process-wide context so later bootstrap tests can publish it.
+    with get_context().override_server_args():
+        yield
 
 
 def _talker_request(rid: int) -> MagicMock:

--- a/tests/unit_test/qwen3_omni/test_talker_admission_env.py
+++ b/tests/unit_test/qwen3_omni/test_talker_admission_env.py
@@ -1,0 +1,100 @@
+# SPDX-License-Identifier: Apache-2.0
+from __future__ import annotations
+
+from pathlib import Path
+
+import pytest
+
+from sglang_omni.config.manager import ConfigManager
+from sglang_omni.models.qwen3_omni import config as qwen3_omni_config
+from sglang_omni.models.qwen3_omni.config import (
+    TALKER_MAX_NEW_TOKENS_ESTIMATION,
+    Qwen3OmniPipelineConfig,
+    Qwen3OmniSpeechPipelineConfig,
+)
+from sglang_omni.pipeline.mp_runner import _build_stage_groups
+from sglang_omni.pipeline.runtime_config import prepare_pipeline_runtime
+from sglang_omni.pipeline.stage_workers import (
+    StageLaunchConfig,
+    StageWorkerProcessSpec,
+    _patched_spawn_env,
+)
+from tests.unit_test.fixtures.pipeline_fakes import FakeMpContext
+
+_CLIP_ENV = "SGLANG_CLIP_MAX_NEW_TOKENS_ESTIMATION"
+_REPO_ROOT = Path(__file__).resolve().parents[3]
+
+
+def _colocated_h100_config():
+    config_path = (
+        _REPO_ROOT / "examples" / "configs" / "qwen3_omni_colocated_h100_bf16.yaml"
+    )
+    return ConfigManager.from_file(str(config_path)).config
+
+
+def _stage_specs_by_name(config) -> dict[str, tuple[str, StageLaunchConfig]]:
+    prep = prepare_pipeline_runtime(config)
+    groups = _build_stage_groups(
+        config,
+        ctx=FakeMpContext(),
+        stages_cfg=prep.stages_cfg,
+        endpoints=prep.endpoints,
+        placement_plan=prep.placement_plan,
+        process_plan=prep.process_plan,
+    )
+    return {
+        stage_spec.stage_name: (process_spec.process_name, stage_spec)
+        for group in groups
+        for process_spec in group.process_specs
+        for stage_spec in process_spec.stage_specs
+    }
+
+
+@pytest.mark.parametrize(
+    "make_config",
+    [
+        pytest.param(_colocated_h100_config, id="colocated-h100"),
+        pytest.param(
+            lambda: Qwen3OmniSpeechPipelineConfig(model_path="dummy"), id="speech"
+        ),
+    ],
+)
+def test_talker_admission_clip_reaches_only_the_talker_process(
+    monkeypatch: pytest.MonkeyPatch, make_config
+) -> None:
+    monkeypatch.setattr(qwen3_omni_config.current_platform, "is_rocm", lambda: False)
+    specs = _stage_specs_by_name(make_config())
+
+    talker_process, talker = specs["talker_ar"]
+    thinker_process, thinker = specs["thinker"]
+
+    assert talker_process != thinker_process
+    assert talker.env_defaults[_CLIP_ENV] == TALKER_MAX_NEW_TOKENS_ESTIMATION
+    assert _CLIP_ENV not in thinker.env_defaults
+
+
+def test_text_pipeline_sets_no_admission_clip(monkeypatch: pytest.MonkeyPatch) -> None:
+    monkeypatch.setattr(qwen3_omni_config.current_platform, "is_rocm", lambda: False)
+    specs = _stage_specs_by_name(Qwen3OmniPipelineConfig(model_path="dummy"))
+
+    assert all(_CLIP_ENV not in spec.env_defaults for _, spec in specs.values())
+
+
+def test_spawn_env_rejects_thinker_and_talker_clips_in_one_process(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    monkeypatch.delenv(_CLIP_ENV, raising=False)
+    spec = StageWorkerProcessSpec(
+        process_name="pipeline",
+        stage_specs=[
+            StageLaunchConfig(stage_name="thinker", env_defaults={_CLIP_ENV: "32"}),
+            StageLaunchConfig(
+                stage_name="talker_ar",
+                env_defaults={_CLIP_ENV: TALKER_MAX_NEW_TOKENS_ESTIMATION},
+            ),
+        ],
+    )
+
+    with pytest.raises(AssertionError, match="conflicting env default"):
+        with _patched_spawn_env(spec):
+            pass


### PR DESCRIPTION
## Motivation

SGLang's `PrefillAdder` reserves `min(max_new_tokens, SGLANG_CLIP_MAX_NEW_TOKENS_ESTIMATION)` KV tokens per request when deciding admission; the clip defaults to 4096. The Talker asks for `max_new_tokens=4096` codec frames (~328 s of audio at 12.5 Hz) while a SeedTTS utterance is ~46 frames at the median and ~142 at most. On the colocated H100 config (~33K-token Talker pool) that reservation admits ~13 of 64 concurrent requests at a time; the C64 TTFT/TTFA tail is the resulting queue.

## Modifications

- `sglang_omni/models/qwen3_omni/config.py`: Talker stage env default `SGLANG_CLIP_MAX_NEW_TOKENS_ESTIMATION=256` (~20 s of speech) via `_talker_stage_env()`; `talker_ar.env.*` in yaml still overrides it.
- `tests/unit_test/qwen3_omni/test_talker_admission.py`: real `PrefillAdder` on CPU, 33,377-token pool, 64 requests of 128 prompt tokens with `max_new_tokens=4096`: clip 4096 admits 7, clip 256 admits 64.
- `tests/unit_test/qwen3_omni/test_talker_admission_env.py`: the env reaches only the `talker_ar` process, the text pipeline sets no clip, and `_patched_spawn_env` rejects thinker and talker clips landing in one process (`CLIP` is a module global).
- `tests/unit_test/qwen3_omni/test_config_manager.py`, `tests/README.md`: env-default assertions and test index.

Utterances longer than 256 frames under KV pressure take SGLang's existing retraction path; stop conditions are unchanged.

## Related Issues

Follow-up upstream: expose the clip as a `--clip-max-new-tokens-estimation` server arg instead of an import-time env (sglang PR to follow; related sgl-project/sglang#16807).

## Accuracy Test

WER / UTMOS / speaker-SIM on the retained C64 WAVs: pending; the table will be posted here before merge.

## Benchmark & Profiling

One H100, 1088 EN SeedTTS utterances, C64, two runs per arm, L5 stack config (Thinker KV 1 GiB, Talker `max_running_requests=64`; the stock yaml keeps 32, which caps the effect).

| C64 | control (clip 4096) | clip 256 (+ thinker clip 32) |
|---|---|---|
| QPS | 17.82 / 16.22 | 19.74 / 19.39 |
| TTFT p95 (ms) | 805 / 675 | 257 / 312 |
| TTFA p95 (ms) | 3027 / 3902 | 1234 / 636 |
| Talker requests admitted, first cohort | ~13 | 63 / 64 |

## Checklist

- [x] Format your code according with pre-commit.
- [x] Add unit tests.
- [x] Update documentation / docstrings / example tutorials as needed.
- [ ] Provide throughput / latency benchmark results and accuracy evaluation results as needed. (throughput/latency above; accuracy pending)
- [ ] For reviewers: If you haven't made any contributions to this PR and are only assisting with merging the main branch, please remove yourself as a co-author when merging the PR.
