### PR TITLE
[Release] Prepare SGLang-Omni 0.1.5

### DIFF
--- a/README.md
+++ b/README.md
@@ -30,7 +30,7 @@
 ## News
 
 - [2026/09] 🐧 Day-0 support for [AuK](https://huggingface.co/tencent/AuK) and [AuK-Flash](https://huggingface.co/tencent/AuK-Flash): text + voice instructions → 24 kHz speech on `/v1/audio/speech`, audio + editing instructions → edited speech on `/generate`. \[[Cookbook](https://sgl-project.github.io/sglang-omni/cookbook/auk.html)\]
-- [2026/09] 🚀 SGLang-Omni **v0.1.4** is on [PyPI](https://pypi.org/project/sglang-omni/). Install with `uv pip install --prerelease=allow "sglang-omni==0.1.4"`. \[[Installation](https://sgl-project.github.io/sglang-omni/get_started/installation.html)\]
+- [2026/09] 🚀 SGLang-Omni **v0.1.5** is on [PyPI](https://pypi.org/project/sglang-omni/). Install with `uv pip install --prerelease=allow "sglang-omni==0.1.5"`. \[[Installation](https://sgl-project.github.io/sglang-omni/get_started/installation.html)\]
 - [2026/08] 🎵 Day-0 support for [MiniMax Music 3](https://huggingface.co/MiniMaxAI/MiniMax-Music3): lyrics + caption → 32 kHz stereo song on `/v1/audio/speech`. \[[Cookbook](https://sgl-project.github.io/sglang-omni/cookbook/minimax_music3.html)\]
 - [2026/08] 🚀 TTS architecture refactor: shared pipeline state, engine construction, reference encoding, capability metadata, and vocoder scheduling. \[[Roadmap](https://github.com/sgl-project/sglang-omni/issues/985)\] \[[Blog](https://github.com/zhaochenyang20/Awesome-ML-SYS-Tutorial/blob/main/sglang/sglang-omni/tts-refactor.md)\]
 - [2026/06] 🔥 MOSS-TTS Local Transformer v1.5 on SGLang-Omni with native-streaming 48 kHz speech. \[[Blog](https://lmsys.org/blog/2026-06-17-moss-tts-local-v15/)\] \[[Cookbook](https://sgl-project.github.io/sglang-omni/cookbook/moss_tts_local.html)\]

--- a/docs/cookbook/qwen3_omni.md
+++ b/docs/cookbook/qwen3_omni.md
@@ -17,7 +17,7 @@ pip install --upgrade pip
 pip install uv
 
 uv venv .venv -p 3.12 && source .venv/bin/activate
-uv pip install --prerelease=allow "sglang-omni==0.1.4"
+uv pip install --prerelease=allow "sglang-omni==0.1.5"
 ```
 
 See [Installation](../get_started/installation.md) for Docker digests and source installs.

--- a/docs/get_started/installation.md
+++ b/docs/get_started/installation.md
@@ -1,6 +1,6 @@
 # 🚀 Installation
 
-Current stable release: **v0.1.4** on [PyPI](https://pypi.org/project/sglang-omni/).
+Current stable release: **v0.1.5** on [PyPI](https://pypi.org/project/sglang-omni/).
 
 Choose the path for your platform. Docker is recommended for NVIDIA CUDA —
 UCX, flash-attn, SGLang, and CUDA are prebuilt. Apple Silicon has a dedicated
@@ -48,7 +48,7 @@ pip install uv
 uv venv .venv -p 3.12
 source .venv/bin/activate
 
-uv pip install --prerelease=allow "sglang-omni==0.1.4"
+uv pip install --prerelease=allow "sglang-omni==0.1.5"
 ```
 
 <a id="macos-apple-silicon"></a>
@@ -137,7 +137,7 @@ pip install uv
 uv venv .venv -p 3.12
 source .venv/bin/activate
 
-uv pip install --prerelease=allow "sglang-omni==0.1.4"
+uv pip install --prerelease=allow "sglang-omni==0.1.5"
 ```
 
 Latest on the index without a pin: `uv pip install --prerelease=allow sglang-omni`.

--- a/sglang_omni/__init__.py
+++ b/sglang_omni/__init__.py
@@ -12,7 +12,7 @@ from importlib import import_module
 
 # This is the single source for both runtime and distribution metadata. Keep
 # release bumps here; setuptools reads it through tool.setuptools.dynamic.
-__version__ = "0.1.4"
+__version__ = "0.1.5"
 
 _EXPORTS: dict[str, tuple[str, str]] = {
     # client


### PR DESCRIPTION
## Motivation

Prepare SGLang-Omni 0.1.5 as the next pinnable PyPI release from the latest merged `main` cutoff.

## Modifications

- Bump the package version from 0.1.4 to 0.1.5.
- Update the existing README announcement, stable installation commands, and Qwen3-Omni cookbook pin to 0.1.5.

## Related Issues

Related to #1399.

## Release Validation

- Built the 0.1.5 wheel and source distribution with Python 3.12.
- Passed `twine check --strict` for both distributions.
- Verified the wheel metadata reports version 0.1.5 and the current SGLang, Torch, Transformers, FlashInfer, and CLI entry-point metadata.
- Passed all repository pre-commit checks.

## Accuracy Test

Not applicable; this PR changes release metadata and documentation only.

## Benchmark & Profiling

Not applicable; this PR does not change runtime or model behavior.

## Checklist

- [x] Format your code according with pre-commit.
- [ ] Add unit tests.
- [x] Update documentation / docstrings / example tutorials as needed.
- [ ] Provide throughput / latency benchmark results and accuracy evaluation results as needed.
- [ ] For reviewers: If you haven't made any contributions to this PR and are only assisting with merging the main branch, please remove yourself as a co-author when merging the PR.

## CI

CI runs on self-hosted GPU runners and requires a maintainer to add the
`run-ci` label. Once labeled, every subsequent push re-triggers CI as
long as the label remains. Use `/tag-and-rerun-ci higgs` or
`/tag-and-rerun-ci moss` or `/tag-and-rerun-ci qwen3-tts` to select a TTS CI
model, and
`/tag-and-rerun-ci fun-asr`, `/tag-and-rerun-ci qwen3-asr` or
`/tag-and-rerun-ci whisper-asr` to select an ASR CI model. One selector from
each family can be combined, for example `/tag-and-rerun-ci moss fun-asr`.
Draft PRs are skipped even if labeled.
