### PR TITLE
[Bug Fix][Ming-Omni] Fix Ming video preprocessing for Transformers 5

### DIFF
--- a/sglang_omni/models/ming_omni/components/preprocessor.py
+++ b/sglang_omni/models/ming_omni/components/preprocessor.py
@@ -253,8 +253,9 @@ class MingPreprocessor:
         if self._video_patch_id is None:
             self._video_patch_id = self._tokenizer.convert_tokens_to_ids(VIDEO_PATCH)
 
-        # Lazy-init image processor
+        # Lazy-init vision processors
         self._image_processor = None
+        self._video_processor = None
 
     def _get_image_processor(self):
         """Lazy-init Qwen2VLImageProcessor (same processor as Ming-Omni uses)."""
@@ -270,6 +271,20 @@ class MingPreprocessor:
                 merge_size=vc.spatial_merge_size,
             )
         return self._image_processor
+
+    def _get_video_processor(self):
+        if self._video_processor is None:
+            from transformers import Qwen2VLVideoProcessor
+
+            vc = self._vision_config
+            self._video_processor = Qwen2VLVideoProcessor(
+                min_pixels=256 * 28 * 28,
+                max_pixels=1280 * 28 * 28,
+                patch_size=vc.patch_size,
+                temporal_patch_size=vc.temporal_patch_size,
+                merge_size=vc.spatial_merge_size,
+            )
+        return self._video_processor
 
     def _process_images(
         self, images: list[Any]
@@ -298,13 +313,13 @@ class MingPreprocessor:
 
         ``videos`` is a list where each item is the per-video frame stack
         produced by ``ensure_video_list_async`` (torch.Tensor shape ``(T, C, H, W)``
-        of float pixels in 0..255). ``Qwen2VLImageProcessor.preprocess(videos=...)``
-        groups consecutive frames by ``temporal_patch_size`` and returns flattened
-        patches plus ``video_grid_thw`` with the merged temporal dim.
+        of float pixels in 0..255). ``Qwen2VLVideoProcessor`` groups consecutive
+        frames by ``temporal_patch_size`` and returns flattened patches plus
+        ``video_grid_thw`` with the merged temporal dim.
         """
-        processor = self._get_image_processor()
+        processor = self._get_video_processor()
         # Convert per-video tensors to numpy arrays in (T, H, W, C) uint8 — the
-        # format Qwen2VLImageProcessor expects when ``videos`` is a list of
+        # format Qwen2VLVideoProcessor expects when ``videos`` is a list of
         # per-video frame stacks.
         np_videos: list[np.ndarray] = []
         for v in videos:
@@ -320,10 +335,10 @@ class MingPreprocessor:
             if arr.ndim == 4 and arr.shape[1] in (1, 3):
                 arr = np.transpose(arr, (0, 2, 3, 1))
             np_videos.append(arr)
-        # ``processor.__call__`` requires ``images`` as a positional argument;
-        # call ``preprocess`` directly so we can pass only ``videos``.
         result = processor.preprocess(
-            images=None, videos=np_videos, return_tensors="pt"
+            videos=np_videos,
+            do_sample_frames=False,
+            return_tensors="pt",
         )
         pixel_values_videos = result["pixel_values_videos"]
         video_grid_thw = result["video_grid_thw"]

--- a/tests/unit_test/ming_omni/test_thinker.py
+++ b/tests/unit_test/ming_omni/test_thinker.py
@@ -269,6 +269,32 @@ def test_ming_preprocessor_uses_config_image_patch_token_id(monkeypatch) -> None
     assert processor._image_patch_id == 222
 
 
+def test_ming_video_preprocessor_uses_transformers_5_contract(monkeypatch) -> None:
+    from sglang_omni.preprocessing.video import load_video_path
+    from transformers import Qwen2VLVideoProcessor
+
+    module = _load_preprocessor_with_fake_deps(monkeypatch)
+    processor = module.MingPreprocessor.__new__(module.MingPreprocessor)
+    processor._vision_config = SimpleNamespace(
+        patch_size=16,
+        temporal_patch_size=2,
+        spatial_merge_size=2,
+    )
+    processor._video_processor = None
+    video, _ = load_video_path(
+        Path("tests/data/draw.mp4"),
+        fps=2.0,
+        max_frames=8,
+    )
+
+    pixel_values, grid_thw, token_counts = processor._process_videos([video])
+
+    assert isinstance(processor._video_processor, Qwen2VLVideoProcessor)
+    assert grid_thw.tolist() == [[4, 36, 64]]
+    assert pixel_values.shape == (9216, 1536)
+    assert token_counts == [2304]
+
+
 def test_ming_config_and_stages_do_not_import_ming_runner() -> None:
     runner_module = "sglang_omni.model_runner.ming_thinker_model_runner"
     sys.modules.pop(runner_module, None)

--- a/tests/unit_test/ming_omni/test_thinker.py
+++ b/tests/unit_test/ming_omni/test_thinker.py
@@ -270,8 +270,9 @@ def test_ming_preprocessor_uses_config_image_patch_token_id(monkeypatch) -> None
 
 
 def test_ming_video_preprocessor_uses_transformers_5_contract(monkeypatch) -> None:
-    from sglang_omni.preprocessing.video import load_video_path
     from transformers import Qwen2VLVideoProcessor
+
+    from sglang_omni.preprocessing.video import load_video_path
 
     module = _load_preprocessor_with_fake_deps(monkeypatch)
     processor = module.MingPreprocessor.__new__(module.MingPreprocessor)


### PR DESCRIPTION
## Motivation

Ming video inputs fail during preprocessing with the repository-pinned
Transformers 5.12.1:

```text
TypeError: Qwen2VLImageProcessorKwargs.__init__() got an unexpected keyword argument 'videos'
```

Ming still routes video frames through the legacy
`Qwen2VLImageProcessor.preprocess(videos=...)` contract. Transformers 5.x
separates image and video preprocessing into `Qwen2VLImageProcessor` and
`Qwen2VLVideoProcessor`.

## Modifications

- Keep `Qwen2VLImageProcessor` for image inputs.
- Lazily create a separate `Qwen2VLVideoProcessor` for video inputs.
- Route `_process_videos()` through the Transformers 5 video API.
- Set `do_sample_frames=False` because `ensure_video_list_async` already
  decodes, resizes, samples, and caps the frames.
- Add a regression test using the repository's real `tests/data/draw.mp4`
  fixture.

## Related Issues
#2093.

## Accuracy Test

The regression test uses Transformers 5.12.1 on CPU and exercises:

```text
draw.mp4
  -> load_video_path
  -> MingPreprocessor._process_videos
  -> Qwen2VLVideoProcessor
```

Observed output:

```text
video_grid_thw: [[4, 36, 64]]
pixel_values_videos.shape: (9216, 1536)
video token count: 2304
```

The former Transformers 4.57.6 path and the new 5.12.1 path produce the same
`video_grid_thw` and pixel tensor shape. The normalized pixel tensors are not
bit-identical: maximum absolute difference was `0.0300157` and mean absolute
difference was `4.67e-5`.

With the repository-pinned SGLang 0.5.19:

```text
187 passed, 2 deselected
```

The two deselected tests are Talker CUDA accelerator tests and are unrelated
to video preprocessing.


## Benchmark & Profiling

N/A. This is a correctness compatibility fix for the repository-pinned
Transformers 5.12.1 API. It does not change the model execution, scheduling,
or batching hot paths and makes no performance claim

## Checklist

- [x] Format your code according with pre-commit.
- [x] Add unit tests.
- [x] Update documentation / docstrings / example tutorials as needed.
- [x] Provide throughput / latency benchmark results and accuracy evaluation results as needed.
- [ ] For reviewers: If you haven't made any contributions to this PR and are only assisting with merging the main branch, please remove yourself as a co-author when merging the PR.

## CI

CI runs on self-hosted GPU runners and requires a maintainer to add the
`run-ci` label. Once labeled, every subsequent push re-triggers CI as
long as the label remains. Use `/tag-and-rerun-ci higgs` or
`/tag-and-rerun-ci moss` to select a TTS CI model, and
`/tag-and-rerun-ci fun-asr`, `/tag-and-rerun-ci qwen3-asr` or
`/tag-and-rerun-ci whisper-asr` to select an ASR CI model. One selector from each family can be combined, for example
`/tag-and-rerun-ci moss fun-asr`. Draft PRs are skipped even if labeled.