### PR TITLE
fix(scheduler): defer abort row filtering to safe boundaries

### DIFF
--- a/sglang_omni/scheduling/omni_scheduler.py
+++ b/sglang_omni/scheduling/omni_scheduler.py
@@ -1833,6 +1833,11 @@ class OmniScheduler:
                 if defer_running_cleanup
                 else False
             )
+            immediate_reqs = (
+                []
+                if running_abort
+                else self._mark_request_finished_immediately(request_id)
+            )
             pending = self._pending_request_builds.pop(request_id, None)
             if pending is not None:
                 pending[2].cancel()
@@ -1867,11 +1872,9 @@ class OmniScheduler:
         self._prefill_start_done.discard(request_id)
         self._prefill_end_done.discard(request_id)
         if not running_abort:
-            self._release_immediate_request_resources(request_id)
-            _remove_from_batch(self.running_batch, request_id)
-            _remove_from_batch(self.cur_batch, request_id)
-            _remove_from_batch(self.last_batch, request_id)
-            _remove_from_batch(self._async_pending_batch(), request_id)
+            for req in immediate_reqs:
+                self._release_request_kv_cache(req)
+                _detach_request_data(req)
         self._drain_inbox_for_request(request_id)
 
     def admin(
@@ -2188,6 +2191,15 @@ class OmniScheduler:
         request_ids = self._active_request_ids()
         for request_id in request_ids:
             self.abort(request_id, defer_running_cleanup=False)
+        seen: set[int] = set()
+        for batch in (self.running_batch, self.cur_batch, self.last_batch):
+            if batch is None or id(batch) in seen:
+                continue
+            seen.add(id(batch))
+            batch.filter_batch()
+            if not batch.reqs:
+                batch.batch_is_full = False
+        self.chunked_req = None
         return len(request_ids)
 
     def _active_request_ids(self) -> list[str]:
@@ -2296,16 +2308,9 @@ class OmniScheduler:
                 marked = True
         return marked
 
-    def _run_abort_callback(self, request_id: str) -> None:
-        callback = self._abort_callback
-        if callback is None:
-            return
-        try:
-            callback(request_id)
-        except Exception:
-            logger.exception("OmniScheduler: abort cleanup failed for %s", request_id)
-
-    def _release_immediate_request_resources(self, request_id: str) -> None:
+    def _mark_request_finished_immediately(self, request_id: str) -> list[Any]:
+        """Make immediate cleanup visible without rewriting prepared batches."""
+        matches = []
         seen: set[int] = set()
         for batch in (
             self.running_batch,
@@ -2319,7 +2324,21 @@ class OmniScheduler:
                 if req.rid != request_id or id(req) in seen:
                     continue
                 seen.add(id(req))
-                self._release_request_kv_cache(req)
+                matches.append(req)
+                if not req.finished():
+                    if req.to_finish is None:
+                        req.to_finish = FINISH_ABORT()
+                    req.update_finish_state()
+        return matches
+
+    def _run_abort_callback(self, request_id: str) -> None:
+        callback = self._abort_callback
+        if callback is None:
+            return
+        try:
+            callback(request_id)
+        except Exception:
+            logger.exception("OmniScheduler: abort cleanup failed for %s", request_id)
 
     def _release_request_kv_cache(self, req: Any) -> None:
         if not req.kv.holds_kv and not req.kv.holds_mamba:
@@ -2714,17 +2733,3 @@ class OmniScheduler:
             req_data.stream_done = True
             return
         self._stream_done_handler(req_data)
-
-
-def _remove_from_batch(batch: Any, request_id: str) -> None:
-    if batch is None:
-        return
-    remaining_reqs = []
-    for req in batch.reqs:
-        if req.rid == request_id:
-            _detach_request_data(req)
-        else:
-            remaining_reqs.append(req)
-    batch.reqs = remaining_reqs
-    if not batch.reqs:
-        batch.batch_is_full = False

--- a/tests/unit_test/pipeline/test_scheduler.py
+++ b/tests/unit_test/pipeline/test_scheduler.py
@@ -86,6 +86,30 @@ def _new_stage_payload(request_id: str) -> StagePayload:
     )
 
 
+def _make_abortable_req(request_id: str, **attributes):
+    values = {
+        "rid": request_id,
+        "to_finish": None,
+        "finished_reason": None,
+        "is_retracted": False,
+        "_omni_terminal_claimed": False,
+        "return_logprob": False,
+        "grammar": None,
+    }
+    values.update(attributes)
+    req = SimpleNamespace(**values)
+    req.finished = lambda: req.finished_reason is not None
+
+    def update_finish_state() -> None:
+        if req.finished() or req.to_finish is None:
+            return
+        req.finished_reason = req.to_finish
+        req.to_finish = None
+
+    req.update_finish_state = update_finish_state
+    return req
+
+
 @pytest.mark.parametrize("tp_size,is_entry_rank", [(1, True), (2, True), (2, False)])
 @pytest.mark.parametrize(
     "pending_queue", ["_pending_request_builds", "_pending_request_admissions"]
@@ -352,14 +376,14 @@ def test_omni_scheduler_run_batch_failure_emits_error_and_aborts(monkeypatch) ->
 
     batch = SimpleNamespace(
         reqs=[
-            SimpleNamespace(
-                rid="req-1",
+            _make_abortable_req(
+                "req-1",
                 _omni_data=SimpleNamespace(),
                 kv=ReqKvInfo(req_pool_idx=1),
                 inflight_middle_chunks=0,
             ),
-            SimpleNamespace(
-                rid="req-2",
+            _make_abortable_req(
+                "req-2",
                 _omni_data=SimpleNamespace(),
                 kv=ReqKvInfo(req_pool_idx=2),
                 inflight_middle_chunks=0,
@@ -385,7 +409,8 @@ def test_omni_scheduler_run_batch_failure_emits_error_and_aborts(monkeypatch) ->
     assert all(isinstance(output.data, RuntimeError) for output in outputs)
     assert all("cuda out of memory" in str(output.data) for output in outputs)
     assert scheduler._aborted_request_ids == {"req-1", "req-2"}
-    assert batch.reqs == []
+    assert batch.reqs == failed_reqs
+    assert all(req.finished() for req in failed_reqs)
     assert all(req._omni_data is None for req in failed_reqs)
     assert release_calls == [("req-1", tree_cache), ("req-2", tree_cache)]
     assert scheduler._pending_stream_ingress == {}
@@ -962,6 +987,47 @@ def test_omni_scheduler_fast_path_drops_retracted_req() -> None:
     assert "keep_indices" not in captured
 
 
+def test_immediate_finish_keeps_async_snapshot_aligned_until_resolve() -> None:
+    reqs = [
+        _make_abortable_req(
+            f"req-{index}",
+        )
+        for index in range(2)
+    ]
+    live_batch = SimpleNamespace(reqs=list(reqs))
+    snapshot = SimpleNamespace(reqs=list(reqs))
+    scheduler = object.__new__(OmniScheduler)
+    scheduler.running_batch = live_batch
+    scheduler.cur_batch = live_batch
+    scheduler.last_batch = None
+    scheduler._async_pending = (snapshot, object(), object())
+    captured = {}
+
+    def resolve(batch, _sched_output, _pending_step, *, skip_rids):
+        assert batch.reqs == reqs
+        captured["skip_rids"] = skip_rids
+        return SimpleNamespace(next_token_ids=torch.tensor([10, 20]))
+
+    def process(batch, result):
+        captured["reqs"] = list(batch.reqs)
+        captured["tokens"] = result.next_token_ids.tolist()
+
+    scheduler._run_batch_resolve = resolve
+    scheduler.process_batch_result = process
+
+    matches = scheduler._mark_request_finished_immediately("req-0")
+
+    assert matches == [reqs[0]]
+    assert live_batch.reqs == reqs
+    assert snapshot.reqs == reqs
+
+    scheduler._resolve_and_process(snapshot, object(), object())
+
+    assert captured["skip_rids"] == {"req-0"}
+    assert captured["reqs"] == [reqs[1]]
+    assert captured["tokens"] == [20]
+
+
 def test_omni_scheduler_abort_propagates_immediate_kv_cleanup_failure(
     monkeypatch,
 ) -> None:
@@ -985,8 +1051,8 @@ def test_omni_scheduler_abort_propagates_immediate_kv_cleanup_failure(
     scheduler.waiting_queue = []
     scheduler.tree_cache = object()
 
-    req = SimpleNamespace(
-        rid="req-fail",
+    req = _make_abortable_req(
+        "req-fail",
         _omni_data=SimpleNamespace(),
         kv=ReqKvInfo(req_pool_idx=1),
     )
@@ -1000,6 +1066,7 @@ def test_omni_scheduler_abort_propagates_immediate_kv_cleanup_failure(
         scheduler.abort("req-fail", defer_running_cleanup=False)
 
     assert batch.reqs == [req]
+    assert req.finished_reason.to_json()["type"] == "abort"
 
 
 def test_omni_scheduler_abort_marks_running_request_for_finish(monkeypatch) -> None:
@@ -1122,18 +1189,20 @@ def test_omni_scheduler_abort_treats_retracted_alias_as_waiting_owned() -> None:
     scheduler.inbox = Queue()
     scheduler.tree_cache = None
 
-    req = SimpleNamespace(
-        rid="req-retracted",
+    req = _make_abortable_req(
+        "req-retracted",
         is_retracted=True,
-        finished=lambda: False,
-        to_finish=None,
-        finished_reason=None,
         kv=ReqKvInfo(),
-        _omni_terminal_claimed=False,
     )
     request_data = SimpleNamespace(req=req)
     req._omni_data = request_data
-    stale_batch = SimpleNamespace(reqs=[req], batch_is_full=True)
+    other_req = SimpleNamespace(rid="req-other")
+    stale_batch = SimpleNamespace(
+        reqs=[req, other_req],
+        req_pool_indices=torch.tensor([10, 11]),
+        input_ids=torch.tensor([20, 21]),
+        batch_is_full=True,
+    )
     scheduler.waiting_queue = [req]
     scheduler.running_batch = SimpleNamespace(reqs=[], batch_is_full=False)
     scheduler.cur_batch = None
@@ -1143,7 +1212,10 @@ def test_omni_scheduler_abort_treats_retracted_alias_as_waiting_owned() -> None:
     scheduler.abort("req-retracted")
 
     assert scheduler.waiting_queue == []
-    assert stale_batch.reqs == []
+    assert stale_batch.reqs == [req, other_req]
+    assert stale_batch.req_pool_indices.tolist() == [10, 11]
+    assert stale_batch.input_ids.tolist() == [20, 21]
+    assert req.finished_reason.to_json()["type"] == "abort"
     assert req.to_finish is None
     assert req._omni_data is None
     assert request_data.req is req
@@ -1572,10 +1644,11 @@ def test_abort_after_terminal_close_runs_its_own_cleanup() -> None:
     _init_sync_request_build_state(scheduler)
 
     data = SimpleNamespace()
-    req = SimpleNamespace(
-        rid="req-abort-after-close",
+    req = _make_abortable_req(
+        "req-abort-after-close",
         _omni_data=data,
         _omni_terminal_claimed=True,
+        finished_reason=object(),
         kv=ReqKvInfo(),
     )
     data.req = req
@@ -1591,7 +1664,7 @@ def test_abort_after_terminal_close_runs_its_own_cleanup() -> None:
     scheduler.abort(req.rid)
 
     assert cleaned == [req.rid]
-    assert batch.reqs == []
+    assert batch.reqs == [req]
 
 
 def test_abort_publishes_request_id_before_marking_terminal_finish() -> None:


### PR DESCRIPTION
Represent immediate cleanup in Req terminal state and let existing scheduler boundaries compact ScheduleBatch rows. This keeps live and async snapshots aligned without duplicating the upstream batch field layout.
