### PR TITLE
add cpu_offload_gb UT

### DIFF
--- a/tests/unit_test/ming_omni/test_omni_serve.py
+++ b/tests/unit_test/ming_omni/test_omni_serve.py
@@ -341,6 +341,18 @@ def test_ming_cli_applies_thinker_sglang_server_args() -> None:
     assert overrides["quantization"] == "fp8"
 
 
+def test_ming_cli_cpu_offload_gb_positive_flows_to_thinker_overrides() -> None:
+    config = MingOmniPipelineConfig(model_path="dummy")
+
+    merged = ConfigManager(config).merge_config(
+        [("thinker.engine.cpu_offload_gb", "8")]
+    )
+
+    overrides = _server_args_overrides(merged, "thinker")
+    assert overrides["cpu_offload_gb"] == 8
+    assert isinstance(overrides["cpu_offload_gb"], int)
+
+
 def test_ming_cli_talker_gpu_targets_talker_stage() -> None:
     config = MingOmniSpeechPipelineConfig(model_path="dummy")
 

--- a/tests/unit_test/pipeline/test_runtime_schema.py
+++ b/tests/unit_test/pipeline/test_runtime_schema.py
@@ -65,6 +65,15 @@ def test_invalid_engine_mem_fraction_static_raises() -> None:
         EngineArgs(mem_fraction_static=1.0)
 
 
+def test_cpu_offload_gb_range_is_enforced_at_validation() -> None:
+    assert EngineArgs().cpu_offload_gb is None
+    assert EngineArgs(cpu_offload_gb=0).cpu_offload_gb == 0
+    assert EngineArgs(cpu_offload_gb=8).cpu_offload_gb == 8
+
+    with pytest.raises(ValueError, match="cpu_offload_gb"):
+        EngineArgs(cpu_offload_gb=-1)
+
+
 def test_invalid_model_group_values_raise() -> None:
     with pytest.raises(ValueError, match="max_seq_len"):
         FactoryArgs(max_seq_len=0)


### PR DESCRIPTION
<!-- Thank you for your contribution! We appreciate it. The following guidelines will help improve your pull request and facilitate feedback. If anything is unclear, don't hesitate to submit your pull request and ask the maintainers for assistance. -->

## Motivation

<!-- Explain the purpose of this PR and the goals it aims to achieve. -->

## Modifications

<!-- Describe the changes made in this PR. -->

## Related Issues
Fixes #1597
<!-- Link to any related issues here. e.g. "Fixes #123" or "Closes #456" -->

## Accuracy Test

<!-- If this PR affects model-side code (e.g., kernels, model architecture), please provide accuracy test results. Ref: https://docs.sglang.io/docs/developer_guide/evaluating_new_models -->

## Benchmark & Profiling

<!-- If this PR is expected to impact performance, please provide benchmark and profiling results. Ref: https://docs.sglang.io/docs/developer_guide/benchmark_and_profiling -->

## Checklist

- [ ] Format your code according with pre-commit.
- [ ] Add unit tests.
- [ ] Update documentation / docstrings / example tutorials as needed.
- [ ] Provide throughput / latency benchmark results and accuracy evaluation results as needed.
- [ ] For reviewers: If you haven't made any contributions to this PR and are only assisting with merging the main branch, please remove yourself as a co-author when merging the PR.

## CI

CI runs on self-hosted GPU runners and requires a maintainer to add the
`run-ci` label. Once labeled, every subsequent push re-triggers CI as
long as the label remains. Use `/tag-and-rerun-ci higgs` or
`/tag-and-rerun-ci moss` or `/tag-and-rerun-ci qwen3-tts` to select a TTS CI
model, and
`/tag-and-rerun-ci fun-asr`, `/tag-and-rerun-ci qwen3-asr` or
`/tag-and-rerun-ci whisper-asr` to select an ASR CI model. One selector from
each family can be combined, for example `/tag-and-rerun-ci moss fun-asr`.
Draft PRs are skipped even if labeled.
