### PR TITLE
[CI] Derive the speed gates from the exact slacked reference

### DIFF
--- a/tests/unit_test/test_ci_threshold_slack.py
+++ b/tests/unit_test/test_ci_threshold_slack.py
@@ -1,0 +1,70 @@
+# SPDX-License-Identifier: Apache-2.0
+"""Contracts for the CI threshold derivation in tests/utils."""
+
+from __future__ import annotations
+
+import pytest
+
+from tests.utils import apply_slack, readable_upper_gate
+
+SLACK_LOWER = 1.125
+
+
+def test_a_sub_second_reference_keeps_its_slack() -> None:
+    # note (luojiaxuan): the MMSU text reference is 0.201 s, and rounding
+    # 0.201 * 1.125 to one decimal gives 0.2, a gate below the reference it
+    # came from, which fails a run that matches its own calibration.
+    thresholds = apply_slack(
+        {
+            16: {
+                "throughput_qps": 78.8,
+                "output_tok_per_req_s": 10.2,
+                "latency_mean_s": 0.201,
+            }
+        }
+    )[16]
+
+    assert thresholds["latency_mean_s_max"] == pytest.approx(0.201 * SLACK_LOWER)
+    assert thresholds["latency_mean_s_max"] > 0.201
+
+
+@pytest.mark.parametrize(
+    ("reference", "digits", "rounds_up"),
+    [
+        (7.964, 1, True),
+        (11.249, 1, True),
+        (0.851, 1, True),
+        (0.5662, 2, True),
+        (0.201, 1, False),
+        (0.2941, 2, False),
+    ],
+)
+def test_rounding_only_ever_loosens(
+    reference: float, digits: int, rounds_up: bool
+) -> None:
+    gate = readable_upper_gate(reference, SLACK_LOWER, digits)
+    slacked = reference * SLACK_LOWER
+
+    assert gate >= slacked
+    # note (luojiaxuan): the readable value stays the gate wherever it is the
+    # looser of the two, so no calibrated suite gets a stricter gate.
+    assert gate >= round(slacked, digits)
+    if rounds_up:
+        assert gate == pytest.approx(round(slacked, digits))
+    else:
+        assert gate == pytest.approx(slacked)
+
+
+def test_higher_is_better_gates_are_untouched() -> None:
+    thresholds = apply_slack(
+        {
+            8: {
+                "throughput_qps": 78.8,
+                "output_tok_per_req_s": 10.2,
+                "latency_mean_s": 7.964,
+            }
+        }
+    )[8]
+
+    assert thresholds["throughput_qps_min"] == pytest.approx(68.95, abs=1e-9)
+    assert thresholds["output_tok_per_req_s_min"] == pytest.approx(8.9, abs=1e-9)

--- a/tests/utils/__init__.py
+++ b/tests/utils/__init__.py
@@ -190,6 +190,19 @@ def assert_per_request_fields(
     _assert_metric_collector_if_local(collector, checks)
 
 
+def readable_upper_gate(reference: float, slack: float, digits: int) -> float:
+    """Round an upper-bound gate for readability without tightening it.
+
+    Rounding to a fixed number of decimals can land below the value the slack
+    asked for, and for a sub-second reference it can land below the reference
+    itself, which fails a run that matched the calibration. Round only when
+    rounding goes up; otherwise keep the slacked value.
+    """
+    gate = reference * slack
+    coarse = round(gate, digits)
+    return coarse if coarse >= gate else gate
+
+
 def apply_slack(
     p95: dict[int, dict[str, float]],
     slack_higher: float = 0.875,
@@ -198,13 +211,15 @@ def apply_slack(
     """Derive CI thresholds from P95 references with uniform slack.
 
     Higher-is-better metrics (throughput, output tok/req-s when present): threshold = P95 x slack_higher
-    Lower-is-better metrics (latency, rtf):            threshold = P95 x slack_lower
+    Lower-is-better metrics (latency, rtf):            threshold >= P95 x slack_lower
     """
     result: dict[int, dict[str, float]] = {}
     for conc, m in p95.items():
         thresholds = {
             "throughput_qps_min": round(m["throughput_qps"] * slack_higher, 2),
-            "latency_mean_s_max": round(m["latency_mean_s"] * slack_lower, 1),
+            "latency_mean_s_max": readable_upper_gate(
+                m["latency_mean_s"], slack_lower, 1
+            ),
         }
         if "output_tok_per_req_s" in m:
             thresholds["output_tok_per_req_s_min"] = round(
@@ -212,7 +227,9 @@ def apply_slack(
                 1,
             )
         if "rtf_mean" in m:
-            thresholds["rtf_mean_max"] = round(m["rtf_mean"] * slack_lower, 2)
+            thresholds["rtf_mean_max"] = readable_upper_gate(
+                m["rtf_mean"], slack_lower, 2
+            )
         result[conc] = thresholds
     return result
 


### PR DESCRIPTION
## Problem

`apply_slack` derived each CI gate as `reference x slack` and then rounded it to
a fixed decimal count. That rounding moved every gate by up to half a decimal
place in either direction, and for a sub-second reference it could land below the
reference itself:

```
MMSU text, latency_mean_s P95 = 0.201
0.201 * 1.125 = 0.226125
round(0.226125, 1) = 0.2      <- gate below the P95 it was calibrated from
```

`Qwen3-Omni MMSU` then failed its speed check while running at exactly its
calibrated latency. Observed twice on the same commit in #1998:

```
1. latency_mean_s 0.203 > 0.2 at concurrency 16
1. latency_mean_s 0.211 > 0.2 at concurrency 16
```

## Fix

Rounding only ever served readability, so it moves to where the number is read:
`assert_speed_thresholds` formats the threshold with `.6g` in the failure
message, and the gate itself is now exactly `reference x slack`. No helper and
no special case for the lower-is-better metrics.

## Blast radius

I replayed the last 25 Omni CI runs, 1,514 gate evaluations across every
calibrated suite, against the old and the new derivation. 20 evaluations change
verdict:

| suite | metric | measured | old gate | new gate | verdict |
| --- | --- | --- | --- | --- | --- |
| Qwen3-Omni MMSU | latency_mean_s | 0.201 to 0.226, 14 obs | 0.2 | 0.226125 | fail to pass |
| Video-AMME Talker TP=2 | throughput_qps | 0.209, 3 obs | 0.21 | 0.2065 | fail to pass |
| Video-AMME | latency_mean_s | 8.913 | 8.9 | 8.919 | fail to pass |
| Video-AMME | output_tok_per_req_s | 5.3 | 5.3 | 5.3375 | pass to fail |
| Video-MME | latency_mean_s | 12.156 | 12.2 | 12.155625 | pass to fail |

The 18 that start passing were inside the calibrated slack and failed on the
rounding alone. The 2 that start failing were outside it and passed on the
rounding alone.

## Test

`tests/unit_test/test_ci_threshold_slack.py` pins all four gates to
`reference x slack` and covers a reference that rounds up as well as one that
rounds down.

```
pytest tests/unit_test/test_ci_threshold_slack.py -q
```
