### PR TITLE
fix(pd): report PD-held KV to the idle check

### DIFF
--- a/sglang_omni/comm/engine.py
+++ b/sglang_omni/comm/engine.py
@@ -1,5 +1,6 @@
 # SPDX-License-Identifier: Apache-2.0
 """Omni communication engine facade used by pipeline stages."""
+
 from __future__ import annotations
 
 import asyncio
@@ -61,6 +62,8 @@ class _PendingTransfer(msgspec.Struct):
     lease: KVPageLease | None = None
     retain_pending_on_failure: bool = False
     receiver_terminal: bool = False
+    # Resolved only by the peer, or by close(). A local failure must not.
+    terminal: asyncio.Future[None] | None = None
 
 
 class _PayloadSendJob(msgspec.Struct, frozen=True):
@@ -125,8 +128,10 @@ class CommEngine:
         self._send_workers: dict[str, asyncio.Task] = {}
         self._pending: dict[str, _PendingTransfer] = {}
         self._stream_send_sequence = count()
-        # Failed pending KV transfers stay pinned until this dying process exits.
-        self._retained_pending_kv_transfers: list[_PendingTransfer] = []
+        # Note(Yue Yin): key retained transfers by object_id so a late ack can
+        # still settle one after the local send failed.
+        self._retained_pending_kv_transfers: dict[str, _PendingTransfer] = {}
+        self._retained_settle_tasks: set[asyncio.Task] = set()
         self._kv_pools: dict[str, KVPool] = {}
         self._kv_receivers: dict[str, KVReceiver] = {}
         self._kv_ready: dict[str, asyncio.Future[KVTransferReadyMessage]] = {}
@@ -791,6 +796,14 @@ class CommEngine:
         for object_id in list(self._pending):
             self._fail_pending(object_id, RuntimeError("comm engine closed"))
         close_error = RuntimeError("comm engine closed")
+        # Note(Yue Yin): end every retained transfer and wait for its task, so
+        # the source pages come back with the engine, not with the process.
+        for pending in list(self._retained_pending_kv_transfers.values()):
+            if pending.terminal is not None and not pending.terminal.done():
+                pending.terminal.set_exception(close_error)
+        settle_tasks = tuple(self._retained_settle_tasks)
+        if settle_tasks:
+            await asyncio.gather(*settle_tasks, return_exceptions=True)
         for state in self._inbound_kv.values():
             with suppress(Exception):
                 state.receiver.abort(state.request, state.destination, close_error)
@@ -808,7 +821,9 @@ class CommEngine:
             raise ValueError(
                 f"data_ack for {ack.to_stage!r} delivered to {self.router.stage_name!r}"
             )
-        pending = self._pending.get(ack.object_id)
+        pending = self._pending.get(ack.object_id) or (
+            self._retained_pending_kv_transfers.get(ack.object_id)
+        )
         if pending is None:
             logger.debug(
                 "Ignoring stale data_ack for %s from %s to %s",
@@ -818,16 +833,25 @@ class CommEngine:
             )
             return
         if ack.success:
-            pending.receiver_terminal = True
-            if not pending.ack.done():
-                pending.ack.set_result(None)
+            self._mark_receiver_terminal(pending, None)
             return
         error = ack.error
         if error is None:
             raise ValueError("failed data_ack is missing error")
+        self._mark_receiver_terminal(pending, RuntimeError(error))
+
+    @staticmethod
+    def _mark_receiver_terminal(
+        pending: _PendingTransfer, error: BaseException | None
+    ) -> None:
         pending.receiver_terminal = True
-        if not pending.ack.done():
-            pending.ack.set_exception(RuntimeError(error))
+        for future in (pending.ack, pending.terminal):
+            if future is None or future.done():
+                continue
+            if error is None:
+                future.set_result(None)
+            else:
+                future.set_exception(error)
 
     def _send_queue_for(
         self, queue_key: str
@@ -1094,7 +1118,17 @@ class CommEngine:
         error: BaseException,
     ) -> None:
         self._pending.pop(object_id, None)
-        self._retained_pending_kv_transfers.append(pending)
+        # Note(Yue Yin): wait on a signal only the peer or close() can set.
+        # cleanup() resolves pending.ack with a locally made error, and the
+        # peer may still be reading the source pages.
+        pending.terminal = asyncio.get_running_loop().create_future()
+        self._retained_pending_kv_transfers[object_id] = pending
+        task = asyncio.create_task(
+            self._settle_retained_kv_transfer(object_id, pending)
+        )
+        self._retained_settle_tasks.add(task)
+        task.add_done_callback(self._retained_settle_tasks.discard)
+        self._track_task(task, f"comm kv retained {object_id}")
         _comm_trace(
             "comm_kv_pending_retained",
             object_id=object_id,
@@ -1107,6 +1141,32 @@ class CommEngine:
             object_id,
             error,
         )
+
+    async def _settle_retained_kv_transfer(
+        self, object_id: str, pending: _PendingTransfer
+    ) -> None:
+        # Note(Yue Yin): log a failure instead of raising it. A tracked task
+        # that raises stops the whole Stage, and a late ack is normal.
+        error: BaseException | None = None
+        try:
+            try:
+                await pending.terminal
+            except Exception as exc:
+                error = exc
+                logger.warning("Retained KV transfer %s ended: %s", object_id, exc)
+            for op in pending.ops:
+                with suppress(Exception):
+                    if error is None:
+                        op.mark_receiver_done()
+                    else:
+                        op.mark_receiver_failed(error)
+            for op in pending.ops:
+                with suppress(Exception):
+                    await op.wait_for_completion(timeout=self._ack_timeout_s)
+        finally:
+            self._retained_pending_kv_transfers.pop(object_id, None)
+            if pending.lease is not None:
+                pending.lease.release()
 
     def _fail_pending(self, object_id: str, exc: BaseException) -> None:
         pending = self._pending.get(object_id)

--- a/sglang_omni/scheduling/pd_scheduler.py
+++ b/sglang_omni/scheduling/pd_scheduler.py
@@ -3,6 +3,7 @@
 
 from __future__ import annotations
 
+import logging
 import queue
 import threading
 import types
@@ -27,8 +28,36 @@ from sglang_omni.scheduling.pd_utils import (
     serialize_kv_allocator,
 )
 
+logger = logging.getLogger(__name__)
 
-class OmniPrefillScheduler(OmniScheduler):
+
+class _PDReleaseOwner(OmniScheduler):
+    """Omni scheduler half whose request table only its own thread mutates."""
+
+    def __init__(self, *args, **kwargs) -> None:
+        self._pd_due_releases: queue.SimpleQueue = queue.SimpleQueue()
+        super().__init__(*args, **kwargs)
+
+    def _drain_due_releases(self) -> None:
+        while True:
+            try:
+                req = self._pd_due_releases.get_nowait()
+            except queue.Empty:
+                return
+            try:
+                self._release_request_kv_cache(req)
+            except Exception:
+                # One bad request must not strand the rest of the queue.
+                logger.exception("PD release failed for %r", getattr(req, "rid", req))
+
+    def flush_cache(self, *args, **kwargs):
+        # Note(Yue Yin): upstream clears both pools once it reads the
+        # scheduler as idle, and it cannot see this queue.
+        self._drain_due_releases()
+        return _Upstream.flush_cache(self, *args, **kwargs)
+
+
+class OmniPrefillScheduler(_PDReleaseOwner):
     """Omni scheduler whose generated requests stop after Prefill."""
 
     scheduler_role = "prefill"
@@ -47,7 +76,6 @@ class OmniPrefillScheduler(OmniScheduler):
         self._pd_stage_name = stage_name
         self._pd_partner_stage = partner_stage
         self._pd_state_builder = state_builder
-        self._pd_due_releases = queue.SimpleQueue()
         self._pd_pool_id = f"{stage_name}:kv"
         pool = build_kv_pool(
             self.token_to_kv_pool_allocator.get_kvcache(),
@@ -56,12 +84,7 @@ class OmniPrefillScheduler(OmniScheduler):
         self.kv_registrations = ((pool, None),)
 
     def get_next_batch_to_run(self):
-        while True:
-            try:
-                req = self._pd_due_releases.get_nowait()
-            except queue.Empty:
-                break
-            self._release_request_kv_cache(req)
+        self._drain_due_releases()
         if (
             self.running_batch.is_empty()
             and self.running_batch.batch_is_full
@@ -152,7 +175,7 @@ class OmniPrefillScheduler(OmniScheduler):
             batch.batch_is_full = False
 
 
-class OmniDecodeScheduler(OmniScheduler):
+class OmniDecodeScheduler(_PDReleaseOwner):
     """Omni scheduler that admits transferred Prefill state for Decode."""
 
     scheduler_role = "decode"
@@ -198,6 +221,7 @@ class OmniDecodeScheduler(OmniScheduler):
 
     def get_next_batch_to_run(self):
         with self._pd_admission_lock:
+            self._drain_due_releases()
             self._drain_decode_admissions()
             # Do not let a new transfer consume the space between the decode
             # memory check and allocation. Abort takes these locks in this order.
@@ -282,7 +306,9 @@ class OmniDecodeScheduler(OmniScheduler):
         with self._pd_admission_lock:
             for req in self.waiting_queue:
                 if req.rid == request_id:
-                    self._release_request_kv_cache(req)
+                    # Note(Yue Yin): abort runs on the Stage event loop, and
+                    # only the scheduler thread may mutate the request table.
+                    self._pd_due_releases.put(req)
                     break
             super().abort(
                 request_id,

--- a/sglang_omni/scheduling/pd_scheduler.py
+++ b/sglang_omni/scheduling/pd_scheduler.py
@@ -36,7 +36,18 @@ class _PDReleaseOwner(OmniScheduler):
 
     def __init__(self, *args, **kwargs) -> None:
         self._pd_due_releases: queue.SimpleQueue = queue.SimpleQueue()
+        self._pd_leased_requests: set[str] = set()
         super().__init__(*args, **kwargs)
+
+    def _pd_holds_kv(self) -> bool:
+        return bool(self._pd_leased_requests) or not self._pd_due_releases.empty()
+
+    def is_fully_idle(self, *args, **kwargs):
+        # Note(Yue Yin): flush_cache() clears both pools once upstream reads
+        # idle, and PD holds KV that sits in none of the queues it reads.
+        if self._pd_holds_kv():
+            return False
+        return _Upstream.is_fully_idle(self, *args, **kwargs)
 
     def _drain_due_releases(self) -> None:
         while True:
@@ -44,6 +55,7 @@ class _PDReleaseOwner(OmniScheduler):
                 req = self._pd_due_releases.get_nowait()
             except queue.Empty:
                 return
+            self._pd_leased_requests.discard(getattr(req, "rid", None))
             try:
                 self._release_request_kv_cache(req)
             except Exception:
@@ -163,6 +175,7 @@ class OmniPrefillScheduler(_PDReleaseOwner):
                 self._emit_request_error(req.rid, exc)
                 continue
             _detach_request_data(req)
+            self._pd_leased_requests.add(req.rid)
             self.outbox.put(
                 OutgoingMessage(
                     request_id=req.rid,
@@ -213,6 +226,14 @@ class OmniDecodeScheduler(_PDReleaseOwner):
             queue=[], retracted_queue=[], num_tokens_pre_allocated=0
         )
         self.disagg_decode_transfer_queue = types.SimpleNamespace(queue=[])
+
+    def _pd_holds_kv(self) -> bool:
+        return (
+            self._pd_deferred_admission is not None
+            or not self._pd_admissions.empty()
+            or self._pd_receiver.has_reservations()
+            or super()._pd_holds_kv()
+        )
 
     def _initial_disaggregation_mode(self):
         from sglang.srt.disaggregation.utils import DisaggregationMode

--- a/sglang_omni/scheduling/pd_utils.py
+++ b/sglang_omni/scheduling/pd_utils.py
@@ -12,7 +12,7 @@ from array import array
 from collections.abc import Callable
 from contextlib import contextmanager
 from functools import wraps
-from typing import Any
+from typing import Any, Literal
 
 import msgspec
 import torch
@@ -77,7 +77,7 @@ class DecodeContinuation:
     top_logprobs_num: int = 0
     token_ids_logprob: list[int] | None = None
     logprob_start_len: int = -1
-    return_hidden_states: bool = False
+    return_hidden_states: bool | Literal["last"] = False
     return_sampling_mask: bool = False
     return_routed_experts: bool = False
     return_indexer_topk: bool = False
@@ -100,6 +100,12 @@ class DecodeContinuation:
             self.multimodal_resume, dict
         ):
             raise TypeError("decode continuation multimodal_resume must be a mapping")
+        hidden_states = self.return_hidden_states
+        if not isinstance(hidden_states, bool) and hidden_states != "last":
+            raise ValueError(
+                f"unsupported decode continuation "
+                f"return_hidden_states {hidden_states!r}"
+            )
 
     def encode(self) -> bytes:
         return msgspec.msgpack.encode(dataclasses.asdict(self))
@@ -193,7 +199,7 @@ def continuation_from_req(
             else None
         ),
         logprob_start_len=int(req.logprob_start_len),
-        return_hidden_states=bool(req.return_hidden_states),
+        return_hidden_states=req.return_hidden_states,
         return_sampling_mask=bool(req.return_sampling_mask),
         return_routed_experts=bool(req.return_routed_experts),
         return_indexer_topk=bool(req.return_indexer_topk),
@@ -298,7 +304,15 @@ def req_from_continuation(
 
 def _sampling_params_to_dict(params: Any) -> dict[str, Any]:
     allowed = inspect.signature(type(params)).parameters
-    return {name: getattr(params, name) for name in allowed if hasattr(params, name)}
+    values = {name: getattr(params, name) for name in allowed if hasattr(params, name)}
+    custom = values.get("custom_params")
+    if isinstance(custom, dict):
+        # Note(Yue Yin): Req.__init__ injects the live Req under "__req__", and
+        # injects it again on the Decode side. Do not serialize it.
+        values["custom_params"] = {
+            key: value for key, value in custom.items() if key != "__req__"
+        }
+    return values
 
 
 @contextmanager

--- a/sglang_omni/scheduling/pd_utils.py
+++ b/sglang_omni/scheduling/pd_utils.py
@@ -505,6 +505,10 @@ class DecodeKVReceiver:
             self._allocator.free(reservation.allocation.slots)
         logger.warning("KV receive aborted for %s: %s", request.request_id, error)
 
+    def has_reservations(self) -> bool:
+        with self._lock:
+            return bool(self._reservations)
+
     def close(self) -> None:
         # CommEngine must finish/abort an in-flight copy before its pages can
         # be freed. Closing only gates new reservations and admissions.

--- a/tests/unit_test/pipeline/test_kv_transfer.py
+++ b/tests/unit_test/pipeline/test_kv_transfer.py
@@ -20,6 +20,7 @@ from sglang_omni.pipeline.control_plane import (
     serialize_message,
 )
 from sglang_omni.proto import (
+    DataAckMessage,
     DataReadyMessage,
     KVBufferSpec,
     KVPoolLayout,
@@ -571,27 +572,33 @@ def test_kv_transfer_rejects_layout_mismatch() -> None:
     asyncio.run(_run())
 
 
-def test_kv_ack_timeout_retains_pending_sender_resources(
+async def _pair_without_data_ready(
+    monkeypatch: pytest.MonkeyPatch,
+) -> tuple[_PagedRelay, CommEngine, CommEngine]:
+    """Start a pair whose DataReady never reaches the destination."""
+
+    relay, source, destination = await _start_pair()
+
+    async def drop_data_ready(
+        sockets: dict[str, Any], target_endpoint: str, message: Any
+    ) -> None:
+        if isinstance(message, DataReadyMessage):
+            return
+        await send_to_endpoint(sockets, target_endpoint, message)
+
+    monkeypatch.setattr("sglang_omni.comm.engine.send_to_endpoint", drop_data_ready)
+    source.register_kv_pool(_pool("source_pool"))
+    destination.register_kv_pool(_pool("destination_pool"))
+    destination.register_kv_receiver("destination_pool", _Receiver((0,)))
+    return relay, source, destination
+
+
+def test_kv_ack_timeout_retains_sender_resources_until_a_late_ack(
     monkeypatch: pytest.MonkeyPatch,
 ) -> None:
     async def _run() -> None:
-        relay, source, destination = await _start_pair()
-
-        async def drop_data_ready(
-            sockets: dict[str, Any], target_endpoint: str, message: Any
-        ) -> None:
-            if isinstance(message, DataReadyMessage):
-                return
-            await send_to_endpoint(sockets, target_endpoint, message)
-
-        monkeypatch.setattr(
-            "sglang_omni.comm.engine.send_to_endpoint",
-            drop_data_ready,
-        )
+        relay, source, destination = await _pair_without_data_ready(monkeypatch)
         source._ack_timeout_s = 0.1
-        source.register_kv_pool(_pool("source_pool"))
-        destination.register_kv_pool(_pool("destination_pool"))
-        destination.register_kv_receiver("destination_pool", _Receiver((0,)))
         lease = Mock()
 
         try:
@@ -611,6 +618,59 @@ def test_kv_ack_timeout_retains_pending_sender_resources(
             assert relay.put_ops[0].failed is None
             assert "transfer" not in source._pending
             assert len(source._retained_pending_kv_transfers) == 1
+            source.ack_transfer(
+                DataAckMessage(
+                    request_id="request",
+                    from_stage="destination",
+                    to_stage="source",
+                    object_id="transfer",
+                )
+            )
+            for _ in range(100):
+                await asyncio.sleep(0)
+                if lease.release.call_count:
+                    break
+            lease.release.assert_called_once()
+            assert source._retained_pending_kv_transfers == {}
+        finally:
+            await source.close()
+            await destination.close()
+
+    asyncio.run(_run())
+
+
+def test_a_local_abort_keeps_the_source_pages_until_the_peer_answers(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    async def _run() -> None:
+        _, source, destination = await _pair_without_data_ready(monkeypatch)
+        lease = Mock()
+
+        transfer = asyncio.create_task(
+            source.send_kv_pages(
+                request_id="request",
+                transfer_id="transfer",
+                source_pool_id="source_pool",
+                source_page_indices=(1,),
+                target_pool_id="destination_pool",
+                to_stage="destination",
+                lease=lease,
+            )
+        )
+        try:
+            for _ in range(200):
+                await asyncio.sleep(0)
+                pending = source._pending.get("transfer")
+                if pending is not None and pending.task is not None:
+                    break
+
+            source.cleanup("request")
+            with pytest.raises(RuntimeError):
+                await asyncio.wait_for(transfer, 5)
+            for _ in range(100):
+                await asyncio.sleep(0)
+            lease.release.assert_not_called()
+            assert "transfer" in source._retained_pending_kv_transfers
         finally:
             await source.close()
             await destination.close()

--- a/tests/unit_test/pipeline/test_pd_lifecycle.py
+++ b/tests/unit_test/pipeline/test_pd_lifecycle.py
@@ -94,6 +94,7 @@ def test_real_allocator_free_cannot_restore_a_concurrent_reservation(
 def test_prefill_ack_releases_once_on_the_scheduler_thread(monkeypatch):
     scheduler = object.__new__(OmniPrefillScheduler)
     scheduler._pd_due_releases = queue.SimpleQueue()
+    scheduler._pd_leased_requests = set()
     scheduler.running_batch = SimpleNamespace(
         is_empty=lambda: True, batch_is_full=False
     )
@@ -172,6 +173,28 @@ def test_a_failing_release_does_not_strand_the_rest_of_the_queue():
     assert scheduler._pd_due_releases.empty()
 
 
+def test_prefill_reports_a_leased_request_as_not_idle(monkeypatch):
+    scheduler = object.__new__(OmniPrefillScheduler)
+    scheduler._pd_due_releases = queue.SimpleQueue()
+    scheduler._pd_leased_requests = {"request-1"}
+    monkeypatch.setattr(_Upstream, "is_fully_idle", lambda self, *a, **k: True)
+    assert scheduler.is_fully_idle() is False
+    scheduler._pd_leased_requests.clear()
+    assert scheduler.is_fully_idle() is True
+
+
+def test_decode_reports_committed_and_reserved_kv_as_not_idle(monkeypatch):
+    scheduler = _decode_scheduler()
+    scheduler._pd_receiver = SimpleNamespace(has_reservations=lambda: False)
+    monkeypatch.setattr(_Upstream, "is_fully_idle", lambda self, *a, **k: True)
+    assert scheduler.is_fully_idle() is True
+    scheduler._pd_admissions.put(DecodeAdmission(_continuation(), _allocation()))
+    assert scheduler.is_fully_idle() is False
+    scheduler._pd_admissions.get_nowait()
+    scheduler._pd_receiver = SimpleNamespace(has_reservations=lambda: True)
+    assert scheduler.is_fully_idle() is False
+
+
 def _message(**updates):
     from sglang_omni.proto import KVBufferSpec, KVPoolLayout, KVTransferPrepareMessage
 
@@ -242,6 +265,7 @@ def _decode_scheduler():
     scheduler = object.__new__(OmniDecodeScheduler)
     scheduler._pd_admissions = queue.SimpleQueue()
     scheduler._pd_due_releases = queue.SimpleQueue()
+    scheduler._pd_leased_requests = set()
     scheduler._pd_deferred_admission = None
     scheduler._pd_admission_lock = threading.RLock()
     scheduler._pd_kv_lock = threading.RLock()

--- a/tests/unit_test/pipeline/test_pd_lifecycle.py
+++ b/tests/unit_test/pipeline/test_pd_lifecycle.py
@@ -11,6 +11,7 @@ from unittest.mock import AsyncMock, Mock
 
 import pytest
 import torch
+from sglang.srt.managers.scheduler import Scheduler as _Upstream
 
 from sglang_omni.comm import KVPageTransfer
 from sglang_omni.scheduling import pd_utils
@@ -111,6 +112,66 @@ def test_prefill_ack_releases_once_on_the_scheduler_thread(monkeypatch):
     assert released == [(req, threading.get_ident())]
 
 
+def _recording_decode_scheduler(done):
+    scheduler = _decode_scheduler()
+    scheduler.waiting_queue = [SimpleNamespace(rid="request-1")]
+    scheduler._release_request_kv_cache = lambda req: done.append(
+        (req.rid, threading.get_ident())
+    )
+    scheduler._drain_decode_admissions = lambda: done.append("admissions")
+    return scheduler
+
+
+def test_decode_abort_releases_on_the_scheduler_thread(monkeypatch):
+    done = []
+    scheduler = _recording_decode_scheduler(done)
+    scheduler.running_batch = None
+    monkeypatch.setattr(OmniScheduler, "abort", lambda self, rid, **kwargs: None)
+    monkeypatch.setattr(
+        _Upstream,
+        "get_next_disagg_decode_batch_to_run",
+        lambda self, running_batch: SimpleNamespace(
+            running_batch=None, batch_to_run=None
+        ),
+        raising=False,
+    )
+    with ThreadPoolExecutor(1) as threads:
+        threads.submit(scheduler.abort, "request-1").result(timeout=5)
+    assert done == []
+    scheduler.get_next_batch_to_run()
+    assert done == [("request-1", threading.get_ident()), "admissions"]
+
+
+def test_flush_cache_returns_deferred_rows_before_upstream_reads_idle(monkeypatch):
+    done = []
+    scheduler = _recording_decode_scheduler(done)
+    monkeypatch.setattr(OmniScheduler, "abort", lambda self, rid, **kwargs: None)
+    monkeypatch.setattr(
+        _Upstream, "flush_cache", lambda self: done.append("upstream_flush") or True
+    )
+    with ThreadPoolExecutor(1) as threads:
+        threads.submit(scheduler.abort, "request-1").result(timeout=5)
+    assert scheduler.flush_cache() is True
+    assert done == [("request-1", threading.get_ident()), "upstream_flush"]
+
+
+def test_a_failing_release_does_not_strand_the_rest_of_the_queue():
+    scheduler = _decode_scheduler()
+    released = []
+
+    def release(req):
+        if req.rid == "bad":
+            raise RuntimeError("release failed")
+        released.append(req.rid)
+
+    scheduler._release_request_kv_cache = release
+    for rid in ("first", "bad", "last"):
+        scheduler._pd_due_releases.put(SimpleNamespace(rid=rid))
+    scheduler._drain_due_releases()
+    assert released == ["first", "last"]
+    assert scheduler._pd_due_releases.empty()
+
+
 def _message(**updates):
     from sglang_omni.proto import KVBufferSpec, KVPoolLayout, KVTransferPrepareMessage
 
@@ -180,8 +241,10 @@ def test_receiver_rejects_mismatched_pages_and_bounds_finished_ids(monkeypatch):
 def _decode_scheduler():
     scheduler = object.__new__(OmniDecodeScheduler)
     scheduler._pd_admissions = queue.SimpleQueue()
+    scheduler._pd_due_releases = queue.SimpleQueue()
     scheduler._pd_deferred_admission = None
     scheduler._pd_admission_lock = threading.RLock()
+    scheduler._pd_kv_lock = threading.RLock()
     scheduler._pd_state_restorer = lambda *args: None
     scheduler._aborted_request_ids = set()
     scheduler.req_to_token_pool = _ReqPool()

--- a/tests/unit_test/pipeline/test_pd_utils.py
+++ b/tests/unit_test/pipeline/test_pd_utils.py
@@ -8,7 +8,7 @@ from array import array
 from types import SimpleNamespace
 
 import torch
-from sglang.srt.managers.schedule_batch import Req
+from sglang.srt.managers.schedule_batch import CaptureHiddenMode, Req
 from sglang.srt.sampling.sampling_params import SamplingParams
 
 from sglang_omni.comm import KVPageTransfer
@@ -78,13 +78,19 @@ class _KVAllocator:
         self.freed.append(slots)
 
 
-def _prefill_req(*, max_new_tokens: int = 16) -> Req:
+def _prefill_req(
+    *,
+    max_new_tokens: int = 16,
+    custom_params: dict | None = None,
+    return_hidden_states: bool | str = False,
+) -> Req:
     sampling = SamplingParams(
         max_new_tokens=max_new_tokens,
         temperature=0.7,
         top_p=0.9,
         stop_token_ids={2},
         sampling_seed=17,
+        custom_params=custom_params,
     )
     sampling.normalize(None)
     req = Req(
@@ -94,6 +100,7 @@ def _prefill_req(*, max_new_tokens: int = 16) -> Req:
         sampling_params=sampling,
         vocab_size=128,
         eos_token_ids={2},
+        return_hidden_states=return_hidden_states,
     )
     req.output_ids.append(42)
     payload = StagePayload(
@@ -137,6 +144,37 @@ def test_continuation_round_trip_rebuilds_prebuilt_request() -> None:
     assert req.sampling_params.stop_token_ids == {2}
     assert req.prefix_indices.tolist() == [7, 8, 9]
     assert req.kv.kv_allocated_len == 3
+
+
+def _rebuilt_req(source):
+    continuation = DecodeContinuation.decode(
+        continuation_from_req(source, "transfer-1", _state_builder).encode()
+    )
+    return req_from_continuation(
+        continuation,
+        _allocation(),
+        req_to_token_pool=_ReqPool(),
+        state_restorer=lambda req, _data, _resume: setattr(req, "tokenizer", None),
+    )
+
+
+def test_continuation_preserves_the_hidden_state_mode() -> None:
+    for mode, capture in (
+        (False, CaptureHiddenMode.NULL),
+        (True, CaptureHiddenMode.FULL),
+        ("last", CaptureHiddenMode.LAST),
+    ):
+        req = _rebuilt_req(_prefill_req(return_hidden_states=mode))
+        assert req.return_hidden_states == mode
+        assert req.return_hidden_states_mode is capture
+
+
+def test_continuation_strips_the_live_req_out_of_custom_params() -> None:
+    source = _prefill_req(custom_params={"segment_timestamps": True})
+    req = _rebuilt_req(source)
+    assert req.sampling_params.custom_params["segment_timestamps"] is True
+    assert req.sampling_params.custom_params["__req__"] is req
+    assert source.sampling_params.custom_params["__req__"] is source
 
 
 def test_decode_receiver_commits_directly_to_admission_queue() -> None:


### PR DESCRIPTION
## Motivation

Once Prefill hands a request off, that request is in no batch and in no waiting
queue. `_handoff_prefilled_requests` takes it out of `batch.reqs`, and from then
until the Decode peer acks, an `SGLangKVLease` holds its KV pages and its
request-table row, and nothing else does. Decode holds KV the same invisible way twice
more: a committed admission sitting in `_pd_admissions`, and pages
`DecodeKVReceiver` reserved for a copy that has not committed yet.

`is_fully_idle()` only looks at upstream's own queues and batches, so it calls
all three of those states idle. `flush_cache()` believes it and wipes both pools
with `req_to_token_pool.clear()` and `token_to_kv_pool_allocator.clear()`. When
the lease finally releases, it pushes an already-reset row and its pages back
onto the free lists, and two live requests end up sharing one request-table row.

`_active_request_ids()` looks in the same places, so a weight update with
`abort_all_requests=true` walks straight into this believing nothing is active.

## Modifications

Add a `_pd_holds_kv` hook that `is_fully_idle` checks before it defers to
upstream. The base tracks every leased request until the scheduler thread
releases it. Decode adds its queued admissions, its deferred admission, and the
receiver's reservations.

`DecodeKVReceiver` gains a `has_reservations` method so the scheduler can ask
without reaching into its private state.

## Related Issues

Fixes a defect in #1773. Part of #1760.
