### PR TITLE
[Fix][MOSS-TTS] Prevent pipeline crashes on empty Local audio output

### DIFF
--- a/sglang_omni/models/moss_tts_local/request_builders.py
+++ b/sglang_omni/models/moss_tts_local/request_builders.py
@@ -428,16 +428,12 @@ def apply_sglang_moss_tts_local_result(
     data: MossTTSLocalSGLangRequestData,
 ) -> StagePayload:
     state = data.state
-    n_vq = (
-        int(data.prompt_rows.shape[1] - 1)
-        if data.prompt_rows is not None and data.prompt_rows.ndim == 2
-        else 12
-    )
-    if data.output_rows:
-        generated_rows = torch.stack(data.output_rows, dim=0).to(dtype=torch.long)
-        state.audio_codes = generated_rows[:, 1:].detach().cpu()
-    else:
-        state.audio_codes = torch.empty((0, n_vq), dtype=torch.long)
+    if not data.output_rows:
+        raise RuntimeError(
+            "MOSS-TTS Local generated no audio frames. Please retry the request."
+        )
+    generated_rows = torch.stack(data.output_rows, dim=0).to(dtype=torch.long)
+    state.audio_codes = generated_rows[:, 1:].detach().cpu()
 
     state.prompt_tokens = len(data.input_ids) if data.input_ids is not None else 0
     state.completion_tokens = len(data.output_rows)

--- a/tests/unit_test/moss_tts_local/test_pipeline.py
+++ b/tests/unit_test/moss_tts_local/test_pipeline.py
@@ -1208,9 +1208,8 @@ def test_result_adapter_empty_generation():
         stage_payload=payload,
         engine_start_s=0.0,
     )
-    result = apply_sglang_moss_tts_local_result(payload, data)
-    codes = torch.as_tensor(result.data["audio_codes"])
-    assert codes.shape == (0, N_VQ)
+    with pytest.raises(RuntimeError, match="generated no audio frames"):
+        apply_sglang_moss_tts_local_result(payload, data)
 
 
 # Repetition penalty parity

--- a/tests/unit_test/moss_tts_local/test_state_pool.py
+++ b/tests/unit_test/moss_tts_local/test_state_pool.py
@@ -9,6 +9,7 @@ from __future__ import annotations
 
 from types import SimpleNamespace
 
+import pytest
 import torch
 
 from sglang_omni.models.moss_tts.model_runner import MossTTSModelRunner
@@ -1205,7 +1206,7 @@ def test_param_gather_matches_old_cache():
     )
 
 
-def test_result_adapter_releases_row_when_apply_raises():
+def test_result_adapter_releases_row_after_empty_generation():
     reset_calls = []
     model = SimpleNamespace(reset_request=lambda rid: reset_calls.append(rid))
     _, result_adapter = make_moss_tts_local_scheduler_adapters(model=model)
@@ -1220,18 +1221,11 @@ def test_result_adapter_releases_row_when_apply_raises():
         temperature=0.0,
         output_ids=[],
         prompt_rows=torch.zeros((1, 13), dtype=torch.long),
-        output_rows=[
-            torch.zeros(13, dtype=torch.long),
-            torch.zeros(12, dtype=torch.long),
-        ],
+        output_rows=[],
         stage_payload=payload,
     )
 
-    try:
+    with pytest.raises(RuntimeError, match="generated no audio frames"):
         result_adapter(data)
-    except RuntimeError:
-        pass
-    else:
-        raise AssertionError("expected malformed output_rows to raise")
 
     assert reset_calls == ["rid"]

--- a/tests/unit_test/serve/test_openai_api.py
+++ b/tests/unit_test/serve/test_openai_api.py
@@ -3446,3 +3446,41 @@ def test_stub_endpoint_checks_auth_before_501() -> None:
 
     resp = client.post("/update_weights_from_tensor", json={})
     assert resp.status_code == 401
+
+
+@pytest.mark.parametrize("stream", [False, True])
+def test_speech_empty_generation_error_allows_next_request(stream: bool) -> None:
+    message = "MOSS-TTS Local generated no audio frames. Please retry the request."
+
+    class FailOnceClient(SuccessfulSpeechClient):
+        failed = False
+
+        async def generate(self, request, request_id=None):
+            if not self.failed:
+                self.failed = True
+                raise RuntimeError(message)
+            async for chunk in super().generate(request, request_id):
+                yield chunk
+
+        async def speech(self, request, **kwargs):
+            if not self.failed:
+                self.failed = True
+                raise ClientError(message)
+            return await super().speech(request, **kwargs)
+
+        async def abort(self, request_id):
+            pass
+
+    client = TestClient(create_app(FailOnceClient(), model_name="moss-tts"))
+    body = {
+        "model": "moss-tts",
+        "input": "hello",
+        "stream": stream,
+        "response_format": "pcm" if stream else "wav",
+    }
+    response = client.post("/v1/audio/speech", json=body)
+    assert response.status_code == 500
+    assert message in response.json()["error"]["message"]
+    response = client.post("/v1/audio/speech", json=body)
+    assert response.status_code == 200
+    assert response.content


### PR DESCRIPTION
## Motivation

This PR addresses a bug observed in production: an empty MOSS-TTS Local result caused the pipeline process to exit. In the reported incident, the triggering request returned HTTP 500, and 47 subsequent requests to the same instance returned HTTP 502.

When MOSS-TTS Local finishes without generating any audio frames, its result adapter creates an empty `audio_codes` tensor. Sending this result to the vocoder through SHM attempts a zero-byte shared-memory allocation and raises `ValueError` outside the request error handling path.

This PR rejects the empty result before stage transfer. The request returns HTTP 500 with `MOSS-TTS Local generated no audio frames. Please retry the request.` and releases its decode-state slot through the existing cleanup path.

## Modifications

- Raise an error in the Local result adapter when `output_rows` is empty, using the scheduler's existing request error handling.
- Remove the empty `audio_codes` construction.
- Add regression coverage for empty-result rejection, request-state cleanup, and streaming/non-streaming API errors followed by a successful request.

## Related Issues

N/A

## Accuracy Test

On commit `7615b259`, all **4 targeted regression tests passed**:

```bash
python -m pytest \
  tests/unit_test/moss_tts_local/test_pipeline.py \
  tests/unit_test/moss_tts_local/test_state_pool.py \
  tests/unit_test/serve/test_openai_api.py \
  -k empty_generation -q
```

The tests verify that an empty result raises the expected error, the result adapter still releases the request's state, and both streaming and non-streaming HTTP requests return the error message while a subsequent request succeeds. The API tests use a simulated generation backend.

The zero-byte SHM failure was reproduced with a CPU reproducer. Replaying the reported request on GPU did not reproduce zero-frame generation, so its generation-side cause remains unconfirmed.

## Benchmark & Profiling

Not run. The change adds a guard at generation completion and does not alter sampling or audio decoding.

## Checklist

- [x] Format your code according with pre-commit.
- [x] Add unit tests.
- [x] Update documentation / docstrings / example tutorials as needed.
- [ ] Provide throughput / latency benchmark results and accuracy evaluation results as needed.
- [ ] For reviewers: If you haven't made any contributions to this PR and are only assisting with merging the main branch, please remove yourself as a co-author when merging the PR.

## CI

CI runs on self-hosted GPU runners and requires a maintainer to add the
`run-ci` label. Once labeled, every subsequent push re-triggers CI as
long as the label remains. Use `/tag-and-rerun-ci higgs` or
`/tag-and-rerun-ci moss` or `/tag-and-rerun-ci qwen3-tts` to select a TTS CI
model, and
`/tag-and-rerun-ci fun-asr`, `/tag-and-rerun-ci qwen3-asr` or
`/tag-and-rerun-ci whisper-asr` to select an ASR CI model. One selector from
each family can be combined, for example `/tag-and-rerun-ci moss fun-asr`.
Draft PRs are skipped even if labeled.
