### PR TITLE
fix(mps): use session identity for shared-daemon health probes

### DIFF
--- a/sglang_omni/mps/control.py
+++ b/sglang_omni/mps/control.py
@@ -15,16 +15,28 @@ from sglang_omni.mps.manager import (
     MpsClientRef,
     MpsControlError,
     MpsDaemonNotStartedError,
+    MpsProcessIdentity,
 )
 
 _CONTROL_BINARY = "nvidia-cuda-mps-control"
+_SERVER_BINARY = "nvidia-cuda-mps-server"
 _QUERY_TIMEOUT_SECONDS = 10
 _SNAPSHOT_RETRY_DELAYS_SECONDS = (0.05, 0.15)
 _CONTROL_LOCK_NAME = ".control.lock"
 
 
+def _parse_proc_stat(stat_text: str) -> tuple[str, int]:
+    """Return process state and start time from ``/proc/<pid>/stat``."""
+
+    try:
+        fields = stat_text.rsplit(")", 1)[1].split()
+        return fields[0], int(fields[19])
+    except (IndexError, ValueError) as exc:
+        raise ValueError("malformed /proc/<pid>/stat") from exc
+
+
 def _stat_says_alive(stat_text: str) -> bool:
-    """Parse ``/proc/<pid>/stat``; the state field follows the last ``)``."""
+    """Treat every non-zombie process state as alive, including ``T``."""
 
     fields = stat_text.rsplit(")", 1)[1].split()
     return bool(fields) and fields[0] != "Z"
@@ -111,9 +123,8 @@ class SubprocessMpsControlClient:
         except subprocess.SubprocessError as exc:
             raise MpsControlError(f"failed to start {_CONTROL_BINARY}: {exc}") from exc
 
-    def read_daemon_identity(self, pipe_dir: Path) -> int:
-        """Read and prove the native control-daemon identity for ``pipe_dir``."""
-
+    @staticmethod
+    def _read_daemon_pid(pipe_dir: Path) -> int:
         pid_file = pipe_dir / f"{_CONTROL_BINARY}.pid"
         try:
             raw_pid = pid_file.read_text().strip()
@@ -125,27 +136,80 @@ class SubprocessMpsControlClient:
             raise MpsControlError(
                 f"native PID file {pid_file} is malformed: {raw_pid!r}"
             )
-        pid = int(raw_pid)
-        if not self.daemon_process_alive(pid):
-            raise MpsControlError(f"native PID file {pid_file} names dead pid {pid}")
+        return int(raw_pid)
 
+    @staticmethod
+    def _read_proc_stat(pid: int) -> tuple[str, int]:
+        try:
+            return _parse_proc_stat(Path(f"/proc/{pid}/stat").read_text())
+        except FileNotFoundError as exc:
+            raise MpsControlError(f"process pid {pid} does not exist") from exc
+        except (OSError, IndexError, ValueError) as exc:
+            raise MpsControlError(f"cannot inspect process pid {pid}: {exc}") from exc
+
+    def _read_process_identity(
+        self,
+        pid: int,
+        pipe_dir: Path,
+        expected_binary: str,
+    ) -> MpsProcessIdentity:
         proc = Path(f"/proc/{pid}")
         try:
+            state, starttime = self._read_proc_stat(pid)
+            if state == "Z":
+                raise MpsControlError(f"process pid {pid} is a zombie")
             cmdline = proc.joinpath("cmdline").read_bytes().split(b"\0", 1)[0]
             environ = proc.joinpath("environ").read_bytes().split(b"\0")
+            final_state, final_starttime = self._read_proc_stat(pid)
         except OSError as exc:
-            raise MpsControlError(f"cannot inspect daemon pid {pid}: {exc}") from exc
-        if Path(os.fsdecode(cmdline)).name != _CONTROL_BINARY:
             raise MpsControlError(
-                f"native PID file {pid_file} names {os.fsdecode(cmdline)!r}, not "
-                f"{_CONTROL_BINARY}"
+                f"cannot inspect {expected_binary} pid {pid}: {exc}"
+            ) from exc
+        except MpsControlError:
+            raise
+        if final_state == "Z":
+            raise MpsControlError(
+                f"process pid {pid} became a zombie during inspection"
+            )
+        if final_starttime != starttime:
+            raise MpsControlError(
+                f"process pid {pid} changed identity during inspection"
+            )
+        executable = Path(os.fsdecode(cmdline)).name
+        if executable != expected_binary:
+            raise MpsControlError(
+                f"process pid {pid} names {os.fsdecode(cmdline)!r}, not "
+                f"{expected_binary}"
             )
         expected_pipe = f"CUDA_MPS_PIPE_DIRECTORY={pipe_dir}".encode()
         if expected_pipe not in environ:
             raise MpsControlError(
-                f"daemon pid {pid} does not own exact pipe directory {pipe_dir}"
+                f"process pid {pid} does not own exact pipe directory {pipe_dir}"
             )
-        return pid
+        return MpsProcessIdentity(pid=pid, starttime=starttime)
+
+    def read_daemon_process_identity(self, pipe_dir: Path) -> MpsProcessIdentity:
+        """Read and prove the native control-daemon identity for ``pipe_dir``."""
+
+        return self._read_process_identity(
+            self._read_daemon_pid(pipe_dir),
+            pipe_dir,
+            _CONTROL_BINARY,
+        )
+
+    def read_daemon_identity(self, pipe_dir: Path) -> int:
+        """Return the PID of the verified native control daemon."""
+
+        return self.read_daemon_process_identity(pipe_dir).pid
+
+    def read_server_process_identity(
+        self,
+        pipe_dir: Path,
+        pid: int,
+    ) -> MpsProcessIdentity:
+        """Read and prove one native MPS server identity for ``pipe_dir``."""
+
+        return self._read_process_identity(pid, pipe_dir, _SERVER_BINARY)
 
     def _snapshot_unlocked(self, pipe_dir: Path) -> set[MpsClientRef]:
         servers = _parse_pid_list(
@@ -164,7 +228,7 @@ class SubprocessMpsControlClient:
     def snapshot(self, pipe_dir: Path) -> set[MpsClientRef]:
         """Return one identity-stable, serialized server/client snapshot."""
 
-        expected_daemon_pid = self.read_daemon_identity(pipe_dir)
+        expected_daemon_identity = self.read_daemon_process_identity(pipe_dir)
         last_error: MpsControlError | None = None
         attempts = len(_SNAPSHOT_RETRY_DELAYS_SECONDS) + 1
 
@@ -177,11 +241,14 @@ class SubprocessMpsControlClient:
             else:
                 last_error = None
 
-            current_daemon_pid = self.read_daemon_identity(pipe_dir)
-            if current_daemon_pid != expected_daemon_pid:
+            current_daemon_identity = self.read_daemon_process_identity(pipe_dir)
+            if current_daemon_identity != expected_daemon_identity:
                 identity_error = MpsControlError(
                     "MPS daemon identity changed during control snapshot "
-                    f"from {expected_daemon_pid} to {current_daemon_pid}"
+                    f"from pid {expected_daemon_identity.pid} "
+                    f"starttime {expected_daemon_identity.starttime} to pid "
+                    f"{current_daemon_identity.pid} "
+                    f"starttime {current_daemon_identity.starttime}"
                 )
                 if last_error is not None:
                     raise identity_error from last_error
@@ -218,7 +285,7 @@ class SubprocessMpsControlClient:
             return _stat_says_alive(Path(f"/proc/{pid}/stat").read_text())
         except FileNotFoundError:
             return False
-        except (OSError, IndexError) as exc:
+        except (OSError, IndexError, ValueError) as exc:
             raise MpsControlError(f"cannot inspect daemon pid {pid}: {exc}") from exc
 
     def client_token(self, pid: int) -> str | None:

--- a/sglang_omni/mps/control.py
+++ b/sglang_omni/mps/control.py
@@ -24,8 +24,6 @@ _CONTROL_LOCK_NAME = ".control.lock"
 
 
 def _parse_proc_stat(stat_text: str) -> tuple[str, int]:
-    """Return process state and start time from ``/proc/<pid>/stat``."""
-
     try:
         fields = stat_text.rsplit(")", 1)[1].split()
         return fields[0], int(fields[19])
@@ -115,21 +113,6 @@ class SubprocessMpsControlClient:
             raise MpsControlError(f"failed to start {_CONTROL_BINARY}: {exc}") from exc
 
     @staticmethod
-    def _read_daemon_pid(pipe_dir: Path) -> int:
-        pid_file = pipe_dir / f"{_CONTROL_BINARY}.pid"
-        try:
-            raw_pid = pid_file.read_text().strip()
-        except OSError as exc:
-            raise MpsControlError(
-                f"cannot read native PID file {pid_file}: {exc}"
-            ) from exc
-        if not raw_pid.isdigit() or int(raw_pid) <= 0:
-            raise MpsControlError(
-                f"native PID file {pid_file} is malformed: {raw_pid!r}"
-            )
-        return int(raw_pid)
-
-    @staticmethod
     def _read_proc_stat(pid: int) -> tuple[str, int]:
         try:
             return _parse_proc_stat(Path(f"/proc/{pid}/stat").read_text())
@@ -178,10 +161,20 @@ class SubprocessMpsControlClient:
         return MpsProcessIdentity(pid=pid, starttime=starttime)
 
     def read_daemon_process_identity(self, pipe_dir: Path) -> MpsProcessIdentity:
-        """Read and prove the native control-daemon identity for ``pipe_dir``."""
+        pid_file = pipe_dir / f"{_CONTROL_BINARY}.pid"
+        try:
+            raw_pid = pid_file.read_text().strip()
+        except OSError as exc:
+            raise MpsControlError(
+                f"cannot read native PID file {pid_file}: {exc}"
+            ) from exc
+        if not raw_pid.isdigit() or int(raw_pid) <= 0:
+            raise MpsControlError(
+                f"native PID file {pid_file} is malformed: {raw_pid!r}"
+            )
 
         return self._read_process_identity(
-            self._read_daemon_pid(pipe_dir),
+            int(raw_pid),
             pipe_dir,
             _CONTROL_BINARY,
         )
@@ -191,8 +184,6 @@ class SubprocessMpsControlClient:
         pipe_dir: Path,
         pid: int,
     ) -> MpsProcessIdentity:
-        """Read and prove one native MPS server identity for ``pipe_dir``."""
-
         return self._read_process_identity(pid, pipe_dir, _SERVER_BINARY)
 
     def _snapshot_unlocked(self, pipe_dir: Path) -> set[MpsClientRef]:
@@ -210,8 +201,6 @@ class SubprocessMpsControlClient:
         return clients
 
     def snapshot(self, pipe_dir: Path) -> set[MpsClientRef]:
-        """Return one identity-stable, serialized server/client snapshot."""
-
         expected_identity = self.read_daemon_process_identity(pipe_dir)
         with self._control_transaction(pipe_dir):
             clients = self._snapshot_unlocked(pipe_dir)

--- a/sglang_omni/mps/control.py
+++ b/sglang_omni/mps/control.py
@@ -6,7 +6,6 @@ from __future__ import annotations
 import fcntl
 import os
 import subprocess
-import time
 from contextlib import contextmanager
 from pathlib import Path
 
@@ -21,7 +20,6 @@ from sglang_omni.mps.manager import (
 _CONTROL_BINARY = "nvidia-cuda-mps-control"
 _SERVER_BINARY = "nvidia-cuda-mps-server"
 _QUERY_TIMEOUT_SECONDS = 10
-_SNAPSHOT_RETRY_DELAYS_SECONDS = (0.05, 0.15)
 _CONTROL_LOCK_NAME = ".control.lock"
 
 
@@ -33,13 +31,6 @@ def _parse_proc_stat(stat_text: str) -> tuple[str, int]:
         return fields[0], int(fields[19])
     except (IndexError, ValueError) as exc:
         raise ValueError("malformed /proc/<pid>/stat") from exc
-
-
-def _stat_says_alive(stat_text: str) -> bool:
-    """Treat every non-zombie process state as alive, including ``T``."""
-
-    fields = stat_text.rsplit(")", 1)[1].split()
-    return bool(fields) and fields[0] != "Z"
 
 
 def _parse_pid_list(output: str, command: str) -> list[int]:
@@ -144,7 +135,7 @@ class SubprocessMpsControlClient:
             return _parse_proc_stat(Path(f"/proc/{pid}/stat").read_text())
         except FileNotFoundError as exc:
             raise MpsControlError(f"process pid {pid} does not exist") from exc
-        except (OSError, IndexError, ValueError) as exc:
+        except (OSError, ValueError) as exc:
             raise MpsControlError(f"cannot inspect process pid {pid}: {exc}") from exc
 
     def _read_process_identity(
@@ -165,8 +156,6 @@ class SubprocessMpsControlClient:
             raise MpsControlError(
                 f"cannot inspect {expected_binary} pid {pid}: {exc}"
             ) from exc
-        except MpsControlError:
-            raise
         if final_state == "Z":
             raise MpsControlError(
                 f"process pid {pid} became a zombie during inspection"
@@ -197,11 +186,6 @@ class SubprocessMpsControlClient:
             _CONTROL_BINARY,
         )
 
-    def read_daemon_identity(self, pipe_dir: Path) -> int:
-        """Return the PID of the verified native control daemon."""
-
-        return self.read_daemon_process_identity(pipe_dir).pid
-
     def read_server_process_identity(
         self,
         pipe_dir: Path,
@@ -228,40 +212,18 @@ class SubprocessMpsControlClient:
     def snapshot(self, pipe_dir: Path) -> set[MpsClientRef]:
         """Return one identity-stable, serialized server/client snapshot."""
 
-        expected_daemon_identity = self.read_daemon_process_identity(pipe_dir)
-        last_error: MpsControlError | None = None
-        attempts = len(_SNAPSHOT_RETRY_DELAYS_SECONDS) + 1
-
-        for attempt in range(attempts):
-            try:
-                with self._control_transaction(pipe_dir):
-                    clients = self._snapshot_unlocked(pipe_dir)
-            except MpsControlError as exc:
-                last_error = exc
-            else:
-                last_error = None
-
-            current_daemon_identity = self.read_daemon_process_identity(pipe_dir)
-            if current_daemon_identity != expected_daemon_identity:
-                identity_error = MpsControlError(
-                    "MPS daemon identity changed during control snapshot "
-                    f"from pid {expected_daemon_identity.pid} "
-                    f"starttime {expected_daemon_identity.starttime} to pid "
-                    f"{current_daemon_identity.pid} "
-                    f"starttime {current_daemon_identity.starttime}"
-                )
-                if last_error is not None:
-                    raise identity_error from last_error
-                raise identity_error
-            if last_error is None:
-                return clients
-            if attempt < len(_SNAPSHOT_RETRY_DELAYS_SECONDS):
-                time.sleep(_SNAPSHOT_RETRY_DELAYS_SECONDS[attempt])
-
-        assert last_error is not None
-        raise MpsControlError(
-            f"MPS control snapshot failed after {attempts} attempts: {last_error}"
-        ) from last_error
+        expected_identity = self.read_daemon_process_identity(pipe_dir)
+        with self._control_transaction(pipe_dir):
+            clients = self._snapshot_unlocked(pipe_dir)
+        current_identity = self.read_daemon_process_identity(pipe_dir)
+        if current_identity != expected_identity:
+            raise MpsControlError(
+                "MPS daemon identity changed during control snapshot "
+                f"from pid {expected_identity.pid} "
+                f"starttime {expected_identity.starttime} to pid "
+                f"{current_identity.pid} starttime {current_identity.starttime}"
+            )
+        return clients
 
     def terminate_client(self, pipe_dir: Path, client: MpsClientRef) -> None:
         command = f"terminate_client {client.server_pid} {client.client_pid}"
@@ -282,10 +244,11 @@ class SubprocessMpsControlClient:
         except PermissionError as exc:
             raise MpsControlError(f"cannot probe daemon pid {pid}: {exc}") from exc
         try:
-            return _stat_says_alive(Path(f"/proc/{pid}/stat").read_text())
+            state, _ = _parse_proc_stat(Path(f"/proc/{pid}/stat").read_text())
+            return state != "Z"
         except FileNotFoundError:
             return False
-        except (OSError, IndexError, ValueError) as exc:
+        except (OSError, ValueError) as exc:
             raise MpsControlError(f"cannot inspect daemon pid {pid}: {exc}") from exc
 
     def client_token(self, pid: int) -> str | None:

--- a/sglang_omni/mps/control.py
+++ b/sglang_omni/mps/control.py
@@ -47,27 +47,25 @@ class SubprocessMpsControlClient:
 
     @contextmanager
     def _control_transaction(self, pipe_dir: Path):
-        """Serialize control CLI transactions for one shared MPS daemon.
-
-        Multiple independent serve processes can share one per-GPU daemon. A
-        process-local lock cannot stop their health snapshots from interleaving
-        on the same native control socket, so use one filesystem flock in the
-        shared GPU state directory. Callers that need a multi-command atomic
-        view, such as :meth:`snapshot`, hold this lock across the whole view.
-        """
+        """Serialize native control transactions for one shared MPS daemon."""
 
         lock_path = pipe_dir.parent / _CONTROL_LOCK_NAME
         try:
-            with lock_path.open("a+") as lock_file:
-                fcntl.flock(lock_file, fcntl.LOCK_EX)
-                try:
-                    yield
-                finally:
-                    fcntl.flock(lock_file, fcntl.LOCK_UN)
+            lock_file = lock_path.open("a+")
         except OSError as exc:
             raise MpsControlError(
-                f"cannot lock MPS control transaction {lock_path}: {exc}"
+                f"cannot open MPS control lock {lock_path}: {exc}"
             ) from exc
+
+        with lock_file:
+            try:
+                fcntl.flock(lock_file, fcntl.LOCK_EX)
+            except OSError as exc:
+                raise MpsControlError(
+                    f"cannot lock MPS control transaction {lock_path}: {exc}"
+                ) from exc
+
+            yield
 
     def _query_unlocked(self, pipe_dir: Path, command: str) -> str:
         try:
@@ -168,15 +166,7 @@ class SubprocessMpsControlClient:
         return clients
 
     def snapshot(self, pipe_dir: Path) -> set[MpsClientRef]:
-        """Return one strict, serialized server/client snapshot.
-
-        A shared daemon may serve several independent pipeline owners. Keep one
-        complete snapshot under the cross-process control lock, and tolerate a
-        small number of transient read-only control failures only while the
-        daemon's native identity remains unchanged. Persistent failures or any
-        identity loss/change still fail closed. Mutating commands are never
-        retried automatically.
-        """
+        """Return one serialized server/client snapshot."""
 
         expected_daemon_pid = self.read_daemon_identity(pipe_dir)
         last_error: MpsControlError | None = None

--- a/sglang_omni/mps/control.py
+++ b/sglang_omni/mps/control.py
@@ -47,8 +47,6 @@ class SubprocessMpsControlClient:
 
     @contextmanager
     def _control_transaction(self, pipe_dir: Path):
-        """Serialize native control transactions for one shared MPS daemon."""
-
         lock_path = pipe_dir.parent / _CONTROL_LOCK_NAME
         try:
             lock_file = lock_path.open("a+")
@@ -89,8 +87,6 @@ class SubprocessMpsControlClient:
         return result.stdout
 
     def _query(self, pipe_dir: Path, command: str) -> str:
-        """Run one serialized control transaction without automatic retries."""
-
         with self._control_transaction(pipe_dir):
             return self._query_unlocked(pipe_dir, command)
 
@@ -166,7 +162,7 @@ class SubprocessMpsControlClient:
         return clients
 
     def snapshot(self, pipe_dir: Path) -> set[MpsClientRef]:
-        """Return one serialized server/client snapshot."""
+        """Return one identity-stable, serialized server/client snapshot."""
 
         expected_daemon_pid = self.read_daemon_identity(pipe_dir)
         last_error: MpsControlError | None = None
@@ -179,20 +175,19 @@ class SubprocessMpsControlClient:
             except MpsControlError as exc:
                 last_error = exc
             else:
-                current_daemon_pid = self.read_daemon_identity(pipe_dir)
-                if current_daemon_pid != expected_daemon_pid:
-                    raise MpsControlError(
-                        "MPS daemon identity changed during control snapshot "
-                        f"from {expected_daemon_pid} to {current_daemon_pid}"
-                    )
-                return clients
+                last_error = None
 
             current_daemon_pid = self.read_daemon_identity(pipe_dir)
             if current_daemon_pid != expected_daemon_pid:
-                raise MpsControlError(
+                identity_error = MpsControlError(
                     "MPS daemon identity changed during control snapshot "
                     f"from {expected_daemon_pid} to {current_daemon_pid}"
-                ) from last_error
+                )
+                if last_error is not None:
+                    raise identity_error from last_error
+                raise identity_error
+            if last_error is None:
+                return clients
             if attempt < len(_SNAPSHOT_RETRY_DELAYS_SECONDS):
                 time.sleep(_SNAPSHOT_RETRY_DELAYS_SECONDS[attempt])
 

--- a/sglang_omni/mps/control.py
+++ b/sglang_omni/mps/control.py
@@ -6,6 +6,8 @@ from __future__ import annotations
 import fcntl
 import os
 import subprocess
+import time
+from contextlib import contextmanager
 from pathlib import Path
 
 from sglang_omni.mps.manager import (
@@ -17,6 +19,8 @@ from sglang_omni.mps.manager import (
 
 _CONTROL_BINARY = "nvidia-cuda-mps-control"
 _QUERY_TIMEOUT_SECONDS = 10
+_SNAPSHOT_RETRY_DELAYS_SECONDS = (0.05, 0.15)
+_CONTROL_LOCK_NAME = ".control.lock"
 
 
 def _stat_says_alive(stat_text: str) -> bool:
@@ -41,7 +45,31 @@ class SubprocessMpsControlClient:
         env["CUDA_MPS_PIPE_DIRECTORY"] = str(pipe_dir)
         return env
 
-    def _query(self, pipe_dir: Path, command: str) -> str:
+    @contextmanager
+    def _control_transaction(self, pipe_dir: Path):
+        """Serialize control CLI transactions for one shared MPS daemon.
+
+        Multiple independent serve processes can share one per-GPU daemon. A
+        process-local lock cannot stop their health snapshots from interleaving
+        on the same native control socket, so use one filesystem flock in the
+        shared GPU state directory. Callers that need a multi-command atomic
+        view, such as :meth:`snapshot`, hold this lock across the whole view.
+        """
+
+        lock_path = pipe_dir.parent / _CONTROL_LOCK_NAME
+        try:
+            with lock_path.open("a+") as lock_file:
+                fcntl.flock(lock_file, fcntl.LOCK_EX)
+                try:
+                    yield
+                finally:
+                    fcntl.flock(lock_file, fcntl.LOCK_UN)
+        except OSError as exc:
+            raise MpsControlError(
+                f"cannot lock MPS control transaction {lock_path}: {exc}"
+            ) from exc
+
+    def _query_unlocked(self, pipe_dir: Path, command: str) -> str:
         try:
             result = subprocess.run(
                 [_CONTROL_BINARY],
@@ -61,6 +89,12 @@ class SubprocessMpsControlClient:
                 f"(rc={result.returncode}): {result.stderr.strip()}"
             )
         return result.stdout
+
+    def _query(self, pipe_dir: Path, command: str) -> str:
+        """Run one serialized control transaction without automatic retries."""
+
+        with self._control_transaction(pipe_dir):
+            return self._query_unlocked(pipe_dir, command)
 
     def start_daemon(self, pipe_dir: Path, log_dir: Path, gpu_uuid: str) -> None:
         env = self._control_env(pipe_dir)
@@ -119,19 +153,63 @@ class SubprocessMpsControlClient:
             )
         return pid
 
-    def snapshot(self, pipe_dir: Path) -> set[MpsClientRef]:
-        """Return one strict server/client snapshot from the selected daemon."""
-
+    def _snapshot_unlocked(self, pipe_dir: Path) -> set[MpsClientRef]:
         servers = _parse_pid_list(
-            self._query(pipe_dir, "get_server_list"), "get_server_list"
+            self._query_unlocked(pipe_dir, "get_server_list"), "get_server_list"
         )
         clients: set[MpsClientRef] = set()
         for server_pid in servers:
             command = f"get_client_list {server_pid}"
-            client_pids = _parse_pid_list(self._query(pipe_dir, command), command)
+            client_pids = _parse_pid_list(
+                self._query_unlocked(pipe_dir, command), command
+            )
             for client_pid in client_pids:
                 clients.add(MpsClientRef(server_pid, client_pid))
         return clients
+
+    def snapshot(self, pipe_dir: Path) -> set[MpsClientRef]:
+        """Return one strict, serialized server/client snapshot.
+
+        A shared daemon may serve several independent pipeline owners. Keep one
+        complete snapshot under the cross-process control lock, and tolerate a
+        small number of transient read-only control failures only while the
+        daemon's native identity remains unchanged. Persistent failures or any
+        identity loss/change still fail closed. Mutating commands are never
+        retried automatically.
+        """
+
+        expected_daemon_pid = self.read_daemon_identity(pipe_dir)
+        last_error: MpsControlError | None = None
+        attempts = len(_SNAPSHOT_RETRY_DELAYS_SECONDS) + 1
+
+        for attempt in range(attempts):
+            try:
+                with self._control_transaction(pipe_dir):
+                    clients = self._snapshot_unlocked(pipe_dir)
+            except MpsControlError as exc:
+                last_error = exc
+            else:
+                current_daemon_pid = self.read_daemon_identity(pipe_dir)
+                if current_daemon_pid != expected_daemon_pid:
+                    raise MpsControlError(
+                        "MPS daemon identity changed during control snapshot "
+                        f"from {expected_daemon_pid} to {current_daemon_pid}"
+                    )
+                return clients
+
+            current_daemon_pid = self.read_daemon_identity(pipe_dir)
+            if current_daemon_pid != expected_daemon_pid:
+                raise MpsControlError(
+                    "MPS daemon identity changed during control snapshot "
+                    f"from {expected_daemon_pid} to {current_daemon_pid}"
+                ) from last_error
+            if attempt < len(_SNAPSHOT_RETRY_DELAYS_SECONDS):
+                time.sleep(_SNAPSHOT_RETRY_DELAYS_SECONDS[attempt])
+
+        assert last_error is not None
+        raise MpsControlError(
+            f"MPS control snapshot failed after {attempts} attempts: {last_error}"
+        ) from last_error
 
     def terminate_client(self, pipe_dir: Path, client: MpsClientRef) -> None:
         command = f"terminate_client {client.server_pid} {client.client_pid}"

--- a/sglang_omni/mps/manager.py
+++ b/sglang_omni/mps/manager.py
@@ -475,9 +475,7 @@ class MpsManager:
         except MpsControlError as exc:
             return f"daemon identity query failed: {exc}"
         if daemon_pid != lease.daemon_pid:
-            return (
-                f"daemon identity changed from {lease.daemon_pid} " f"to {daemon_pid}"
-            )
+            return f"daemon identity changed from {lease.daemon_pid} to {daemon_pid}"
         return None
 
     def release(

--- a/sglang_omni/mps/manager.py
+++ b/sglang_omni/mps/manager.py
@@ -86,8 +86,6 @@ class MpsControlClient(Protocol):
 
     def start_daemon(self, pipe_dir: Path, log_dir: Path, gpu_uuid: str) -> None: ...
 
-    def read_daemon_identity(self, pipe_dir: Path) -> int: ...
-
     def read_daemon_process_identity(self, pipe_dir: Path) -> MpsProcessIdentity: ...
 
     def read_server_process_identity(
@@ -111,7 +109,6 @@ class MpsControlClient(Protocol):
 
 @dataclass
 class _ExistingState:
-    daemon_pid: int | None = None
     daemon_identity: MpsProcessIdentity | None = None
     owners: dict[int, bool] = field(default_factory=dict)
     owner_statuses: dict[int, str] = field(default_factory=dict)
@@ -222,7 +219,6 @@ class MpsManager:
         state = self._inspect_existing_state()
         if (
             not state.errors
-            and state.daemon_pid is not None
             and state.daemon_identity is not None
             and state.clients is not None
             and state.owners
@@ -232,7 +228,7 @@ class MpsManager:
             owner_fd = self._publish_owner()
             logger.info(
                 "Joining shared MPS daemon pid %d on %s (owners: %s)",
-                state.daemon_pid,
+                state.daemon_identity.pid,
                 self.gpu_uuid,
                 sorted(state.owners),
             )
@@ -302,7 +298,6 @@ class MpsManager:
             state.daemon_identity = self.client.read_daemon_process_identity(
                 self.paths.pipe_dir
             )
-            state.daemon_pid = state.daemon_identity.pid
         except MpsControlError as exc:
             state.errors.append(f"daemon identity: {exc}")
         try:
@@ -326,8 +321,8 @@ class MpsManager:
 
     def _dirty_state_report(self, state: _ExistingState) -> str:
         daemon = (
-            f"pid {state.daemon_pid} with verified native identity"
-            if state.daemon_pid is not None
+            f"pid {state.daemon_identity.pid} with verified native identity"
+            if state.daemon_identity is not None
             else "identity unverified"
         )
         owners = {

--- a/sglang_omni/mps/manager.py
+++ b/sglang_omni/mps/manager.py
@@ -56,10 +56,8 @@ class MpsClientRef:
     client_pid: int
 
 
-@dataclass(frozen=True, order=True)
+@dataclass(frozen=True)
 class MpsProcessIdentity:
-    """A native process PID paired with its immutable Linux start time."""
-
     pid: int
     starttime: int
 
@@ -76,8 +74,6 @@ class MpsLease:
 
     @property
     def daemon_pid(self) -> int:
-        """Keep the native daemon PID convenient for lifecycle callers."""
-
         return self.daemon_identity.pid
 
 
@@ -432,8 +428,6 @@ class MpsManager:
         }
 
     def verify(self, lease: MpsLease) -> set[MpsClientRef]:
-        """Gate startup on one current MPS client per managed process."""
-
         self._require_live_lease(lease)
         lease.attachment_verified = False
         lease.server_identities = frozenset()
@@ -454,32 +448,30 @@ class MpsManager:
                     expected_by_token[token]
                     for token in expected_by_token.keys() - observed_tokens
                 }
-                last_error = None
                 if not missing:
-                    server_pids = {client.server_pid for client in attached}
-                    if not server_pids:
-                        raise MpsControlError(
-                            "MPS startup verification found no managed server identity"
+                    server_pids = {ref.server_pid for ref in attached}
+                    try:
+                        server_identities = frozenset(
+                            self.client.read_server_process_identity(
+                                self.paths.pipe_dir,
+                                server_pid,
+                            )
+                            for server_pid in sorted(server_pids)
                         )
-                    lease.server_identities = frozenset(
-                        self.client.read_server_process_identity(
-                            self.paths.pipe_dir,
-                            server_pid,
-                        )
-                        for server_pid in sorted(server_pids)
-                    )
+                    except MpsControlError as exc:
+                        raise MpsError(
+                            "MPS startup verification could not prove server identity "
+                            f"(pipe dir {self.paths.pipe_dir}): {exc}. State dir "
+                            f"preserved for inspection: {self.paths.state_dir}"
+                        ) from exc
+                    lease.server_identities = server_identities
                     lease.attachment_verified = True
                     return attached
+                last_error = None
             except MpsControlError as exc:
                 last_error = exc
             if time.monotonic() >= deadline:
                 detail = f"; last control error: {last_error}" if last_error else ""
-                if not missing and last_error is not None:
-                    raise MpsError(
-                        f"MPS startup verification could not prove server identity "
-                        f"(pipe dir {self.paths.pipe_dir}): {last_error}. State dir "
-                        f"preserved for inspection: {self.paths.state_dir}"
-                    )
                 raise MpsError(
                     f"stage process(es) {sorted(missing)} never attached to the MPS "
                     f"server (pipe dir {self.paths.pipe_dir}){detail}. State dir "
@@ -514,37 +506,35 @@ class MpsManager:
         return targets
 
     def probe(self, lease: MpsLease) -> str | None:
-        """Check verified MPS session identities without control commands."""
-
         self._require_live_lease(lease)
         try:
             daemon_identity = self.client.read_daemon_process_identity(
                 self.paths.pipe_dir
             )
         except MpsControlError as exc:
-            return f"control identity query failed: {exc}"
+            return f"control identity unavailable: {exc}"
         if daemon_identity != lease.daemon_identity:
             expected = lease.daemon_identity
             return (
-                "control identity changed from "
-                f"pid {expected.pid} starttime {expected.starttime} to "
-                f"pid {daemon_identity.pid} starttime {daemon_identity.starttime}"
+                "control identity changed: "
+                f"expected {expected.pid}/{expected.starttime}, "
+                f"got {daemon_identity.pid}/{daemon_identity.starttime}"
             )
-        if not lease.attachment_verified or not lease.server_identities:
-            return "server identity was not captured during MPS attachment verification"
-        for expected in sorted(lease.server_identities):
+        if not lease.server_identities:
+            return "server identity unavailable"
+        for expected in lease.server_identities:
             try:
                 server_identity = self.client.read_server_process_identity(
                     self.paths.pipe_dir,
                     expected.pid,
                 )
             except MpsControlError as exc:
-                return f"server identity query failed for pid {expected.pid}: {exc}"
+                return f"server identity unavailable for pid {expected.pid}: {exc}"
             if server_identity != expected:
                 return (
-                    "server identity changed from "
-                    f"pid {expected.pid} starttime {expected.starttime} to "
-                    f"pid {server_identity.pid} starttime {server_identity.starttime}"
+                    "server identity changed: "
+                    f"expected {expected.pid}/{expected.starttime}, "
+                    f"got {server_identity.pid}/{server_identity.starttime}"
                 )
         return None
 

--- a/sglang_omni/mps/manager.py
+++ b/sglang_omni/mps/manager.py
@@ -467,15 +467,7 @@ class MpsManager:
         return targets
 
     def probe(self, lease: MpsLease) -> str | None:
-        """Prove the exact native daemon identity is still alive.
-
-        Steady-state health must not enumerate every MPS client. Client snapshots
-        are ownership/lifecycle operations and may contend when several independent
-        serve processes share one native daemon. ``read_daemon_identity`` already
-        proves the PID is live, non-zombie, names the MPS control binary, and owns
-        this exact pipe directory. Keep full snapshots for attach, retirement, and
-        release decisions where client ownership is actually required.
-        """
+        """Check steady state daemon identity without enumerating MPS clients."""
 
         self._require_live_lease(lease)
         try:

--- a/sglang_omni/mps/manager.py
+++ b/sglang_omni/mps/manager.py
@@ -467,7 +467,15 @@ class MpsManager:
         return targets
 
     def probe(self, lease: MpsLease) -> str | None:
-        """Return the first failed health proof, or ``None`` when healthy."""
+        """Prove the exact native daemon identity is still alive.
+
+        Steady-state health must not enumerate every MPS client. Client snapshots
+        are ownership/lifecycle operations and may contend when several independent
+        serve processes share one native daemon. ``read_daemon_identity`` already
+        proves the PID is live, non-zombie, names the MPS control binary, and owns
+        this exact pipe directory. Keep full snapshots for attach, retirement, and
+        release decisions where client ownership is actually required.
+        """
 
         self._require_live_lease(lease)
         try:
@@ -478,10 +486,6 @@ class MpsManager:
             return (
                 f"daemon identity changed from {lease.daemon_pid} " f"to {daemon_pid}"
             )
-        try:
-            self.client.snapshot(self.paths.pipe_dir)
-        except MpsControlError as exc:
-            return f"client snapshot query failed: {exc}"
         return None
 
     def release(

--- a/sglang_omni/mps/manager.py
+++ b/sglang_omni/mps/manager.py
@@ -56,14 +56,29 @@ class MpsClientRef:
     client_pid: int
 
 
+@dataclass(frozen=True, order=True)
+class MpsProcessIdentity:
+    """A native process PID paired with its immutable Linux start time."""
+
+    pid: int
+    starttime: int
+
+
 @dataclass
 class MpsLease:
     """All authority and runtime-local evidence owned by one acquisition."""
 
-    daemon_pid: int
+    daemon_identity: MpsProcessIdentity
     owner_fd: int
     client_tokens: dict[str, str]
     attachment_verified: bool = False
+    server_identities: frozenset[MpsProcessIdentity] = field(default_factory=frozenset)
+
+    @property
+    def daemon_pid(self) -> int:
+        """Keep the native daemon PID convenient for lifecycle callers."""
+
+        return self.daemon_identity.pid
 
 
 class MpsControlClient(Protocol):
@@ -72,6 +87,14 @@ class MpsControlClient(Protocol):
     def start_daemon(self, pipe_dir: Path, log_dir: Path, gpu_uuid: str) -> None: ...
 
     def read_daemon_identity(self, pipe_dir: Path) -> int: ...
+
+    def read_daemon_process_identity(self, pipe_dir: Path) -> MpsProcessIdentity: ...
+
+    def read_server_process_identity(
+        self,
+        pipe_dir: Path,
+        pid: int,
+    ) -> MpsProcessIdentity: ...
 
     def snapshot(self, pipe_dir: Path) -> set[MpsClientRef]: ...
 
@@ -89,6 +112,7 @@ class MpsControlClient(Protocol):
 @dataclass
 class _ExistingState:
     daemon_pid: int | None = None
+    daemon_identity: MpsProcessIdentity | None = None
     owners: dict[int, bool] = field(default_factory=dict)
     owner_statuses: dict[int, str] = field(default_factory=dict)
     clients: set[MpsClientRef] | None = None
@@ -154,8 +178,11 @@ class MpsManager:
             startup_error = exc
         else:
             try:
+                daemon_identity = self.client.read_daemon_process_identity(
+                    self.paths.pipe_dir
+                )
                 lease = MpsLease(
-                    daemon_pid=self.client.read_daemon_identity(self.paths.pipe_dir),
+                    daemon_identity=daemon_identity,
                     owner_fd=owner_fd,
                     client_tokens=client_tokens,
                 )
@@ -170,10 +197,11 @@ class MpsManager:
             cleanup_error: MpsError | None = None
             if lease is None:
                 try:
+                    daemon_identity = self.client.read_daemon_process_identity(
+                        self.paths.pipe_dir
+                    )
                     lease = MpsLease(
-                        daemon_pid=self.client.read_daemon_identity(
-                            self.paths.pipe_dir
-                        ),
+                        daemon_identity=daemon_identity,
                         owner_fd=owner_fd,
                         client_tokens=client_tokens,
                     )
@@ -195,6 +223,7 @@ class MpsManager:
         if (
             not state.errors
             and state.daemon_pid is not None
+            and state.daemon_identity is not None
             and state.clients is not None
             and state.owners
             and all(state.owners.values())
@@ -208,7 +237,7 @@ class MpsManager:
                 sorted(state.owners),
             )
             return MpsLease(
-                daemon_pid=state.daemon_pid,
+                daemon_identity=state.daemon_identity,
                 owner_fd=owner_fd,
                 client_tokens=client_tokens,
             )
@@ -270,7 +299,10 @@ class MpsManager:
     def _inspect_existing_state(self) -> _ExistingState:
         state = _ExistingState()
         try:
-            state.daemon_pid = self.client.read_daemon_identity(self.paths.pipe_dir)
+            state.daemon_identity = self.client.read_daemon_process_identity(
+                self.paths.pipe_dir
+            )
+            state.daemon_pid = state.daemon_identity.pid
         except MpsControlError as exc:
             state.errors.append(f"daemon identity: {exc}")
         try:
@@ -408,6 +440,8 @@ class MpsManager:
         """Gate startup on one current MPS client per managed process."""
 
         self._require_live_lease(lease)
+        lease.attachment_verified = False
+        lease.server_identities = frozenset()
         expected_by_token = {
             token: process_name for process_name, token in lease.client_tokens.items()
         }
@@ -427,12 +461,30 @@ class MpsManager:
                 }
                 last_error = None
                 if not missing:
+                    server_pids = {client.server_pid for client in attached}
+                    if not server_pids:
+                        raise MpsControlError(
+                            "MPS startup verification found no managed server identity"
+                        )
+                    lease.server_identities = frozenset(
+                        self.client.read_server_process_identity(
+                            self.paths.pipe_dir,
+                            server_pid,
+                        )
+                        for server_pid in sorted(server_pids)
+                    )
                     lease.attachment_verified = True
                     return attached
             except MpsControlError as exc:
                 last_error = exc
             if time.monotonic() >= deadline:
                 detail = f"; last control error: {last_error}" if last_error else ""
+                if not missing and last_error is not None:
+                    raise MpsError(
+                        f"MPS startup verification could not prove server identity "
+                        f"(pipe dir {self.paths.pipe_dir}): {last_error}. State dir "
+                        f"preserved for inspection: {self.paths.state_dir}"
+                    )
                 raise MpsError(
                     f"stage process(es) {sorted(missing)} never attached to the MPS "
                     f"server (pipe dir {self.paths.pipe_dir}){detail}. State dir "
@@ -467,15 +519,38 @@ class MpsManager:
         return targets
 
     def probe(self, lease: MpsLease) -> str | None:
-        """Check steady state daemon identity without enumerating MPS clients."""
+        """Check verified MPS session identities without control commands."""
 
         self._require_live_lease(lease)
         try:
-            daemon_pid = self.client.read_daemon_identity(self.paths.pipe_dir)
+            daemon_identity = self.client.read_daemon_process_identity(
+                self.paths.pipe_dir
+            )
         except MpsControlError as exc:
-            return f"daemon identity query failed: {exc}"
-        if daemon_pid != lease.daemon_pid:
-            return f"daemon identity changed from {lease.daemon_pid} to {daemon_pid}"
+            return f"control identity query failed: {exc}"
+        if daemon_identity != lease.daemon_identity:
+            expected = lease.daemon_identity
+            return (
+                "control identity changed from "
+                f"pid {expected.pid} starttime {expected.starttime} to "
+                f"pid {daemon_identity.pid} starttime {daemon_identity.starttime}"
+            )
+        if not lease.attachment_verified or not lease.server_identities:
+            return "server identity was not captured during MPS attachment verification"
+        for expected in sorted(lease.server_identities):
+            try:
+                server_identity = self.client.read_server_process_identity(
+                    self.paths.pipe_dir,
+                    expected.pid,
+                )
+            except MpsControlError as exc:
+                return f"server identity query failed for pid {expected.pid}: {exc}"
+            if server_identity != expected:
+                return (
+                    "server identity changed from "
+                    f"pid {expected.pid} starttime {expected.starttime} to "
+                    f"pid {server_identity.pid} starttime {server_identity.starttime}"
+                )
         return None
 
     def release(
@@ -534,13 +609,15 @@ class MpsManager:
             self._wait_for_owned_clients_to_detach(lease)
 
         try:
-            daemon_pid = self.client.read_daemon_identity(self.paths.pipe_dir)
+            daemon_identity = self.client.read_daemon_process_identity(
+                self.paths.pipe_dir
+            )
             snapshot = self.client.snapshot(self.paths.pipe_dir)
         except MpsControlError:
             raise
-        if daemon_pid != lease.daemon_pid:
+        if daemon_identity != lease.daemon_identity:
             raise MpsError(
-                f"MPS daemon identity changed from {lease.daemon_pid} to {daemon_pid}; "
+                "MPS control identity changed during release; "
                 "owner lease and shared state preserved"
             )
 
@@ -621,11 +698,13 @@ class MpsManager:
         except BaseException as exc:
             status_error = exc
 
-        observed_daemon_pid: int | None = None
+        observed_daemon_identity: MpsProcessIdentity | None = None
         owned_clients: set[MpsClientRef] | None = None
         query_error: MpsControlError | None = None
         try:
-            observed_daemon_pid = self.client.read_daemon_identity(self.paths.pipe_dir)
+            observed_daemon_identity = self.client.read_daemon_process_identity(
+                self.paths.pipe_dir
+            )
             if clients is None:
                 clients = self.client.snapshot(self.paths.pipe_dir)
             owned_clients, _, _ = self._classify_clients(clients, lease)
@@ -643,8 +722,8 @@ class MpsManager:
             else f"unconfirmed because the retained-status write failed: {status_error}"
         )
         observed = (
-            str(observed_daemon_pid)
-            if observed_daemon_pid is not None
+            str(observed_daemon_identity.pid)
+            if observed_daemon_identity is not None
             else f"unavailable ({query_error})"
         )
         snapshot = "unavailable" if clients is None else repr(sorted(clients))

--- a/tests/test_ci/test_mps_native.py
+++ b/tests/test_ci/test_mps_native.py
@@ -324,7 +324,7 @@ def _operator_cleanup(session_ids: int | Iterable[int]) -> None:
     daemon_pids: dict[Path, int] = {}
     try:
         for pipe_dir in pipe_dirs:
-            daemon_pids[pipe_dir] = control.read_daemon_identity(pipe_dir)
+            daemon_pids[pipe_dir] = control.read_daemon_process_identity(pipe_dir).pid
             control.snapshot(pipe_dir)
     finally:
         _signal_test_sessions(live_sessions, signal.SIGKILL)

--- a/tests/unit_test/mps/test_mps_control.py
+++ b/tests/unit_test/mps/test_mps_control.py
@@ -14,7 +14,13 @@ from sglang_omni.mps.manager import (
     MpsClientRef,
     MpsControlError,
     MpsDaemonNotStartedError,
+    MpsProcessIdentity,
 )
+
+
+def _proc_stat(pid: int, comm: str, state: str, starttime: int) -> str:
+    fields = [state, "1"] + ["0"] * 17 + [str(starttime)]
+    return f"{pid} ({comm}) " + " ".join(fields)
 
 
 def test_snapshot_parses_driver_output_and_retains_server_client_pairs(
@@ -23,7 +29,11 @@ def test_snapshot_parses_driver_output_and_retains_server_client_pairs(
     pipe_dir = tmp_path / "pipe"
     pipe_dir.mkdir()
     client = control.SubprocessMpsControlClient()
-    monkeypatch.setattr(client, "read_daemon_identity", lambda _pipe: 123)
+    monkeypatch.setattr(
+        client,
+        "read_daemon_process_identity",
+        lambda _pipe: MpsProcessIdentity(123, 1),
+    )
     monkeypatch.setattr(control.time, "sleep", lambda _seconds: None)
     responses = {
         "get_server_list\n": "7000  8000\n",
@@ -56,7 +66,11 @@ def test_snapshot_holds_one_control_lock_across_all_queries(monkeypatch, tmp_pat
     pipe_dir = tmp_path / "pipe"
     pipe_dir.mkdir()
     client = control.SubprocessMpsControlClient()
-    monkeypatch.setattr(client, "read_daemon_identity", lambda _pipe: 123)
+    monkeypatch.setattr(
+        client,
+        "read_daemon_process_identity",
+        lambda _pipe: MpsProcessIdentity(123, 1),
+    )
     events: list[str] = []
     responses = {
         "get_server_list\n": "7000 8000\n",
@@ -99,7 +113,11 @@ def test_snapshot_retries_transient_query_failure_while_identity_is_stable(
     pipe_dir = tmp_path / "pipe"
     pipe_dir.mkdir()
     client = control.SubprocessMpsControlClient()
-    monkeypatch.setattr(client, "read_daemon_identity", lambda _pipe: 123)
+    monkeypatch.setattr(
+        client,
+        "read_daemon_process_identity",
+        lambda _pipe: MpsProcessIdentity(123, 1),
+    )
     monkeypatch.setattr(control.time, "sleep", lambda _seconds: None)
     calls: list[str] = []
     first_server_query = True
@@ -137,8 +155,17 @@ def test_snapshot_aborts_retry_when_daemon_identity_changes(monkeypatch, tmp_pat
     pipe_dir = tmp_path / "pipe"
     pipe_dir.mkdir()
     client = control.SubprocessMpsControlClient()
-    identities = iter([123, 124])
-    monkeypatch.setattr(client, "read_daemon_identity", lambda _pipe: next(identities))
+    identities = iter(
+        [
+            MpsProcessIdentity(123, 1),
+            MpsProcessIdentity(124, 1),
+        ]
+    )
+    monkeypatch.setattr(
+        client,
+        "read_daemon_process_identity",
+        lambda _pipe: next(identities),
+    )
     calls = 0
 
     def run(args, **kwargs):
@@ -163,7 +190,11 @@ def test_snapshot_rejects_nonzero_exit_and_timeout(monkeypatch, tmp_path):
     pipe_dir = tmp_path / "pipe"
     pipe_dir.mkdir()
     client = control.SubprocessMpsControlClient()
-    monkeypatch.setattr(client, "read_daemon_identity", lambda _pipe: 123)
+    monkeypatch.setattr(
+        client,
+        "read_daemon_process_identity",
+        lambda _pipe: MpsProcessIdentity(123, 1),
+    )
     monkeypatch.setattr(control.time, "sleep", lambda _seconds: None)
 
     def nonzero(args, **kwargs):
@@ -240,8 +271,10 @@ def test_daemon_identity_requires_exact_binary_and_pipe_environment(monkeypatch)
     environ = [b"CUDA_MPS_PIPE_DIRECTORY=/mps/pipe", b"PATH=/usr/bin", b""]
 
     def read_text(path):
-        assert path == pipe_dir / "nvidia-cuda-mps-control.pid"
-        return "123\n"
+        if path == pipe_dir / "nvidia-cuda-mps-control.pid":
+            return "123\n"
+        assert path == Path("/proc/123/stat")
+        return _proc_stat(123, "nvidia-cuda-mps-control", "T", 42)
 
     def read_bytes(path):
         if path == Path("/proc/123/cmdline"):
@@ -251,13 +284,136 @@ def test_daemon_identity_requires_exact_binary_and_pipe_environment(monkeypatch)
 
     monkeypatch.setattr(Path, "read_text", read_text)
     monkeypatch.setattr(Path, "read_bytes", read_bytes)
-    monkeypatch.setattr(client, "daemon_process_alive", lambda pid: pid == 123)
 
+    assert client.read_daemon_process_identity(pipe_dir) == MpsProcessIdentity(123, 42)
     assert client.read_daemon_identity(pipe_dir) == 123
 
     environ[0] = b"CUDA_MPS_PIPE_DIRECTORY=/another/pipe"
     with pytest.raises(MpsControlError, match="exact pipe directory"):
-        client.read_daemon_identity(pipe_dir)
+        client.read_daemon_process_identity(pipe_dir)
+
+    environ[0] = b"CUDA_MPS_PIPE_DIRECTORY=/mps/pipe"
+    monkeypatch.setattr(
+        Path,
+        "read_bytes",
+        lambda path: (
+            b"/usr/bin/python\x00"
+            if path == Path("/proc/123/cmdline")
+            else b"\x00".join(environ)
+        ),
+    )
+    with pytest.raises(MpsControlError, match="not nvidia-cuda-mps-control"):
+        client.read_daemon_process_identity(pipe_dir)
+
+
+@pytest.mark.parametrize("state", ["R", "S", "D", "T"])
+def test_process_identity_accepts_non_zombie_states(monkeypatch, state):
+    pipe_dir = Path("/mps/pipe")
+    client = control.SubprocessMpsControlClient()
+
+    monkeypatch.setattr(
+        Path,
+        "read_text",
+        lambda _path: _proc_stat(456, "nvidia-cuda-mps-server", state, 84),
+    )
+
+    def read_bytes(path):
+        if path == Path("/proc/456/cmdline"):
+            return b"/usr/bin/nvidia-cuda-mps-server\x00"
+        assert path == Path("/proc/456/environ")
+        return b"CUDA_MPS_PIPE_DIRECTORY=/mps/pipe\x00"
+
+    monkeypatch.setattr(Path, "read_bytes", read_bytes)
+
+    assert client.read_server_process_identity(pipe_dir, 456) == MpsProcessIdentity(
+        456, 84
+    )
+
+
+def test_process_identity_rejects_missing_or_zombie_process(monkeypatch):
+    pipe_dir = Path("/mps/pipe")
+    client = control.SubprocessMpsControlClient()
+
+    def missing(_path):
+        raise FileNotFoundError("gone")
+
+    monkeypatch.setattr(Path, "read_text", missing)
+    with pytest.raises(MpsControlError, match="does not exist"):
+        client.read_server_process_identity(pipe_dir, 456)
+
+    monkeypatch.setattr(
+        Path,
+        "read_text",
+        lambda _path: _proc_stat(456, "nvidia-cuda-mps-server", "Z", 84),
+    )
+    with pytest.raises(MpsControlError, match="zombie"):
+        client.read_server_process_identity(pipe_dir, 456)
+
+
+def test_process_identity_rejects_starttime_change_during_capture(monkeypatch):
+    pipe_dir = Path("/mps/pipe")
+    client = control.SubprocessMpsControlClient()
+    stats = iter(
+        [
+            _proc_stat(456, "nvidia-cuda-mps-server", "S", 84),
+            _proc_stat(456, "nvidia-cuda-mps-server", "S", 85),
+        ]
+    )
+    monkeypatch.setattr(Path, "read_text", lambda _path: next(stats))
+    monkeypatch.setattr(
+        Path,
+        "read_bytes",
+        lambda path: (
+            b"/usr/bin/nvidia-cuda-mps-server\x00"
+            if path == Path("/proc/456/cmdline")
+            else b"CUDA_MPS_PIPE_DIRECTORY=/mps/pipe\x00"
+        ),
+    )
+
+    with pytest.raises(MpsControlError, match="changed identity during inspection"):
+        client.read_server_process_identity(pipe_dir, 456)
+
+
+@pytest.mark.parametrize(
+    ("cmdline", "environ", "message"),
+    [
+        (
+            b"/usr/bin/python\x00",
+            b"CUDA_MPS_PIPE_DIRECTORY=/mps/pipe\x00",
+            "not nvidia-cuda-mps-server",
+        ),
+        (
+            b"/usr/bin/nvidia-cuda-mps-server\x00",
+            b"CUDA_MPS_PIPE_DIRECTORY=/other/pipe\x00",
+            "exact pipe directory",
+        ),
+    ],
+)
+def test_server_process_identity_requires_expected_binary_and_pipe(
+    monkeypatch,
+    cmdline,
+    environ,
+    message,
+):
+    pipe_dir = Path("/mps/pipe")
+    client = control.SubprocessMpsControlClient()
+
+    monkeypatch.setattr(
+        Path,
+        "read_text",
+        lambda _path: _proc_stat(456, "nvidia-cuda-mps-server", "S", 84),
+    )
+
+    def read_bytes(path):
+        if path == Path("/proc/456/cmdline"):
+            return cmdline
+        assert path == Path("/proc/456/environ")
+        return environ
+
+    monkeypatch.setattr(Path, "read_bytes", read_bytes)
+
+    with pytest.raises(MpsControlError, match=message):
+        client.read_server_process_identity(pipe_dir, 456)
 
 
 def test_owner_liveness_comes_from_the_kernel_held_lease(tmp_path):

--- a/tests/unit_test/mps/test_mps_control.py
+++ b/tests/unit_test/mps/test_mps_control.py
@@ -168,33 +168,6 @@ def test_snapshot_rejects_nonzero_exit_and_timeout(monkeypatch, tmp_path):
         client.snapshot(pipe_dir)
 
 
-def test_mutating_control_query_is_serialized(monkeypatch, tmp_path):
-    pipe_dir = tmp_path / "pipe"
-    pipe_dir.mkdir()
-    client = control.SubprocessMpsControlClient()
-    events: list[str] = []
-
-    def flock(_file, operation):
-        if operation == fcntl.LOCK_EX:
-            events.append("lock")
-
-    def run(args, **kwargs):
-        events.append(kwargs["input"].strip())
-        return subprocess.CompletedProcess(
-            args,
-            returncode=2,
-            stdout="",
-            stderr="control failed",
-        )
-
-    monkeypatch.setattr(control.fcntl, "flock", flock)
-    monkeypatch.setattr(control.subprocess, "run", run)
-
-    with pytest.raises(MpsControlError, match="control failed"):
-        client.quit_daemon(pipe_dir)
-    assert events == ["lock", "quit"]
-
-
 def test_daemon_preexec_failure_is_distinct_from_ambiguous_start(monkeypatch):
     client = control.SubprocessMpsControlClient()
 
@@ -208,12 +181,9 @@ def test_daemon_preexec_failure_is_distinct_from_ambiguous_start(monkeypatch):
         client.start_daemon(Path("/mps/pipe"), Path("/mps/log"), "GPU-abc")
 
 
-def test_daemon_process_identity_requires_exact_binary_and_pipe_environment(
-    monkeypatch,
-):
+def test_daemon_process_identity_from_native_pid_file(monkeypatch):
     pipe_dir = Path("/mps/pipe")
     client = control.SubprocessMpsControlClient()
-    environ = [b"CUDA_MPS_PIPE_DIRECTORY=/mps/pipe", b"PATH=/usr/bin", b""]
 
     def read_text(path):
         if path == pipe_dir / "nvidia-cuda-mps-control.pid":
@@ -225,128 +195,71 @@ def test_daemon_process_identity_requires_exact_binary_and_pipe_environment(
         if path == Path("/proc/123/cmdline"):
             return b"/usr/bin/nvidia-cuda-mps-control\x00-d\x00"
         assert path == Path("/proc/123/environ")
-        return b"\x00".join(environ)
+        return b"CUDA_MPS_PIPE_DIRECTORY=/mps/pipe\x00"
 
     monkeypatch.setattr(Path, "read_text", read_text)
     monkeypatch.setattr(Path, "read_bytes", read_bytes)
 
     assert client.read_daemon_process_identity(pipe_dir) == MpsProcessIdentity(123, 42)
 
-    environ[0] = b"CUDA_MPS_PIPE_DIRECTORY=/another/pipe"
-    with pytest.raises(MpsControlError, match="exact pipe directory"):
-        client.read_daemon_process_identity(pipe_dir)
-
-    environ[0] = b"CUDA_MPS_PIPE_DIRECTORY=/mps/pipe"
-    monkeypatch.setattr(
-        Path,
-        "read_bytes",
-        lambda path: (
-            b"/usr/bin/python\x00"
-            if path == Path("/proc/123/cmdline")
-            else b"\x00".join(environ)
-        ),
-    )
-    with pytest.raises(MpsControlError, match="not nvidia-cuda-mps-control"):
-        client.read_daemon_process_identity(pipe_dir)
-
-
-@pytest.mark.parametrize("state", ["R", "S", "D", "T"])
-def test_process_identity_accepts_non_zombie_states(monkeypatch, state):
-    pipe_dir = Path("/mps/pipe")
-    client = control.SubprocessMpsControlClient()
-
-    monkeypatch.setattr(
-        Path,
-        "read_text",
-        lambda _path: _proc_stat(456, "nvidia-cuda-mps-server", state, 84),
-    )
-
-    def read_bytes(path):
-        if path == Path("/proc/456/cmdline"):
-            return b"/usr/bin/nvidia-cuda-mps-server\x00"
-        assert path == Path("/proc/456/environ")
-        return b"CUDA_MPS_PIPE_DIRECTORY=/mps/pipe\x00"
-
-    monkeypatch.setattr(Path, "read_bytes", read_bytes)
-
-    assert client.read_server_process_identity(pipe_dir, 456) == MpsProcessIdentity(
-        456, 84
-    )
-
-
-def test_process_identity_rejects_missing_or_zombie_process(monkeypatch):
-    pipe_dir = Path("/mps/pipe")
-    client = control.SubprocessMpsControlClient()
-
-    def missing(_path):
-        raise FileNotFoundError("gone")
-
-    monkeypatch.setattr(Path, "read_text", missing)
-    with pytest.raises(MpsControlError, match="does not exist"):
-        client.read_server_process_identity(pipe_dir, 456)
-
-    monkeypatch.setattr(
-        Path,
-        "read_text",
-        lambda _path: _proc_stat(456, "nvidia-cuda-mps-server", "Z", 84),
-    )
-    with pytest.raises(MpsControlError, match="zombie"):
-        client.read_server_process_identity(pipe_dir, 456)
-
-
-def test_process_identity_rejects_starttime_change_during_capture(monkeypatch):
-    pipe_dir = Path("/mps/pipe")
-    client = control.SubprocessMpsControlClient()
-    stats = iter(
-        [
-            _proc_stat(456, "nvidia-cuda-mps-server", "S", 84),
-            _proc_stat(456, "nvidia-cuda-mps-server", "S", 85),
-        ]
-    )
-    monkeypatch.setattr(Path, "read_text", lambda _path: next(stats))
-    monkeypatch.setattr(
-        Path,
-        "read_bytes",
-        lambda path: (
-            b"/usr/bin/nvidia-cuda-mps-server\x00"
-            if path == Path("/proc/456/cmdline")
-            else b"CUDA_MPS_PIPE_DIRECTORY=/mps/pipe\x00"
-        ),
-    )
-
-    with pytest.raises(MpsControlError, match="changed identity during inspection"):
-        client.read_server_process_identity(pipe_dir, 456)
-
 
 @pytest.mark.parametrize(
-    ("cmdline", "environ", "message"),
+    ("stat_texts", "cmdline", "environ", "message"),
     [
         (
+            (_proc_stat(456, "nvidia-cuda-mps-server", "T", 84),) * 2,
+            b"/usr/bin/nvidia-cuda-mps-server\x00",
+            b"CUDA_MPS_PIPE_DIRECTORY=/mps/pipe\x00",
+            None,
+        ),
+        ((), b"", b"", "does not exist"),
+        (
+            (_proc_stat(456, "nvidia-cuda-mps-server", "Z", 84),) * 2,
+            b"",
+            b"",
+            "zombie",
+        ),
+        (
+            (_proc_stat(456, "nvidia-cuda-mps-server", "S", 84),) * 2,
             b"/usr/bin/python\x00",
             b"CUDA_MPS_PIPE_DIRECTORY=/mps/pipe\x00",
             "not nvidia-cuda-mps-server",
         ),
         (
+            (_proc_stat(456, "nvidia-cuda-mps-server", "S", 84),) * 2,
             b"/usr/bin/nvidia-cuda-mps-server\x00",
             b"CUDA_MPS_PIPE_DIRECTORY=/other/pipe\x00",
             "exact pipe directory",
         ),
+        (
+            (
+                _proc_stat(456, "nvidia-cuda-mps-server", "S", 84),
+                _proc_stat(456, "nvidia-cuda-mps-server", "S", 85),
+            ),
+            b"/usr/bin/nvidia-cuda-mps-server\x00",
+            b"CUDA_MPS_PIPE_DIRECTORY=/mps/pipe\x00",
+            "changed identity during inspection",
+        ),
     ],
 )
-def test_server_process_identity_requires_expected_binary_and_pipe(
+def test_server_process_identity_contract(
     monkeypatch,
+    stat_texts,
     cmdline,
     environ,
     message,
 ):
     pipe_dir = Path("/mps/pipe")
     client = control.SubprocessMpsControlClient()
+    stats = iter(stat_texts)
 
-    monkeypatch.setattr(
-        Path,
-        "read_text",
-        lambda _path: _proc_stat(456, "nvidia-cuda-mps-server", "S", 84),
-    )
+    def read_text(_path):
+        try:
+            return next(stats)
+        except StopIteration as exc:
+            raise FileNotFoundError("gone") from exc
+
+    monkeypatch.setattr(Path, "read_text", read_text)
 
     def read_bytes(path):
         if path == Path("/proc/456/cmdline"):
@@ -356,8 +269,13 @@ def test_server_process_identity_requires_expected_binary_and_pipe(
 
     monkeypatch.setattr(Path, "read_bytes", read_bytes)
 
-    with pytest.raises(MpsControlError, match=message):
-        client.read_server_process_identity(pipe_dir, 456)
+    if message is None:
+        assert client.read_server_process_identity(pipe_dir, 456) == (
+            MpsProcessIdentity(456, 84)
+        )
+    else:
+        with pytest.raises(MpsControlError, match=message):
+            client.read_server_process_identity(pipe_dir, 456)
 
 
 def test_owner_liveness_comes_from_the_kernel_held_lease(tmp_path):

--- a/tests/unit_test/mps/test_mps_control.py
+++ b/tests/unit_test/mps/test_mps_control.py
@@ -75,8 +75,6 @@ def test_snapshot_holds_one_control_lock_across_all_queries(monkeypatch, tmp_pat
     def flock(_file, operation):
         if operation == fcntl.LOCK_EX:
             events.append("lock")
-        elif operation == fcntl.LOCK_UN:
-            events.append("unlock")
 
     def run(args, **kwargs):
         command = kwargs["input"].strip()
@@ -100,7 +98,6 @@ def test_snapshot_holds_one_control_lock_across_all_queries(monkeypatch, tmp_pat
         "get_server_list",
         "get_client_list 7000",
         "get_client_list 8000",
-        "unlock",
     ]
 
 
@@ -205,8 +202,6 @@ def test_mutating_control_query_is_serialized_without_retry(monkeypatch, tmp_pat
     def flock(_file, operation):
         if operation == fcntl.LOCK_EX:
             events.append("lock")
-        elif operation == fcntl.LOCK_UN:
-            events.append("unlock")
 
     def run(args, **kwargs):
         events.append(kwargs["input"].strip())
@@ -222,7 +217,7 @@ def test_mutating_control_query_is_serialized_without_retry(monkeypatch, tmp_pat
 
     with pytest.raises(MpsControlError, match="control failed"):
         client.quit_daemon(pipe_dir)
-    assert events == ["lock", "quit", "unlock"]
+    assert events == ["lock", "quit"]
 
 
 def test_daemon_preexec_failure_is_distinct_from_ambiguous_start(monkeypatch):

--- a/tests/unit_test/mps/test_mps_control.py
+++ b/tests/unit_test/mps/test_mps_control.py
@@ -34,7 +34,6 @@ def test_snapshot_parses_driver_output_and_retains_server_client_pairs(
         "read_daemon_process_identity",
         lambda _pipe: MpsProcessIdentity(123, 1),
     )
-    monkeypatch.setattr(control.time, "sleep", lambda _seconds: None)
     responses = {
         "get_server_list\n": "7000  8000\n",
         "get_client_list 7000\n": "101\n102\n",
@@ -107,51 +106,7 @@ def test_snapshot_holds_one_control_lock_across_all_queries(monkeypatch, tmp_pat
     ]
 
 
-def test_snapshot_retries_transient_query_failure_while_identity_is_stable(
-    monkeypatch, tmp_path
-):
-    pipe_dir = tmp_path / "pipe"
-    pipe_dir.mkdir()
-    client = control.SubprocessMpsControlClient()
-    monkeypatch.setattr(
-        client,
-        "read_daemon_process_identity",
-        lambda _pipe: MpsProcessIdentity(123, 1),
-    )
-    monkeypatch.setattr(control.time, "sleep", lambda _seconds: None)
-    calls: list[str] = []
-    first_server_query = True
-
-    def run(args, **kwargs):
-        nonlocal first_server_query
-        command = kwargs["input"]
-        calls.append(command.strip())
-        if command == "get_server_list\n" and first_server_query:
-            first_server_query = False
-            return subprocess.CompletedProcess(
-                args,
-                returncode=1,
-                stdout="",
-                stderr="Cannot send command to MPS control daemon process",
-            )
-        responses = {
-            "get_server_list\n": "7000\n",
-            "get_client_list 7000\n": "101\n",
-        }
-        return subprocess.CompletedProcess(
-            args,
-            returncode=0,
-            stdout=responses[command],
-            stderr="",
-        )
-
-    monkeypatch.setattr(control.subprocess, "run", run)
-
-    assert client.snapshot(pipe_dir) == {MpsClientRef(7000, 101)}
-    assert calls == ["get_server_list", "get_server_list", "get_client_list 7000"]
-
-
-def test_snapshot_aborts_retry_when_daemon_identity_changes(monkeypatch, tmp_path):
+def test_snapshot_rejects_daemon_identity_change(monkeypatch, tmp_path):
     pipe_dir = tmp_path / "pipe"
     pipe_dir.mkdir()
     client = control.SubprocessMpsControlClient()
@@ -166,24 +121,19 @@ def test_snapshot_aborts_retry_when_daemon_identity_changes(monkeypatch, tmp_pat
         "read_daemon_process_identity",
         lambda _pipe: next(identities),
     )
-    calls = 0
 
     def run(args, **kwargs):
-        nonlocal calls
-        del kwargs
-        calls += 1
         return subprocess.CompletedProcess(
             args,
-            returncode=1,
-            stdout="",
-            stderr="control failed",
+            returncode=0,
+            stdout="7000\n" if kwargs["input"] == "get_server_list\n" else "101\n",
+            stderr="",
         )
 
     monkeypatch.setattr(control.subprocess, "run", run)
 
     with pytest.raises(MpsControlError, match="identity changed.*123.*124"):
         client.snapshot(pipe_dir)
-    assert calls == 1
 
 
 def test_snapshot_rejects_nonzero_exit_and_timeout(monkeypatch, tmp_path):
@@ -195,7 +145,6 @@ def test_snapshot_rejects_nonzero_exit_and_timeout(monkeypatch, tmp_path):
         "read_daemon_process_identity",
         lambda _pipe: MpsProcessIdentity(123, 1),
     )
-    monkeypatch.setattr(control.time, "sleep", lambda _seconds: None)
 
     def nonzero(args, **kwargs):
         del kwargs
@@ -207,10 +156,7 @@ def test_snapshot_rejects_nonzero_exit_and_timeout(monkeypatch, tmp_path):
         )
 
     monkeypatch.setattr(control.subprocess, "run", nonzero)
-    with pytest.raises(
-        MpsControlError,
-        match="snapshot failed after 3 attempts: .*control failed",
-    ):
+    with pytest.raises(MpsControlError, match="control failed"):
         client.snapshot(pipe_dir)
 
     def timeout(args, **kwargs):
@@ -218,14 +164,11 @@ def test_snapshot_rejects_nonzero_exit_and_timeout(monkeypatch, tmp_path):
         raise subprocess.TimeoutExpired(args, 10)
 
     monkeypatch.setattr(control.subprocess, "run", timeout)
-    with pytest.raises(
-        MpsControlError,
-        match="snapshot failed after 3 attempts: .*timed out",
-    ):
+    with pytest.raises(MpsControlError, match="timed out"):
         client.snapshot(pipe_dir)
 
 
-def test_mutating_control_query_is_serialized_without_retry(monkeypatch, tmp_path):
+def test_mutating_control_query_is_serialized(monkeypatch, tmp_path):
     pipe_dir = tmp_path / "pipe"
     pipe_dir.mkdir()
     client = control.SubprocessMpsControlClient()
@@ -265,7 +208,9 @@ def test_daemon_preexec_failure_is_distinct_from_ambiguous_start(monkeypatch):
         client.start_daemon(Path("/mps/pipe"), Path("/mps/log"), "GPU-abc")
 
 
-def test_daemon_identity_requires_exact_binary_and_pipe_environment(monkeypatch):
+def test_daemon_process_identity_requires_exact_binary_and_pipe_environment(
+    monkeypatch,
+):
     pipe_dir = Path("/mps/pipe")
     client = control.SubprocessMpsControlClient()
     environ = [b"CUDA_MPS_PIPE_DIRECTORY=/mps/pipe", b"PATH=/usr/bin", b""]
@@ -286,7 +231,6 @@ def test_daemon_identity_requires_exact_binary_and_pipe_environment(monkeypatch)
     monkeypatch.setattr(Path, "read_bytes", read_bytes)
 
     assert client.read_daemon_process_identity(pipe_dir) == MpsProcessIdentity(123, 42)
-    assert client.read_daemon_identity(pipe_dir) == 123
 
     environ[0] = b"CUDA_MPS_PIPE_DIRECTORY=/another/pipe"
     with pytest.raises(MpsControlError, match="exact pipe directory"):

--- a/tests/unit_test/mps/test_mps_control.py
+++ b/tests/unit_test/mps/test_mps_control.py
@@ -17,7 +17,23 @@ from sglang_omni.mps.manager import (
 )
 
 
-def test_snapshot_parses_driver_output_and_retains_server_client_pairs(monkeypatch):
+def _test_pipe_dir(tmp_path: Path) -> Path:
+    pipe_dir = tmp_path / "GPU-test" / "pipe"
+    pipe_dir.mkdir(parents=True)
+    return pipe_dir
+
+
+def _stable_identity(monkeypatch, client, pid: int = 123) -> None:
+    monkeypatch.setattr(client, "read_daemon_identity", lambda _pipe: pid)
+
+
+def test_snapshot_parses_driver_output_and_retains_server_client_pairs(
+    monkeypatch, tmp_path
+):
+    pipe_dir = _test_pipe_dir(tmp_path)
+    client = control.SubprocessMpsControlClient()
+    _stable_identity(monkeypatch, client)
+    monkeypatch.setattr(control.time, "sleep", lambda _seconds: None)
     responses = {
         "get_server_list\n": "7000  8000\n",
         "get_client_list 7000\n": "101\n102\n",
@@ -34,7 +50,7 @@ def test_snapshot_parses_driver_output_and_retains_server_client_pairs(monkeypat
 
     monkeypatch.setattr(control.subprocess, "run", run)
 
-    assert control.SubprocessMpsControlClient().snapshot(Path("/mps/pipe")) == {
+    assert client.snapshot(pipe_dir) == {
         MpsClientRef(7000, 101),
         MpsClientRef(7000, 102),
         MpsClientRef(8000, 909),
@@ -42,11 +58,122 @@ def test_snapshot_parses_driver_output_and_retains_server_client_pairs(monkeypat
 
     responses["get_client_list 7000\n"] = "101\nserver=202\n"
     with pytest.raises(MpsControlError, match="unexpected output"):
-        control.SubprocessMpsControlClient().snapshot(Path("/mps/pipe"))
+        client.snapshot(pipe_dir)
 
 
-def test_control_query_rejects_nonzero_exit_and_timeout(monkeypatch):
+def test_snapshot_holds_one_control_lock_across_all_queries(monkeypatch, tmp_path):
+    pipe_dir = _test_pipe_dir(tmp_path)
     client = control.SubprocessMpsControlClient()
+    _stable_identity(monkeypatch, client)
+    events: list[str] = []
+    responses = {
+        "get_server_list\n": "7000 8000\n",
+        "get_client_list 7000\n": "101\n",
+        "get_client_list 8000\n": "202\n",
+    }
+
+    def flock(_file, operation):
+        if operation == fcntl.LOCK_EX:
+            events.append("lock")
+        elif operation == fcntl.LOCK_UN:
+            events.append("unlock")
+
+    def run(args, **kwargs):
+        command = kwargs["input"].strip()
+        events.append(command)
+        return subprocess.CompletedProcess(
+            args,
+            returncode=0,
+            stdout=responses[kwargs["input"]],
+            stderr="",
+        )
+
+    monkeypatch.setattr(control.fcntl, "flock", flock)
+    monkeypatch.setattr(control.subprocess, "run", run)
+
+    assert client.snapshot(pipe_dir) == {
+        MpsClientRef(7000, 101),
+        MpsClientRef(8000, 202),
+    }
+    assert events == [
+        "lock",
+        "get_server_list",
+        "get_client_list 7000",
+        "get_client_list 8000",
+        "unlock",
+    ]
+
+
+def test_snapshot_retries_transient_query_failure_while_identity_is_stable(
+    monkeypatch, tmp_path
+):
+    pipe_dir = _test_pipe_dir(tmp_path)
+    client = control.SubprocessMpsControlClient()
+    _stable_identity(monkeypatch, client)
+    monkeypatch.setattr(control.time, "sleep", lambda _seconds: None)
+    calls: list[str] = []
+    first_server_query = True
+
+    def run(args, **kwargs):
+        nonlocal first_server_query
+        command = kwargs["input"]
+        calls.append(command.strip())
+        if command == "get_server_list\n" and first_server_query:
+            first_server_query = False
+            return subprocess.CompletedProcess(
+                args,
+                returncode=1,
+                stdout="",
+                stderr="Cannot send command to MPS control daemon process",
+            )
+        responses = {
+            "get_server_list\n": "7000\n",
+            "get_client_list 7000\n": "101\n",
+        }
+        return subprocess.CompletedProcess(
+            args,
+            returncode=0,
+            stdout=responses[command],
+            stderr="",
+        )
+
+    monkeypatch.setattr(control.subprocess, "run", run)
+
+    assert client.snapshot(pipe_dir) == {MpsClientRef(7000, 101)}
+    assert calls == ["get_server_list", "get_server_list", "get_client_list 7000"]
+
+
+def test_snapshot_aborts_retry_when_daemon_identity_changes(monkeypatch, tmp_path):
+    pipe_dir = _test_pipe_dir(tmp_path)
+    client = control.SubprocessMpsControlClient()
+    identities = iter([123, 124])
+    monkeypatch.setattr(client, "read_daemon_identity", lambda _pipe: next(identities))
+    monkeypatch.setattr(control.time, "sleep", lambda _seconds: None)
+    calls = 0
+
+    def run(args, **kwargs):
+        nonlocal calls
+        del kwargs
+        calls += 1
+        return subprocess.CompletedProcess(
+            args,
+            returncode=1,
+            stdout="",
+            stderr="control failed",
+        )
+
+    monkeypatch.setattr(control.subprocess, "run", run)
+
+    with pytest.raises(MpsControlError, match="identity changed.*123.*124"):
+        client.snapshot(pipe_dir)
+    assert calls == 1
+
+
+def test_control_query_rejects_nonzero_exit_and_timeout(monkeypatch, tmp_path):
+    pipe_dir = _test_pipe_dir(tmp_path)
+    client = control.SubprocessMpsControlClient()
+    _stable_identity(monkeypatch, client)
+    monkeypatch.setattr(control.time, "sleep", lambda _seconds: None)
 
     def nonzero(args, **kwargs):
         del kwargs
@@ -58,16 +185,44 @@ def test_control_query_rejects_nonzero_exit_and_timeout(monkeypatch):
         )
 
     monkeypatch.setattr(control.subprocess, "run", nonzero)
-    with pytest.raises(MpsControlError, match="control failed"):
-        client.snapshot(Path("/mps/pipe"))
+    with pytest.raises(MpsControlError, match="snapshot failed after 3 attempts"):
+        client.snapshot(pipe_dir)
 
     def timeout(args, **kwargs):
         del kwargs
         raise subprocess.TimeoutExpired(args, 10)
 
     monkeypatch.setattr(control.subprocess, "run", timeout)
-    with pytest.raises(MpsControlError, match="timed out"):
-        client.snapshot(Path("/mps/pipe"))
+    with pytest.raises(MpsControlError, match="snapshot failed after 3 attempts"):
+        client.snapshot(pipe_dir)
+
+
+def test_mutating_control_query_is_serialized_without_retry(monkeypatch, tmp_path):
+    pipe_dir = _test_pipe_dir(tmp_path)
+    client = control.SubprocessMpsControlClient()
+    events: list[str] = []
+
+    def flock(_file, operation):
+        if operation == fcntl.LOCK_EX:
+            events.append("lock")
+        elif operation == fcntl.LOCK_UN:
+            events.append("unlock")
+
+    def run(args, **kwargs):
+        events.append(kwargs["input"].strip())
+        return subprocess.CompletedProcess(
+            args,
+            returncode=2,
+            stdout="",
+            stderr="control failed",
+        )
+
+    monkeypatch.setattr(control.fcntl, "flock", flock)
+    monkeypatch.setattr(control.subprocess, "run", run)
+
+    with pytest.raises(MpsControlError, match="control failed"):
+        client.quit_daemon(pipe_dir)
+    assert events == ["lock", "quit", "unlock"]
 
 
 def test_daemon_preexec_failure_is_distinct_from_ambiguous_start(monkeypatch):

--- a/tests/unit_test/mps/test_mps_control.py
+++ b/tests/unit_test/mps/test_mps_control.py
@@ -17,22 +17,13 @@ from sglang_omni.mps.manager import (
 )
 
 
-def _test_pipe_dir(tmp_path: Path) -> Path:
-    pipe_dir = tmp_path / "GPU-test" / "pipe"
-    pipe_dir.mkdir(parents=True)
-    return pipe_dir
-
-
-def _stable_identity(monkeypatch, client, pid: int = 123) -> None:
-    monkeypatch.setattr(client, "read_daemon_identity", lambda _pipe: pid)
-
-
 def test_snapshot_parses_driver_output_and_retains_server_client_pairs(
     monkeypatch, tmp_path
 ):
-    pipe_dir = _test_pipe_dir(tmp_path)
+    pipe_dir = tmp_path / "pipe"
+    pipe_dir.mkdir()
     client = control.SubprocessMpsControlClient()
-    _stable_identity(monkeypatch, client)
+    monkeypatch.setattr(client, "read_daemon_identity", lambda _pipe: 123)
     monkeypatch.setattr(control.time, "sleep", lambda _seconds: None)
     responses = {
         "get_server_list\n": "7000  8000\n",
@@ -62,9 +53,10 @@ def test_snapshot_parses_driver_output_and_retains_server_client_pairs(
 
 
 def test_snapshot_holds_one_control_lock_across_all_queries(monkeypatch, tmp_path):
-    pipe_dir = _test_pipe_dir(tmp_path)
+    pipe_dir = tmp_path / "pipe"
+    pipe_dir.mkdir()
     client = control.SubprocessMpsControlClient()
-    _stable_identity(monkeypatch, client)
+    monkeypatch.setattr(client, "read_daemon_identity", lambda _pipe: 123)
     events: list[str] = []
     responses = {
         "get_server_list\n": "7000 8000\n",
@@ -104,9 +96,10 @@ def test_snapshot_holds_one_control_lock_across_all_queries(monkeypatch, tmp_pat
 def test_snapshot_retries_transient_query_failure_while_identity_is_stable(
     monkeypatch, tmp_path
 ):
-    pipe_dir = _test_pipe_dir(tmp_path)
+    pipe_dir = tmp_path / "pipe"
+    pipe_dir.mkdir()
     client = control.SubprocessMpsControlClient()
-    _stable_identity(monkeypatch, client)
+    monkeypatch.setattr(client, "read_daemon_identity", lambda _pipe: 123)
     monkeypatch.setattr(control.time, "sleep", lambda _seconds: None)
     calls: list[str] = []
     first_server_query = True
@@ -141,11 +134,11 @@ def test_snapshot_retries_transient_query_failure_while_identity_is_stable(
 
 
 def test_snapshot_aborts_retry_when_daemon_identity_changes(monkeypatch, tmp_path):
-    pipe_dir = _test_pipe_dir(tmp_path)
+    pipe_dir = tmp_path / "pipe"
+    pipe_dir.mkdir()
     client = control.SubprocessMpsControlClient()
     identities = iter([123, 124])
     monkeypatch.setattr(client, "read_daemon_identity", lambda _pipe: next(identities))
-    monkeypatch.setattr(control.time, "sleep", lambda _seconds: None)
     calls = 0
 
     def run(args, **kwargs):
@@ -166,10 +159,11 @@ def test_snapshot_aborts_retry_when_daemon_identity_changes(monkeypatch, tmp_pat
     assert calls == 1
 
 
-def test_control_query_rejects_nonzero_exit_and_timeout(monkeypatch, tmp_path):
-    pipe_dir = _test_pipe_dir(tmp_path)
+def test_snapshot_rejects_nonzero_exit_and_timeout(monkeypatch, tmp_path):
+    pipe_dir = tmp_path / "pipe"
+    pipe_dir.mkdir()
     client = control.SubprocessMpsControlClient()
-    _stable_identity(monkeypatch, client)
+    monkeypatch.setattr(client, "read_daemon_identity", lambda _pipe: 123)
     monkeypatch.setattr(control.time, "sleep", lambda _seconds: None)
 
     def nonzero(args, **kwargs):
@@ -182,7 +176,10 @@ def test_control_query_rejects_nonzero_exit_and_timeout(monkeypatch, tmp_path):
         )
 
     monkeypatch.setattr(control.subprocess, "run", nonzero)
-    with pytest.raises(MpsControlError, match="snapshot failed after 3 attempts"):
+    with pytest.raises(
+        MpsControlError,
+        match="snapshot failed after 3 attempts: .*control failed",
+    ):
         client.snapshot(pipe_dir)
 
     def timeout(args, **kwargs):
@@ -190,12 +187,16 @@ def test_control_query_rejects_nonzero_exit_and_timeout(monkeypatch, tmp_path):
         raise subprocess.TimeoutExpired(args, 10)
 
     monkeypatch.setattr(control.subprocess, "run", timeout)
-    with pytest.raises(MpsControlError, match="snapshot failed after 3 attempts"):
+    with pytest.raises(
+        MpsControlError,
+        match="snapshot failed after 3 attempts: .*timed out",
+    ):
         client.snapshot(pipe_dir)
 
 
 def test_mutating_control_query_is_serialized_without_retry(monkeypatch, tmp_path):
-    pipe_dir = _test_pipe_dir(tmp_path)
+    pipe_dir = tmp_path / "pipe"
+    pipe_dir.mkdir()
     client = control.SubprocessMpsControlClient()
     events: list[str] = []
 

--- a/tests/unit_test/mps/test_mps_manager.py
+++ b/tests/unit_test/mps/test_mps_manager.py
@@ -25,6 +25,11 @@ from sglang_omni.mps.manager import (
 from sglang_omni.mps.state import MpsGpuPaths
 
 
+def _proc_stat(pid: int, comm: str, state: str, starttime: int = 1) -> str:
+    fields = [state, "1"] + ["0"] * 17 + [str(starttime)]
+    return f"{pid} ({comm}) " + " ".join(fields)
+
+
 class FakeControlClient:
     """Strict, pipe-scoped stand-in for the MPS control interface."""
 
@@ -37,9 +42,8 @@ class FakeControlClient:
         self.held_owner_pids: set[int] = set()
         self.client_tokens: dict[int, str] = {}
         self.snapshots: dict[str, set[MpsClientRef]] = {}
-        self.snapshot_calls = 0
         self.server_identities: dict[int, MpsProcessIdentity] = {}
-        self.server_identity_errors: dict[int, str] = {}
+        self.server_identity_error: str | None = None
         self.start_fails = False
         self.snapshot_error: str | None = None
         self.identity_error: str | None = None
@@ -63,7 +67,7 @@ class FakeControlClient:
             str(self.daemon_pid)
         )
 
-    def read_daemon_identity(self, pipe_dir):
+    def read_daemon_process_identity(self, pipe_dir):
         if self.identity_error is not None:
             raise MpsControlError(self.identity_error)
         pid_file = Path(pipe_dir) / "nvidia-cuda-mps-control.pid"
@@ -73,14 +77,9 @@ class FakeControlClient:
             raise MpsControlError(f"cannot read native PID file: {exc}") from exc
         if self.daemons.get(str(pipe_dir)) != pid or pid not in self.alive_pids:
             raise MpsControlError(f"unverified daemon pid {pid}")
-        return pid
-
-    def read_daemon_process_identity(self, pipe_dir):
-        pid = self.read_daemon_identity(pipe_dir)
         return MpsProcessIdentity(pid, self.daemon_starttimes.setdefault(pid, 1))
 
     def snapshot(self, pipe_dir):
-        self.snapshot_calls += 1
         if self.snapshot_error is not None:
             raise MpsControlError(self.snapshot_error)
         if str(pipe_dir) not in self.daemons:
@@ -100,8 +99,8 @@ class FakeControlClient:
             )
 
     def read_server_process_identity(self, pipe_dir, pid):
-        if self.server_identity_errors.get(pid) is not None:
-            raise MpsControlError(self.server_identity_errors[pid])
+        if self.server_identity_error is not None:
+            raise MpsControlError(self.server_identity_error)
         if str(pipe_dir) not in self.daemons:
             raise MpsControlError("control socket unavailable")
         try:
@@ -416,7 +415,6 @@ def test_verify_matches_inherited_process_token_on_cuda_client(short_root):
     client.client_tokens[200] = "owner-worker"
 
     assert manager.verify(lease) == {MpsClientRef(7000, 200)}
-    assert lease.server_identities == frozenset({MpsProcessIdentity(7000, 1)})
 
 
 def test_verify_retains_all_managed_server_identities(short_root):
@@ -446,7 +444,7 @@ def test_verify_requires_each_managed_server_identity(short_root):
     lease = manager.acquire({"worker": "owner-worker"})
     client.set_clients(manager.paths.pipe_dir, {7000: [200]})
     client.client_tokens[200] = "owner-worker"
-    client.server_identity_errors[7000] = "server disappeared"
+    client.server_identity_error = "server disappeared"
 
     with pytest.raises(MpsError, match="could not prove server identity"):
         manager.verify(lease)
@@ -478,24 +476,21 @@ def test_verify_does_not_accumulate_clients_across_snapshots(short_root, monkeyp
 def test_probe_allows_a_verified_client_to_exit(short_root):
     client = FakeControlClient()
     manager, lease = start_serving(short_root, client)
-    client.snapshot_calls = 0
     assert manager.probe(lease) is None
 
+    client.snapshot_error = "snapshot must not run"
     client.set_clients(manager.paths.pipe_dir, {})
     assert manager.probe(lease) is None
-    assert client.snapshot_calls == 0
 
 
 def test_probe_checks_identity_without_client_snapshot(short_root):
     client = FakeControlClient()
     manager, lease = start_serving(short_root, client)
-    client.snapshot_calls = 0
 
     client.identity_error = "native PID unavailable"
     assert manager.probe(lease) == (
         "control identity query failed: native PID unavailable"
     )
-    assert client.snapshot_calls == 0
 
     client.identity_error = None
     replacement_pid = lease.daemon_pid + 1
@@ -522,29 +517,26 @@ def test_probe_checks_identity_without_client_snapshot(short_root):
     )
     client.server_identities[7000] = MpsProcessIdentity(7000, 1)
 
-    client.server_identity_errors[7000] = "wrong binary"
+    client.server_identity_error = "wrong binary"
     assert manager.probe(lease) == (
         "server identity query failed for pid 7000: wrong binary"
     )
-    client.server_identity_errors.clear()
+    client.server_identity_error = None
 
     client.snapshot_error = "unexpected snapshot"
     assert manager.probe(lease) is None
-    assert client.snapshot_calls == 0
 
 
 def test_probe_fails_when_verified_server_disappears_with_live_control(short_root):
     client = FakeControlClient()
     manager, lease = start_serving(short_root, client)
     client.server_identities.pop(7000)
-    client.snapshot_calls = 0
 
     reason = manager.probe(lease)
 
     assert reason == (
         "server identity query failed for pid 7000: unverified server pid 7000"
     )
-    assert client.snapshot_calls == 0
 
 
 def test_dead_root_with_live_descendant_persists_dirty_and_reports_cleanup(
@@ -890,9 +882,9 @@ def test_daemon_liveness_rejects_zombie_proc_entries(monkeypatch):
     from sglang_omni.mps import control
 
     stats = {
-        Path("/proc/430465/stat"): "430465 (nvidia-cuda-mps) Z 1 430465 0",
-        Path("/proc/53748/stat"): "53748 (nvidia-cuda-mps-control) S 1 0 0",
-        Path("/proc/7/stat"): "7 (weird) name) Z 1 0",
+        Path("/proc/430465/stat"): _proc_stat(430465, "nvidia-cuda-mps", "Z"),
+        Path("/proc/53748/stat"): _proc_stat(53748, "nvidia-cuda-mps-control", "S"),
+        Path("/proc/7/stat"): _proc_stat(7, "weird) name", "Z"),
     }
     monkeypatch.setattr(Path, "read_text", lambda path: stats[path])
     monkeypatch.setattr(control.os, "kill", lambda _pid, _signal: None)

--- a/tests/unit_test/mps/test_mps_manager.py
+++ b/tests/unit_test/mps/test_mps_manager.py
@@ -20,6 +20,7 @@ from sglang_omni.mps.manager import (
     MpsError,
     MpsLease,
     MpsManager,
+    MpsProcessIdentity,
 )
 from sglang_omni.mps.state import MpsGpuPaths
 
@@ -30,11 +31,15 @@ class FakeControlClient:
     def __init__(self):
         self.daemon_pid = 4242
         self._next_daemon_pid = 4242
+        self.daemon_starttimes: dict[int, int] = {}
         self.daemons: dict[str, int] = {}
         self.alive_pids: set[int] = set()
         self.held_owner_pids: set[int] = set()
         self.client_tokens: dict[int, str] = {}
         self.snapshots: dict[str, set[MpsClientRef]] = {}
+        self.snapshot_calls = 0
+        self.server_identities: dict[int, MpsProcessIdentity] = {}
+        self.server_identity_errors: dict[int, str] = {}
         self.start_fails = False
         self.snapshot_error: str | None = None
         self.identity_error: str | None = None
@@ -51,6 +56,7 @@ class FakeControlClient:
             raise MpsControlError("spawn failed")
         self.daemon_pid = self._next_daemon_pid
         self._next_daemon_pid += 1
+        self.daemon_starttimes[self.daemon_pid] = 1
         self.daemons[str(pipe_dir)] = self.daemon_pid
         self.alive_pids.add(self.daemon_pid)
         (Path(pipe_dir) / "nvidia-cuda-mps-control.pid").write_text(
@@ -69,7 +75,12 @@ class FakeControlClient:
             raise MpsControlError(f"unverified daemon pid {pid}")
         return pid
 
+    def read_daemon_process_identity(self, pipe_dir):
+        pid = self.read_daemon_identity(pipe_dir)
+        return MpsProcessIdentity(pid, self.daemon_starttimes.setdefault(pid, 1))
+
     def snapshot(self, pipe_dir):
+        self.snapshot_calls += 1
         if self.snapshot_error is not None:
             raise MpsControlError(self.snapshot_error)
         if str(pipe_dir) not in self.daemons:
@@ -82,6 +93,21 @@ class FakeControlClient:
             for server_pid, client_pids in clients.items()
             for client_pid in client_pids
         }
+        for server_pid in clients:
+            self.server_identities.setdefault(
+                server_pid,
+                MpsProcessIdentity(server_pid, 1),
+            )
+
+    def read_server_process_identity(self, pipe_dir, pid):
+        if self.server_identity_errors.get(pid) is not None:
+            raise MpsControlError(self.server_identity_errors[pid])
+        if str(pipe_dir) not in self.daemons:
+            raise MpsControlError("control socket unavailable")
+        try:
+            return self.server_identities[pid]
+        except KeyError as exc:
+            raise MpsControlError(f"unverified server pid {pid}") from exc
 
     def terminate_client(self, pipe_dir, client):
         if self.terminate_error is not None:
@@ -378,6 +404,8 @@ def test_verify_returns_current_exact_client_refs(short_root):
     attached = manager.verify(lease)
 
     assert attached == {MpsClientRef(7000, 101), MpsClientRef(7000, 102)}
+    assert lease.server_identities == frozenset({MpsProcessIdentity(7000, 1)})
+    assert lease.attachment_verified
 
 
 def test_verify_matches_inherited_process_token_on_cuda_client(short_root):
@@ -388,6 +416,43 @@ def test_verify_matches_inherited_process_token_on_cuda_client(short_root):
     client.client_tokens[200] = "owner-worker"
 
     assert manager.verify(lease) == {MpsClientRef(7000, 200)}
+    assert lease.server_identities == frozenset({MpsProcessIdentity(7000, 1)})
+
+
+def test_verify_retains_all_managed_server_identities(short_root):
+    client = FakeControlClient()
+    manager = make_manager(short_root, client)
+    lease = manager.acquire({"a": "owner-a", "b": "owner-b"})
+    client.set_clients(
+        manager.paths.pipe_dir,
+        {7000: [101], 8000: [102], 9000: [909]},
+    )
+    client.client_tokens.update({101: "owner-a", 102: "owner-b", 909: "foreign-owner"})
+
+    attached = manager.verify(lease)
+
+    assert attached == {MpsClientRef(7000, 101), MpsClientRef(8000, 102)}
+    assert lease.server_identities == frozenset(
+        {
+            MpsProcessIdentity(7000, 1),
+            MpsProcessIdentity(8000, 1),
+        }
+    )
+
+
+def test_verify_requires_each_managed_server_identity(short_root):
+    client = FakeControlClient()
+    manager = make_manager(short_root, client)
+    lease = manager.acquire({"worker": "owner-worker"})
+    client.set_clients(manager.paths.pipe_dir, {7000: [200]})
+    client.client_tokens[200] = "owner-worker"
+    client.server_identity_errors[7000] = "server disappeared"
+
+    with pytest.raises(MpsError, match="could not prove server identity"):
+        manager.verify(lease)
+
+    assert not lease.attachment_verified
+    assert lease.server_identities == frozenset()
 
 
 def test_verify_does_not_accumulate_clients_across_snapshots(short_root, monkeypatch):
@@ -413,35 +478,73 @@ def test_verify_does_not_accumulate_clients_across_snapshots(short_root, monkeyp
 def test_probe_allows_a_verified_client_to_exit(short_root):
     client = FakeControlClient()
     manager, lease = start_serving(short_root, client)
+    client.snapshot_calls = 0
     assert manager.probe(lease) is None
 
     client.set_clients(manager.paths.pipe_dir, {})
     assert manager.probe(lease) is None
+    assert client.snapshot_calls == 0
 
 
 def test_probe_checks_identity_without_client_snapshot(short_root):
     client = FakeControlClient()
     manager, lease = start_serving(short_root, client)
+    client.snapshot_calls = 0
 
     client.identity_error = "native PID unavailable"
     assert manager.probe(lease) == (
-        "daemon identity query failed: native PID unavailable"
+        "control identity query failed: native PID unavailable"
     )
+    assert client.snapshot_calls == 0
 
     client.identity_error = None
     replacement_pid = lease.daemon_pid + 1
     client.daemons[str(manager.paths.pipe_dir)] = replacement_pid
     client.alive_pids.add(replacement_pid)
     daemon_pid_file(manager.paths).write_text(str(replacement_pid))
+    client.daemon_starttimes[replacement_pid] = 2
     assert manager.probe(lease) == (
-        f"daemon identity changed from {lease.daemon_pid} to {replacement_pid}"
+        "control identity changed from pid 4242 starttime 1 to "
+        f"pid {replacement_pid} starttime 2"
     )
 
     client.daemons[str(manager.paths.pipe_dir)] = lease.daemon_pid
     daemon_pid_file(manager.paths).write_text(str(lease.daemon_pid))
+    client.daemon_starttimes[lease.daemon_pid] = 2
+    assert manager.probe(lease) == (
+        "control identity changed from pid 4242 starttime 1 to pid 4242 starttime 2"
+    )
+    client.daemon_starttimes[lease.daemon_pid] = 1
+
+    client.server_identities[7000] = MpsProcessIdentity(7000, 2)
+    assert manager.probe(lease) == (
+        "server identity changed from pid 7000 starttime 1 to pid 7000 starttime 2"
+    )
+    client.server_identities[7000] = MpsProcessIdentity(7000, 1)
+
+    client.server_identity_errors[7000] = "wrong binary"
+    assert manager.probe(lease) == (
+        "server identity query failed for pid 7000: wrong binary"
+    )
+    client.server_identity_errors.clear()
 
     client.snapshot_error = "unexpected snapshot"
     assert manager.probe(lease) is None
+    assert client.snapshot_calls == 0
+
+
+def test_probe_fails_when_verified_server_disappears_with_live_control(short_root):
+    client = FakeControlClient()
+    manager, lease = start_serving(short_root, client)
+    client.server_identities.pop(7000)
+    client.snapshot_calls = 0
+
+    reason = manager.probe(lease)
+
+    assert reason == (
+        "server identity query failed for pid 7000: unverified server pid 7000"
+    )
+    assert client.snapshot_calls == 0
 
 
 def test_dead_root_with_live_descendant_persists_dirty_and_reports_cleanup(
@@ -774,7 +877,7 @@ def test_release_requires_the_acquisition_token(short_root, tmp_path):
         with pytest.raises(MpsError, match="live MPS lease"):
             manager.release(
                 MpsLease(
-                    daemon_pid=123,
+                    daemon_identity=MpsProcessIdentity(123, 1),
                     owner_fd=foreign_fd,
                     client_tokens={"worker": "owner-worker"},
                 )

--- a/tests/unit_test/mps/test_mps_manager.py
+++ b/tests/unit_test/mps/test_mps_manager.py
@@ -419,7 +419,7 @@ def test_probe_allows_a_verified_client_to_exit(short_root):
     assert manager.probe(lease) is None
 
 
-def test_probe_distinguishes_identity_and_snapshot_failures(short_root):
+def test_probe_checks_identity_without_client_snapshot(short_root, monkeypatch):
     client = FakeControlClient()
     manager, lease = start_serving(short_root, client)
 
@@ -439,10 +439,12 @@ def test_probe_distinguishes_identity_and_snapshot_failures(short_root):
 
     client.daemons[str(manager.paths.pipe_dir)] = lease.daemon_pid
     daemon_pid_file(manager.paths).write_text(str(lease.daemon_pid))
-    client.snapshot_error = "control socket unavailable"
-    assert manager.probe(lease) == (
-        "client snapshot query failed: control socket unavailable"
-    )
+
+    def snapshot_must_not_run(_pipe_dir):
+        raise AssertionError("steady-state probe must not enumerate MPS clients")
+
+    monkeypatch.setattr(client, "snapshot", snapshot_must_not_run)
+    assert manager.probe(lease) is None
 
 
 def test_dead_root_with_live_descendant_persists_dirty_and_reports_cleanup(

--- a/tests/unit_test/mps/test_mps_manager.py
+++ b/tests/unit_test/mps/test_mps_manager.py
@@ -43,7 +43,6 @@ class FakeControlClient:
         self.client_tokens: dict[int, str] = {}
         self.snapshots: dict[str, set[MpsClientRef]] = {}
         self.server_identities: dict[int, MpsProcessIdentity] = {}
-        self.server_identity_error: str | None = None
         self.start_fails = False
         self.snapshot_error: str | None = None
         self.identity_error: str | None = None
@@ -99,8 +98,6 @@ class FakeControlClient:
             )
 
     def read_server_process_identity(self, pipe_dir, pid):
-        if self.server_identity_error is not None:
-            raise MpsControlError(self.server_identity_error)
         if str(pipe_dir) not in self.daemons:
             raise MpsControlError("control socket unavailable")
         try:
@@ -417,34 +414,18 @@ def test_verify_matches_inherited_process_token_on_cuda_client(short_root):
     assert manager.verify(lease) == {MpsClientRef(7000, 200)}
 
 
-def test_verify_retains_all_managed_server_identities(short_root):
-    client = FakeControlClient()
-    manager = make_manager(short_root, client)
-    lease = manager.acquire({"a": "owner-a", "b": "owner-b"})
-    client.set_clients(
-        manager.paths.pipe_dir,
-        {7000: [101], 8000: [102], 9000: [909]},
-    )
-    client.client_tokens.update({101: "owner-a", 102: "owner-b", 909: "foreign-owner"})
-
-    attached = manager.verify(lease)
-
-    assert attached == {MpsClientRef(7000, 101), MpsClientRef(8000, 102)}
-    assert lease.server_identities == frozenset(
-        {
-            MpsProcessIdentity(7000, 1),
-            MpsProcessIdentity(8000, 1),
-        }
-    )
-
-
-def test_verify_requires_each_managed_server_identity(short_root):
+def test_verify_requires_each_managed_server_identity(short_root, monkeypatch):
     client = FakeControlClient()
     manager = make_manager(short_root, client)
     lease = manager.acquire({"worker": "owner-worker"})
     client.set_clients(manager.paths.pipe_dir, {7000: [200]})
     client.client_tokens[200] = "owner-worker"
-    client.server_identity_error = "server disappeared"
+
+    def unavailable(*args):
+        del args
+        raise MpsControlError("server disappeared")
+
+    monkeypatch.setattr(client, "read_server_process_identity", unavailable)
 
     with pytest.raises(MpsError, match="could not prove server identity"):
         manager.verify(lease)
@@ -473,7 +454,7 @@ def test_verify_does_not_accumulate_clients_across_snapshots(short_root, monkeyp
     assert lease.owner_fd >= 0
 
 
-def test_probe_allows_a_verified_client_to_exit(short_root):
+def test_probe_checks_session_identities_without_client_snapshot(short_root):
     client = FakeControlClient()
     manager, lease = start_serving(short_root, client)
     assert manager.probe(lease) is None
@@ -482,15 +463,9 @@ def test_probe_allows_a_verified_client_to_exit(short_root):
     client.set_clients(manager.paths.pipe_dir, {})
     assert manager.probe(lease) is None
 
-
-def test_probe_checks_identity_without_client_snapshot(short_root):
-    client = FakeControlClient()
-    manager, lease = start_serving(short_root, client)
-
     client.identity_error = "native PID unavailable"
-    assert manager.probe(lease) == (
-        "control identity query failed: native PID unavailable"
-    )
+    reason = manager.probe(lease)
+    assert reason is not None and "control identity" in reason
 
     client.identity_error = None
     replacement_pid = lease.daemon_pid + 1
@@ -498,45 +473,24 @@ def test_probe_checks_identity_without_client_snapshot(short_root):
     client.alive_pids.add(replacement_pid)
     daemon_pid_file(manager.paths).write_text(str(replacement_pid))
     client.daemon_starttimes[replacement_pid] = 2
-    assert manager.probe(lease) == (
-        "control identity changed from pid 4242 starttime 1 to "
-        f"pid {replacement_pid} starttime 2"
-    )
+    reason = manager.probe(lease)
+    assert reason is not None and "control identity" in reason
 
     client.daemons[str(manager.paths.pipe_dir)] = lease.daemon_pid
     daemon_pid_file(manager.paths).write_text(str(lease.daemon_pid))
     client.daemon_starttimes[lease.daemon_pid] = 2
-    assert manager.probe(lease) == (
-        "control identity changed from pid 4242 starttime 1 to pid 4242 starttime 2"
-    )
+    reason = manager.probe(lease)
+    assert reason is not None and "control identity" in reason
     client.daemon_starttimes[lease.daemon_pid] = 1
 
     client.server_identities[7000] = MpsProcessIdentity(7000, 2)
-    assert manager.probe(lease) == (
-        "server identity changed from pid 7000 starttime 1 to pid 7000 starttime 2"
-    )
+    reason = manager.probe(lease)
+    assert reason is not None and "server identity" in reason
     client.server_identities[7000] = MpsProcessIdentity(7000, 1)
 
-    client.server_identity_error = "wrong binary"
-    assert manager.probe(lease) == (
-        "server identity query failed for pid 7000: wrong binary"
-    )
-    client.server_identity_error = None
-
-    client.snapshot_error = "unexpected snapshot"
-    assert manager.probe(lease) is None
-
-
-def test_probe_fails_when_verified_server_disappears_with_live_control(short_root):
-    client = FakeControlClient()
-    manager, lease = start_serving(short_root, client)
     client.server_identities.pop(7000)
-
     reason = manager.probe(lease)
-
-    assert reason == (
-        "server identity query failed for pid 7000: unverified server pid 7000"
-    )
+    assert reason is not None and "server identity" in reason
 
 
 def test_dead_root_with_live_descendant_persists_dirty_and_reports_cleanup(

--- a/tests/unit_test/mps/test_mps_manager.py
+++ b/tests/unit_test/mps/test_mps_manager.py
@@ -419,7 +419,7 @@ def test_probe_allows_a_verified_client_to_exit(short_root):
     assert manager.probe(lease) is None
 
 
-def test_probe_checks_identity_without_client_snapshot(short_root, monkeypatch):
+def test_probe_checks_identity_without_client_snapshot(short_root):
     client = FakeControlClient()
     manager, lease = start_serving(short_root, client)
 
@@ -440,10 +440,7 @@ def test_probe_checks_identity_without_client_snapshot(short_root, monkeypatch):
     client.daemons[str(manager.paths.pipe_dir)] = lease.daemon_pid
     daemon_pid_file(manager.paths).write_text(str(lease.daemon_pid))
 
-    def snapshot_must_not_run(_pipe_dir):
-        raise AssertionError("steady-state probe must not enumerate MPS clients")
-
-    monkeypatch.setattr(client, "snapshot", snapshot_must_not_run)
+    client.snapshot_error = "unexpected snapshot"
     assert manager.probe(lease) is None
 
 

--- a/tests/unit_test/mps/test_mps_native_ci_helpers.py
+++ b/tests/unit_test/mps/test_mps_native_ci_helpers.py
@@ -8,6 +8,7 @@ import signal
 import pytest
 
 from sglang_omni.mps import control as mps_control
+from sglang_omni.mps.manager import MpsProcessIdentity
 from tests.test_ci import test_mps_native as mps_ci
 
 
@@ -29,9 +30,9 @@ def test_operator_cleanup_preserves_signal_and_control_order(
     class Control:
         daemon_alive = True
 
-        def read_daemon_identity(self, selected_pipe_dir):
+        def read_daemon_process_identity(self, selected_pipe_dir):
             events.append(("read", selected_pipe_dir))
-            return 900
+            return MpsProcessIdentity(900, 1)
 
         def snapshot(self, selected_pipe_dir):
             events.append(("snapshot", selected_pipe_dir, frozenset(clients)))
@@ -137,8 +138,8 @@ def test_operator_cleanup_kills_owned_sessions_but_preserves_state_on_snapshot_e
     signals: list[int] = []
 
     class Control:
-        def read_daemon_identity(self, _pipe_dir):
-            return 900
+        def read_daemon_process_identity(self, _pipe_dir):
+            return MpsProcessIdentity(900, 1)
 
         def snapshot(self, _pipe_dir):
             raise RuntimeError("snapshot failed")
@@ -167,8 +168,8 @@ def test_operator_cleanup_preserves_state_while_foreign_clients_remain(
     _make_pipe_dir(tmp_path)
 
     class Control:
-        def read_daemon_identity(self, _pipe_dir):
-            return 900
+        def read_daemon_process_identity(self, _pipe_dir):
+            return MpsProcessIdentity(900, 1)
 
         def snapshot(self, _pipe_dir):
             return {"foreign-client"}

--- a/tests/unit_test/mps/test_mps_runtime.py
+++ b/tests/unit_test/mps/test_mps_runtime.py
@@ -259,10 +259,9 @@ async def test_probe_failures_reports_verified_server_loss(short_root):
     await runtime.verify()
 
     client.server_identities.pop(7000)
-    assert await runtime.probe_failures() == {
-        gpu_uuid(0): "server identity query failed for pid 7000: "
-        "unverified server pid 7000"
-    }
+    failures = await runtime.probe_failures()
+    assert gpu_uuid(0) in failures
+    assert "server identity" in failures[gpu_uuid(0)]
 
     client.set_clients(manager.paths.pipe_dir, {})
     await runtime.close()

--- a/tests/unit_test/mps/test_mps_runtime.py
+++ b/tests/unit_test/mps/test_mps_runtime.py
@@ -242,6 +242,32 @@ async def test_logical_gpu_aliases_coalesce_by_physical_uuid(short_root):
     assert not manager.paths.state_dir.exists()
 
 
+@pytest.mark.asyncio
+async def test_probe_failures_reports_verified_server_loss(short_root):
+    client = FakeControlClient()
+    runtime = create(short_root, client=client)
+    await runtime.start()
+
+    manager = manager_on(runtime, 0)
+    client.set_clients(manager.paths.pipe_dir, {7000: [11, 12]})
+    client.client_tokens.update(
+        {
+            11: runtime.env_for_process("a")[MPS_CLIENT_TOKEN_ENV],
+            12: runtime.env_for_process("b")[MPS_CLIENT_TOKEN_ENV],
+        }
+    )
+    await runtime.verify()
+
+    client.server_identities.pop(7000)
+    assert await runtime.probe_failures() == {
+        gpu_uuid(0): "server identity query failed for pid 7000: "
+        "unverified server pid 7000"
+    }
+
+    client.set_clients(manager.paths.pipe_dir, {})
+    await runtime.close()
+
+
 @pytest.mark.parametrize("mode", ["auto", "on"])
 def test_one_process_cannot_resolve_to_multiple_physical_gpus(
     short_root,


### PR DESCRIPTION
## Motivation

Multiple independent `sglang_omni.cli serve` processes can share one native CUDA MPS daemon on the same physical GPU.

The previous steady-state MPS health probe used a full native control snapshot:

```text
get_server_list
get_client_list <server_pid>
```

Each query launches `nvidia-cuda-mps-control`. Independent serve processes cannot coordinate through process-local synchronization, so their health snapshots can overlap on the same shared MPS control endpoint.

On one H200 with four Qwen3-TTS replicas sharing one MPS daemon, four concurrent raw snapshot workers reproduced this failure mode:

```text
800 snapshots
202 snapshot failures
202 native query failures
```

Every successful snapshot observed the same stable topology: one MPS server with eight CUDA clients.

This shows that native control-query responsiveness is not a reliable steady-state serving-health signal.

At the same time, checking only the MPS control-daemon identity is insufficient. Fault injection showed that killing the MPS server immediately breaks existing CUDA clients while the control daemon can remain alive for multiple seconds.

The steady-state invariant therefore needs to be the identity continuity of the verified MPS serving session:

```text
control process identity
+
managed MPS server process identity / identities
```

## Modifications

This PR separates lifecycle ownership checks from steady-state session health.

1. Serialize native MPS lifecycle control transactions across serve processes with one per-GPU filesystem `flock`.

   A complete `get_server_list` plus `get_client_list` snapshot is performed under one cross-process lock.

2. Represent native MPS process identity with PID plus Linux `/proc` start time.

   Identity validation also verifies:

   - the expected native binary;
   - the exact `CUDA_MPS_PIPE_DIRECTORY`;
   - the process is present and non-zombie.

   Linux stopped state `T` remains valid because the process identity is unchanged.

3. During startup attachment verification, capture the native MPS server identity or identities associated with managed CUDA clients.

   Foreign clients do not contribute identities to the lease.

4. Make the steady-state probe validate only the startup-verified control and server identities through `/proc`.

   The periodic probe issues no:

   ```text
   get_server_list
   get_client_list
   native MPS heartbeat
   ```

5. Keep strict client snapshots for lifecycle operations that actually require ownership information, including startup verification, join, retirement, release, and cleanup.

6. Fail closed if a verified control or server process disappears or is replaced.

   A replacement server is not automatically adopted because the verified serving session has changed.

The existing runner fail-fast behavior is unchanged.

The earlier experimental snapshot retry/backoff mechanism is not part of the final implementation.

## Validation

### Unit tests

```text
tests/unit_test/mps

130 passed
```

### H200 fault qualification

Each fault used a fresh MPS lifecycle.

| Gate | Fault | Result |
| --- | --- | --- |
| E1 | `SIGSTOP` control | control stayed `T` for 30 s; serving continued; 61/61 `/health` probes returned 200; final 272/272 requests completed |
| E2 | `SIGKILL` control | CUDA MPS RPC failure surfaced; health monitor reported `control identity unavailable` and failed the pipeline |
| E3 | `SIGKILL` server | server disappeared while control remained alive; health monitor reported `server identity unavailable` and failed the pipeline |
| E4 | `SIGSTOP` server | server stayed `T` for 15 s; serving continued; 31/31 `/health` probes returned 200 |

E3 is the key regression case for tracking the complete MPS session rather than only the control daemon.

Representative E3 timing:

```text
t =    0 ms  server SIGKILL
t =   ~6 ms  first CUDA MPS RPC failure
t = ~1002 ms health failure: server identity unavailable
t = ~2567 ms control still S, server absent
t = ~2818 ms control absent
t = ~3320 ms cell terminal error
```

No complete WAV finished after the server was killed.

### H200 DP4 clean serving

Topology:

```text
GPU: H200
replicas: 4
per-replica concurrency: 20
requests per replica: 272
total requests: 1088
one shared MPS daemon
```

Two independent fresh lifecycles both completed:

```text
R1: 1088 / 1088
R2: 1088 / 1088
```

For both runs:

```text
0 matched production MPS/CUDA fatal signatures
private MPS root removed
post-run GPU residue clean
```

### Hostile shared-control validation

A final DP4 run was executed while four external workers issued 200 uncoordinated raw MPS snapshots each.

Raw native control results:

```text
snapshots:          800
snapshot successes: 598
snapshot failures:  202
native queries:     1482
query failures:     202
successful client topologies: 1
```

Despite the reproduced native control contention, production serving completed:

```text
replica0: 272 / 272
replica1: 272 / 272
replica2: 272 / 272
replica3: 272 / 272

total: 1088 / 1088
production fatal signatures: 0
MPS teardown: clean
GPU residue: none
```

This directly validates the separation in this PR: native control queries can fail transiently under contention while the verified MPS serving session remains healthy.

## Accuracy Test

This PR changes MPS lifecycle and health monitoring only and does not modify
model kernels, sampling, codec execution, or generated-audio logic.

The 1088 outputs from a clean H200 DP4 qualification run were scored with the
repository's SeedTTS transcription pipeline:

| Metric | Result |
| --- | ---: |
| Evaluated | 1088 / 1088 |
| Corpus WER | 1.4318% |
| Corpus WER excluding >50% WER outliers | 1.0057% |
| Normalized no-space CER | 0.5696% |
| Median per-sample WER | 0% |
| >50% WER outliers | 1 / 1088 |

The single >50% outlier was a 163.84 s runaway repetition sample; all 1088
samples were transcribed successfully.

This is a post-generation sanity check rather than a model-accuracy A/B because
the PR does not modify the model generation path.

## Checklist

- [x] Format code according to pre-commit.
- [x] Add unit tests.
- [x] Update documentation / docstrings / example tutorials as needed.
- [x] Provide robustness and hardware validation results.
- [ ] For reviewers: If you haven't made any contributions to this PR and are only assisting with merging the main branch, please remove yourself as a co-author when merging the PR.

## CI

CI runs on self-hosted GPU runners and requires a maintainer to add the `run-ci` label. Once labeled, every subsequent push re-triggers CI as long as the label remains.

Use `/tag-and-rerun-ci higgs`, `/tag-and-rerun-ci moss`, or `/tag-and-rerun-ci qwen3-tts` to select a TTS CI model.

Use `/tag-and-rerun-ci fun-asr`, `/tag-and-rerun-ci qwen3-asr`, or `/tag-and-rerun-ci whisper-asr` to select an ASR CI model.

One selector from each family can be combined. Draft PRs are skipped even if labeled.

## Related Issues

- Investigation and reproduction details: charliechenye/sglang-omni#39
- Related upstream MPS runtime work: #1635