### PR TITLE
perf(auk): add opt-in singleton mask fast path

### DIFF
--- a/docs/cookbook/auk.md
+++ b/docs/cookbook/auk.md
@@ -92,6 +92,11 @@ The DiT stores its weights in BF16 and runs without autocast by default (`--auk_
 
 Conditioning and DiT sampling use dynamic batching, with default maximum batch sizes of 8 and 16. VAE decoding groups equal-length latents (up to 4 requests) to preserve boundary behavior. The stages can overlap on separate CUDA streams and share VAE weights within the same process/device. Conditioning loads the Qwen encoder, the VAE and the two hidden-state fusion parameters; only the sampling stage loads the DiT. Set `--conditioning.factory.max_batch_size`, `--auk_engine.factory.max_batch_size`, or `--decode.factory.max_batch_size` to tune them. Audio is returned after decoding completes; incremental audio streaming is not implemented.
 
+For serial workloads, `--auk_engine.factory.enable_dit_singleton_mask_elision true`
+trims stored conditioning and reference padding to their recorded valid lengths
+and skips all-valid DiT masks when the engine forms a singleton batch. The
+option is disabled by default; multi-request batches retain the padded-mask path.
+
 ## SeedTTS Evaluation
 
 The standard benchmark detects `tencent/AuK` and `tencent/AuK-Flash` and starts the server from `--model-path`. It defaults to the full English dataset, concurrency 1, one warmup, and seed 1234. It estimates duration from the reference audio and transcript, then automatically starts and stops the TTS and ASR servers:

--- a/sglang_omni/models/auk/config.py
+++ b/sglang_omni/models/auk/config.py
@@ -49,6 +49,7 @@ class AuKPipelineConfig(PipelineConfig):
                 device=current_platform.device_type,
                 dtype="bfloat16",
                 nfe=C.DEFAULT_NFE,
+                enable_dit_singleton_mask_elision=False,
                 cfg_strength=C.DEFAULT_CFG_STRENGTH,
                 sway_sampling_coef=C.DEFAULT_SWAY_SAMPLING_COEF,
                 max_seconds=C.MAX_SECONDS,

--- a/sglang_omni/models/auk/dit.py
+++ b/sglang_omni/models/auk/dit.py
@@ -542,6 +542,9 @@ class AuKDit(nn.Module):
         prompt_len = ref_emb.shape[1]
         audio = torch.cat([ref_emb, x_emb], dim=1)
 
+        if mask is None and ref_mask is None:
+            return audio, None, prompt_len
+
         batch, n = x_emb.shape[:2]
         if mask is None:
             mask = torch.ones(batch, n, dtype=torch.bool, device=x_emb.device)
@@ -566,13 +569,14 @@ class AuKDit(nn.Module):
         ref_mask: torch.Tensor | None = None,
         audio_positions: torch.Tensor | None = None,
         joint_positions: torch.Tensor | None = None,
+        all_valid_masks: bool = False,
     ) -> torch.Tensor:
         batch = x.shape[0]
         if time.ndim == 0:
             time = time.repeat(batch)
         t = self.time_embed(time)
 
-        if c_mask is None:
+        if c_mask is None and not all_valid_masks:
             c_mask = text.abs().sum(-1) > 0
 
         if cfg_infer:
@@ -604,7 +608,8 @@ class AuKDit(nn.Module):
                 if a_mask_cond is not None and a_mask_uncond is not None
                 else None
             )
-            c_mask = torch.cat((c_mask, c_mask), dim=0)
+            if c_mask is not None:
+                c_mask = torch.cat((c_mask, c_mask), dim=0)
             if audio_positions is not None:
                 audio_positions = audio_positions.repeat(2, 1)
                 joint_positions = joint_positions.repeat(2, 1)

--- a/sglang_omni/models/auk/flow_matching.py
+++ b/sglang_omni/models/auk/flow_matching.py
@@ -52,7 +52,7 @@ def build_time_grid(
 @dataclass
 class AuKSampleItem:
     conditioning: torch.Tensor
-    text_mask: torch.Tensor
+    text_mask: torch.Tensor | None
     target_frames: int
     ref_latent: torch.Tensor | None = None
     seed: int | None = None
@@ -97,6 +97,7 @@ class AuKFlowMatching(nn.Module):
         cfg_strength: float,
         sway_sampling_coef: float | None = None,
         t_grid: Sequence[float] | None = None,
+        elide_singleton_masks: bool = False,
     ) -> list[torch.Tensor]:
         device = next(self.parameters()).device
         dim = self.transformer.latent_dim
@@ -118,13 +119,18 @@ class AuKFlowMatching(nn.Module):
             )
             for item in items
         ]
+        all_valid_masks = elide_singleton_masks and len(items) == 1
         ref = pack(references).to(weight_dtype)
         ref_mask = (
-            torch.arange(ref.shape[1], device=device)[None, :]
+            None
+            if all_valid_masks
+            else torch.arange(ref.shape[1], device=device)[None, :]
             < torch.tensor([item.ref_length for item in items], device=device)[:, None]
         )
         text = pack([item.conditioning for item in items]).to(weight_dtype)
-        text_mask = pack([item.text_mask for item in items])
+        text_mask = (
+            None if all_valid_masks else pack([item.text_mask for item in items])
+        )
         noise = []
         for item in items:
             generator = request_generator(item.seed, device)
@@ -184,6 +190,7 @@ class AuKFlowMatching(nn.Module):
                 cache=True,
                 audio_positions=audio_positions,
                 joint_positions=joint_positions,
+                all_valid_masks=all_valid_masks,
             )
             if cfg_strength < 1e-5:
                 return self.transformer(

--- a/sglang_omni/models/auk/stages.py
+++ b/sglang_omni/models/auk/stages.py
@@ -213,17 +213,27 @@ def create_conditioning_executor(
 def _sample_batch(payloads, flow, device, dtype, max_frames, sampling):
     started = time.perf_counter()
     states = [load_state(payload, AuKState) for payload in payloads]
-    items = [
-        AuKSampleItem(
-            state.conditioning.to(device),
-            state.text_mask.to(device),
-            min(max(state.gen_frames, 1), max_frames),
-            state.ref_latent.to(device) if state.ref_latent is not None else None,
-            state.seed,
-            state.ref_length,
+    elide_masks = sampling.get("elide_singleton_masks", False) and len(states) == 1
+    items = []
+    for state in states:
+        conditioning = (
+            state.conditioning[: state.prompt_tokens]
+            if elide_masks
+            else state.conditioning
         )
-        for state in states
-    ]
+        reference = state.ref_latent
+        if elide_masks and reference is not None:
+            reference = reference[: state.ref_length]
+        items.append(
+            AuKSampleItem(
+                conditioning=conditioning.to(device),
+                text_mask=None if elide_masks else state.text_mask.to(device),
+                target_frames=min(max(state.gen_frames, 1), max_frames),
+                ref_latent=reference.to(device) if reference is not None else None,
+                seed=state.seed,
+                ref_length=state.ref_length,
+            )
+        )
     logger.info("AuK DiT: sampling batch of %d requests", len(items))
     with _autocast(device, dtype):
         latents = flow.sample_batch(items, **sampling)
@@ -244,6 +254,7 @@ def create_auk_engine_executor(
     gpu_id: int | None = None,
     dtype: str = "bfloat16",
     nfe: int = C.DEFAULT_NFE,
+    enable_dit_singleton_mask_elision: bool = False,
     cfg_strength: float = C.DEFAULT_CFG_STRENGTH,
     sway_sampling_coef: float | None = C.DEFAULT_SWAY_SAMPLING_COEF,
     max_seconds: float = C.MAX_SECONDS,
@@ -273,6 +284,8 @@ def create_auk_engine_executor(
         sway_sampling_coef=None if config.is_flash else sway_sampling_coef,
         t_grid=C.FLASH_T_GRID if config.is_flash else None,
     )
+    if enable_dit_singleton_mask_elision:
+        sampling["elide_singleton_masks"] = True
     return _scheduler(
         lambda payloads: _sample_batch(
             payloads,

--- a/tests/unit_test/auk/test_flow_matching.py
+++ b/tests/unit_test/auk/test_flow_matching.py
@@ -7,6 +7,22 @@ import torch.nn.functional as F
 from sglang_omni.models.auk.flow_matching import fuse_hidden_states
 
 
+class RecordingTransformer(torch.nn.Module):
+    latent_dim = 8
+
+    def __init__(self):
+        super().__init__()
+        self.anchor = torch.nn.Parameter(torch.zeros(()))
+        self.calls = []
+
+    def forward(self, **kwargs):
+        self.calls.append(kwargs)
+        return torch.zeros_like(kwargs["x"])
+
+    def clear_cache(self):
+        pass
+
+
 def test_fusion_matches_upstream_layerwise_normalization():
     torch.manual_seed(42)
     hidden = torch.randn(2, 5, 7, 16)
@@ -102,3 +118,90 @@ def test_bf16_backbone_integrates_in_fp32_and_tracks_fp32_backbone():
             output.flatten(), reference.flatten(), dim=0
         )
         assert cosine > 0.99, cosine
+
+
+def test_singleton_elision_passes_no_masks_to_transformer():
+    from sglang_omni.models.auk.flow_matching import AuKFlowMatching, AuKSampleItem
+
+    transformer = RecordingTransformer()
+    flow = AuKFlowMatching(transformer, num_llm_layers=2)
+    item = AuKSampleItem(
+        conditioning=torch.zeros(4, 16),
+        text_mask=None,
+        target_frames=5,
+        ref_latent=torch.zeros(3, 8),
+        ref_length=3,
+    )
+    flow.sample_batch([item], steps=1, cfg_strength=0, elide_singleton_masks=True)
+    call = transformer.calls[0]
+    assert call["mask"] is None
+    assert call["c_mask"] is None
+    assert call["ref_mask"] is None
+    assert call["all_valid_masks"] is True
+
+
+def test_enabled_multi_request_batch_retains_padded_masks():
+    from sglang_omni.models.auk.flow_matching import AuKFlowMatching, AuKSampleItem
+
+    transformer = RecordingTransformer()
+    flow = AuKFlowMatching(transformer, num_llm_layers=2)
+    items = [
+        AuKSampleItem(
+            conditioning=torch.zeros(text, 16),
+            text_mask=torch.ones(text, dtype=torch.bool),
+            target_frames=frames,
+            ref_latent=torch.zeros(reference, 8),
+            ref_length=reference,
+        )
+        for text, frames, reference in ((4, 5, 3), (2, 3, 1))
+    ]
+    flow.sample_batch(items, steps=1, cfg_strength=0, elide_singleton_masks=True)
+    call = transformer.calls[0]
+    assert call["mask"].tolist() == [[True] * 5, [True] * 3 + [False] * 2]
+    assert call["c_mask"].tolist() == [[True] * 4, [True] * 2 + [False] * 2]
+    assert call["ref_mask"].tolist() == [[True] * 3, [True, False, False]]
+    assert call["all_valid_masks"] is False
+
+
+def test_real_dit_singleton_elision_matches_all_valid_masks():
+    from sglang_omni.models.auk.dit import AuKDit
+    from sglang_omni.models.auk.flow_matching import AuKFlowMatching, AuKSampleItem
+
+    torch.manual_seed(42)
+    flow = AuKFlowMatching(
+        AuKDit(
+            dim=32,
+            heads=2,
+            dim_head=16,
+            latent_dim=8,
+            text_hidden_dim=16,
+            num_layers=1,
+            num_single_layers=1,
+        ),
+        num_llm_layers=2,
+    ).eval()
+    for parameter in flow.parameters():
+        torch.nn.init.uniform_(parameter, -0.2, 0.2)
+    conditioning = torch.randn(4, 16)
+    reference = torch.randn(3, 8)
+    baseline = AuKSampleItem(
+        conditioning=conditioning,
+        text_mask=torch.ones(4, dtype=torch.bool),
+        target_frames=5,
+        ref_latent=reference,
+        ref_length=3,
+        seed=7,
+    )
+    elided = AuKSampleItem(
+        conditioning=conditioning,
+        text_mask=None,
+        target_frames=5,
+        ref_latent=reference,
+        ref_length=3,
+        seed=7,
+    )
+    expected = flow.sample_batch([baseline], steps=2, cfg_strength=2)[0]
+    actual = flow.sample_batch(
+        [elided], steps=2, cfg_strength=2, elide_singleton_masks=True
+    )[0]
+    torch.testing.assert_close(actual, expected, rtol=1e-5, atol=1e-6)

--- a/tests/unit_test/auk/test_stages.py
+++ b/tests/unit_test/auk/test_stages.py
@@ -184,3 +184,34 @@ def test_backbone_dtype_is_chosen_when_the_flow_is_loaded(stages, monkeypatch):
         )
     assert requested == [torch.bfloat16, torch.float32]
     assert autocast == [False, True]
+
+
+def test_singleton_mask_elision_trims_to_valid_lengths():
+    flow = Mock()
+    flow.sample_batch.return_value = [torch.zeros(5, 64)]
+    state = AuKState(
+        gen_frames=5,
+        prompt_tokens=4,
+        conditioning=torch.zeros(6, 16),
+        text_mask=torch.tensor([True, True, True, True, False, False]),
+        ref_latent=torch.zeros(5, 64),
+        ref_length=3,
+    )
+    payload = StagePayload(
+        request_id="test", request=OmniRequest(inputs="hello"), data=state.to_dict()
+    )
+
+    _sample_batch(
+        [payload],
+        flow,
+        torch.device("cpu"),
+        "float32",
+        1500,
+        {"elide_singleton_masks": True},
+    )
+
+    item = flow.sample_batch.call_args.args[0][0]
+    assert item.conditioning.shape == (4, 16)
+    assert item.text_mask is None
+    assert item.ref_latent.shape == (3, 64)
+    assert flow.sample_batch.call_args.kwargs["elide_singleton_masks"] is True


### PR DESCRIPTION
## Summary

Add an opt-in AuK singleton fast path that trims stored conditioning/reference
padding to recorded valid lengths and passes `None` instead of materializing
all-valid DiT masks when the engine forms a one-request batch.

Enable with:

```bash
--auk_engine.factory.enable_dit_singleton_mask_elision true
```

The option defaults to `false`. Multi-request batches retain the existing
padded-mask behavior.

## H100 validation

The exact branch was built directly from local `upstream/main`
`80b5aaed74be473096846e81f5e217f92d11dcda` and tested in the pinned CI image
on one Modal H100. Two resident baseline servers received equal substantial and
per-shape warmups, followed by three off/off A/A pairs. The second server was
then replaced by the candidate, both arms were rewarmed equally, and three
alternating A/B pairs ran at c1/c8/c16.

| Shape | Throughput changes | Mean | p99 changes | Max absolute A/A throughput delta |
|---|---|---:|---|---:|
| c1 | +14.08%, +17.68%, +12.89% | **+14.88%** | -15.00%, -20.78%, -14.54% | 0.84% |
| c8 | -1.34%, -1.19%, +1.43% | -0.37% | +4.15%, +3.84%, -0.61% | 2.53% |
| c16 | +3.08%, -0.48%, -2.87% | -0.09% | -9.80%, -3.92%, +1.76% | 5.50% |

c1 used identical singleton batches in every arm and shows the intended strong
serial improvement. c8/c16 changes remain inside their measured A/A variation;
no concurrent speedup is claimed. Actual batch rows are preserved and fully
accounted for in the profiling artifacts.

Existing SeedTTS corpus WER matched baseline exactly at c1 (1.087%), c8
(0.850%), c16 (0.554%), and the four-long-input cohort (0%). All 184 ASR
evaluations completed with zero skips, and every generation phase completed
without failed requests. Output differences caused by valid-length trimming
were evaluated through the existing WER standard, not a new tensor threshold.

The reviewed tree passed 39 AuK CPU tests, including direct singleton and
multi-request mask-contract coverage plus a real small-AuK masked-vs-elided
forward comparison, and real source/CLI materialization.
Final GPU state was 0% utilization / 4 MiB with no compute applications.

Refs #2064, #2067, #1798.
