### PR TITLE
fix(image): apply EXIF orientation when loading images

### DIFF
--- a/sglang_omni/preprocessing/image.py
+++ b/sglang_omni/preprocessing/image.py
@@ -9,7 +9,7 @@ from io import BytesIO
 from pathlib import Path
 from typing import Any
 
-from PIL import Image, UnidentifiedImageError
+from PIL import Image, ImageOps, UnidentifiedImageError
 
 from .base import MediaIO, _is_url
 from .cache_key import compute_media_cache_key
@@ -17,7 +17,7 @@ from .cache_key import compute_media_cache_key
 
 def load_image_path(path: str | Path) -> Image.Image:
     """Load an image from disk as RGB."""
-    return Image.open(path).convert("RGB")
+    return ImageOps.exif_transpose(Image.open(path)).convert("RGB")
 
 
 class ImageMediaIO(MediaIO[Image.Image]):
@@ -37,7 +37,9 @@ class ImageMediaIO(MediaIO[Image.Image]):
     def load_bytes(self, data: bytes) -> Image.Image:
         """Load image from raw bytes."""
         try:
-            return Image.open(BytesIO(data)).convert(self.image_mode)
+            return ImageOps.exif_transpose(Image.open(BytesIO(data))).convert(
+                self.image_mode
+            )
         except UnidentifiedImageError as e:
             raise ValueError(f"Failed to identify image: {e}") from e
 
@@ -52,7 +54,9 @@ class ImageMediaIO(MediaIO[Image.Image]):
     def load_file(self, filepath: Path) -> Image.Image:
         """Load image from a local file path."""
         try:
-            return Image.open(filepath).convert(self.image_mode)
+            return ImageOps.exif_transpose(Image.open(filepath)).convert(
+                self.image_mode
+            )
         except UnidentifiedImageError as e:
             raise ValueError(f"Failed to identify image: {e}") from e
 

--- a/tests/unit_test/preprocessing/test_image.py
+++ b/tests/unit_test/preprocessing/test_image.py
@@ -1,0 +1,56 @@
+# SPDX-License-Identifier: Apache-2.0
+
+import base64
+from io import BytesIO
+
+import pytest
+from PIL import Image
+
+from sglang_omni.preprocessing.image import (
+    ImageMediaIO,
+    ensure_image_list_async,
+    load_image_path,
+)
+from sglang_omni.preprocessing.resource_connector import MultiModalResourceConnector
+
+
+@pytest.mark.asyncio
+@pytest.mark.parametrize("source", ["bytes", "file", "path", "data_url"])
+@pytest.mark.parametrize("orientation", [None, 2, 6])
+async def test_image_loading_applies_exif_orientation(tmp_path, source, orientation):
+    image = Image.new("RGB", (12, 8), "red")
+    image.paste("blue", (0, 0, 6, 4))
+    exif = Image.Exif()
+    if orientation is not None:
+        exif[274] = orientation
+    buffer = BytesIO()
+    image.save(buffer, format="JPEG", exif=exif)
+    data = buffer.getvalue()
+    expected = Image.open(BytesIO(data)).convert("RGB")
+    if orientation == 2:
+        expected = expected.transpose(Image.Transpose.FLIP_LEFT_RIGHT)
+    elif orientation == 6:
+        expected = expected.transpose(Image.Transpose.ROTATE_270)
+
+    if source == "bytes":
+        actual = ImageMediaIO().load_bytes(data)
+    elif source == "data_url":
+        url = "data:image/jpeg;base64," + base64.b64encode(data).decode()
+        actual = (
+            await ensure_image_list_async(
+                [url], media_connector=MultiModalResourceConnector()
+            )
+        )[0]
+    else:
+        path = tmp_path / "image.jpg"
+        path.write_bytes(data)
+        actual = (
+            ImageMediaIO().load_file(path)
+            if source == "file"
+            else load_image_path(path)
+        )
+
+    assert actual.mode == "RGB"
+    assert actual.size == expected.size
+    assert actual.tobytes() == expected.tobytes()
+    assert actual.getexif().get(274) is None


### PR DESCRIPTION
## Motivation

JPEGs with EXIF rotation reach the vision processor sideways, producing the wrong image dimensions and patch grid.

## Modifications

Apply EXIF orientation before converting loaded images. Cover rotated and mirrored JPEGs from bytes, files and data URLs.

`pytest tests/unit_test/preprocessing -q`: 44 passed.
