### PR TITLE
[Perf][Qwen3-TTS] Read back semantic tokens before code prediction

### DIFF
--- a/sglang_omni/models/qwen3_tts/model_runner.py
+++ b/sglang_omni/models/qwen3_tts/model_runner.py
@@ -185,15 +185,16 @@ class Qwen3TTSModelRunner(ModelRunner):
         if isinstance(hidden, torch.Tensor) and hidden.ndim == 2:
             hidden = hidden.unsqueeze(1)
         semantic_positions = self._sample_positions(forward_batch, layer0_codes.device)
+        # The host only consumes the semantic token IDs. Fence their copy
+        # before launching the residual-code predictor so CPU bookkeeping can
+        # overlap its GPU work. Codec snapshots and their ready event are still
+        # recorded after the predictor in post_process_outputs on this stream.
+        self._stage_token_ids(result, result.next_token_ids)
         self.model.code_predictor_forward(
             layer0_codes,
             hidden,
             semantic_positions=semantic_positions,
         )
-        # Note: (Jiaxin Deng) stage the ids into pinned host memory now so the
-        # output processor's .tolist() waits on an event instead of issuing a
-        # blocking pageable copy inside the decode loop.
-        self._stage_token_ids(result, result.next_token_ids)
         self._has_pending_code_step = True
 
     def post_process_outputs(

--- a/tests/unit_test/qwen3_tts/test_token_readback.py
+++ b/tests/unit_test/qwen3_tts/test_token_readback.py
@@ -1,0 +1,127 @@
+# SPDX-License-Identifier: Apache-2.0
+"""Semantic readback must not publish unfinished or reusable codec buffers."""
+
+from collections import deque
+from types import SimpleNamespace
+
+import pytest
+import torch
+
+from sglang_omni.models.qwen3_tts.model_runner import Qwen3TTSModelRunner
+
+
+@pytest.mark.skipif(not torch.cuda.is_available(), reason="requires CUDA")
+@pytest.mark.parametrize("batch_size", [1, 4])
+@pytest.mark.parametrize("prefill", [False, True])
+@pytest.mark.parametrize("graphed", [False, True])
+def test_codec_snapshots_after_early_semantic_readback(batch_size, prefill, graphed):
+    device = torch.device("cuda")
+    producer = torch.cuda.Stream()
+    consumer = torch.cuda.Stream()
+    codes = torch.zeros(batch_size, 3, device=device, dtype=torch.long)
+    embeds = torch.zeros(batch_size, 4, device=device)
+    static_ids = torch.arange(1, batch_size + 1, device=device)
+
+    def predict():
+        # Keep the output asynchronous so host token readiness cannot be used
+        # as a substitute for the codec's own completion event.
+        torch.cuda._sleep(10_000_000)
+        codes.copy_(static_ids[:, None].expand(-1, 3))
+        embeds.copy_(static_ids[:, None].expand(-1, 4))
+
+    producer.wait_stream(torch.cuda.current_stream())
+    with torch.cuda.stream(producer):
+        graph = None
+        if graphed:
+            predict()
+            producer.synchronize()
+            graph = torch.cuda.CUDAGraph()
+            with torch.cuda.graph(graph, stream=producer):
+                predict()
+
+        def forward(layer0_codes, hidden, semantic_positions):
+            static_ids.copy_(layer0_codes.flatten())
+            if graph is None:
+                predict()
+            else:
+                graph.replay()
+
+        model = SimpleNamespace(
+            config=SimpleNamespace(codec_eos_token_id=99),
+            _output_codes=codes,
+            _output_embeds=embeds,
+            code_predictor_forward=forward,
+        )
+        runner = Qwen3TTSModelRunner.__new__(Qwen3TTSModelRunner)
+        runner.model = model
+        runner._token_id_host_bufs = None
+        runner._token_id_host_slot = 0
+        snapshots = []
+        retained_requests = []
+        for step in range(3):
+            # Changing membership/size exercises pinned-buffer reuse and growth.
+            n = 1 if step == 0 else batch_size
+            ids = torch.arange(1 + step * 10, 1 + step * 10 + n, device=device)
+            if step == 2:
+                ids[-1] = 99
+            result = SimpleNamespace(
+                next_token_ids=ids,
+                logits_output=SimpleNamespace(
+                    hidden_states=torch.zeros(n, 4, device=device)
+                ),
+            )
+            batch = SimpleNamespace(
+                forward_mode=SimpleNamespace(is_decode=lambda: not prefill),
+                positions=torch.zeros(n, device=device, dtype=torch.long),
+                seq_lens=torch.ones(n, device=device, dtype=torch.long),
+            )
+
+            # Our predictor has a fixed graph shape; pad live IDs as a real
+            # graph runner does, then expose only the live rows to collection.
+            def live_forward(layer0_codes, hidden, semantic_positions):
+                padded = torch.zeros(batch_size, device=device, dtype=torch.long)
+                padded[:n].copy_(layer0_codes.flatten())
+                forward(padded, hidden, semantic_positions)
+
+            model.code_predictor_forward = live_forward
+            runner._collect_codes(result, batch, None, [])
+            host_ids = runner._resolve_host_token_ids(result).tolist()
+            expected = list(range(1 + step * 10, 1 + step * 10 + n))
+            if step == 2:
+                expected[-1] = 99
+            assert host_ids == expected
+            requests = [
+                SimpleNamespace(
+                    request_id=str(i),
+                    data=SimpleNamespace(
+                        output_codes=[], pending_feedback_queue=deque()
+                    ),
+                )
+                for i in range(n)
+            ]
+            retained_requests.extend(requests)
+            outputs = {
+                str(i): SimpleNamespace(data=token) for i, token in enumerate(host_ids)
+            }
+            runner.post_process_outputs(
+                result, SimpleNamespace(requests=requests), outputs
+            )
+            for request, token in zip(requests, expected):
+                data = request.data
+                if token == 99:
+                    assert not data.output_codes
+                    assert not data.pending_feedback_queue
+                    continue
+                with torch.cuda.stream(consumer):
+                    consumer.wait_event(data.codes_ready_event)
+                    observed_codes = data.output_codes[0].clone()
+                    observed_embed = data.pending_feedback_queue[0].clone()
+                snapshots.append((observed_codes, observed_embed, token))
+        # Overwrite reusable graph outputs before inspecting saved snapshots.
+        codes.fill_(-1)
+        embeds.fill_(-1)
+    producer.synchronize()
+    consumer.synchronize()
+    for observed_codes, observed_embed, token in snapshots:
+        assert observed_codes.cpu().tolist() == [token] * 3
+        assert observed_embed.cpu().tolist() == [token] * 4


### PR DESCRIPTION
## Motivation

Qwen3-TTS stages its semantic token IDs to pinned host memory after launching the residual-code predictor. The host output processor only needs those semantic IDs, but its completion event also fences the predictor. This delays CPU bookkeeping until the entire predictor has completed on every generation step.

On an RTX 5090, moving the copy before the predictor improved warm-server throughput by 9.4% at c1 and 8.4% at c4 in the measured CustomVoice workload.

## Modifications

Move `_stage_token_ids` immediately before `code_predictor_forward` in `_collect_codes`. This allows CPU output processing to overlap residual-code prediction without adding lookahead or changing model operations, sampling, penalties, or admission policy.

The execution bridge is single-stream. Predictor writes, codec/feedback snapshot clones, and `codes_ready_event` remain ordered on that stream. The early event only authorizes the host token read; it does not authorize vocoder access. No extra persistent buffers or CUDA streams are introduced.

Add CUDA regression coverage for eager/graphed prediction, prefill/decode, host-buffer growth/reuse, EOS exclusion, and snapshot consumption on another stream after reusable outputs are overwritten.

## Related Issues

Related to #1754 (remaining Qwen3-TTS host/runtime overhead). This is independent of prefill graphs in #1998 and admission coalescing in #1891.

## Accuracy Test

End-to-end A/B on the same checkpoint with `enable_deterministic_inference: true` and Triton attention: 32 cases per variant (c1/c4, English/Chinese, Ryan/Vivian, buffered/streamed, sampled/greedy subtalker, short/long text, and instructions).

- All 32 output lengths match. All **16 buffered outputs are byte-identical**.
- Of 16 streamed outputs, one is byte-identical; the others have waveform SNR **>=54.67 dB** relative to control. The control itself is not stream-byte-invariant between c1/c4 (54.75–61.70 dB in these cases, identical lengths), despite enabling deterministic mode. Thus this is not a claim of strict streamed PCM identity or a perceptual quality evaluation.
- Three concurrent streaming clients disconnected after their first PCM chunk while a fourth request completed. Request state returned to empty; buffered PCM before, during and after that sequence was byte-identical.

The deterministic config above adds:
```yaml
enable_deterministic_inference: true
stages:
  tts_engine:
    engine:
      attention_backend: triton
```
The production-mode performance table below uses the original graph-enabled configuration, not this slower correctness configuration.

<details>
<summary>Accuracy request reproducer (run once on each variant; compare same-named PCM files)</summary>

Start each variant with the deterministic config, save this as `check_pcm.py`, and run `python check_pcm.py control` / `python check_pcm.py candidate`.

```python
"""Save exact PCM for deterministic serial/concurrent, streamed/buffered requests."""

import concurrent.futures
import hashlib
import io
import json
import sys
import wave
from pathlib import Path

import requests

out = Path(sys.argv[1])
out.mkdir()
texts = [
    ("Ryan", "English", "Hello."),
    ("Ryan", "English", "Get the trust fund to the bank early."),
    ("Vivian", "Chinese", "你好，这是一次语音生成测试。"),
    (
        "Ryan",
        "English",
        "This longer sentence checks that speech generation continues correctly after multiple audio chunks and ends without losing the final words.",
    ),
]
cases = []
for i, (voice, language, text) in enumerate(texts):
    for stream in (False, True):
        for sampled in (False, True):
            key = f"t{i}-stream{int(stream)}-sample{int(sampled)}"
            p = {
                "model": "qwen3-tts",
                "input": text,
                "voice": voice,
                "language": language,
                "seed": 123456,
                "response_format": "pcm" if stream else "wav",
                "stream": stream,
                "max_new_tokens": 512,
                "stage_params": {"tts_engine": {"subtalker_dosample": sampled}},
            }
            if i == 3:
                p["instructions"] = "Speak calmly."
            cases.append((key, p))


def send(case, c):
    key, p = case
    r = requests.post("http://127.0.0.1:8000/v1/audio/speech", json=p, timeout=180)
    r.raise_for_status()
    pcm = r.content
    if not p["stream"]:
        with wave.open(io.BytesIO(pcm)) as w:
            assert (w.getframerate(), w.getnchannels(), w.getsampwidth()) == (
                24000,
                1,
                2,
            )
            pcm = w.readframes(w.getnframes())
    assert len(pcm) > 0 and len(pcm) % 2 == 0 and any(pcm)
    (out / f"c{c}-{key}.pcm").write_bytes(pcm)
    return {
        "case": key,
        "concurrency": c,
        "sha256": hashlib.sha256(pcm).hexdigest(),
        "samples": len(pcm) // 2,
        "payload": p,
    }


results = []
for c in (1, 4):
    with concurrent.futures.ThreadPoolExecutor(max_workers=c) as pool:
        results.extend(pool.map(lambda case: send(case, c), cases))
(out / "results.json").write_text(
    json.dumps(results, indent=2, ensure_ascii=False) + "\n"
)
a = {r["case"]: r for r in results if r["concurrency"] == 1}
matched = sum(
    r["sha256"] == a[r["case"]]["sha256"] for r in results if r["concurrency"] == 4
)
print(
    json.dumps(
        {
            "run": out.name,
            "completed": len(results),
            "batch_invariant": matched,
            "cases": len(cases),
        }
    )
)
```
</details>

Related unit suites: **254 passed** (pipeline, retract/prefill, logit shaping, and 8 new CUDA cases).

## Benchmark & Profiling

Base: `490a29654c0de9b5a528d3d242cbb920ba9ec03e`, versus that same base plus this change.

- One RTX 5090 (32 GB), driver 580.178.04, Python 3.12.3, PyTorch 2.13.0+cu130, SGLang 0.5.19.
- Image: `hongccc/sglang-omni@sha256:ebe4239e29a764ee3a2806385c061c5fd438a26f01458e503d3822dcba5790df`.
- Model: `Qwen/Qwen3-TTS-12Hz-1.7B-CustomVoice`, revision `0c0e3051f131929182e2c023b9537f8b1c68adfe`.
- First 100 SeedTTS EN samples, Ryan, seed 1234, streaming PCM, closed-loop c1/c4, 8 warmup requests per cell. Two repetitions per concurrency per variant, 800 measured requests total. Candidate measured first, then restored control; an earlier 40-sample screening also measured control before candidate.
- All 800 succeeded, with zero measured playback underruns. No profiling/tests ran concurrently with these measurements. This was a desktop GPU without locked clocks.

| Metric (mean of two runs) | Control c1 | Change c1 | Control c4 | Change c4 |
|---|---:|---:|---:|---:|
| Throughput, req/s | 2.147 | 2.348 (+9.4%) | 6.278 | 6.806 (+8.4%) |
| Audio throughput, audio s/s | 9.792 | 10.710 (+9.4%) | 28.949 | 31.367 (+8.4%) |
| Mean request latency, ms | 465.5 | 426.0 | 631.0 | 580.5 |
| Mean first PCM, ms | 18.95 | 17.50 | 34.55 | 33.30 |
| p95 first PCM, ms | 20.05 | 18.60 | 38.25 | 38.25 |
| Mean inter-chunk interval, ms | 51.5 | 47.0 | 68.2 | 62.4 |

Throughput repetitions: control c1 **2.149 / 2.145**, change c1 **2.386 / 2.310**; control c4 **6.280 / 6.276**, change c4 **6.809 / 6.802**. c4 p95 first-PCM latency is unchanged; this is primarily a throughput/inter-chunk improvement. First PCM is not audible TTFA.

A separate one-request CUDA trace has the same **79,012 kernels** before/after. `cudaEventSynchronize` totals **325.0 -> 271.9 ms** (56 calls each); kernel totals are similar (**380.7 -> 375.9 ms**). These instrumented times support the wait-overlap mechanism, not an additional serving speed claim.

Reproduction config (set `model_path` to the pinned local checkpoint):

```yaml
config_cls: Qwen3TTSPipelineConfig
model_path: /path/to/Qwen3-TTS-12Hz-1.7B-CustomVoice
stages:
  tts_engine:
    engine:
      max_running_requests: 4
      max_queued_requests: 8
      cuda_graph_max_bs: 4
      torch_compile_max_bs: 4
      mem_fraction_static: 0.65
```

```bash
sgl-omni serve --config qwen3tts5090.yaml --model-name qwen3-tts --host 127.0.0.1 --port 8000

# Run c1, c4, c4, c1 with distinct output directories on each variant.
python -m benchmarks.eval.benchmark_tts_seedtts \
  --generate-only --use-existing-server --stream --skip-gpu-cleanup \
  --base-url http://127.0.0.1:8000 --model qwen3-tts \
  --meta zhaochenyang20/seed-tts-eval-arrow \
  --no-ref-audio --voice Ryan --lang en --seed 1234 \
  --max-samples 100 --warmup 8 --concurrency 1 --output-dir results/control-c1-r1
```

Performance and end-to-end accuracy validation are limited to this CustomVoice model and CUDA hardware. Base/VoiceDesign and other devices were not benchmarked. No WER or listening-quality improvement is claimed.

## Checklist

- [x] Format your code according with pre-commit.
- [x] Add unit tests.
- [x] Update documentation / docstrings / example tutorials as needed.
- [x] Provide throughput / latency benchmark results and accuracy evaluation results as needed.
