### PR TITLE
[Probe] Exercise omni-xpu-ci.yaml pull path (source-only, DO NOT MERGE)

### DIFF
--- a/tests/unit_test/xpu/test_device_layer.py
+++ b/tests/unit_test/xpu/test_device_layer.py
@@ -1,5 +1,10 @@
 # SPDX-License-Identifier: Apache-2.0
-"""Unit tests for device-spec retargeting (no accelerator required)."""
+"""Unit tests for device-spec retargeting (no accelerator required).
+
+The tests here run against Python objects only and never construct a real
+XPU context, so they are the safe target for exercising the pull path of
+omni-xpu-ci.yaml on source-only PRs.
+"""
 
 from __future__ import annotations
 


### PR DESCRIPTION
## Purpose (do not merge)

Probe PR for the XPU CI pull path introduced by #1906. This PR intentionally touches only `tests/unit_test/xpu/test_device_layer.py` (a docstring), so `check-changes` should emit `xpu=true` + `image=false` — exercising the `docker pull intel/sglang-omni-xpu-dev:img-<fp>` path rather than a local image build.

## What to look for in the run

1. `check-changes` outputs: `xpu=true`, `image=false`.
2. `xpu-ci → Build XPU docker image` is skipped (image != true).
3. `xpu-ci → Compute image fingerprint` runs and computes `IMG_FP` from `docker/xpu.Dockerfile` + `pyproject_xpu.toml` on this PR's tree (should match main's `<fp>` since neither file changed here).
4. `xpu-ci → Pull XPU docker image` runs:
   - **Happy path**: `docker pull intel/sglang-omni-xpu-dev:img-<fp>` succeeds → retag to local `IMAGE_TAG` → container starts → `test_device_layer.py` passes.
   - **Bootstrap-pending path**: pull fails (registry has no `:img-<fp>` yet because the release workflow hasn't been dispatched post-merge). `Fallback local build` fires with its own 90-min budget and everything proceeds. This is the expected behavior until `omni-xpu-docker-release.yaml` seeds the fingerprint tag.

## Notes

- Requires the `run-ci` label to actually trigger CI (author does not have write access; a maintainer needs to add it).
- If the bootstrap has not been run yet, expect the fallback build. Not a bug.

## Cleanup

Close (do not merge) once we've observed the run and confirmed the pull-vs-fallback logic.
