### PR TITLE
[NPU] Give the Qwen3-ASR encoder its own device stream

### DIFF
--- a/sglang_omni/models/qwen3_asr/encoder_service.py
+++ b/sglang_omni/models/qwen3_asr/encoder_service.py
@@ -121,9 +121,16 @@ class Qwen3ASRPreLMEncoderService(PreLMEncoderService[Any, torch.Tensor, torch.T
         self._device = reference.device
         self._dtype = reference.dtype
         self._hidden_size = _text_hidden_size(model)
+        # note (wangyao-i): the encoder must not submit on the generation's
+        # stream on Ascend. When it does, three host threads -- the encoder,
+        # the decode graph's `replay()` and its graph-update helper -- share
+        # one submission lane, and the device never completes the graph update
+        # task, which wedges the service. CUDA has always given the encoder its
+        # own stream, so this restores the same layout on NPU instead of adding
+        # a cross-thread lock.
         self._stream = (
-            torch.cuda.Stream(device=self._device)
-            if self._device.type == "cuda"
+            torch.get_device_module(self._device).Stream(device=self._device)
+            if self._device.type in {"cuda", "npu"}
             else None
         )
         self._cache = StageOutputCache(
@@ -359,12 +366,15 @@ class Qwen3ASRPreLMEncoderService(PreLMEncoderService[Any, torch.Tensor, torch.T
 
     def attach_embedding(self, item: Any, embedding: torch.Tensor) -> None:
         embedding = embedding.to(self._device, non_blocking=True)
-        if self._stream is not None and embedding.is_cuda:
+        if self._stream is not None and embedding.device.type != "cpu":
             # note (luojiaxuan): the batch path allocates on the private
             # stream while the LM consumes on the default stream; register
             # the consumer so the allocator cannot recycle the block for a
             # later batch while LM reads are still queued.
-            embedding.record_stream(torch.cuda.default_stream(self._device))
+            device_module = torch.get_device_module(embedding.device)
+            record_stream = getattr(embedding, "record_stream", None)
+            if record_stream is not None:
+                record_stream(device_module.default_stream(embedding.device))
         item.precomputed_embeddings = embedding
         item.feature = None
         item.format = MultimodalInputFormat.PRECOMPUTED_EMBEDDING

--- a/sglang_omni/models/qwen3_asr/encoder_service.py
+++ b/sglang_omni/models/qwen3_asr/encoder_service.py
@@ -362,7 +362,7 @@ class Qwen3ASRPreLMEncoderService(PreLMEncoderService[Any, torch.Tensor, torch.T
 
     def attach_embedding(self, item: Any, embedding: torch.Tensor) -> None:
         embedding = embedding.to(self._device, non_blocking=True)
-        if self._stream is not None and embedding.device.type != "cpu":
+        if self._stream is not None:
             # note (luojiaxuan): the batch path allocates on the private
             # stream while the LM consumes on the default stream; register
             # the consumer so the allocator cannot recycle the block for a

--- a/sglang_omni/models/qwen3_asr/encoder_service.py
+++ b/sglang_omni/models/qwen3_asr/encoder_service.py
@@ -27,6 +27,7 @@ from typing import Any, cast
 
 import torch
 from sglang.srt.managers.schedule_batch import MultimodalInputFormat
+from sglang.srt.utils import create_device_stream, device_stream_context
 
 from sglang_omni.scheduling.pre_lm_encoder import PreLMEncoderService, QueueEntry
 from sglang_omni.scheduling.stage_cache import StageOutputCache
@@ -121,15 +122,10 @@ class Qwen3ASRPreLMEncoderService(PreLMEncoderService[Any, torch.Tensor, torch.T
         self._device = reference.device
         self._dtype = reference.dtype
         self._hidden_size = _text_hidden_size(model)
-        # note (wangyao-i): the encoder must not submit on the generation's
-        # stream on Ascend. When it does, three host threads -- the encoder,
-        # the decode graph's `replay()` and its graph-update helper -- share
-        # one submission lane, and the device never completes the graph update
-        # task, which wedges the service. CUDA has always given the encoder its
-        # own stream, so this restores the same layout on NPU instead of adding
-        # a cross-thread lock.
+        # Keep encoder submissions off the generation lane on Ascend, where the
+        # decode graph replay and update threads can otherwise stall behind it.
         self._stream = (
-            torch.get_device_module(self._device).Stream(device=self._device)
+            create_device_stream(self._device)
             if self._device.type in {"cuda", "npu"}
             else None
         )
@@ -372,9 +368,7 @@ class Qwen3ASRPreLMEncoderService(PreLMEncoderService[Any, torch.Tensor, torch.T
             # the consumer so the allocator cannot recycle the block for a
             # later batch while LM reads are still queued.
             device_module = torch.get_device_module(embedding.device)
-            record_stream = getattr(embedding, "record_stream", None)
-            if record_stream is not None:
-                record_stream(device_module.default_stream(embedding.device))
+            embedding.record_stream(device_module.default_stream(embedding.device))
         item.precomputed_embeddings = embedding
         item.feature = None
         item.format = MultimodalInputFormat.PRECOMPUTED_EMBEDDING
@@ -418,7 +412,7 @@ class Qwen3ASRPreLMEncoderService(PreLMEncoderService[Any, torch.Tensor, torch.T
             if self._stream is None:
                 yield
             else:
-                with torch.cuda.stream(self._stream):
+                with device_stream_context(self._stream):
                     yield
 
     def encode_batch(self, items: list[Any]) -> torch.Tensor:

--- a/tests/unit_test/qwen3_asr/test_encoder_service.py
+++ b/tests/unit_test/qwen3_asr/test_encoder_service.py
@@ -2,6 +2,7 @@
 
 from __future__ import annotations
 
+import contextlib
 import threading
 import time
 from collections.abc import Iterator
@@ -214,18 +215,27 @@ def test_batch_context_unwinds_inference_mode_when_stream_context_fails(
     monkeypatch: pytest.MonkeyPatch,
 ) -> None:
     service = object.__new__(Qwen3ASRPreLMEncoderService)
-    service._stream = object()
+    service._stream = SimpleNamespace(device=torch.device("cuda", 0))
 
-    def fail_stream(_stream):  # noqa: ANN001, ANN202
-        raise RuntimeError("stream context failed")
+    class _FakeDeviceModule:
+        def __init__(self) -> None:
+            self.stream_calls: list[object] = []
 
-    monkeypatch.setattr(torch.cuda, "stream", fail_stream)
+        @contextlib.contextmanager
+        def stream(self, stream):  # noqa: ANN001, ANN202
+            self.stream_calls.append(stream)
+            raise RuntimeError("stream context failed")
+            yield
+
+    device_module = _FakeDeviceModule()
+    monkeypatch.setattr(torch, "get_device_module", lambda _device=None: device_module)
 
     assert not torch.is_inference_mode_enabled()
     with pytest.raises(RuntimeError, match="stream context failed"):
         with service._batch_context():
             pass
     assert not torch.is_inference_mode_enabled()
+    assert device_module.stream_calls == [service._stream]
 
 
 def test_cache_hit_skips_reencode() -> None:


### PR DESCRIPTION
## Summary

The Qwen3-ASR pre-LM encoder now runs on its own device stream on Ascend - the layout CUDA has always had.

## Why

Three host threads submit device work in this process: the encoder worker, the decode graph's `replay()`, and the input-update helper SGLang starts for every replay and then joins (`npu_cudagraph_backend.py` runs `graph.update(cpu_update_input=...)` in a thread the caller blocks on).

On CUDA the encoder has its own stream, so they never shared a lane. On Ascend they did. With the encoder active the device stopped completing the graph update, the join never returned, and requests stopped completing while the NPU sat idle. It reproduces with the encoder busy and disappears when the encoder cache is pre-warmed so it submits nothing - the encoder is the trigger.

Two other fixes were tried and rejected: a cross-thread FIFO guard, and a per-batch device fence. Both still hang or lose throughput.

## What changed

- `sglang_omni/models/qwen3_asr/encoder_service.py`: use SGLang's `create_device_stream()` and `device_stream_context()` so stream creation and activation dispatch through the same device module. `attach_embedding` registers the consuming default stream directly instead of probing for `record_stream`.
- `tests/unit_test/qwen3_asr/test_encoder_service.py`: fake the selected device module and assert `_batch_context()` enters its `stream()` context, including the failure-unwind path.

## Qualification

The task-pinned candidate at `d58afeda` passed `910C-071`: 3/3 cold concurrency-8 gates, the 140-request correctness gate at WER `0.0181` with zero garbled outputs, and 3/3 fresh-process C70 repeats at p95 `1.460-1.623` s and `58.47-59.16` requests/s.

This branch later advanced through `f89d565f` and `872e5502` to incorporate review-driven stream-helper changes. Those commits are behavior-preserving in intent but are outside the exact-head `910C-071` hardware record and require separate re-attestation before they are described as hardware-qualified.

## Checklist

- [x] Format your code according with pre-commit.
- [x] Add unit tests.
- [ ] Update documentation / docstrings.
- [x] Provide throughput / latency benchmark results and accuracy evaluation.