### PR TITLE
[Bugfix][Fun-CosyVoice3] Preserve deferred stream chunk order

### DIFF
--- a/sglang_omni/models/fun_cosyvoice3/streaming_vocoder.py
+++ b/sglang_omni/models/fun_cosyvoice3/streaming_vocoder.py
@@ -193,8 +193,6 @@ class FunCosyVoice3StreamingVocoderScheduler(
     def _collect_new_request_batch(
         self, first_msg: IncomingMessage
     ) -> list[IncomingMessage]:
-        if self._pending_messages:
-            return [first_msg]
         if not self._can_batch_stream_chunks:
             return super()._collect_new_request_batch(first_msg)
         try:
@@ -208,7 +206,7 @@ class FunCosyVoice3StreamingVocoderScheduler(
         cap = max(int(self._max_batch_size), 1)
         while len(batch) < cap:
             try:
-                msg = self.inbox.get_nowait()
+                msg = self._get_batch_message()
             except _queue_mod.Empty:
                 break
             if self._is_aborted(msg.request_id):
@@ -257,20 +255,18 @@ class FunCosyVoice3StreamingVocoderScheduler(
     def _collect_stream_chunk_batch(
         self, first_msg: IncomingMessage
     ) -> list[IncomingMessage]:
-        # Deferred messages precede every new inbox arrival,
-        # including those a superclass collector might inspect while batching.
-        if self._pending_messages:
-            return [first_msg]
         if not self._can_batch_stream_chunks:
             return super()._collect_stream_chunk_batch(first_msg)
         batch = [first_msg]
         seen = {first_msg.request_id}
+        # Keep duplicate-request chunks aside until collection ends so they
+        # cannot be re-read while looking for compatible peers.
         deferred: list[IncomingMessage] = []
         leftover: IncomingMessage | None = None
         cap = self._stream_chunk_batch_max or max(self._max_batch_size, 1)
         while len(batch) < cap:
             try:
-                msg = self.inbox.get_nowait()
+                msg = self._get_batch_message()
             except _queue_mod.Empty:
                 break
             if msg.type != "stream_chunk":

--- a/sglang_omni/models/fun_cosyvoice3/streaming_vocoder.py
+++ b/sglang_omni/models/fun_cosyvoice3/streaming_vocoder.py
@@ -257,7 +257,7 @@ class FunCosyVoice3StreamingVocoderScheduler(
     def _collect_stream_chunk_batch(
         self, first_msg: IncomingMessage
     ) -> list[IncomingMessage]:
-        # note (Jshipper-art): Deferred messages precede every new inbox arrival,
+        # Deferred messages precede every new inbox arrival,
         # including those a superclass collector might inspect while batching.
         if self._pending_messages:
             return [first_msg]
@@ -452,7 +452,7 @@ class FunCosyVoice3StreamingVocoderScheduler(
         """
         while True:
             try:
-                # note (Jshipper-art): The collector may have pushed back an older
+                # The collector may have pushed back an older
                 # chunk or done marker. Consume it before newer inbox messages.
                 if self._pending_messages:
                     msg = self._pending_messages.popleft()

--- a/sglang_omni/models/fun_cosyvoice3/streaming_vocoder.py
+++ b/sglang_omni/models/fun_cosyvoice3/streaming_vocoder.py
@@ -193,6 +193,8 @@ class FunCosyVoice3StreamingVocoderScheduler(
     def _collect_new_request_batch(
         self, first_msg: IncomingMessage
     ) -> list[IncomingMessage]:
+        if self._pending_messages:
+            return [first_msg]
         if not self._can_batch_stream_chunks:
             return super()._collect_new_request_batch(first_msg)
         try:
@@ -255,6 +257,10 @@ class FunCosyVoice3StreamingVocoderScheduler(
     def _collect_stream_chunk_batch(
         self, first_msg: IncomingMessage
     ) -> list[IncomingMessage]:
+        # note (Jshipper-art): Deferred messages precede every new inbox arrival,
+        # including those a superclass collector might inspect while batching.
+        if self._pending_messages:
+            return [first_msg]
         if not self._can_batch_stream_chunks:
             return super()._collect_stream_chunk_batch(first_msg)
         batch = [first_msg]
@@ -356,7 +362,9 @@ class FunCosyVoice3StreamingVocoderScheduler(
                 return
             remaining = deadline - time.monotonic()
             try:
-                if remaining <= 0:
+                if self._pending_messages:
+                    msg = self._pending_messages.popleft()
+                elif remaining <= 0:
                     msg = self.inbox.get_nowait()
                 else:
                     msg = self.inbox.get(timeout=remaining)
@@ -422,7 +430,9 @@ class FunCosyVoice3StreamingVocoderScheduler(
                 return
             remaining = deadline - time.monotonic()
             try:
-                if remaining <= 0:
+                if self._pending_messages:
+                    msg = self._pending_messages.popleft()
+                elif remaining <= 0:
                     msg = self.inbox.get_nowait()
                 else:
                     msg = self.inbox.get(timeout=remaining)
@@ -442,7 +452,12 @@ class FunCosyVoice3StreamingVocoderScheduler(
         """
         while True:
             try:
-                msg = self.inbox.get_nowait()
+                # note (Jshipper-art): The collector may have pushed back an older
+                # chunk or done marker. Consume it before newer inbox messages.
+                if self._pending_messages:
+                    msg = self._pending_messages.popleft()
+                else:
+                    msg = self.inbox.get_nowait()
             except _queue_mod.Empty:
                 return
             if not self._ingest_peer_message(msg):

--- a/sglang_omni/scheduling/streaming_simple_scheduler.py
+++ b/sglang_omni/scheduling/streaming_simple_scheduler.py
@@ -246,6 +246,12 @@ class StreamingSimpleScheduler:
             return 0
         return max(int(self._request_cost_fn(msg.data)), 0)
 
+    def _get_batch_message(self, *, timeout: float = 0.0) -> IncomingMessage:
+        """Consume deferred work before new arrivals without running dispatch hooks."""
+        if self._pending_messages:
+            return self._pending_messages.popleft()
+        return self.inbox.get(timeout=timeout)
+
     def _collect_new_request_batch(
         self, first_msg: IncomingMessage
     ) -> list[IncomingMessage]:
@@ -257,17 +263,18 @@ class StreamingSimpleScheduler:
         ):
             return batch
 
+        deferred: list[IncomingMessage] = []
         batch_cost = self._message_cost(first_msg)
         deadline = time.monotonic() + self._max_batch_wait_s
         while len(batch) < self._max_batch_size:
             try:
-                msg = self.inbox.get_nowait()
+                msg = self._get_batch_message()
             except _queue_mod.Empty:
                 remaining = deadline - time.monotonic()
                 if remaining <= 0:
                     break
                 try:
-                    msg = self.inbox.get(timeout=remaining)
+                    msg = self._get_batch_message(timeout=remaining)
                 except _queue_mod.Empty:
                     break
 
@@ -280,9 +287,9 @@ class StreamingSimpleScheduler:
                 ):
                     # Note(Chenchen Hong): Done-before-payload only latches state,
                     # so defer it and keep looking for terminal payloads that can batch.
-                    self._pending_messages.append(msg)
+                    deferred.append(msg)
                     continue
-                self._pending_messages.append(msg)
+                deferred.append(msg)
                 break
             try:
                 is_streaming = self.is_streaming_payload(msg.data)
@@ -291,7 +298,7 @@ class StreamingSimpleScheduler:
                 self.abort(msg.request_id)
                 continue
             if is_streaming:
-                self._pending_messages.append(msg)
+                deferred.append(msg)
                 break
             if self._max_batch_cost is not None:
                 try:
@@ -301,10 +308,13 @@ class StreamingSimpleScheduler:
                     self.abort(msg.request_id)
                     continue
                 if batch and batch_cost + msg_cost > self._max_batch_cost:
-                    self._pending_messages.appendleft(msg)
+                    deferred.append(msg)
                     break
                 batch_cost += msg_cost
             batch.append(msg)
+        # Do not re-read done-before-payload markers during this collection.
+        # Restore them ahead of any unconsumed pending or inbox messages.
+        self._pending_messages.extendleft(reversed(deferred))
         return batch
 
     def _collect_stream_chunk_batch(
@@ -323,7 +333,7 @@ class StreamingSimpleScheduler:
             return batch
         while len(batch) < cap:
             try:
-                msg = self.inbox.get_nowait()
+                msg = self._get_batch_message()
             except _queue_mod.Empty:
                 break
             if msg.type != "stream_chunk":

--- a/tests/unit_test/fun_cosyvoice3/test_streaming.py
+++ b/tests/unit_test/fun_cosyvoice3/test_streaming.py
@@ -784,37 +784,94 @@ def test_backlogged_chunks_stay_ordered_before_stream_done(
     assert "req-a" not in scheduler._stream_states
 
 
-@pytest.mark.parametrize(
-    "kind,streaming",
-    [("stream_chunk", True), ("new_request", True), ("new_request", False)],
-)
-def test_collectors_preserve_residual_pending_messages(
-    kind: str, streaming: bool
-) -> None:
+@pytest.mark.parametrize("streaming", [False, True])
+def test_new_request_collection_stops_at_pending_chunk(streaming: bool) -> None:
     _, scheduler = _scheduler(max_batch_size=8)
     payload = _stream_payload("req-a")
     payload.request.params["stream"] = streaming
-    first = IncomingMessage(
-        request_id="req-a",
-        type=kind,
-        data=payload if kind == "new_request" else _item([1]),
-    )
+    first = IncomingMessage(request_id="req-a", type="new_request", data=payload)
     pending = IncomingMessage(request_id="req-a", type="stream_chunk", data=_item([2]))
     newer = IncomingMessage(request_id="req-a", type="stream_chunk", data=_item([3]))
-    done = IncomingMessage(request_id="req-a", type="stream_done")
     scheduler._pending_messages.append(pending)
     scheduler.inbox.put(newer)
-    scheduler.inbox.put(done)
 
-    if kind == "new_request":
-        batch = scheduler._collect_new_request_batch(first)
-    else:
-        batch = scheduler._collect_stream_chunk_batch(first)
-
-    assert batch == [first]
+    assert scheduler._collect_new_request_batch(first) == [first]
     assert list(scheduler._pending_messages) == [pending]
     assert scheduler.inbox.get_nowait() is newer
-    assert scheduler.inbox.get_nowait() is done
+
+
+def test_chunk_collection_batches_pending_peers_without_reordering_followups() -> None:
+    _, scheduler = _scheduler(max_batch_size=8)
+    first = IncomingMessage("a", "stream_chunk", _item([1]))
+    second = IncomingMessage("a", "stream_chunk", _item([2]))
+    third = IncomingMessage("a", "stream_chunk", _item([3]))
+    peer_b = IncomingMessage("b", "stream_chunk", _item([4]))
+    peer_c = IncomingMessage("c", "stream_chunk", _item([5]))
+    done = IncomingMessage("a", "stream_done")
+    later = IncomingMessage("d", "stream_chunk", _item([6]))
+    scheduler._pending_messages.extend([second, peer_b])
+    for msg in (third, peer_c, done, later):
+        scheduler.inbox.put(msg)
+
+    batch = scheduler._collect_stream_chunk_batch(first)
+
+    assert batch == [first, peer_b, peer_c]
+    assert list(scheduler._pending_messages) == [second, third, done]
+    assert scheduler.inbox.get_nowait() is later
+
+
+def test_streaming_payload_collection_batches_pending_before_inbox() -> None:
+    _, scheduler = _scheduler(max_batch_size=3)
+    messages = [
+        IncomingMessage(rid, "new_request", _stream_payload(rid))
+        for rid in ("a", "b", "c", "d")
+    ]
+    scheduler._pending_messages.extend(messages[1:3])
+    scheduler.inbox.put(messages[3])
+
+    assert scheduler._collect_new_request_batch(messages[0]) == messages[:3]
+    assert not scheduler._pending_messages
+    assert scheduler.inbox.get_nowait() is messages[3]
+
+
+@pytest.mark.parametrize("coalescing", [False, True])
+def test_non_streaming_fallback_batches_past_pending_done_with_cost_limit(
+    coalescing: bool,
+) -> None:
+    _, scheduler = _scheduler(
+        max_batch_size=8, request_cost_fn=lambda payload: 1, max_batch_cost=2
+    )
+    scheduler._can_batch_stream_chunks = coalescing
+    messages = []
+    for rid in ("a", "b", "c", "d"):
+        payload = _stream_payload(rid)
+        payload.request.params["stream"] = False
+        messages.append(IncomingMessage(rid, "new_request", payload))
+    done = IncomingMessage("b", "stream_done")
+    scheduler._pending_messages.extend([done, messages[1], messages[2]])
+    scheduler.inbox.put(messages[3])
+
+    assert scheduler._collect_new_request_batch(messages[0]) == messages[:2]
+    assert list(scheduler._pending_messages) == [done, messages[2]]
+    assert scheduler.inbox.get_nowait() is messages[3]
+
+
+def test_pending_peer_payloads_still_share_a_causal_flow_batch() -> None:
+    flow, scheduler = _packed_scheduler()
+    first = IncomingMessage("a", "new_request", _aligned_payload("a"))
+    peer = IncomingMessage("b", "new_request", _aligned_payload("b"))
+    for rid in ("a", "b"):
+        scheduler._ingest_stream_item(rid, _item(list(range(28))))
+    scheduler._pending_messages.append(peer)
+
+    batch = scheduler._collect_new_request_batch(first)
+    assert batch == [first, peer]
+    scheduler._handle_new_request_batch(batch)
+
+    assert flow.decoder.estimator.calls
+    # CFG packs each request twice: two requests share one causal Flow call.
+    assert flow.decoder.estimator.calls[0]["x"].shape[0] == 4
+    assert len([msg for msg in _drain(scheduler) if msg.type == "stream"]) == 2
 
 
 @pytest.mark.parametrize("follow_up", [False, True])

--- a/tests/unit_test/fun_cosyvoice3/test_streaming.py
+++ b/tests/unit_test/fun_cosyvoice3/test_streaming.py
@@ -741,6 +741,156 @@ def test_inbox_first_hop_preempts_follow_up_backlog() -> None:
     assert len(messages) == 4
 
 
+def test_backlogged_chunks_stay_ordered_before_stream_done(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    flow, scheduler = _scheduler(max_batch_size=8)
+    tokens = list(range(78))
+    scheduler._on_streaming_new_request("req-a", _stream_payload("req-a", codes=tokens))
+    for codes in (tokens[:28], tokens[28:53]):
+        scheduler.inbox.put(
+            IncomingMessage(request_id="req-a", type="stream_chunk", data=_item(codes))
+        )
+    original_inference = flow.inference
+
+    def inference(**kwargs):
+        result = original_inference(**kwargs)
+        if len(flow.calls) == 1:
+            # note (Jshipper-art): The AR producer adds a newer chunk and
+            # completion during Flow's first hop, with an older chunk deferred.
+            scheduler.inbox.put(
+                IncomingMessage(
+                    request_id="req-a", type="stream_chunk", data=_item(tokens[53:])
+                )
+            )
+            scheduler.inbox.put(IncomingMessage(request_id="req-a", type="stream_done"))
+        return result
+
+    monkeypatch.setattr(flow, "inference", inference)
+
+    while scheduler._pending_messages or not scheduler.inbox.empty():
+        scheduler._handle_message(scheduler._next_message(), None)
+
+    # note (Jshipper-art): The first batch defers the second chunk because its
+    # request ID is already in the batch. Pumping must not ingest the third chunk
+    # or finalize the request ahead of that second chunk.
+    assert flow.calls[-1]["finalize"] is True
+    assert flow.calls[-1]["token"].flatten().tolist() == tokens
+    messages = _drain(scheduler)
+    assert [m.type for m in messages].count("result") == 1
+    assert messages[-1].type == "result"
+    audio = np.concatenate([_waveform(m.data) for m in messages if m.type == "stream"])
+    np.testing.assert_array_equal(audio, np.arange(len(tokens) * TOKEN_MEL_RATIO))
+    assert "req-a" not in scheduler._stream_states
+
+
+@pytest.mark.parametrize(
+    "kind,streaming",
+    [("stream_chunk", True), ("new_request", True), ("new_request", False)],
+)
+def test_collectors_preserve_residual_pending_messages(
+    kind: str, streaming: bool
+) -> None:
+    _, scheduler = _scheduler(max_batch_size=8)
+    payload = _stream_payload("req-a")
+    payload.request.params["stream"] = streaming
+    first = IncomingMessage(
+        request_id="req-a",
+        type=kind,
+        data=payload if kind == "new_request" else _item([1]),
+    )
+    pending = IncomingMessage(request_id="req-a", type="stream_chunk", data=_item([2]))
+    newer = IncomingMessage(request_id="req-a", type="stream_chunk", data=_item([3]))
+    done = IncomingMessage(request_id="req-a", type="stream_done")
+    scheduler._pending_messages.append(pending)
+    scheduler.inbox.put(newer)
+    scheduler.inbox.put(done)
+
+    if kind == "new_request":
+        batch = scheduler._collect_new_request_batch(first)
+    else:
+        batch = scheduler._collect_stream_chunk_batch(first)
+
+    assert batch == [first]
+    assert list(scheduler._pending_messages) == [pending]
+    assert scheduler.inbox.get_nowait() is newer
+    assert scheduler.inbox.get_nowait() is done
+
+
+@pytest.mark.parametrize("follow_up", [False, True])
+def test_peer_wait_consumes_pending_chunks_before_inbox(follow_up: bool) -> None:
+    _, scheduler = _scheduler(max_batch_size=8)
+    for rid in ("req-a", "req-b"):
+        scheduler._on_streaming_new_request(rid, _stream_payload(rid))
+    target = 78 if follow_up else 28
+    start = 28 if follow_up else 0
+    middle = 53 if follow_up else 14
+    scheduler._ingest_stream_item("req-a", _item(list(range(target))))
+    scheduler._ingest_stream_item("req-b", _item(list(range(start))))
+    if follow_up:
+        for state in scheduler._stream_states.values():
+            state.token_offset = 25
+            state.hop_len = 50
+    scheduler._pending_messages.append(
+        IncomingMessage(
+            request_id="req-b",
+            type="stream_chunk",
+            data=_item(list(range(start, middle))),
+        )
+    )
+    scheduler.inbox.put(
+        IncomingMessage(
+            request_id="req-b",
+            type="stream_chunk",
+            data=_item(list(range(middle, target))),
+        )
+    )
+    scheduler.inbox.put(IncomingMessage(request_id="req-b", type="stream_done"))
+
+    if follow_up:
+        scheduler._wait_for_follow_up_peers()
+    else:
+        scheduler._wait_for_first_hop_peers()
+
+    assert scheduler._stream_states["req-b"].tokens == list(range(target))
+    assert not scheduler._pending_messages
+    assert scheduler.inbox.get_nowait().type == "stream_done"
+
+
+@pytest.mark.parametrize(
+    "reader",
+    ["_ingest_ready_inbox", "_wait_for_first_hop_peers", "_wait_for_follow_up_peers"],
+)
+def test_peer_readers_do_not_pass_pending_done(reader: str) -> None:
+    _, scheduler = _scheduler(max_batch_size=8)
+    for rid in ("req-a", "req-b"):
+        scheduler._on_streaming_new_request(rid, _stream_payload(rid))
+    follow_up = reader == "_wait_for_follow_up_peers"
+    target = 78 if follow_up else 28
+    start = 28 if follow_up else 0
+    scheduler._ingest_stream_item("req-a", _item(list(range(target))))
+    scheduler._ingest_stream_item("req-b", _item(list(range(start))))
+    if follow_up:
+        for state in scheduler._stream_states.values():
+            state.token_offset = 25
+            state.hop_len = 50
+    done = IncomingMessage(request_id="req-a", type="stream_done")
+    scheduler._pending_messages.append(done)
+    scheduler.inbox.put(
+        IncomingMessage(
+            request_id="req-b",
+            type="stream_chunk",
+            data=_item(list(range(start, target))),
+        )
+    )
+
+    getattr(scheduler, reader)()
+
+    assert list(scheduler._pending_messages) == [done]
+    assert scheduler._stream_states["req-b"].tokens == list(range(start))
+    assert scheduler.inbox.qsize() == 1
+
+
 def test_disable_hop_growth_keeps_fixed_follow_up_windows() -> None:
     flow, scheduler = _scheduler(disable_hop_growth=True)
     scheduler._on_streaming_new_request("req-a", _stream_payload("req-a"))

--- a/tests/unit_test/fun_cosyvoice3/test_streaming.py
+++ b/tests/unit_test/fun_cosyvoice3/test_streaming.py
@@ -756,7 +756,7 @@ def test_backlogged_chunks_stay_ordered_before_stream_done(
     def inference(**kwargs):
         result = original_inference(**kwargs)
         if len(flow.calls) == 1:
-            # note (Jshipper-art): The AR producer adds a newer chunk and
+            # The AR producer adds a newer chunk and
             # completion during Flow's first hop, with an older chunk deferred.
             scheduler.inbox.put(
                 IncomingMessage(
@@ -771,7 +771,7 @@ def test_backlogged_chunks_stay_ordered_before_stream_done(
     while scheduler._pending_messages or not scheduler.inbox.empty():
         scheduler._handle_message(scheduler._next_message(), None)
 
-    # note (Jshipper-art): The first batch defers the second chunk because its
+    # The first batch defers the second chunk because its
     # request ID is already in the batch. Pumping must not ingest the third chunk
     # or finalize the request ahead of that second chunk.
     assert flow.calls[-1]["finalize"] is True

--- a/tests/unit_test/pipeline/test_streaming_simple_scheduler.py
+++ b/tests/unit_test/pipeline/test_streaming_simple_scheduler.py
@@ -3,6 +3,8 @@ from __future__ import annotations
 
 import queue
 
+import pytest
+
 from sglang_omni.pipeline.stage.stream_queue import StreamItem
 from sglang_omni.proto import OmniRequest, StagePayload
 from sglang_omni.scheduling.messages import IncomingMessage, OutgoingMessage
@@ -95,13 +97,20 @@ def test_streaming_simple_scheduler_batches_non_streaming_requests() -> None:
     assert [msg.request_id for msg in _drain_results(scheduler)] == ["a", "b", "c"]
 
 
-def test_non_streaming_batch_skips_done_before_later_payloads() -> None:
+@pytest.mark.parametrize("source", ["inbox", "pending", "split"])
+def test_non_streaming_batch_skips_done_before_later_payloads(source: str) -> None:
     scheduler = _TestStreamingScheduler(max_batch_size=3)
     first = IncomingMessage("a", "new_request", _payload("a"))
-    scheduler.inbox.put(IncomingMessage("b", "stream_done"))
-    scheduler.inbox.put(IncomingMessage("b", "new_request", _payload("b")))
-    scheduler.inbox.put(IncomingMessage("c", "stream_done"))
-    scheduler.inbox.put(IncomingMessage("c", "new_request", _payload("c")))
+    messages = [
+        IncomingMessage("b", "stream_done"),
+        IncomingMessage("b", "new_request", _payload("b")),
+        IncomingMessage("c", "stream_done"),
+        IncomingMessage("c", "new_request", _payload("c")),
+    ]
+    pending_count = {"inbox": 0, "pending": 4, "split": 2}[source]
+    scheduler._pending_messages.extend(messages[:pending_count])
+    for msg in messages[pending_count:]:
+        scheduler.inbox.put(msg)
 
     batch = scheduler._collect_new_request_batch(first)
     scheduler._handle_new_request_batch(batch)
@@ -112,6 +121,55 @@ def test_non_streaming_batch_skips_done_before_later_payloads() -> None:
     assert [msg.request_id for msg in _drain_results(scheduler)] == ["a", "b", "c"]
     assert not scheduler._pending_messages
     assert not scheduler._pending_done
+
+
+def test_non_streaming_batch_preserves_pending_cost_boundary() -> None:
+    scheduler = _TestStreamingScheduler(max_batch_size=4)
+    scheduler._request_cost_fn = lambda payload: payload.data["cost"]
+    scheduler._max_batch_cost = 3
+    requests = []
+    for rid, cost in (("a", 1), ("b", 2), ("c", 3), ("d", 1), ("e", 1)):
+        payload = _payload(rid)
+        payload.data["cost"] = cost
+        requests.append(IncomingMessage(rid, "new_request", payload))
+    done = IncomingMessage("b", "stream_done")
+    scheduler._pending_messages.extend([done, *requests[1:4]])
+    scheduler.inbox.put(requests[4])
+
+    batch = scheduler._collect_new_request_batch(requests[0])
+
+    assert batch == requests[:2]
+    assert list(scheduler._pending_messages) == [done, *requests[2:4]]
+    assert scheduler.inbox.qsize() == 1
+    scheduler._handle_new_request_batch(batch)
+    while scheduler._pending_messages or not scheduler.inbox.empty():
+        scheduler._handle_message(scheduler._next_message(), None)
+
+    assert scheduler.batch_calls == [["a", "b"], ["d", "e"]]
+    assert scheduler.single_calls == ["c"]
+    assert [msg.request_id for msg in _drain_results(scheduler)] == [
+        "a",
+        "b",
+        "c",
+        "d",
+        "e",
+    ]
+    assert not scheduler._pending_done
+
+
+def test_non_streaming_batch_stops_at_pending_active_stream_done() -> None:
+    scheduler = _TestStreamingScheduler(max_batch_size=3)
+    scheduler._on_streaming_new_request("stream", _payload("stream", stream=True))
+    first = IncomingMessage("a", "new_request", _payload("a"))
+    done = IncomingMessage("stream", "stream_done")
+    pending = IncomingMessage("b", "new_request", _payload("b"))
+    newer = IncomingMessage("c", "new_request", _payload("c"))
+    scheduler._pending_messages.extend([done, pending])
+    scheduler.inbox.put(newer)
+
+    assert scheduler._collect_new_request_batch(first) == [first]
+    assert list(scheduler._pending_messages) == [done, pending]
+    assert scheduler.inbox.get_nowait() is newer
 
 
 def test_streaming_simple_scheduler_keeps_streaming_request_out_of_batch() -> None:
@@ -239,6 +297,23 @@ def test_stream_chunk_batch_coalesces_queued_chunks_into_one_pump() -> None:
     scheduler._handle_message(_chunk("a", "x"), None)
     assert scheduler.pump_batches == [["a", "b", "c"]]
     assert [m.data["chunk"] for m in _drain_results(scheduler)] == ["x", "y", "z"]
+
+
+@pytest.mark.parametrize("cap", [3, 4])
+def test_stream_chunk_batch_coalesces_pending_before_inbox(cap: int) -> None:
+    scheduler = _BatchStreamingScheduler(max_batch_size=cap)
+    chunks = [_chunk(rid, rid) for rid in ("a", "b", "c", "d", "e")]
+    scheduler._pending_messages.extend(chunks[1:3])
+    for msg in chunks[3:]:
+        scheduler.inbox.put(msg)
+
+    scheduler._handle_message(chunks[0], None)
+
+    assert scheduler.pump_batches == [[msg.request_id for msg in chunks[:cap]]]
+    assert [m.data["chunk"] for m in _drain_results(scheduler)] == [
+        msg.data.data for msg in chunks[:cap]
+    ]
+    assert [scheduler._next_message() for _ in chunks[cap:]] == chunks[cap:]
 
 
 def test_stream_chunk_batch_can_stop_before_duplicate_request() -> None:


### PR DESCRIPTION
## Motivation

Fun-CosyVoice3 streaming can return HTTP 200 with words missing when the AR producer gets ahead of the vocoder. A newer chunk or stream_done can overtake an older deferred chunk; completion then clears the request before the older chunk is consumed.

The fix also needs to preserve concurrent scheduling. A global pending-first rule prevents that reordering but can delay unrelated requests and terminal-payload registration, substantially increasing first-audio latency under backlog.

## Modifications

- Preserve each request's stream_chunk/stream_done order across pending and inbox while allowing CosyVoice to admit unrelated peers and batch compatible work. Bound between-hop scanning so continuing arrivals cannot extend one scan indefinitely.
- Allow the first terminal payload to register early only through immediate-ingestion paths, for an active conditioned stream with received tokens, no processed done, no existing payload, and no older same-request payload. Registration does not consume audio or complete the request. Both batch collectors retain stricter payload handling for locally held duplicates.
- Keep the shared StreamingSimpleScheduler collectors pending-first, retaining batch/cost limits and done-before-payload behavior. Hold skipped duplicate chunks and done markers until collection ends, then restore their order.
- Cover complete token/audio output, completion boundaries, peer admission, payload lifecycle/duplicate guards, non-streaming fallback batching and single-request no-wait behavior with regressions.

The existing causal pump, model math, public API and serving options are unchanged by the latency follow-up.

## Related Issues

Addresses #2138. Related implementation context: #1652 and #1656.

## Accuracy Test

Current head: 2841a0a. All 106 targeted tests passed under normal Linux imports across the CosyVoice streaming, shared streaming-scheduler and shared streaming-vocoder test files. Changed-file pre-commit checks pass. The deterministic scheduler tests use fake Flow/HiFT outputs to check exact audio and single completion independently of ASR; real-model quality is measured below.

On two disjoint 128-input Chinese SeedTTS cohorts, all 256 revised requests completed. Corpus WER was 9/4,857 reference units (0.185%) versus 469/4,857 (9.656%) on main. The previous PR and revised source both scored 3/2,458 (0.122%) on the matched offset-128 cohort.

For example, ASR transcribed main’s audio as “现在的意。” for “现在的男孩子，大大咧咧惯惯了，生活大多粗枝大叶。” The previous PR and revised output both retain the full sentence. The evidence also includes the revised run's worst last-gap case so the remaining latency cost can be inspected.

[Current reproduction bundle: raw metrics, ASR results, selected audio, tests and pinned commands](https://github.com/user-attachments/files/32171594/pr2086-c16-validation-2841a0a.zip).

The [original ordering reproduction](https://github.com/user-attachments/files/32065079/cosyvoice-stream-order-evidence.zip) and [earlier collector validation](https://github.com/user-attachments/files/32074723/cosyvoice-batching-review-evidence.zip) remain evidence for their recorded historical revisions.

## Benchmark & Profiling

One H200, Fun-CosyVoice3-0.5B-2512, Chinese SeedTTS, c=16, 16 warm-ups, seed 42, Qwen3-ASR-1.7B scoring. Torch Flow is used; TRT, Flow CUDA Graph and DiT torch.compile are disabled. AR decode CUDA Graph is enabled. Each arm uses the same benchmark client, input IDs/text and settings; servers run sequentially and ASR runs after generation.

Main is f58228df; previous PR is 4de7afcc. Timed revised servers use that PR base with the selected scheduler revision. The later merged main change fixes a Flow CUDA Graph keyword, on a path disabled in these runs. The CosyVoice streaming_vocoder.py file matches current head byte-for-byte (SHA256 10effa66fda4e4e7c86ecf48cdb5aeb8872fc267c14036af8b8676e6bffca4ad). The final test-only commit replaces two timing assertions; it does not change the timed code.

Offset 128, 128 inputs per arm:

| Metric | Main | Previous PR | Revised |
|---|---:|---:|---:|
| Completed | 128/128 | 128/128 | 128/128 |
| Corpus WER | 9.24% | 0.12% | 0.12% |
| TTFP median | 4.273 s | 18.077 s | 1.299 s |
| Latency median | 7.884 s | 19.102 s | 3.399 s |
| Latency p95 | 60.256 s | 22.042 s | 76.986 s |
| Inter-chunk mean | 4.757 s | 0.701 s | 6.059 s |
| Throughput | 1.084 qps | 0.843 qps | 1.035 qps |
| C50 | 42.97% | 85.94% | 60.16% |

Separate offset-0 cohort, 128 inputs per arm:

| Metric | Main | Revised |
|---|---:|---:|
| Completed | 128/128 | 128/128 |
| Corpus WER | 10.09% | 0.25% |
| TTFP median | 4.489 s | 3.680 s |
| Latency median | 8.720 s | 7.434 s |
| Latency p95 | 58.799 s | 70.749 s |
| Inter-chunk mean | 4.792 s | 5.475 s |
| Throughput | 1.079 qps | 0.984 qps |
| C50 | 42.19% | 42.19% |

Both cohorts retain the completeness improvement and lower median TTFP, but completion p95 and mean inter-chunk gaps remain higher than main, and request throughput is lower. These remaining costs are not resolved. Main sometimes produces incomplete speech, which also changes the closed-loop workload; that does not remove the need to report the unfavorable metrics. The same-machine results do not establish universal performance neutrality or reproduce the reviewer's different hardware/scale exactly.

TTFP measures time to first audio; latency measures time to completion. C50 is the percentage of requests whose maximum playback underrun after audio starts is at most 50 ms. Delaying the first packet can improve C50 by accumulating audio in advance. Full per-request distributions are in the bundle.

## Checklist

- [x] Format your code according with pre-commit.
- [x] Add unit tests.
- [x] Update documentation / docstrings / example tutorials as needed.
- [x] Provide throughput / latency benchmark results and accuracy evaluation results as needed. Remaining performance costs are disclosed above.
- [ ] For reviewers: If you haven't made any contributions to this PR and are only assisting with merging the main branch, please remove yourself as a co-author when merging the PR.

## CI

Local validation is tied to 2841a0a. Updated PR CI must be evaluated on that head; successful checks on earlier commits do not cover this update.

CI runs on self-hosted GPU runners and requires a maintainer to add the
run-ci label. Once labeled, every subsequent push re-triggers CI as
long as the label remains. Use /tag-and-rerun-ci higgs or
/tag-and-rerun-ci moss or /tag-and-rerun-ci qwen3-tts to select a TTS CI
model, and
/tag-and-rerun-ci fun-asr, /tag-and-rerun-ci qwen3-asr or
/tag-and-rerun-ci whisper-asr to select an ASR CI model. One selector from
each family can be combined, for example /tag-and-rerun-ci moss fun-asr.
Draft PRs are skipped even if labeled.
