### PR TITLE
[Perf][AuK] Fuse DiT AdaLN scale/shift and gated residual

### DIFF
--- a/sglang_omni/models/auk/dit.py
+++ b/sglang_omni/models/auk/dit.py
@@ -13,6 +13,8 @@ import torch.nn.functional as F
 from torch import nn
 from x_transformers.x_transformers import RotaryEmbedding, apply_rotary_pos_emb
 
+from sglang_omni.models.auk.modulation import gated_residual, scale_shift
+
 
 def _attention_bias(key_mask: torch.Tensor, dtype: torch.dtype) -> torch.Tensor:
     """Additive SDPA bias ``[B, 1, 1, K]`` from a boolean key-padding mask ``[B, K]``."""
@@ -102,7 +104,7 @@ class AdaLayerNorm(nn.Module):
             emb, 6, dim=1
         )
 
-        x = self.norm(x) * (1 + scale_msa[:, None]) + shift_msa[:, None]
+        x = scale_shift(self.norm(x), scale_msa, shift_msa)
         return x, gate_msa, shift_mlp, scale_mlp, gate_mlp
 
 
@@ -118,7 +120,7 @@ class AdaLayerNormFinal(nn.Module):
     def forward(self, x: torch.Tensor, emb: torch.Tensor) -> torch.Tensor:
         emb = self.linear(self.silu(emb))
         scale, shift = torch.chunk(emb, 2, dim=1)
-        return self.norm(x) * (1 + scale)[:, None, :] + shift[:, None, :]
+        return scale_shift(self.norm(x), scale, shift)
 
 
 class SwiGLU(nn.Module):
@@ -304,12 +306,12 @@ class DiTBlock(nn.Module):
         bias: torch.Tensor | None = None,
     ) -> torch.Tensor:
         norm, gate_msa, shift_mlp, scale_mlp, gate_mlp = self.attn_norm(x, emb=t)
-        x = x + gate_msa.unsqueeze(1) * self.attn(
-            x=norm, mask=mask, rope=rope, bias=bias
+        x = gated_residual(
+            x, gate_msa, self.attn(x=norm, mask=mask, rope=rope, bias=bias)
         )
 
-        norm = self.ff_norm(x) * (1 + scale_mlp[:, None]) + shift_mlp[:, None]
-        return x + gate_mlp.unsqueeze(1) * self.ff(norm)
+        norm = scale_shift(self.ff_norm(x), scale_mlp, shift_mlp)
+        return gated_residual(x, gate_mlp, self.ff(norm))
 
 
 class MMDiTBlock(nn.Module):
@@ -369,13 +371,13 @@ class MMDiTBlock(nn.Module):
             bias=bias,
         )
 
-        c = c + c_gate_msa.unsqueeze(1) * c_attn
-        norm_c = self.ff_norm_c(c) * (1 + c_scale_mlp[:, None]) + c_shift_mlp[:, None]
-        c = c + c_gate_mlp.unsqueeze(1) * self.ff_c(norm_c)
+        c = gated_residual(c, c_gate_msa, c_attn)
+        norm_c = scale_shift(self.ff_norm_c(c), c_scale_mlp, c_shift_mlp)
+        c = gated_residual(c, c_gate_mlp, self.ff_c(norm_c))
 
-        x = x + x_gate_msa.unsqueeze(1) * x_attn
-        norm_x = self.ff_norm_x(x) * (1 + x_scale_mlp[:, None]) + x_shift_mlp[:, None]
-        x = x + x_gate_mlp.unsqueeze(1) * self.ff_x(norm_x)
+        x = gated_residual(x, x_gate_msa, x_attn)
+        norm_x = scale_shift(self.ff_norm_x(x), x_scale_mlp, x_shift_mlp)
+        x = gated_residual(x, x_gate_mlp, self.ff_x(norm_x))
         return c, x
 
 

--- a/sglang_omni/models/auk/modulation.py
+++ b/sglang_omni/models/auk/modulation.py
@@ -1,0 +1,100 @@
+# SPDX-License-Identifier: Apache-2.0
+"""AuK modulation fusions preserving eager intermediate rounding."""
+
+import torch
+
+try:
+    import triton
+    import triton.language as tl
+except ImportError:
+    triton = None
+
+
+if triton is not None:
+
+    @triton.autotune(
+        configs=[
+            triton.Config({"BLOCK": 512}, num_warps=4),
+            triton.Config({"BLOCK": 1024}, num_warps=4),
+        ],
+        # Tune once per hidden size/operator, not for every request length.
+        key=["D", "MODULATE"],
+    )
+    @triton.jit(do_not_specialize=["N", "T", "stride_a", "stride_b"])
+    def _modulation_kernel(
+        X,
+        A,
+        B,
+        Y,
+        N,
+        T,
+        stride_a,
+        stride_b,
+        D: tl.constexpr,
+        MODULATE: tl.constexpr,
+        BLOCK: tl.constexpr,
+    ):
+        i = tl.program_id(0) * BLOCK + tl.arange(0, BLOCK)
+        mask = i < N
+        batch = i // (T * D)
+        col = i % D
+        x = tl.load(X + i, mask, other=0).to(tl.float32)
+        a = tl.load(A + batch * stride_a + col, mask, other=0).to(tl.float32)
+        if MODULATE:
+            b = tl.load(B + batch * stride_b + col, mask, other=0).to(tl.float32)
+            scale = (1 + a).to(A.dtype.element_ty).to(tl.float32)
+            product = (x * scale).to(Y.dtype.element_ty).to(tl.float32)
+            y = product + b
+        else:
+            b = tl.load(B + i, mask, other=0).to(tl.float32)
+            # gate * update rounds before the (often FP32) residual addition.
+            product = (a * b).to(B.dtype.element_ty).to(tl.float32)
+            y = x + product
+        tl.store(Y + i, y.to(Y.dtype.element_ty), mask)
+
+
+def _can_fuse(x, a, b):
+    # Small tensors do not amortize the Python/Triton launch overhead.
+    return (
+        x.numel() >= 2**22
+        and triton is not None
+        and x.is_cuda
+        and not torch.is_grad_enabled()
+        and x.is_contiguous()
+        and a.stride(-1) == b.stride(-1) == 1
+        and a.dtype == b.dtype
+        and x.dtype in (torch.float32, torch.bfloat16, torch.float16)
+        and a.dtype in (torch.float32, torch.bfloat16, torch.float16)
+    )
+
+
+def _fused(x, a, b, *, modulate):
+    out = torch.empty_like(x, dtype=torch.promote_types(x.dtype, a.dtype))
+    _modulation_kernel[lambda meta: (triton.cdiv(x.numel(), meta["BLOCK"]),)](
+        x,
+        a,
+        b,
+        out,
+        x.numel(),
+        x.shape[1],
+        a.stride(0),
+        b.stride(0),
+        x.shape[-1],
+        modulate,
+        enable_fp_fusion=False,
+    )
+    return out
+
+
+def scale_shift(x, scale, shift):
+    """Apply per-request AdaLN scale/shift to an already normalized [B,T,D]."""
+    if _can_fuse(x, scale, shift):
+        return _fused(x, scale, shift, modulate=True)
+    return x * (1 + scale[:, None]) + shift[:, None]
+
+
+def gated_residual(x, gate, update):
+    """Apply a [B,D] gate and add the update with eager dtype promotion."""
+    if _can_fuse(x, gate, update) and update.is_contiguous():
+        return _fused(x, gate, update, modulate=False)
+    return x + gate[:, None] * update

--- a/tests/unit_test/auk/test_modulation.py
+++ b/tests/unit_test/auk/test_modulation.py
@@ -1,0 +1,75 @@
+# SPDX-License-Identifier: Apache-2.0
+
+import pytest
+import torch
+
+from sglang_omni.models.auk.modulation import _fused, gated_residual, scale_shift
+
+
+@pytest.mark.skipif(not torch.cuda.is_available(), reason="CUDA required")
+@pytest.mark.parametrize("shape", [(1, 7, 32), (3, 17, 1536), (4, 683, 1536)])
+@pytest.mark.parametrize(
+    "x_dtype,param_dtype",
+    [
+        (torch.float32, torch.bfloat16),
+        (torch.bfloat16, torch.bfloat16),
+        (torch.float32, torch.float32),
+        (torch.float32, torch.float16),
+    ],
+)
+@torch.inference_mode()
+def test_modulation_preserves_eager_rounding(shape, x_dtype, param_dtype):
+    torch.manual_seed(42)
+    b, _, d = shape
+    x = torch.randn(shape, device="cuda", dtype=x_dtype)
+    update = torch.randn(shape, device="cuda", dtype=param_dtype)
+    # Real AdaLN parameters are noncontiguous chunks of a [B,6D] projection.
+    shift, scale, gate, *_ = torch.randn(
+        b, 6 * d, device="cuda", dtype=param_dtype
+    ).chunk(6, dim=-1)
+    for actual, expected in [
+        (
+            _fused(x, scale, shift, modulate=True),
+            x * (1 + scale[:, None]) + shift[:, None],
+        ),
+        (scale_shift(x, scale, shift), x * (1 + scale[:, None]) + shift[:, None]),
+        (_fused(x, gate, update, modulate=False), x + gate[:, None] * update),
+        (gated_residual(x, gate, update), x + gate[:, None] * update),
+    ]:
+        torch.testing.assert_close(actual, expected, rtol=0, atol=0)
+        assert actual.dtype == expected.dtype
+
+
+@pytest.mark.parametrize("device", ["cpu", "cuda"])
+def test_modulation_keeps_autograd(device):
+    if device == "cuda" and not torch.cuda.is_available():
+        pytest.skip("CUDA required")
+    x = torch.randn(2, 7, 32, device=device, requires_grad=True)
+    params = torch.randn(2, 96, device=device, requires_grad=True)
+    shift, scale, gate = params.chunk(3, dim=-1)
+    update = torch.randn_like(x, requires_grad=True)
+    actual = gated_residual(scale_shift(x, scale, shift), gate, update)
+    expected = x * (1 + scale[:, None]) + shift[:, None] + gate[:, None] * update
+    actual_grads = torch.autograd.grad(actual.sum(), (x, params, update))
+    expected_grads = torch.autograd.grad(expected.sum(), (x, params, update))
+    for a, b in zip(actual_grads, expected_grads, strict=True):
+        torch.testing.assert_close(a, b, rtol=0, atol=0)
+
+
+@pytest.mark.skipif(not torch.cuda.is_available(), reason="CUDA required")
+@torch.inference_mode()
+def test_modulation_handles_sliced_activations():
+    x = torch.randn(3, 19, 32, device="cuda")[:, 2:-2]
+    update = torch.randn(3, 19, 32, device="cuda", dtype=torch.bfloat16)[:, 2:-2]
+    shift, scale, gate = torch.randn(3, 96, device="cuda", dtype=torch.bfloat16).chunk(
+        3, -1
+    )
+    torch.testing.assert_close(
+        scale_shift(x, scale, shift),
+        x * (1 + scale[:, None]) + shift[:, None],
+        rtol=0,
+        atol=0,
+    )
+    torch.testing.assert_close(
+        gated_residual(x, gate, update), x + gate[:, None] * update, rtol=0, atol=0
+    )

--- a/tests/unit_test/auk/test_modulation.py
+++ b/tests/unit_test/auk/test_modulation.py
@@ -27,14 +27,13 @@ def test_modulation_preserves_eager_rounding(shape, x_dtype, param_dtype):
     shift, scale, gate, *_ = torch.randn(
         b, 6 * d, device="cuda", dtype=param_dtype
     ).chunk(6, dim=-1)
+    expected_scale_shift = x * (1 + scale[:, None]) + shift[:, None]
+    expected_residual = x + gate[:, None] * update
     for actual, expected in [
-        (
-            _fused(x, scale, shift, modulate=True),
-            x * (1 + scale[:, None]) + shift[:, None],
-        ),
-        (scale_shift(x, scale, shift), x * (1 + scale[:, None]) + shift[:, None]),
-        (_fused(x, gate, update, modulate=False), x + gate[:, None] * update),
-        (gated_residual(x, gate, update), x + gate[:, None] * update),
+        (_fused(x, scale, shift, modulate=True), expected_scale_shift),
+        (scale_shift(x, scale, shift), expected_scale_shift),
+        (_fused(x, gate, update, modulate=False), expected_residual),
+        (gated_residual(x, gate, update), expected_residual),
     ]:
         torch.testing.assert_close(actual, expected, rtol=0, atol=0)
         assert actual.dtype == expected.dtype
@@ -64,12 +63,14 @@ def test_modulation_handles_sliced_activations():
     shift, scale, gate = torch.randn(3, 96, device="cuda", dtype=torch.bfloat16).chunk(
         3, -1
     )
+    expected_scale_shift = x * (1 + scale[:, None]) + shift[:, None]
+    expected_residual = x + gate[:, None] * update
     torch.testing.assert_close(
         scale_shift(x, scale, shift),
-        x * (1 + scale[:, None]) + shift[:, None],
+        expected_scale_shift,
         rtol=0,
         atol=0,
     )
     torch.testing.assert_close(
-        gated_residual(x, gate, update), x + gate[:, None] * update, rtol=0, atol=0
+        gated_residual(x, gate, update), expected_residual, rtol=0, atol=0
     )


### PR DESCRIPTION
## Motivation

AuK DiT repeatedly launches separate elementwise operators for AdaLN scale/shift and gated residual updates throughout sampling. Fusing these operations reduces kernel launches and intermediate tensor traffic. On the measured workload, HTTP throughput improves by 9–11% at concurrency 8 and approximately 7% at concurrency 16.

## Modifications

- Add Triton scale/shift and gated residual kernels and integrate them into the single-stream blocks, both branches of the double-stream blocks, and final AdaLN modulation.
- Preserve eager intermediate rounding and dtype promotion, with `enable_fp_fusion=False`.
- Use fusion for eligible inference tensors with at least `2**22` elements. Smaller tensors retain eager execution to avoid launch overhead outweighing the savings.
- Add regression tests for mixed dtypes, noncontiguous AdaLN parameter chunks, tail masking, sliced activations, and autograd behavior.

## Related Issues

Related to #2067.

## Accuracy Test

Validated on H100 80GB with PyTorch 2.13.0 and Triton 3.7.1:

- AuK unit suite: 54 tests passed. The final test cleanup was followed by another passing run of all 15 modulation tests.
- Kernel comparisons use `rtol=0, atol=0` and verify output dtypes.
- Full 32-step sampling with the real checkpoint and fixed conditioning inputs: all 25 outputs across request batches 1/8/16 have exactly equal latents and VAE-decoded waveforms against main, with maximum absolute error 0. Inputs include reference-conditioned and no-reference cases.

Both arms use the same default serving configuration, 32 Euler steps, CFG=2, and seed=1234.

## Benchmark & Profiling

Baseline: main `b2cc93b0`. Candidate: `4776ed27` (production implementation: `b5f35f91`).

Hardware and workload: one H100 80GB, AuK with Qwen2.5-Omni-3B conditioning, the first 192 SeedTTS EN voice-cloning requests, and 48 warmup requests per run. CPU affinity (`0-9,88-97`) and thread count (`OMP_NUM_THREADS=4`) are fixed.

### HTTP

Measured in main → candidate → main order on the same GPU. All six concurrency/run combinations completed 192/192 requests.

| Concurrency | Initial main req/s | Candidate req/s | Repeated main req/s | Throughput gain vs. both main runs |
|---|---:|---:|---:|---:|
| 8 | 1.651 | 1.800 | 1.621 | 9.0–11.0% |
| 16 | 2.071 | 2.214 | 2.068 | 6.9–7.1% |

| Concurrency | Initial main P99 (s) | Candidate P99 (s) | Repeated main P99 (s) |
|---|---:|---:|---:|
| 8 | 8.399 | 7.601 | 7.645 |
| 16 | 11.745 | 10.938 | 11.735 |

### Full DiT sampling

Fixed real conditioning inputs, two warmups and five timed samples per batch size; medians below include all 32 sampling steps and exclude conditioning encoding and VAE decoding.

| Request batch | Main (ms) | Candidate (ms) | Time reduction |
|---|---:|---:|---:|
| 8 | 4447.091 | 4118.958 | 7.38% |
| 16 | 8576.032 | 7967.109 | 7.10% |

For two DiT forwards on the same batch-8 input, kernel launches decrease from 4,352 to 3,868 and summed GPU kernel duration decreases from 271.255 ms to 251.422 ms.

### Limitations

- Full-model equality covers 16 distinct conditioning inputs reused across batch sizes, producing 25 compared outputs at a fixed seed. HTTP completion counts are reported separately from these numerical comparisons.
- The measured batch-1 inputs use eager operations. Alternating main/candidate measurements were noisy; no batch-1 speedup is claimed.
- Full-model correctness and performance results are limited to this H100 environment and workload.

## Checklist

- [x] Format your code according with pre-commit.
- [x] Add unit tests.
- [x] Update documentation / docstrings / example tutorials as needed.
- [x] Provide throughput / latency benchmark results and accuracy evaluation results as needed.
- [ ] For reviewers: If you haven't made any contributions to this PR and are only assisting with merging the main branch, please remove yourself as a co-author when merging the PR.

## CI

Local validation is complete. Repository GPU CI requires a maintainer to add the `run-ci` label.
