### PR TITLE
fix(pd): preserve the hidden-state mode and custom sampling params across handoff

### DIFF
--- a/sglang_omni/scheduling/pd_utils.py
+++ b/sglang_omni/scheduling/pd_utils.py
@@ -12,7 +12,7 @@ from array import array
 from collections.abc import Callable
 from contextlib import contextmanager
 from functools import wraps
-from typing import Any
+from typing import Any, Literal
 
 import msgspec
 import torch
@@ -77,7 +77,7 @@ class DecodeContinuation:
     top_logprobs_num: int = 0
     token_ids_logprob: list[int] | None = None
     logprob_start_len: int = -1
-    return_hidden_states: bool = False
+    return_hidden_states: bool | Literal["last"] = False
     return_sampling_mask: bool = False
     return_routed_experts: bool = False
     return_indexer_topk: bool = False
@@ -100,6 +100,12 @@ class DecodeContinuation:
             self.multimodal_resume, dict
         ):
             raise TypeError("decode continuation multimodal_resume must be a mapping")
+        hidden_states = self.return_hidden_states
+        if not isinstance(hidden_states, bool) and hidden_states != "last":
+            raise ValueError(
+                f"unsupported decode continuation "
+                f"return_hidden_states {hidden_states!r}"
+            )
 
     def encode(self) -> bytes:
         return msgspec.msgpack.encode(dataclasses.asdict(self))
@@ -193,7 +199,7 @@ def continuation_from_req(
             else None
         ),
         logprob_start_len=int(req.logprob_start_len),
-        return_hidden_states=bool(req.return_hidden_states),
+        return_hidden_states=req.return_hidden_states,
         return_sampling_mask=bool(req.return_sampling_mask),
         return_routed_experts=bool(req.return_routed_experts),
         return_indexer_topk=bool(req.return_indexer_topk),
@@ -298,7 +304,15 @@ def req_from_continuation(
 
 def _sampling_params_to_dict(params: Any) -> dict[str, Any]:
     allowed = inspect.signature(type(params)).parameters
-    return {name: getattr(params, name) for name in allowed if hasattr(params, name)}
+    values = {name: getattr(params, name) for name in allowed if hasattr(params, name)}
+    custom = values.get("custom_params")
+    if isinstance(custom, dict):
+        # Note(Yue Yin): Req.__init__ injects the live Req under "__req__", and
+        # injects it again on the Decode side. Do not serialize it.
+        values["custom_params"] = {
+            key: value for key, value in custom.items() if key != "__req__"
+        }
+    return values
 
 
 @contextmanager

--- a/tests/unit_test/pipeline/test_pd_utils.py
+++ b/tests/unit_test/pipeline/test_pd_utils.py
@@ -8,7 +8,7 @@ from array import array
 from types import SimpleNamespace
 
 import torch
-from sglang.srt.managers.schedule_batch import Req
+from sglang.srt.managers.schedule_batch import CaptureHiddenMode, Req
 from sglang.srt.sampling.sampling_params import SamplingParams
 
 from sglang_omni.comm import KVPageTransfer
@@ -78,13 +78,19 @@ class _KVAllocator:
         self.freed.append(slots)
 
 
-def _prefill_req(*, max_new_tokens: int = 16) -> Req:
+def _prefill_req(
+    *,
+    max_new_tokens: int = 16,
+    custom_params: dict | None = None,
+    return_hidden_states: bool | str = False,
+) -> Req:
     sampling = SamplingParams(
         max_new_tokens=max_new_tokens,
         temperature=0.7,
         top_p=0.9,
         stop_token_ids={2},
         sampling_seed=17,
+        custom_params=custom_params,
     )
     sampling.normalize(None)
     req = Req(
@@ -94,6 +100,7 @@ def _prefill_req(*, max_new_tokens: int = 16) -> Req:
         sampling_params=sampling,
         vocab_size=128,
         eos_token_ids={2},
+        return_hidden_states=return_hidden_states,
     )
     req.output_ids.append(42)
     payload = StagePayload(
@@ -137,6 +144,37 @@ def test_continuation_round_trip_rebuilds_prebuilt_request() -> None:
     assert req.sampling_params.stop_token_ids == {2}
     assert req.prefix_indices.tolist() == [7, 8, 9]
     assert req.kv.kv_allocated_len == 3
+
+
+def _rebuilt_req(source):
+    continuation = DecodeContinuation.decode(
+        continuation_from_req(source, "transfer-1", _state_builder).encode()
+    )
+    return req_from_continuation(
+        continuation,
+        _allocation(),
+        req_to_token_pool=_ReqPool(),
+        state_restorer=lambda req, _data, _resume: setattr(req, "tokenizer", None),
+    )
+
+
+def test_continuation_preserves_the_hidden_state_mode() -> None:
+    for mode, capture in (
+        (False, CaptureHiddenMode.NULL),
+        (True, CaptureHiddenMode.FULL),
+        ("last", CaptureHiddenMode.LAST),
+    ):
+        req = _rebuilt_req(_prefill_req(return_hidden_states=mode))
+        assert req.return_hidden_states == mode
+        assert req.return_hidden_states_mode is capture
+
+
+def test_continuation_strips_the_live_req_out_of_custom_params() -> None:
+    source = _prefill_req(custom_params={"segment_timestamps": True})
+    req = _rebuilt_req(source)
+    assert req.sampling_params.custom_params["segment_timestamps"] is True
+    assert req.sampling_params.custom_params["__req__"] is req
+    assert source.sampling_params.custom_params["__req__"] is source
 
 
 def test_decode_receiver_commits_directly_to_admission_queue() -> None:


### PR DESCRIPTION
## Motivation

`DecodeContinuation` is the snapshot that carries a request from Prefill to
Decode. Two fields lose information on the way.

`return_hidden_states` has three states, not two. SGLang accepts `True`,
`False`, or the string `"last"`, but the snapshot ran it through `bool()`, so
`"last"` reached Decode as `True`. Decode then captures every hidden state
instead of only the last one, and the caller gets back a different shape than it
asked for.

`custom_params` cannot be serialized as-is. `Req.__init__` copies the sampling
params and drops the live `Req` into them under the key `"__req__"`, so
`encode()` dies with `TypeError: Encoding objects of type Req is unsupported`.
The snapshot already rejects the features it cannot carry, with a clear
`NotImplementedError` for custom logit processors, projected input embeddings
and structured output. It just never covered this one. Whisper ASR sets
`custom_params` for segment timestamps, so a real request builder reaches it.

## Modifications

Pass `return_hidden_states` through untouched, and drop the `"__req__"` key
before encoding. Decode does not need it shipped over: `Req.__init__` puts the
link back when it rebuilds the request. The snapshot builds a fresh dict, so the
Prefill request keeps its own link.

The field is now typed `bool | Literal["last"]` and checked in `__post_init__`
next to the other field checks, so a bad value fails when the continuation
arrives rather than deep inside `Req.__init__` after Decode has already
committed the KV.

Two things deliberately left alone. `CONTINUATION_VERSION` stays at 1: the
`bool()` call was only ever on the encode side, so a Decode process running
older code already handles `"last"` correctly, and bumping the version would
make it reject the continuation outright. And `lora_id` also gets dropped by the
snapshot, but `OmniScheduler` hardcodes `enable_lora = False`, so `req.lora_id`
is always `None` and a guard would be dead code. `priority` belongs to Stage 3
of #1760.

## Related Issues

Fixes a defect in #1773. Part of #1760.
