### PR TITLE
fix(comm): settle a retained KV transfer when its peer answers

### DIFF
--- a/sglang_omni/comm/engine.py
+++ b/sglang_omni/comm/engine.py
@@ -1,5 +1,6 @@
 # SPDX-License-Identifier: Apache-2.0
 """Omni communication engine facade used by pipeline stages."""
+
 from __future__ import annotations
 
 import asyncio
@@ -61,6 +62,8 @@ class _PendingTransfer(msgspec.Struct):
     lease: KVPageLease | None = None
     retain_pending_on_failure: bool = False
     receiver_terminal: bool = False
+    # Resolved only by the peer, or by close(). A local failure must not.
+    terminal: asyncio.Future[None] | None = None
 
 
 class _PayloadSendJob(msgspec.Struct, frozen=True):
@@ -125,8 +128,10 @@ class CommEngine:
         self._send_workers: dict[str, asyncio.Task] = {}
         self._pending: dict[str, _PendingTransfer] = {}
         self._stream_send_sequence = count()
-        # Failed pending KV transfers stay pinned until this dying process exits.
-        self._retained_pending_kv_transfers: list[_PendingTransfer] = []
+        # Note(Yue Yin): key retained transfers by object_id so a late ack can
+        # still settle one after the local send failed.
+        self._retained_pending_kv_transfers: dict[str, _PendingTransfer] = {}
+        self._retained_settle_tasks: set[asyncio.Task] = set()
         self._kv_pools: dict[str, KVPool] = {}
         self._kv_receivers: dict[str, KVReceiver] = {}
         self._kv_ready: dict[str, asyncio.Future[KVTransferReadyMessage]] = {}
@@ -791,6 +796,14 @@ class CommEngine:
         for object_id in list(self._pending):
             self._fail_pending(object_id, RuntimeError("comm engine closed"))
         close_error = RuntimeError("comm engine closed")
+        # Note(Yue Yin): end every retained transfer and wait for its task, so
+        # the source pages come back with the engine, not with the process.
+        for pending in list(self._retained_pending_kv_transfers.values()):
+            if pending.terminal is not None and not pending.terminal.done():
+                pending.terminal.set_exception(close_error)
+        settle_tasks = tuple(self._retained_settle_tasks)
+        if settle_tasks:
+            await asyncio.gather(*settle_tasks, return_exceptions=True)
         for state in self._inbound_kv.values():
             with suppress(Exception):
                 state.receiver.abort(state.request, state.destination, close_error)
@@ -808,7 +821,9 @@ class CommEngine:
             raise ValueError(
                 f"data_ack for {ack.to_stage!r} delivered to {self.router.stage_name!r}"
             )
-        pending = self._pending.get(ack.object_id)
+        pending = self._pending.get(ack.object_id) or (
+            self._retained_pending_kv_transfers.get(ack.object_id)
+        )
         if pending is None:
             logger.debug(
                 "Ignoring stale data_ack for %s from %s to %s",
@@ -818,16 +833,25 @@ class CommEngine:
             )
             return
         if ack.success:
-            pending.receiver_terminal = True
-            if not pending.ack.done():
-                pending.ack.set_result(None)
+            self._mark_receiver_terminal(pending, None)
             return
         error = ack.error
         if error is None:
             raise ValueError("failed data_ack is missing error")
+        self._mark_receiver_terminal(pending, RuntimeError(error))
+
+    @staticmethod
+    def _mark_receiver_terminal(
+        pending: _PendingTransfer, error: BaseException | None
+    ) -> None:
         pending.receiver_terminal = True
-        if not pending.ack.done():
-            pending.ack.set_exception(RuntimeError(error))
+        for future in (pending.ack, pending.terminal):
+            if future is None or future.done():
+                continue
+            if error is None:
+                future.set_result(None)
+            else:
+                future.set_exception(error)
 
     def _send_queue_for(
         self, queue_key: str
@@ -1094,7 +1118,17 @@ class CommEngine:
         error: BaseException,
     ) -> None:
         self._pending.pop(object_id, None)
-        self._retained_pending_kv_transfers.append(pending)
+        # Note(Yue Yin): wait on a signal only the peer or close() can set.
+        # cleanup() resolves pending.ack with a locally made error, and the
+        # peer may still be reading the source pages.
+        pending.terminal = asyncio.get_running_loop().create_future()
+        self._retained_pending_kv_transfers[object_id] = pending
+        task = asyncio.create_task(
+            self._settle_retained_kv_transfer(object_id, pending)
+        )
+        self._retained_settle_tasks.add(task)
+        task.add_done_callback(self._retained_settle_tasks.discard)
+        self._track_task(task, f"comm kv retained {object_id}")
         _comm_trace(
             "comm_kv_pending_retained",
             object_id=object_id,
@@ -1107,6 +1141,32 @@ class CommEngine:
             object_id,
             error,
         )
+
+    async def _settle_retained_kv_transfer(
+        self, object_id: str, pending: _PendingTransfer
+    ) -> None:
+        # Note(Yue Yin): log a failure instead of raising it. A tracked task
+        # that raises stops the whole Stage, and a late ack is normal.
+        error: BaseException | None = None
+        try:
+            try:
+                await pending.terminal
+            except Exception as exc:
+                error = exc
+                logger.warning("Retained KV transfer %s ended: %s", object_id, exc)
+            for op in pending.ops:
+                with suppress(Exception):
+                    if error is None:
+                        op.mark_receiver_done()
+                    else:
+                        op.mark_receiver_failed(error)
+            for op in pending.ops:
+                with suppress(Exception):
+                    await op.wait_for_completion(timeout=self._ack_timeout_s)
+        finally:
+            self._retained_pending_kv_transfers.pop(object_id, None)
+            if pending.lease is not None:
+                pending.lease.release()
 
     def _fail_pending(self, object_id: str, exc: BaseException) -> None:
         pending = self._pending.get(object_id)

--- a/sglang_omni/scheduling/pd_scheduler.py
+++ b/sglang_omni/scheduling/pd_scheduler.py
@@ -3,6 +3,7 @@
 
 from __future__ import annotations
 
+import logging
 import queue
 import threading
 import types
@@ -27,8 +28,36 @@ from sglang_omni.scheduling.pd_utils import (
     serialize_kv_allocator,
 )
 
+logger = logging.getLogger(__name__)
 
-class OmniPrefillScheduler(OmniScheduler):
+
+class _PDReleaseOwner(OmniScheduler):
+    """Omni scheduler half whose request table only its own thread mutates."""
+
+    def __init__(self, *args, **kwargs) -> None:
+        self._pd_due_releases: queue.SimpleQueue = queue.SimpleQueue()
+        super().__init__(*args, **kwargs)
+
+    def _drain_due_releases(self) -> None:
+        while True:
+            try:
+                req = self._pd_due_releases.get_nowait()
+            except queue.Empty:
+                return
+            try:
+                self._release_request_kv_cache(req)
+            except Exception:
+                # One bad request must not strand the rest of the queue.
+                logger.exception("PD release failed for %r", getattr(req, "rid", req))
+
+    def flush_cache(self, *args, **kwargs):
+        # Note(Yue Yin): upstream clears both pools once it reads the
+        # scheduler as idle, and it cannot see this queue.
+        self._drain_due_releases()
+        return _Upstream.flush_cache(self, *args, **kwargs)
+
+
+class OmniPrefillScheduler(_PDReleaseOwner):
     """Omni scheduler whose generated requests stop after Prefill."""
 
     scheduler_role = "prefill"
@@ -47,7 +76,6 @@ class OmniPrefillScheduler(OmniScheduler):
         self._pd_stage_name = stage_name
         self._pd_partner_stage = partner_stage
         self._pd_state_builder = state_builder
-        self._pd_due_releases = queue.SimpleQueue()
         self._pd_pool_id = f"{stage_name}:kv"
         pool = build_kv_pool(
             self.token_to_kv_pool_allocator.get_kvcache(),
@@ -56,12 +84,7 @@ class OmniPrefillScheduler(OmniScheduler):
         self.kv_registrations = ((pool, None),)
 
     def get_next_batch_to_run(self):
-        while True:
-            try:
-                req = self._pd_due_releases.get_nowait()
-            except queue.Empty:
-                break
-            self._release_request_kv_cache(req)
+        self._drain_due_releases()
         if (
             self.running_batch.is_empty()
             and self.running_batch.batch_is_full
@@ -152,7 +175,7 @@ class OmniPrefillScheduler(OmniScheduler):
             batch.batch_is_full = False
 
 
-class OmniDecodeScheduler(OmniScheduler):
+class OmniDecodeScheduler(_PDReleaseOwner):
     """Omni scheduler that admits transferred Prefill state for Decode."""
 
     scheduler_role = "decode"
@@ -198,6 +221,7 @@ class OmniDecodeScheduler(OmniScheduler):
 
     def get_next_batch_to_run(self):
         with self._pd_admission_lock:
+            self._drain_due_releases()
             self._drain_decode_admissions()
             # Do not let a new transfer consume the space between the decode
             # memory check and allocation. Abort takes these locks in this order.
@@ -282,7 +306,9 @@ class OmniDecodeScheduler(OmniScheduler):
         with self._pd_admission_lock:
             for req in self.waiting_queue:
                 if req.rid == request_id:
-                    self._release_request_kv_cache(req)
+                    # Note(Yue Yin): abort runs on the Stage event loop, and
+                    # only the scheduler thread may mutate the request table.
+                    self._pd_due_releases.put(req)
                     break
             super().abort(
                 request_id,

--- a/tests/unit_test/pipeline/test_kv_transfer.py
+++ b/tests/unit_test/pipeline/test_kv_transfer.py
@@ -20,6 +20,7 @@ from sglang_omni.pipeline.control_plane import (
     serialize_message,
 )
 from sglang_omni.proto import (
+    DataAckMessage,
     DataReadyMessage,
     KVBufferSpec,
     KVPoolLayout,
@@ -571,27 +572,33 @@ def test_kv_transfer_rejects_layout_mismatch() -> None:
     asyncio.run(_run())
 
 
-def test_kv_ack_timeout_retains_pending_sender_resources(
+async def _pair_without_data_ready(
+    monkeypatch: pytest.MonkeyPatch,
+) -> tuple[_PagedRelay, CommEngine, CommEngine]:
+    """Start a pair whose DataReady never reaches the destination."""
+
+    relay, source, destination = await _start_pair()
+
+    async def drop_data_ready(
+        sockets: dict[str, Any], target_endpoint: str, message: Any
+    ) -> None:
+        if isinstance(message, DataReadyMessage):
+            return
+        await send_to_endpoint(sockets, target_endpoint, message)
+
+    monkeypatch.setattr("sglang_omni.comm.engine.send_to_endpoint", drop_data_ready)
+    source.register_kv_pool(_pool("source_pool"))
+    destination.register_kv_pool(_pool("destination_pool"))
+    destination.register_kv_receiver("destination_pool", _Receiver((0,)))
+    return relay, source, destination
+
+
+def test_kv_ack_timeout_retains_sender_resources_until_a_late_ack(
     monkeypatch: pytest.MonkeyPatch,
 ) -> None:
     async def _run() -> None:
-        relay, source, destination = await _start_pair()
-
-        async def drop_data_ready(
-            sockets: dict[str, Any], target_endpoint: str, message: Any
-        ) -> None:
-            if isinstance(message, DataReadyMessage):
-                return
-            await send_to_endpoint(sockets, target_endpoint, message)
-
-        monkeypatch.setattr(
-            "sglang_omni.comm.engine.send_to_endpoint",
-            drop_data_ready,
-        )
+        relay, source, destination = await _pair_without_data_ready(monkeypatch)
         source._ack_timeout_s = 0.1
-        source.register_kv_pool(_pool("source_pool"))
-        destination.register_kv_pool(_pool("destination_pool"))
-        destination.register_kv_receiver("destination_pool", _Receiver((0,)))
         lease = Mock()
 
         try:
@@ -611,6 +618,59 @@ def test_kv_ack_timeout_retains_pending_sender_resources(
             assert relay.put_ops[0].failed is None
             assert "transfer" not in source._pending
             assert len(source._retained_pending_kv_transfers) == 1
+            source.ack_transfer(
+                DataAckMessage(
+                    request_id="request",
+                    from_stage="destination",
+                    to_stage="source",
+                    object_id="transfer",
+                )
+            )
+            for _ in range(100):
+                await asyncio.sleep(0)
+                if lease.release.call_count:
+                    break
+            lease.release.assert_called_once()
+            assert source._retained_pending_kv_transfers == {}
+        finally:
+            await source.close()
+            await destination.close()
+
+    asyncio.run(_run())
+
+
+def test_a_local_abort_keeps_the_source_pages_until_the_peer_answers(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    async def _run() -> None:
+        _, source, destination = await _pair_without_data_ready(monkeypatch)
+        lease = Mock()
+
+        transfer = asyncio.create_task(
+            source.send_kv_pages(
+                request_id="request",
+                transfer_id="transfer",
+                source_pool_id="source_pool",
+                source_page_indices=(1,),
+                target_pool_id="destination_pool",
+                to_stage="destination",
+                lease=lease,
+            )
+        )
+        try:
+            for _ in range(200):
+                await asyncio.sleep(0)
+                pending = source._pending.get("transfer")
+                if pending is not None and pending.task is not None:
+                    break
+
+            source.cleanup("request")
+            with pytest.raises(RuntimeError):
+                await asyncio.wait_for(transfer, 5)
+            for _ in range(100):
+                await asyncio.sleep(0)
+            lease.release.assert_not_called()
+            assert "transfer" in source._retained_pending_kv_transfers
         finally:
             await source.close()
             await destination.close()

--- a/tests/unit_test/pipeline/test_pd_lifecycle.py
+++ b/tests/unit_test/pipeline/test_pd_lifecycle.py
@@ -11,6 +11,7 @@ from unittest.mock import AsyncMock, Mock
 
 import pytest
 import torch
+from sglang.srt.managers.scheduler import Scheduler as _Upstream
 
 from sglang_omni.comm import KVPageTransfer
 from sglang_omni.scheduling import pd_utils
@@ -111,6 +112,66 @@ def test_prefill_ack_releases_once_on_the_scheduler_thread(monkeypatch):
     assert released == [(req, threading.get_ident())]
 
 
+def _recording_decode_scheduler(done):
+    scheduler = _decode_scheduler()
+    scheduler.waiting_queue = [SimpleNamespace(rid="request-1")]
+    scheduler._release_request_kv_cache = lambda req: done.append(
+        (req.rid, threading.get_ident())
+    )
+    scheduler._drain_decode_admissions = lambda: done.append("admissions")
+    return scheduler
+
+
+def test_decode_abort_releases_on_the_scheduler_thread(monkeypatch):
+    done = []
+    scheduler = _recording_decode_scheduler(done)
+    scheduler.running_batch = None
+    monkeypatch.setattr(OmniScheduler, "abort", lambda self, rid, **kwargs: None)
+    monkeypatch.setattr(
+        _Upstream,
+        "get_next_disagg_decode_batch_to_run",
+        lambda self, running_batch: SimpleNamespace(
+            running_batch=None, batch_to_run=None
+        ),
+        raising=False,
+    )
+    with ThreadPoolExecutor(1) as threads:
+        threads.submit(scheduler.abort, "request-1").result(timeout=5)
+    assert done == []
+    scheduler.get_next_batch_to_run()
+    assert done == [("request-1", threading.get_ident()), "admissions"]
+
+
+def test_flush_cache_returns_deferred_rows_before_upstream_reads_idle(monkeypatch):
+    done = []
+    scheduler = _recording_decode_scheduler(done)
+    monkeypatch.setattr(OmniScheduler, "abort", lambda self, rid, **kwargs: None)
+    monkeypatch.setattr(
+        _Upstream, "flush_cache", lambda self: done.append("upstream_flush") or True
+    )
+    with ThreadPoolExecutor(1) as threads:
+        threads.submit(scheduler.abort, "request-1").result(timeout=5)
+    assert scheduler.flush_cache() is True
+    assert done == [("request-1", threading.get_ident()), "upstream_flush"]
+
+
+def test_a_failing_release_does_not_strand_the_rest_of_the_queue():
+    scheduler = _decode_scheduler()
+    released = []
+
+    def release(req):
+        if req.rid == "bad":
+            raise RuntimeError("release failed")
+        released.append(req.rid)
+
+    scheduler._release_request_kv_cache = release
+    for rid in ("first", "bad", "last"):
+        scheduler._pd_due_releases.put(SimpleNamespace(rid=rid))
+    scheduler._drain_due_releases()
+    assert released == ["first", "last"]
+    assert scheduler._pd_due_releases.empty()
+
+
 def _message(**updates):
     from sglang_omni.proto import KVBufferSpec, KVPoolLayout, KVTransferPrepareMessage
 
@@ -180,8 +241,10 @@ def test_receiver_rejects_mismatched_pages_and_bounds_finished_ids(monkeypatch):
 def _decode_scheduler():
     scheduler = object.__new__(OmniDecodeScheduler)
     scheduler._pd_admissions = queue.SimpleQueue()
+    scheduler._pd_due_releases = queue.SimpleQueue()
     scheduler._pd_deferred_admission = None
     scheduler._pd_admission_lock = threading.RLock()
+    scheduler._pd_kv_lock = threading.RLock()
     scheduler._pd_state_restorer = lambda *args: None
     scheduler._aborted_request_ids = set()
     scheduler.req_to_token_pool = _ReqPool()


### PR DESCRIPTION
## Motivation

When a KV transfer fails in a way that leaves the outcome unknown, `CommEngine`
holds on to the source pages rather than risk freeing pages the peer is still
reading. It parked those transfers in a list that nothing ever drained, and
`ack_transfer` only looked at `_pending`, so an ack arriving late had nowhere to
land. That was fine under the old assumption, written in the code: the process
is about to exit anyway.

#1773 breaks that assumption. Before it, `send_kv_pages` had no production
caller at all, only tests. Now it is a live path with a real lease that owns a
Prefill request's KV pages and its request-table row, and an ack timeout just
fails that one request while the Stage keeps serving. So every timeout leaked
one request's pages for the rest of the process's life. A slow Decode peer
drains the Prefill pool until Prefill cannot schedule anything.

## Modifications

Retained transfers are now keyed by `object_id` so `ack_transfer` can find them,
and a task releases the lease once the peer is actually done.

That task waits on a new `pending.terminal` future rather than on `pending.ack`.
Only the peer and `close()` resolve it. This matters: `cleanup()` resolves
`pending.ack` with an error we made up locally, and a local abort is not
evidence that the peer stopped reading. Waiting on `pending.ack` would free the
source pages mid-copy, which is the corruption the whole retain mechanism exists
to prevent. There is a test for it.

`close()` ends every retained transfer and waits for its task, so the pages come
back when the engine shuts down instead of when the process dies.

The task logs failures instead of raising, because any tracked task that raises
takes the whole Stage down with it.

## Related Issues

Fixes a defect in #1773. Part of #1760.
