### PR TITLE
fix(pd): release aborted Decode requests on the scheduler thread

### DIFF
--- a/sglang_omni/scheduling/pd_scheduler.py
+++ b/sglang_omni/scheduling/pd_scheduler.py
@@ -3,6 +3,7 @@
 
 from __future__ import annotations
 
+import logging
 import queue
 import threading
 import types
@@ -27,8 +28,36 @@ from sglang_omni.scheduling.pd_utils import (
     serialize_kv_allocator,
 )
 
+logger = logging.getLogger(__name__)
 
-class OmniPrefillScheduler(OmniScheduler):
+
+class _PDReleaseOwner(OmniScheduler):
+    """Omni scheduler half whose request table only its own thread mutates."""
+
+    def __init__(self, *args, **kwargs) -> None:
+        self._pd_due_releases: queue.SimpleQueue = queue.SimpleQueue()
+        super().__init__(*args, **kwargs)
+
+    def _drain_due_releases(self) -> None:
+        while True:
+            try:
+                req = self._pd_due_releases.get_nowait()
+            except queue.Empty:
+                return
+            try:
+                self._release_request_kv_cache(req)
+            except Exception:
+                # One bad request must not strand the rest of the queue.
+                logger.exception("PD release failed for %r", getattr(req, "rid", req))
+
+    def flush_cache(self, *args, **kwargs):
+        # Note(Yue Yin): upstream clears both pools once it reads the
+        # scheduler as idle, and it cannot see this queue.
+        self._drain_due_releases()
+        return _Upstream.flush_cache(self, *args, **kwargs)
+
+
+class OmniPrefillScheduler(_PDReleaseOwner):
     """Omni scheduler whose generated requests stop after Prefill."""
 
     scheduler_role = "prefill"
@@ -47,7 +76,6 @@ class OmniPrefillScheduler(OmniScheduler):
         self._pd_stage_name = stage_name
         self._pd_partner_stage = partner_stage
         self._pd_state_builder = state_builder
-        self._pd_due_releases = queue.SimpleQueue()
         self._pd_pool_id = f"{stage_name}:kv"
         pool = build_kv_pool(
             self.token_to_kv_pool_allocator.get_kvcache(),
@@ -56,12 +84,7 @@ class OmniPrefillScheduler(OmniScheduler):
         self.kv_registrations = ((pool, None),)
 
     def get_next_batch_to_run(self):
-        while True:
-            try:
-                req = self._pd_due_releases.get_nowait()
-            except queue.Empty:
-                break
-            self._release_request_kv_cache(req)
+        self._drain_due_releases()
         if (
             self.running_batch.is_empty()
             and self.running_batch.batch_is_full
@@ -184,7 +207,7 @@ class OmniPrefillScheduler(OmniScheduler):
         return terminal_error, abort_cleanup_needed
 
 
-class OmniDecodeScheduler(OmniScheduler):
+class OmniDecodeScheduler(_PDReleaseOwner):
     """Omni scheduler that admits transferred Prefill state for Decode."""
 
     scheduler_role = "decode"
@@ -230,6 +253,7 @@ class OmniDecodeScheduler(OmniScheduler):
 
     def get_next_batch_to_run(self):
         with self._pd_admission_lock:
+            self._drain_due_releases()
             self._drain_decode_admissions()
             # Do not let a new transfer consume the space between the decode
             # memory check and allocation. Abort takes these locks in this order.
@@ -314,7 +338,9 @@ class OmniDecodeScheduler(OmniScheduler):
         with self._pd_admission_lock:
             for req in self.waiting_queue:
                 if req.rid == request_id:
-                    self._release_request_kv_cache(req)
+                    # Note(Yue Yin): abort runs on the Stage event loop, and
+                    # only the scheduler thread may mutate the request table.
+                    self._pd_due_releases.put(req)
                     break
             super().abort(
                 request_id,

--- a/tests/unit_test/pipeline/test_pd_lifecycle.py
+++ b/tests/unit_test/pipeline/test_pd_lifecycle.py
@@ -11,6 +11,7 @@ from unittest.mock import AsyncMock, Mock
 
 import pytest
 import torch
+from sglang.srt.managers.scheduler import Scheduler as _Upstream
 
 from sglang_omni.comm import KVPageTransfer
 from sglang_omni.scheduling import pd_utils
@@ -213,6 +214,66 @@ def test_prefill_handoff_cleanup_failure_emits_error_and_releases_kv(
     assert not batch.batch_is_full
 
 
+def _recording_decode_scheduler(done):
+    scheduler = _decode_scheduler()
+    scheduler.waiting_queue = [SimpleNamespace(rid="request-1")]
+    scheduler._release_request_kv_cache = lambda req: done.append(
+        (req.rid, threading.get_ident())
+    )
+    scheduler._drain_decode_admissions = lambda: done.append("admissions")
+    return scheduler
+
+
+def test_decode_abort_releases_on_the_scheduler_thread(monkeypatch):
+    done = []
+    scheduler = _recording_decode_scheduler(done)
+    scheduler.running_batch = None
+    monkeypatch.setattr(OmniScheduler, "abort", lambda self, rid, **kwargs: None)
+    monkeypatch.setattr(
+        _Upstream,
+        "get_next_disagg_decode_batch_to_run",
+        lambda self, running_batch: SimpleNamespace(
+            running_batch=None, batch_to_run=None
+        ),
+        raising=False,
+    )
+    with ThreadPoolExecutor(1) as threads:
+        threads.submit(scheduler.abort, "request-1").result(timeout=5)
+    assert done == []
+    scheduler.get_next_batch_to_run()
+    assert done == [("request-1", threading.get_ident()), "admissions"]
+
+
+def test_flush_cache_returns_deferred_rows_before_upstream_reads_idle(monkeypatch):
+    done = []
+    scheduler = _recording_decode_scheduler(done)
+    monkeypatch.setattr(OmniScheduler, "abort", lambda self, rid, **kwargs: None)
+    monkeypatch.setattr(
+        _Upstream, "flush_cache", lambda self: done.append("upstream_flush") or True
+    )
+    with ThreadPoolExecutor(1) as threads:
+        threads.submit(scheduler.abort, "request-1").result(timeout=5)
+    assert scheduler.flush_cache() is True
+    assert done == [("request-1", threading.get_ident()), "upstream_flush"]
+
+
+def test_a_failing_release_does_not_strand_the_rest_of_the_queue():
+    scheduler = _decode_scheduler()
+    released = []
+
+    def release(req):
+        if req.rid == "bad":
+            raise RuntimeError("release failed")
+        released.append(req.rid)
+
+    scheduler._release_request_kv_cache = release
+    for rid in ("first", "bad", "last"):
+        scheduler._pd_due_releases.put(SimpleNamespace(rid=rid))
+    scheduler._drain_due_releases()
+    assert released == ["first", "last"]
+    assert scheduler._pd_due_releases.empty()
+
+
 def _message(**updates):
     from sglang_omni.proto import KVBufferSpec, KVPoolLayout, KVTransferPrepareMessage
 
@@ -282,8 +343,10 @@ def test_receiver_rejects_mismatched_pages_and_bounds_finished_ids(monkeypatch):
 def _decode_scheduler():
     scheduler = object.__new__(OmniDecodeScheduler)
     scheduler._pd_admissions = queue.SimpleQueue()
+    scheduler._pd_due_releases = queue.SimpleQueue()
     scheduler._pd_deferred_admission = None
     scheduler._pd_admission_lock = threading.RLock()
+    scheduler._pd_kv_lock = threading.RLock()
     scheduler._pd_state_restorer = lambda *args: None
     scheduler._aborted_request_ids = set()
     scheduler.req_to_token_pool = _ReqPool()


### PR DESCRIPTION
## Motivation

When Decode admits a transferred request it allocates the request-table row
straight away, then parks the request in `waiting_queue`. Base Omni never does
that: a normal request gets its row later, when `prepare_for_extend` builds a
batch. So in PD, and only in PD, a waiting request already owns a row.

`OmniDecodeScheduler.abort` freed that row on the spot. Abort runs on the Stage
event loop, while the scheduler thread frees the same structures from
`process_batch_result`, so two threads now write the request table.
`_pd_admission_lock` does not help: the scheduler thread holds it only inside
`get_next_batch_to_run`.

`ReqToTokenPool` cannot take that. `alloc` reads a slice of `free_slots` and
deletes the same slice in a second step, and `free` appends. A `free` that lands
between those two steps makes `alloc` delete the appended entry instead of the
one it just handed out. That row is then both allocated and free, the aborted
row is lost, and two live requests end up sharing one `req_to_token` row.

#1773 already states the rule this breaks, in `SGLangKVLease`: only the
scheduler thread may touch the request table and the prefix cache. Prefill obeys
it. Decode did not.

## Modifications

Both PD schedulers now extend a small `_PDReleaseOwner` base. It owns the
`_pd_due_releases` queue and does the releasing on the scheduler thread, so
`abort` just hands the request over. No new lock: the request table goes back to
having one owner thread.

The scheduler drains that queue in `get_next_batch_to_run` before it drains
admissions, so a row freed this pass can be reused this pass. It drains in
`flush_cache` too, because upstream wipes both pools as soon as it thinks the
scheduler is idle and it cannot see this queue. If one release raises, it is
logged and the drain keeps going, so a single bad request cannot strand
everything behind it.

## Related Issues

Fixes a defect in #1773. Part of #1760.
