### PR TITLE
perf(auk): cache request-local reference audio embeddings

### DIFF
--- a/docs/cookbook/auk.md
+++ b/docs/cookbook/auk.md
@@ -92,6 +92,8 @@ The DiT stores its weights in BF16 and runs without autocast by default (`--auk_
 
 Conditioning and DiT sampling use dynamic batching, with default maximum batch sizes of 8 and 16. VAE decoding groups equal-length latents (up to 4 requests) to preserve boundary behavior. The stages can overlap on separate CUDA streams and share VAE weights within the same process/device. Conditioning loads the Qwen encoder, the VAE and the two hidden-state fusion parameters; only the sampling stage loads the DiT. Set `--conditioning.factory.max_batch_size`, `--auk_engine.factory.max_batch_size`, or `--decode.factory.max_batch_size` to tune them. Audio is returned after decoding completes; incremental audio streaming is not implemented.
 
+Base AuK can cache the conditional and unconditional reference-audio embeddings across the Euler integration with `--auk_engine.factory.cache_reference_audio_embedding true`. The option is disabled by default and does not cache the changing noisy-latent embedding.
+
 ## SeedTTS Evaluation
 
 The standard benchmark detects `tencent/AuK` and `tencent/AuK-Flash` and starts the server from `--model-path`. It defaults to the full English dataset, concurrency 1, one warmup, and seed 1234. It estimates duration from the reference audio and transcript, then automatically starts and stops the TTS and ASR servers:

--- a/sglang_omni/models/auk/config.py
+++ b/sglang_omni/models/auk/config.py
@@ -55,6 +55,7 @@ class AuKPipelineConfig(PipelineConfig):
                 max_batch_size=16,
                 max_batch_wait_ms=10,
                 weight_dtype="bfloat16",
+                cache_reference_audio_embedding=False,
             ),
             gpu=0,
             next=DECODE_STAGE,

--- a/sglang_omni/models/auk/dit.py
+++ b/sglang_omni/models/auk/dit.py
@@ -391,6 +391,17 @@ class AudioPromptEmbedding(nn.Module):
         x = self.linear(x)
         return self.conv_pos_embed(x, mask=mask) + x
 
+    def embed_reference(
+        self,
+        ref: torch.Tensor,
+        *,
+        drop_audio_cond: bool,
+        mask: torch.Tensor | None,
+    ) -> torch.Tensor:
+        if drop_audio_cond:
+            ref = torch.zeros_like(ref)
+        return self._embed(ref, mask=mask)
+
     def forward(
         self,
         x: torch.Tensor,
@@ -402,9 +413,9 @@ class AudioPromptEmbedding(nn.Module):
         x_emb = self._embed(x, mask=mask)
         if ref is None:
             return x_emb
-        if drop_audio_cond:
-            ref = torch.zeros_like(ref)
-        return x_emb, self._embed(ref, mask=ref_mask)
+        return x_emb, self.embed_reference(
+            ref, drop_audio_cond=drop_audio_cond, mask=ref_mask
+        )
 
 
 @dataclass
@@ -485,6 +496,8 @@ class AuKDit(nn.Module):
 
         self.text_cond: torch.Tensor | None = None
         self.text_uncond: torch.Tensor | None = None
+        self.reference_audio_cond: torch.Tensor | None = None
+        self.reference_audio_uncond: torch.Tensor | None = None
 
         self.initialize_weights()
 
@@ -504,6 +517,7 @@ class AuKDit(nn.Module):
 
     def clear_cache(self) -> None:
         self.text_cond, self.text_uncond = None, None
+        self.reference_audio_cond, self.reference_audio_uncond = None, None
 
     @property
     def dtype(self) -> torch.dtype:
@@ -513,6 +527,29 @@ class AuKDit(nn.Module):
         c = self.txt_norm(self.txt_proj(text))
         return torch.zeros_like(c) if drop_text else c
 
+    def _embed_reference_audio(
+        self,
+        ref: torch.Tensor,
+        *,
+        drop_audio_cond: bool,
+        ref_mask: torch.Tensor | None,
+    ) -> torch.Tensor:
+        cached = (
+            self.reference_audio_uncond
+            if drop_audio_cond
+            else self.reference_audio_cond
+        )
+        if cached is not None:
+            return cached
+        embedded = self.audio_embed.embed_reference(
+            ref, drop_audio_cond=drop_audio_cond, mask=ref_mask
+        )
+        if drop_audio_cond:
+            self.reference_audio_uncond = embedded
+        else:
+            self.reference_audio_cond = embedded
+        return embedded
+
     def _embed_audio(
         self,
         x: torch.Tensor,
@@ -520,6 +557,7 @@ class AuKDit(nn.Module):
         drop_audio_cond: bool,
         mask: torch.Tensor | None,
         ref_mask: torch.Tensor | None,
+        cache_reference_audio_embedding: bool = False,
     ):
         if ref is not None and ref.shape[1] == 0:
             ref = None
@@ -532,13 +570,19 @@ class AuKDit(nn.Module):
                 0,
             )
 
-        x_emb, ref_emb = self.audio_embed(
-            x,
-            ref=ref,
-            drop_audio_cond=drop_audio_cond,
-            mask=mask,
-            ref_mask=ref_mask,
-        )
+        if cache_reference_audio_embedding:
+            x_emb = self.audio_embed(x, mask=mask)
+            ref_emb = self._embed_reference_audio(
+                ref, drop_audio_cond=drop_audio_cond, ref_mask=ref_mask
+            )
+        else:
+            x_emb, ref_emb = self.audio_embed(
+                x,
+                ref=ref,
+                drop_audio_cond=drop_audio_cond,
+                mask=mask,
+                ref_mask=ref_mask,
+            )
         prompt_len = ref_emb.shape[1]
         audio = torch.cat([ref_emb, x_emb], dim=1)
 
@@ -562,6 +606,7 @@ class AuKDit(nn.Module):
         drop_text: bool = False,
         cfg_infer: bool = False,
         cache: bool = False,
+        cache_reference_audio_embedding: bool = False,
         ref: torch.Tensor | None = None,
         ref_mask: torch.Tensor | None = None,
         audio_positions: torch.Tensor | None = None,
@@ -583,7 +628,14 @@ class AuKDit(nn.Module):
                 if cache:
                     self.text_cond = c_cond
             x_cond, a_mask_cond, prompt_len = self._embed_audio(
-                x, ref, drop_audio_cond=False, mask=mask, ref_mask=ref_mask
+                x,
+                ref,
+                drop_audio_cond=False,
+                mask=mask,
+                ref_mask=ref_mask,
+                cache_reference_audio_embedding=(
+                    cache and cache_reference_audio_embedding
+                ),
             )
 
             if cache and self.text_uncond is not None:
@@ -593,7 +645,14 @@ class AuKDit(nn.Module):
                 if cache:
                     self.text_uncond = c_uncond
             x_uncond, a_mask_uncond, _ = self._embed_audio(
-                x, ref, drop_audio_cond=True, mask=mask, ref_mask=ref_mask
+                x,
+                ref,
+                drop_audio_cond=True,
+                mask=mask,
+                ref_mask=ref_mask,
+                cache_reference_audio_embedding=(
+                    cache and cache_reference_audio_embedding
+                ),
             )
 
             x = torch.cat((x_cond, x_uncond), dim=0)

--- a/sglang_omni/models/auk/flow_matching.py
+++ b/sglang_omni/models/auk/flow_matching.py
@@ -79,6 +79,7 @@ class AuKFlowMatching(nn.Module):
         cfg_strength: float,
         sway_sampling_coef: float | None = None,
         t_grid: Sequence[float] | None = None,
+        cache_reference_audio_embedding: bool = False,
     ) -> torch.Tensor:
         return self.sample_batch(
             [item],
@@ -86,6 +87,7 @@ class AuKFlowMatching(nn.Module):
             cfg_strength=cfg_strength,
             sway_sampling_coef=sway_sampling_coef,
             t_grid=t_grid,
+            cache_reference_audio_embedding=cache_reference_audio_embedding,
         )[0]
 
     @torch.no_grad()
@@ -97,6 +99,7 @@ class AuKFlowMatching(nn.Module):
         cfg_strength: float,
         sway_sampling_coef: float | None = None,
         t_grid: Sequence[float] | None = None,
+        cache_reference_audio_embedding: bool = False,
     ) -> list[torch.Tensor]:
         device = next(self.parameters()).device
         dim = self.transformer.latent_dim
@@ -182,6 +185,7 @@ class AuKFlowMatching(nn.Module):
                 ref=ref,
                 ref_mask=ref_mask,
                 cache=True,
+                cache_reference_audio_embedding=cache_reference_audio_embedding,
                 audio_positions=audio_positions,
                 joint_positions=joint_positions,
             )

--- a/sglang_omni/models/auk/stages.py
+++ b/sglang_omni/models/auk/stages.py
@@ -250,6 +250,7 @@ def create_auk_engine_executor(
     max_batch_size: int = 16,
     max_batch_wait_ms: int = 10,
     weight_dtype: str = "float32",
+    cache_reference_audio_embedding: bool = False,
 ) -> SimpleScheduler:
     """Build the DiT sampling stage.
 
@@ -272,6 +273,7 @@ def create_auk_engine_executor(
         cfg_strength=C.FLASH_CFG_STRENGTH if config.is_flash else cfg_strength,
         sway_sampling_coef=None if config.is_flash else sway_sampling_coef,
         t_grid=C.FLASH_T_GRID if config.is_flash else None,
+        cache_reference_audio_embedding=cache_reference_audio_embedding,
     )
     return _scheduler(
         lambda payloads: _sample_batch(

--- a/tests/unit_test/auk/test_reference_audio_embedding_cache.py
+++ b/tests/unit_test/auk/test_reference_audio_embedding_cache.py
@@ -1,0 +1,180 @@
+# SPDX-License-Identifier: Apache-2.0
+
+from __future__ import annotations
+
+import inspect
+
+import pytest
+import torch
+
+from sglang_omni.models.auk.config import ENGINE_STAGE, AuKPipelineConfig
+from sglang_omni.models.auk.dit import AuKDit
+from sglang_omni.models.auk.flow_matching import AuKFlowMatching, AuKSampleItem
+from sglang_omni.models.auk.stages import create_auk_engine_executor
+
+
+def _flow() -> AuKFlowMatching:
+    torch.manual_seed(7)
+    flow = AuKFlowMatching(
+        AuKDit(
+            dim=16,
+            heads=1,
+            dim_head=16,
+            latent_dim=4,
+            text_hidden_dim=8,
+            num_layers=1,
+            num_single_layers=1,
+            dropout=0.0,
+        ),
+        num_llm_layers=2,
+    ).eval()
+    for parameter in flow.parameters():
+        torch.nn.init.uniform_(parameter, -0.2, 0.2)
+    return flow
+
+
+def _item(*, text: int = 3, frames: int = 5, ref: int = 2, seed: int = 11):
+    return AuKSampleItem(
+        conditioning=torch.randn(text, 8),
+        text_mask=torch.ones(text, dtype=torch.bool),
+        target_frames=frames,
+        ref_latent=torch.randn(ref, 4) if ref else None,
+        seed=seed,
+        ref_length=ref,
+    )
+
+
+@pytest.mark.parametrize("cfg_strength", [0.0, 2.0])
+@pytest.mark.parametrize("ref", [0, 2])
+@pytest.mark.parametrize("shape", [(3, 5), (4, 7)])
+def test_cache_preserves_exact_cpu_output(cfg_strength, ref, shape):
+    flow = _flow()
+    item = _item(text=shape[0], frames=shape[1], ref=ref)
+
+    baseline = flow.sample(
+        item,
+        steps=3,
+        cfg_strength=cfg_strength,
+        cache_reference_audio_embedding=False,
+    )
+    cached = flow.sample(
+        item,
+        steps=3,
+        cfg_strength=cfg_strength,
+        cache_reference_audio_embedding=True,
+    )
+
+    assert torch.equal(cached, baseline)
+
+
+def test_cfg_cache_reduces_only_reference_embedding_calls(monkeypatch):
+    flow = _flow()
+    item = _item(frames=5, ref=2)
+    counts = {"dynamic": 0, "reference": 0}
+    original = flow.transformer.audio_embed._embed
+
+    def counted(value, mask=None):
+        kind = "dynamic" if value.shape[1] == item.target_frames else "reference"
+        counts[kind] += 1
+        return original(value, mask=mask)
+
+    monkeypatch.setattr(flow.transformer.audio_embed, "_embed", counted)
+    flow.sample(
+        item,
+        steps=32,
+        cfg_strength=2.0,
+        cache_reference_audio_embedding=True,
+    )
+
+    assert counts == {"dynamic": 64, "reference": 2}
+
+
+def test_first_step_populates_and_next_step_reuses_reference_tensors(monkeypatch):
+    dit = _flow().transformer
+    inputs = dict(
+        text=torch.randn(1, 3, 8),
+        time=torch.tensor(0.0),
+        ref=torch.randn(1, 2, 4),
+        cfg_infer=True,
+        cache=True,
+        cache_reference_audio_embedding=True,
+    )
+    reference_calls = 0
+    original = dit.audio_embed._embed
+
+    def counted(value, mask=None):
+        nonlocal reference_calls
+        if value.shape[1] == 2:
+            reference_calls += 1
+        return original(value, mask=mask)
+
+    monkeypatch.setattr(dit.audio_embed, "_embed", counted)
+    dit(x=torch.randn(1, 5, 4), **inputs)
+    cached = (dit.reference_audio_cond, dit.reference_audio_uncond)
+    assert reference_calls == 2
+    assert all(value is not None for value in cached)
+
+    dit(x=torch.randn(1, 5, 4), **inputs)
+    assert reference_calls == 2
+    assert cached[0] is dit.reference_audio_cond
+    assert cached[1] is dit.reference_audio_uncond
+
+
+def test_cache_is_cleared_after_each_shape_and_after_exception(monkeypatch):
+    flow = _flow()
+    first = _item(text=3, frames=5, ref=2)
+    second = _item(text=4, frames=7, ref=3, seed=12)
+
+    flow.sample(
+        first,
+        steps=2,
+        cfg_strength=2.0,
+        cache_reference_audio_embedding=True,
+    )
+    assert flow.transformer.reference_audio_cond is None
+    assert flow.transformer.reference_audio_uncond is None
+    flow.sample(
+        second,
+        steps=2,
+        cfg_strength=2.0,
+        cache_reference_audio_embedding=True,
+    )
+    assert flow.transformer.reference_audio_cond is None
+    assert flow.transformer.reference_audio_uncond is None
+
+    original = flow.transformer.forward
+
+    def fail_after_forward(*args, **kwargs):
+        original(*args, **kwargs)
+        raise RuntimeError("injected failure")
+
+    monkeypatch.setattr(flow.transformer, "forward", fail_after_forward)
+    with pytest.raises(RuntimeError, match="injected failure"):
+        flow.sample(
+            first,
+            steps=2,
+            cfg_strength=2.0,
+            cache_reference_audio_embedding=True,
+        )
+    assert flow.transformer.reference_audio_cond is None
+    assert flow.transformer.reference_audio_uncond is None
+
+    monkeypatch.setattr(flow.transformer, "forward", original)
+    assert torch.isfinite(
+        flow.sample(
+            second,
+            steps=2,
+            cfg_strength=2.0,
+            cache_reference_audio_embedding=True,
+        )
+    ).all()
+
+
+def test_cache_is_default_false_and_plumbed_to_engine_factory():
+    config = AuKPipelineConfig(model_path="tencent/AuK")
+    engine = next(stage for stage in config.stages if stage.name == ENGINE_STAGE)
+    assert engine.factory.cache_reference_audio_embedding is False
+    parameter = inspect.signature(create_auk_engine_executor).parameters[
+        "cache_reference_audio_embedding"
+    ]
+    assert parameter.default is False

--- a/tests/unit_test/auk/test_stages.py
+++ b/tests/unit_test/auk/test_stages.py
@@ -126,6 +126,7 @@ def test_engine_uses_checkpoint_sampling_recipe(monkeypatch, flash):
         cfg_strength=0 if flash else 3,
         sway_sampling_coef=None if flash else -1,
         t_grid=C.FLASH_T_GRID if flash else None,
+        cache_reference_audio_embedding=False,
     )
 
 


### PR DESCRIPTION
## Summary

- cache AuK conditional and unconditional reference-audio embeddings across one Euler integration
- keep the changing noisy-latent embedding uncached
- clear reference tensors with the existing request-local text cache in `finally`
- expose the behavior as a default-false engine option

## Motivation and evidence

A 32-step CFG request previously computed 64 reference embeddings. This change reduces that to 2 while leaving the 64 dynamic noisy-latent calls unchanged.

Cold-removed H100 direct checks over three representative shapes plus the deterministic longest sample produced byte-identical latents/WAVs and a 3.095% integration improvement. Same-server A/A measured a 0.824% floor; three c1 A/B gains were 3.946%, 3.121%, and 3.121% (3.396% mean).

The option remains off by default. Additional c8/c16 task-level quality validation is being run separately; earlier independently scheduled concurrent arms changed batch formation, so PCM identity across those arms is not used as the sole quality metric.

Full profiling record: https://github.com/sgl-project/sglang-omni/issues/2067
Evidence bundle: https://gist.github.com/wirybeaver/feeadd13590b9c8fcafdf3183d688e81

## Test plan

- pinned CI image: reference-cache focused tests + existing AuK flow/config tests, **23 passed**
- exact CPU parity across CFG/non-CFG, reference/no-reference, and multiple shapes
- 32-step call-count assertion: dynamic 64, reference 2
- first-step/reuse, cross-shape isolation, exception cleanup, and next-request recovery
- formatting, targeted lint, and diff checks

Refs #2064
Refs #2067