### PR TITLE
[Fun-ASR] Support the current HF flat checkpoint layout

### DIFF
--- a/.github/workflows/omni-ci.yaml
+++ b/.github/workflows/omni-ci.yaml
@@ -58,7 +58,7 @@ env:
   QWEN3_TTS_MODEL_PATH: Qwen/Qwen3-TTS-12Hz-1.7B-Base
   QWEN3_ASR_MODEL_PATH: Qwen/Qwen3-ASR-1.7B
   MOSS_TRANSCRIBE_DIARIZE_MODEL_PATH: OpenMOSS-Team/MOSS-Transcribe-Diarize
-  FUN_ASR_MODEL_PATH: FunAudioLLM/Fun-ASR-Nano-2512-hf@7ef6cafdc445b5beff0b730cbeb51952c793ca6e
+  FUN_ASR_MODEL_PATH: FunAudioLLM/Fun-ASR-Nano-2512-hf
   WHISPER_ASR_MODEL_PATH: openai/whisper-large-v3
 
 

--- a/.github/workflows/omni-ci.yaml
+++ b/.github/workflows/omni-ci.yaml
@@ -58,7 +58,7 @@ env:
   QWEN3_TTS_MODEL_PATH: Qwen/Qwen3-TTS-12Hz-1.7B-Base
   QWEN3_ASR_MODEL_PATH: Qwen/Qwen3-ASR-1.7B
   MOSS_TRANSCRIBE_DIARIZE_MODEL_PATH: OpenMOSS-Team/MOSS-Transcribe-Diarize
-  FUN_ASR_MODEL_PATH: FunAudioLLM/Fun-ASR-Nano-2512-hf@972ee603a3abb40a66c802ffaa9ba0ce88742b60
+  FUN_ASR_MODEL_PATH: FunAudioLLM/Fun-ASR-Nano-2512-hf@7ef6cafdc445b5beff0b730cbeb51952c793ca6e
   WHISPER_ASR_MODEL_PATH: openai/whisper-large-v3
 
 

--- a/benchmarks/tasks/asr.py
+++ b/benchmarks/tasks/asr.py
@@ -50,7 +50,6 @@ OMNI_WHISPER_SAMPLE_RATE = 16000
 QWEN3_ASR_MODEL_PATH = "Qwen/Qwen3-ASR-1.7B"
 QWEN3_ASR_REQUEST_TIMEOUT_S = 300
 FUN_ASR_MODEL_PATH = "FunAudioLLM/Fun-ASR-Nano-2512-hf"
-FUN_ASR_MODEL_REVISION = "7ef6cafdc445b5beff0b730cbeb51952c793ca6e"
 # note (aaron): ASR transcription fan-out for WER, not TTS generation concurrency.
 DEFAULT_ASR_TRANSCRIBE_CONCURRENCY = 32
 # note (aaron): warmup requests sent before the timed window, per unit of concurrency.

--- a/benchmarks/tasks/asr.py
+++ b/benchmarks/tasks/asr.py
@@ -50,7 +50,7 @@ OMNI_WHISPER_SAMPLE_RATE = 16000
 QWEN3_ASR_MODEL_PATH = "Qwen/Qwen3-ASR-1.7B"
 QWEN3_ASR_REQUEST_TIMEOUT_S = 300
 FUN_ASR_MODEL_PATH = "FunAudioLLM/Fun-ASR-Nano-2512-hf"
-FUN_ASR_MODEL_REVISION = "972ee603a3abb40a66c802ffaa9ba0ce88742b60"
+FUN_ASR_MODEL_REVISION = "7ef6cafdc445b5beff0b730cbeb51952c793ca6e"
 # note (aaron): ASR transcription fan-out for WER, not TTS generation concurrency.
 DEFAULT_ASR_TRANSCRIBE_CONCURRENCY = 32
 # note (aaron): warmup requests sent before the timed window, per unit of concurrency.

--- a/docs/cookbook/fun_asr.md
+++ b/docs/cookbook/fun_asr.md
@@ -14,7 +14,7 @@ then download the model:
 
 ```bash
 # Use the -hf variant
-hf download FunAudioLLM/Fun-ASR-Nano-2512-hf --revision 7ef6cafdc445b5beff0b730cbeb51952c793ca6e
+hf download FunAudioLLM/Fun-ASR-Nano-2512-hf
 ```
 
 ## Server Configuration
@@ -26,13 +26,6 @@ sgl-omni serve \
   --model-path FunAudioLLM/Fun-ASR-Nano-2512-hf \
   --port 8000
 ```
-
-For reproducibility, pass the snapshot directory printed by `hf download` as
-`--model-path`. Passing the repository ID uses its default revision instead.
-The loader supports both the flat HF encoder layout and earlier split-layout
-checkpoints, including revisions `972ee603a3abb40a66c802ffaa9ba0ce88742b60` and
-`1fd03aa58072a4c00bf0a0b149cc4cf0d36d11ed`. Split checkpoints retain the prior
-audio-token length behavior; flat checkpoints use one token per valid LFR frame.
 
 ## Transcribe Audio
 

--- a/docs/cookbook/fun_asr.md
+++ b/docs/cookbook/fun_asr.md
@@ -14,7 +14,7 @@ then download the model:
 
 ```bash
 # Use the -hf variant
-hf download FunAudioLLM/Fun-ASR-Nano-2512-hf
+hf download FunAudioLLM/Fun-ASR-Nano-2512-hf --revision 7ef6cafdc445b5beff0b730cbeb51952c793ca6e
 ```
 
 ## Server Configuration
@@ -26,6 +26,13 @@ sgl-omni serve \
   --model-path FunAudioLLM/Fun-ASR-Nano-2512-hf \
   --port 8000
 ```
+
+For reproducibility, pass the snapshot directory printed by `hf download` as
+`--model-path`. Passing the repository ID uses its default revision instead.
+The loader supports both the flat HF encoder layout and earlier split-layout
+checkpoints, including revisions `972ee603a3abb40a66c802ffaa9ba0ce88742b60` and
+`1fd03aa58072a4c00bf0a0b149cc4cf0d36d11ed`. Split checkpoints retain the prior
+audio-token length behavior; flat checkpoints use one token per valid LFR frame.
 
 ## Transcribe Audio
 

--- a/sglang_omni/models/fun_asr/checkpoint.py
+++ b/sglang_omni/models/fun_asr/checkpoint.py
@@ -50,11 +50,10 @@ def canonical_weight_name(
         raise ValueError(
             f"Fun-ASR {layout} config disagrees with checkpoint weight {name}"
         )
-    if layout == "flat":
-        return name
-    name = name.replace("model.audio_adaptor.", "model.multi_modal_projector.")
+    if layout == "split":
+        name = name.replace("model.audio_adaptor.", "model.multi_modal_projector.")
     prefix = "model.audio_tower."
-    if name.startswith(prefix):
+    if layout == "split" and name.startswith(prefix):
         suffix = name[len(prefix) :]
         if suffix.startswith("stem."):
             suffix = "layers.0." + suffix[len("stem.") :]
@@ -80,19 +79,21 @@ def canonical_weight_name(
                 index += 1 if group == "layers" else num_blocks
                 suffix = f"layers.{index}.{tail}"
         name = prefix + suffix
-    else:
+    elif layout == "split":
         name = name.replace(".blocks.", ".layers.")
-    for old_part, new_part in (
-        (".self_attn_layer_norm.", ".input_layernorm."),
-        (".final_layer_norm.", ".post_attention_layernorm."),
-        (".self_attn.out_proj.", ".self_attn.o_proj."),
-        (".feedforward_sequential_memory.", ".self_attn.fsmn."),
-        (".fsmn.", ".self_attn.fsmn."),
-        (".fc1.", ".mlp.fc1."),
-        (".fc2.", ".mlp.fc2."),
-    ):
-        # FSMN was a sibling of attention in both split export variants.
-        if old_part == ".fsmn." and ".self_attn.fsmn." in name:
-            continue
-        name = name.replace(old_part, new_part)
+    # Keep the local projection name stable; current HF calls it `o_proj`.
+    name = name.replace(".self_attn.o_proj.", ".self_attn.out_proj.")
+    if layout == "split":
+        for old_part, new_part in (
+            (".self_attn_layer_norm.", ".input_layernorm."),
+            (".final_layer_norm.", ".post_attention_layernorm."),
+            (".feedforward_sequential_memory.", ".self_attn.fsmn."),
+            (".fsmn.", ".self_attn.fsmn."),
+            (".fc1.", ".mlp.fc1."),
+            (".fc2.", ".mlp.fc2."),
+        ):
+            # FSMN was a sibling of attention in both split export variants.
+            if old_part == ".fsmn." and ".self_attn.fsmn." in name:
+                continue
+            name = name.replace(old_part, new_part)
     return name

--- a/sglang_omni/models/fun_asr/checkpoint.py
+++ b/sglang_omni/models/fun_asr/checkpoint.py
@@ -1,0 +1,98 @@
+# SPDX-License-Identifier: Apache-2.0
+"""Translate split-layout checkpoints into the canonical HF flat layout."""
+
+from __future__ import annotations
+
+import re
+
+
+def checkpoint_layout(audio_config: dict) -> str:
+    if "num_timestamp_prediction_layers" in audio_config:
+        if "num_timestamp_prediction_blocks" in audio_config:
+            raise ValueError("Fun-ASR config mixes split and flat layer counts")
+        return "flat"
+    return "split"
+
+
+def canonical_weight_name(
+    name: str, *, layout: str, num_blocks: int, tp_blocks: int
+) -> str:
+    """Map a single key without buffering checkpoint tensors or guessing from order."""
+    if layout not in {"split", "flat"}:
+        raise ValueError(f"Unknown Fun-ASR checkpoint layout: {layout}")
+    if not name.startswith(
+        ("model.audio_tower.", "model.audio_adaptor.", "model.multi_modal_projector.")
+    ):
+        return name
+    old = any(
+        part in name
+        for part in (
+            ".stem.",
+            ".timestamp_prediction_layers.",
+            ".timestamp_prediction_layer_norm.",
+            ".self_attn_layer_norm.",
+            ".final_layer_norm.",
+            ".blocks.",
+            ".audio_adaptor.",
+            ".audio_tower.layer_norm.",
+        )
+    )
+    new = any(
+        part in name
+        for part in (
+            ".input_layernorm.",
+            ".post_attention_layernorm.",
+            ".final_layernorm.",
+            ".mlp.",
+        )
+    )
+    if (layout == "flat" and old) or (layout == "split" and new):
+        raise ValueError(
+            f"Fun-ASR {layout} config disagrees with checkpoint weight {name}"
+        )
+    if layout == "flat":
+        return name
+    name = name.replace("model.audio_adaptor.", "model.multi_modal_projector.")
+    prefix = "model.audio_tower."
+    if name.startswith(prefix):
+        suffix = name[len(prefix) :]
+        if suffix.startswith("stem."):
+            suffix = "layers.0." + suffix[len("stem.") :]
+        elif suffix.startswith("timestamp_prediction_layer_norm."):
+            suffix = (
+                f"layers.{num_blocks + tp_blocks - 1}.final_layernorm."
+                + suffix.split(".", 1)[1]
+            )
+        elif suffix.startswith("layer_norm."):
+            suffix = (
+                f"layers.{num_blocks - 1}.final_layernorm." + suffix.split(".", 1)[1]
+            )
+        else:
+            match = re.match(
+                r"(layers|timestamp_prediction_layers)\.(\d+)\.(.+)", suffix
+            )
+            if match:
+                group, index, tail = match.groups()
+                index = int(index)
+                limit = num_blocks - 1 if group == "layers" else tp_blocks
+                if not 0 <= index < limit:
+                    raise ValueError(f"Fun-ASR checkpoint layer out of range: {name}")
+                index += 1 if group == "layers" else num_blocks
+                suffix = f"layers.{index}.{tail}"
+        name = prefix + suffix
+    else:
+        name = name.replace(".blocks.", ".layers.")
+    for old_part, new_part in (
+        (".self_attn_layer_norm.", ".input_layernorm."),
+        (".final_layer_norm.", ".post_attention_layernorm."),
+        (".self_attn.out_proj.", ".self_attn.o_proj."),
+        (".feedforward_sequential_memory.", ".self_attn.fsmn."),
+        (".fsmn.", ".self_attn.fsmn."),
+        (".fc1.", ".mlp.fc1."),
+        (".fc2.", ".mlp.fc2."),
+    ):
+        # FSMN was a sibling of attention in both split export variants.
+        if old_part == ".fsmn." and ".self_attn.fsmn." in name:
+            continue
+        name = name.replace(old_part, new_part)
+    return name

--- a/sglang_omni/models/fun_asr/configuration_fun_asr.py
+++ b/sglang_omni/models/fun_asr/configuration_fun_asr.py
@@ -20,6 +20,7 @@ from transformers.feature_extraction_sequence_utils import SequenceFeatureExtrac
 
 from sglang_omni.utils.audio_features import cached_fbank
 
+from .checkpoint import checkpoint_layout
 from .tool_funcs.audio_lengths import fun_asr_low_frame_rate_length
 
 AUDIO_PLACEHOLDER_TOKEN = "<|object_ref_start|>"
@@ -37,6 +38,15 @@ class FunAsrNanoFeatureExtractor(SequenceFeatureExtractor):
 
     model_input_names = ["input_features"]
 
+    @classmethod
+    def from_pretrained(cls, pretrained_model_name_or_path, **kwargs):
+        extractor = super().from_pretrained(pretrained_model_name_or_path, **kwargs)
+        config = FunAsrNanoConfig.from_pretrained(
+            pretrained_model_name_or_path, **kwargs
+        )
+        extractor.legacy_audio_lengths = config.checkpoint_layout == "split"
+        return extractor
+
     def __init__(
         self,
         feature_size: int = 80,
@@ -48,6 +58,9 @@ class FunAsrNanoFeatureExtractor(SequenceFeatureExtractor):
         window: str = "hamming",
         padding_value: float = 0.0,
         return_attention_mask: bool = True,
+        num_frames_lfr: int | None = None,
+        stride_lfr: int | None = None,
+        legacy_audio_lengths: bool = True,
         **kwargs,
     ):
         super().__init__(
@@ -67,8 +80,9 @@ class FunAsrNanoFeatureExtractor(SequenceFeatureExtractor):
         self.n_fft = int(round(frame_length * sampling_rate / 1000))  # 400 @ 16k
         self.hop_length = int(round(frame_shift * sampling_rate / 1000))  # 160 @ 16k
         self.win_length = self.n_fft
-        self.lfr_m = lfr_m
-        self.lfr_n = lfr_n
+        self.lfr_m = lfr_m if num_frames_lfr is None else num_frames_lfr
+        self.lfr_n = lfr_n if stride_lfr is None else stride_lfr
+        self.legacy_audio_lengths = legacy_audio_lengths
         self.window = window
         self.padding_value = padding_value
         self.return_attention_mask = return_attention_mask
@@ -246,7 +260,9 @@ class FunAsrNanoProcessor:
 
     def _get_feat_extract_output_lengths(self, input_lengths):
         """LFR frames -> adaptor audio-token count (3x stride-2)."""
-        return fun_asr_low_frame_rate_length(input_lengths)
+        return fun_asr_low_frame_rate_length(
+            input_lengths, legacy=self.feature_extractor.legacy_audio_lengths
+        )
 
     def __call__(self, text=None, audio=None, audio_kwargs=None, **kwargs):
         inputs: dict[str, Any] = {}
@@ -326,6 +342,7 @@ class FunAsrNanoEncoderConfig(PretrainedConfig):
         attention_dropout: float = 0.1,
         activation_dropout: float = 0.1,
         activation_function: str = "relu",
+        layer_norm_eps: float = 1e-5,
         **kwargs,
     ):
         super().__init__(**kwargs)
@@ -341,6 +358,7 @@ class FunAsrNanoEncoderConfig(PretrainedConfig):
         self.attention_dropout = attention_dropout
         self.activation_dropout = activation_dropout
         self.activation_function = activation_function
+        self.layer_norm_eps = layer_norm_eps
 
     @property
     def input_size(self) -> int:
@@ -359,6 +377,8 @@ class FunAsrNanoConfig(PretrainedConfig):
     def __init__(
         self,
         encoder_config=None,
+        audio_config=None,
+        adaptor_config=None,
         text_config=None,
         audio_token_id: int = 151646,
         adaptor_intermediate_size: int = 2048,
@@ -369,6 +389,71 @@ class FunAsrNanoConfig(PretrainedConfig):
         tie_word_embeddings: bool = True,
         **kwargs,
     ):
+        saved_layout = kwargs.pop("checkpoint_layout", None)
+        if audio_config is not None:
+            if encoder_config is not None:
+                raise ValueError(
+                    "Fun-ASR config must specify only audio_config or encoder_config"
+                )
+            audio = (
+                audio_config.to_dict()
+                if hasattr(audio_config, "to_dict")
+                else dict(audio_config)
+            )
+            layout = checkpoint_layout(audio)
+            total = audio.get("num_hidden_layers", 70 if layout == "flat" else 50)
+            timestamp = audio.get(
+                "num_timestamp_prediction_layers",
+                audio.get("num_timestamp_prediction_blocks", 20),
+            )
+            transcription = total - timestamp if layout == "flat" else total
+            if transcription < 1 or timestamp < 0:
+                raise ValueError("Invalid Fun-ASR transcription/timestamp layer counts")
+            encoder_config = dict(
+                num_mel_bins=audio.get("num_mel_bins", 80),
+                num_stacked_frames=audio.get("num_stacked_frames", 7),
+                d_model=audio.get("hidden_size", 512),
+                encoder_attention_heads=audio.get("num_attention_heads", 4),
+                encoder_ffn_dim=audio.get("intermediate_size", 2048),
+                encoder_layers=transcription,
+                num_timestamp_prediction_blocks=timestamp,
+                kernel_size=audio.get("fsmn_kernel_size", 11),
+                dropout=audio.get("hidden_dropout", 0.1),
+                attention_dropout=audio.get("attention_dropout", 0.1),
+                activation_dropout=audio.get("activation_dropout", 0.1),
+                activation_function=audio.get("hidden_act", "relu"),
+                layer_norm_eps=audio.get("layer_norm_eps", 1e-5),
+            )
+        else:
+            layout = saved_layout or "split"
+        if saved_layout is not None and saved_layout != layout:
+            raise ValueError(
+                "Fun-ASR saved checkpoint layout disagrees with audio_config"
+            )
+        self.checkpoint_layout = layout
+        adaptor = (
+            adaptor_config.to_dict()
+            if hasattr(adaptor_config, "to_dict")
+            else dict(adaptor_config or {})
+        )
+        adaptor_intermediate_size = adaptor.get(
+            "projector_hidden_size",
+            kwargs.pop("projector_hidden_size", adaptor_intermediate_size),
+        )
+        self.projector_hidden_act = adaptor.get(
+            "projector_hidden_act",
+            kwargs.pop("projector_hidden_act", activation_function),
+        )
+        adaptor_num_hidden_layers = adaptor.get(
+            "num_hidden_layers", adaptor_num_hidden_layers
+        )
+        adaptor_num_attention_heads = adaptor.get(
+            "num_attention_heads", adaptor_num_attention_heads
+        )
+        activation_function = adaptor.get("hidden_act", activation_function)
+        self.adaptor_layer_norm_eps = adaptor.get(
+            "layer_norm_eps", kwargs.pop("adaptor_layer_norm_eps", 1e-5)
+        )
         if isinstance(encoder_config, dict):
             encoder_config = FunAsrNanoEncoderConfig(**encoder_config)
         elif encoder_config is None:
@@ -384,6 +469,15 @@ class FunAsrNanoConfig(PretrainedConfig):
         elif text_config is None:
             text_config = HFQwen3Config()
         self.text_config = text_config
+        if (
+            adaptor.get("hidden_size", text_config.hidden_size)
+            != text_config.hidden_size
+        ):
+            raise ValueError("Fun-ASR adaptor hidden size must match text hidden size")
+        self.adaptor_ffn_dim = adaptor.get(
+            "intermediate_size",
+            kwargs.pop("adaptor_ffn_dim", text_config.hidden_size // 4),
+        )
         self.audio_token_id = audio_token_id
         self.adaptor_intermediate_size = adaptor_intermediate_size
         self.adaptor_num_hidden_layers = adaptor_num_hidden_layers

--- a/sglang_omni/models/fun_asr/configuration_fun_asr.py
+++ b/sglang_omni/models/fun_asr/configuration_fun_asr.py
@@ -21,7 +21,7 @@ from transformers.feature_extraction_sequence_utils import SequenceFeatureExtrac
 from sglang_omni.utils.audio_features import cached_fbank
 
 from .checkpoint import checkpoint_layout
-from .tool_funcs.audio_lengths import fun_asr_low_frame_rate_length
+from .tool_funcs.audio_lengths import fun_asr_audio_token_length
 
 AUDIO_PLACEHOLDER_TOKEN = "<|object_ref_start|>"
 
@@ -32,8 +32,8 @@ class FunAsrNanoFeatureExtractor(SequenceFeatureExtractor):
     Output ``input_features`` shape is ``[batch, lfr_m * n_mels, T_lfr]`` =
     ``[batch, 560, T_lfr]`` where ``T_lfr = ceil(T_mel / lfr_n)``. The encoder's
     ``input_size`` is 560 (= 7 * 80). ``attention_mask`` tracks valid LFR
-    frames; its per-row sum is the post-LFR frame count fed to
-    :func:`fun_asr_low_frame_rate_length`.
+    frames; its per-row sum is the post-LFR frame count used to size audio
+    placeholders and embeddings.
     """
 
     model_input_names = ["input_features"]
@@ -44,7 +44,7 @@ class FunAsrNanoFeatureExtractor(SequenceFeatureExtractor):
         config = FunAsrNanoConfig.from_pretrained(
             pretrained_model_name_or_path, **kwargs
         )
-        extractor.legacy_audio_lengths = config.checkpoint_layout == "split"
+        extractor.checkpoint_layout = config.checkpoint_layout
         return extractor
 
     def __init__(
@@ -60,7 +60,6 @@ class FunAsrNanoFeatureExtractor(SequenceFeatureExtractor):
         return_attention_mask: bool = True,
         num_frames_lfr: int | None = None,
         stride_lfr: int | None = None,
-        legacy_audio_lengths: bool = True,
         **kwargs,
     ):
         super().__init__(
@@ -82,7 +81,6 @@ class FunAsrNanoFeatureExtractor(SequenceFeatureExtractor):
         self.win_length = self.n_fft
         self.lfr_m = lfr_m if num_frames_lfr is None else num_frames_lfr
         self.lfr_n = lfr_n if stride_lfr is None else stride_lfr
-        self.legacy_audio_lengths = legacy_audio_lengths
         self.window = window
         self.padding_value = padding_value
         self.return_attention_mask = return_attention_mask
@@ -259,9 +257,12 @@ class FunAsrNanoProcessor:
         return cls(feature_extractor=feature_extractor, tokenizer=tokenizer)
 
     def _get_feat_extract_output_lengths(self, input_lengths):
-        """LFR frames -> adaptor audio-token count (3x stride-2)."""
-        return fun_asr_low_frame_rate_length(
-            input_lengths, legacy=self.feature_extractor.legacy_audio_lengths
+        """LFR frames -> audio placeholders and adaptor embeddings."""
+        return fun_asr_audio_token_length(
+            input_lengths,
+            checkpoint_layout=getattr(
+                self.feature_extractor, "checkpoint_layout", "split"
+            ),
         )
 
     def __call__(self, text=None, audio=None, audio_kwargs=None, **kwargs):
@@ -365,6 +366,40 @@ class FunAsrNanoEncoderConfig(PretrainedConfig):
         return self.num_mel_bins * self.num_stacked_frames
 
 
+def _as_config_dict(config: Any) -> dict[str, Any]:
+    return config.to_dict() if hasattr(config, "to_dict") else dict(config)
+
+
+def _normalize_audio_config(audio_config: Any) -> tuple[str, dict[str, Any]]:
+    """Convert either HF audio schema to the encoder schema used locally."""
+    audio = _as_config_dict(audio_config)
+    layout = checkpoint_layout(audio)
+    if layout == "flat":
+        total_blocks = audio["num_hidden_layers"]
+        timestamp_blocks = audio["num_timestamp_prediction_layers"]
+        transcription_blocks = total_blocks - timestamp_blocks
+    else:
+        transcription_blocks = audio["num_hidden_layers"]
+        timestamp_blocks = audio["num_timestamp_prediction_blocks"]
+    if transcription_blocks < 1 or timestamp_blocks < 0:
+        raise ValueError("Invalid Fun-ASR transcription/timestamp layer counts")
+    return layout, {
+        "num_mel_bins": audio.get("num_mel_bins", 80),
+        "num_stacked_frames": audio.get("num_stacked_frames", 7),
+        "d_model": audio.get("hidden_size", 512),
+        "encoder_attention_heads": audio.get("num_attention_heads", 4),
+        "encoder_ffn_dim": audio.get("intermediate_size", 2048),
+        "encoder_layers": transcription_blocks,
+        "num_timestamp_prediction_blocks": timestamp_blocks,
+        "kernel_size": audio.get("fsmn_kernel_size", 11),
+        "dropout": audio.get("hidden_dropout", 0.1),
+        "attention_dropout": audio.get("attention_dropout", 0.1),
+        "activation_dropout": audio.get("activation_dropout", 0.1),
+        "activation_function": audio.get("hidden_act", "relu"),
+        "layer_norm_eps": audio.get("layer_norm_eps", 1e-5),
+    }
+
+
 @register_customized_processor(FunAsrNanoProcessor)
 class FunAsrNanoConfig(PretrainedConfig):
     """Configuration for the Fun-ASR-Nano checkpoint."""
@@ -395,35 +430,7 @@ class FunAsrNanoConfig(PretrainedConfig):
                 raise ValueError(
                     "Fun-ASR config must specify only audio_config or encoder_config"
                 )
-            audio = (
-                audio_config.to_dict()
-                if hasattr(audio_config, "to_dict")
-                else dict(audio_config)
-            )
-            layout = checkpoint_layout(audio)
-            total = audio.get("num_hidden_layers", 70 if layout == "flat" else 50)
-            timestamp = audio.get(
-                "num_timestamp_prediction_layers",
-                audio.get("num_timestamp_prediction_blocks", 20),
-            )
-            transcription = total - timestamp if layout == "flat" else total
-            if transcription < 1 or timestamp < 0:
-                raise ValueError("Invalid Fun-ASR transcription/timestamp layer counts")
-            encoder_config = dict(
-                num_mel_bins=audio.get("num_mel_bins", 80),
-                num_stacked_frames=audio.get("num_stacked_frames", 7),
-                d_model=audio.get("hidden_size", 512),
-                encoder_attention_heads=audio.get("num_attention_heads", 4),
-                encoder_ffn_dim=audio.get("intermediate_size", 2048),
-                encoder_layers=transcription,
-                num_timestamp_prediction_blocks=timestamp,
-                kernel_size=audio.get("fsmn_kernel_size", 11),
-                dropout=audio.get("hidden_dropout", 0.1),
-                attention_dropout=audio.get("attention_dropout", 0.1),
-                activation_dropout=audio.get("activation_dropout", 0.1),
-                activation_function=audio.get("hidden_act", "relu"),
-                layer_norm_eps=audio.get("layer_norm_eps", 1e-5),
-            )
+            layout, encoder_config = _normalize_audio_config(audio_config)
         else:
             layout = saved_layout or "split"
         if saved_layout is not None and saved_layout != layout:
@@ -431,11 +438,7 @@ class FunAsrNanoConfig(PretrainedConfig):
                 "Fun-ASR saved checkpoint layout disagrees with audio_config"
             )
         self.checkpoint_layout = layout
-        adaptor = (
-            adaptor_config.to_dict()
-            if hasattr(adaptor_config, "to_dict")
-            else dict(adaptor_config or {})
-        )
+        adaptor = _as_config_dict(adaptor_config or {})
         adaptor_intermediate_size = adaptor.get(
             "projector_hidden_size",
             kwargs.pop("projector_hidden_size", adaptor_intermediate_size),

--- a/sglang_omni/models/fun_asr/engine_builder.py
+++ b/sglang_omni/models/fun_asr/engine_builder.py
@@ -99,7 +99,10 @@ class FunASREngineBuilder(AsrEngineBuilder):
             checkpoint_dir, trust_remote_code=True
         )
         encoder_token_count = int(
-            fun_asr_low_frame_rate_length(self.feature_extractor.nb_max_frames)
+            fun_asr_low_frame_rate_length(
+                self.feature_extractor.nb_max_frames,
+                legacy=getattr(self.feature_extractor, "legacy_audio_lengths", True),
+            )
         )
         prompt_overhead = request_builders.fun_asr_prompt_overhead_tokens(
             self.tokenizer

--- a/sglang_omni/models/fun_asr/engine_builder.py
+++ b/sglang_omni/models/fun_asr/engine_builder.py
@@ -15,7 +15,7 @@ from sglang_omni.models.fun_asr.encoder_service import (
     build_cache_namespace,
 )
 from sglang_omni.models.fun_asr.tool_funcs.audio_lengths import (
-    fun_asr_low_frame_rate_length,
+    fun_asr_audio_token_length,
 )
 from sglang_omni.scheduling.engine_factory import AsrEngineBuilder
 from sglang_omni.scheduling.generation_batch_policy import (
@@ -99,9 +99,11 @@ class FunASREngineBuilder(AsrEngineBuilder):
             checkpoint_dir, trust_remote_code=True
         )
         encoder_token_count = int(
-            fun_asr_low_frame_rate_length(
+            fun_asr_audio_token_length(
                 self.feature_extractor.nb_max_frames,
-                legacy=getattr(self.feature_extractor, "legacy_audio_lengths", True),
+                checkpoint_layout=getattr(
+                    self.feature_extractor, "checkpoint_layout", "split"
+                ),
             )
         )
         prompt_overhead = request_builders.fun_asr_prompt_overhead_tokens(

--- a/sglang_omni/models/fun_asr/request_builders.py
+++ b/sglang_omni/models/fun_asr/request_builders.py
@@ -208,7 +208,12 @@ def make_fun_asr_scheduler_adapters(
                 (features.shape[0], features.shape[-1]), dtype=torch.long
             )
         num_lfr_frames = int(feature_attention_mask.sum().item())
-        num_audio_tokens = int(fun_asr_low_frame_rate_length(num_lfr_frames))
+        num_audio_tokens = int(
+            fun_asr_low_frame_rate_length(
+                num_lfr_frames,
+                legacy=getattr(feature_extractor, "legacy_audio_lengths", True),
+            )
+        )
         logger.debug(
             f"[fun-asr] lfr_frames={num_lfr_frames} "
             f"num_audio_tokens={num_audio_tokens} feat_shape={tuple(features.shape)}"

--- a/sglang_omni/models/fun_asr/request_builders.py
+++ b/sglang_omni/models/fun_asr/request_builders.py
@@ -26,7 +26,7 @@ from sglang_omni.scheduling.token_text_streaming import (
 )
 
 from .configuration_fun_asr import AUDIO_PLACEHOLDER_TOKEN as _AUDIO_PAD
-from .tool_funcs.audio_lengths import fun_asr_low_frame_rate_length
+from .tool_funcs.audio_lengths import fun_asr_audio_token_length
 
 logger = logging.getLogger(__name__)
 
@@ -209,9 +209,11 @@ def make_fun_asr_scheduler_adapters(
             )
         num_lfr_frames = int(feature_attention_mask.sum().item())
         num_audio_tokens = int(
-            fun_asr_low_frame_rate_length(
+            fun_asr_audio_token_length(
                 num_lfr_frames,
-                legacy=getattr(feature_extractor, "legacy_audio_lengths", True),
+                checkpoint_layout=getattr(
+                    feature_extractor, "checkpoint_layout", "split"
+                ),
             )
         )
         logger.debug(

--- a/sglang_omni/models/fun_asr/sglang_model.py
+++ b/sglang_omni/models/fun_asr/sglang_model.py
@@ -22,25 +22,14 @@ from sglang.srt.managers.schedule_batch import (
 from sglang.srt.model_executor.forward_batch_info import ForwardBatch
 from sglang.srt.model_loader.weight_utils import default_weight_loader
 from sglang.srt.models.qwen3 import Qwen3ForCausalLM
-from sglang.srt.models.utils import WeightsMapper
 from sglang.srt.utils import add_prefix
 from transformers.activations import ACT2FN
 
+from .checkpoint import canonical_weight_name
 from .configuration_fun_asr import FunAsrNanoConfig
 from .tool_funcs.audio_lengths import fun_asr_low_frame_rate_length
 
 logger = logging.getLogger(__name__)
-
-# Note (Akazaakane): Normalize the September 2026 HF key renames while keeping
-# the existing module names compatible with the pinned earlier checkpoint.
-FUN_ASR_HF_TO_SGLANG_MAPPER = WeightsMapper(
-    orig_to_new_substr={
-        ".feedforward_sequential_memory.": ".fsmn.",
-    },
-    orig_to_new_prefix={
-        "model.audio_adaptor.": "model.multi_modal_projector.",
-    },
-)
 
 
 def _sanm_mask_from_lengths(
@@ -81,17 +70,22 @@ def _fused_qkv_project(
 
 class SinusoidalPositionEncoder(nn.Module):
 
+    def __init__(self, *, compute_in_fp32: bool = True):
+        super().__init__()
+        self.compute_in_fp32 = compute_in_fp32
+
     def forward(self, x: torch.Tensor) -> torch.Tensor:
         batch_size, timesteps, input_dim = x.size()
-        positions = torch.arange(1, timesteps + 1, device=x.device, dtype=x.dtype)
+        dtype = torch.float32 if self.compute_in_fp32 else x.dtype
+        positions = torch.arange(1, timesteps + 1, device=x.device, dtype=dtype)
         log_timescale_increment = math.log(10000.0) / (input_dim / 2 - 1)
         inv_timescales = torch.exp(
-            torch.arange(input_dim / 2, device=x.device, dtype=x.dtype)
+            torch.arange(input_dim / 2, device=x.device, dtype=dtype)
             * (-log_timescale_increment)
         )
         scaled_time = positions.view(1, -1, 1) * inv_timescales.view(1, 1, -1)
         encoding = torch.cat([torch.sin(scaled_time), torch.cos(scaled_time)], dim=2)
-        return x + encoding
+        return x + encoding.to(dtype=x.dtype)
 
 
 class MultiHeadedAttentionSANM(nn.Module):
@@ -110,7 +104,7 @@ class MultiHeadedAttentionSANM(nn.Module):
         self.q_proj = nn.Linear(in_feat, n_feat)
         self.k_proj = nn.Linear(in_feat, n_feat)
         self.v_proj = nn.Linear(in_feat, n_feat)
-        self.out_proj = nn.Linear(n_feat, n_feat)
+        self.o_proj = nn.Linear(n_feat, n_feat)
         self.attn_dropout_p = float(dropout_rate)
 
     def forward(
@@ -134,7 +128,7 @@ class MultiHeadedAttentionSANM(nn.Module):
             is_causal=False,
         )
         out = out.transpose(1, 2).contiguous().view(b, t, self.h * self.d_k)
-        return self.out_proj(out), v
+        return self.o_proj(out), v
 
 
 class FunAsrNanoFSMN(nn.Module):
@@ -167,6 +161,13 @@ class FunAsrNanoFSMN(nn.Module):
         return _apply_time_mask(hidden_states, mask)
 
 
+class FunAsrNanoMLP(nn.Module):
+    def __init__(self, size: int, intermediate_size: int) -> None:
+        super().__init__()
+        self.fc1 = nn.Linear(size, intermediate_size)
+        self.fc2 = nn.Linear(intermediate_size, size)
+
+
 class EncoderLayerSANM(nn.Module):
 
     def __init__(
@@ -180,16 +181,20 @@ class EncoderLayerSANM(nn.Module):
         attention_dropout_rate: float,
         activation_dropout_rate: float,
         activation_function: str,
+        layer_norm_eps: float = 1e-5,
+        add_norm: bool = False,
     ) -> None:
         super().__init__()
         self.self_attn = MultiHeadedAttentionSANM(
             attention_heads, in_size, size, attention_dropout_rate
         )
-        self.self_attn_layer_norm = nn.LayerNorm(in_size, eps=1e-5)
-        self.final_layer_norm = nn.LayerNorm(size, eps=1e-5)
-        self.fc1 = nn.Linear(size, linear_units)
-        self.fc2 = nn.Linear(linear_units, size)
-        self.fsmn = FunAsrNanoFSMN(size, kernel_size, attention_dropout_rate)
+        self.input_layernorm = nn.LayerNorm(in_size, eps=layer_norm_eps)
+        self.post_attention_layernorm = nn.LayerNorm(size, eps=layer_norm_eps)
+        self.mlp = FunAsrNanoMLP(size, linear_units)
+        self.self_attn.fsmn = FunAsrNanoFSMN(size, kernel_size, attention_dropout_rate)
+        self.final_layernorm = (
+            nn.LayerNorm(size, eps=layer_norm_eps) if add_norm else nn.Identity()
+        )
         self.dropout = nn.Dropout(dropout_rate)
         self.activation_dropout = nn.Dropout(activation_dropout_rate)
         self.activation = ACT2FN[activation_function]
@@ -200,22 +205,22 @@ class EncoderLayerSANM(nn.Module):
         self, x: torch.Tensor, mask: Optional[torch.Tensor] = None
     ) -> torch.Tensor:
         residual = x
-        x = self.self_attn_layer_norm(x)
+        x = self.input_layernorm(x)
         # note (guozhihao): attn returns v so FSMN does not recompute v_proj.
         attn_out, value_states = self.self_attn(x, mask)
-        x = self.dropout(attn_out + self.fsmn(value_states, mask))
+        x = self.dropout(attn_out + self.self_attn.fsmn(value_states, mask))
         x = _apply_time_mask(x, mask)
         if self.in_size == self.size:
             x = residual + x
         residual = x
-        x = self.final_layer_norm(x)
-        x = self.activation_dropout(self.activation(self.fc1(x)))
-        x = residual + self.dropout(self.fc2(x))
+        x = self.post_attention_layernorm(x)
+        x = self.activation_dropout(self.activation(self.mlp.fc1(x)))
+        x = residual + self.dropout(self.mlp.fc2(x))
         x = _apply_time_mask(x, mask)
         if x.dtype == torch.float16:
             clamp_value = torch.finfo(x.dtype).max - 1000
             x = torch.clamp(x, min=-clamp_value, max=clamp_value)
-        return x
+        return _apply_time_mask(self.final_layernorm(x), mask)
 
 
 class FunAsrNanoAudioEncoder(nn.Module):
@@ -233,14 +238,21 @@ class FunAsrNanoAudioEncoder(nn.Module):
         attention_dropout_rate: float = 0.1,
         activation_dropout_rate: float = 0.1,
         activation_function: str = "relu",
+        layer_norm_eps: float = 1e-5,
+        position_embedding_fp32: bool = True,
     ) -> None:
         super().__init__()
         self._output_size = output_size
-        self.embed = SinusoidalPositionEncoder()
+        self.embed = SinusoidalPositionEncoder(compute_in_fp32=position_embedding_fp32)
 
-        def make_layer(in_size: int) -> EncoderLayerSANM:
+        if num_blocks < 1 or tp_blocks < 0:
+            raise ValueError(
+                "Fun-ASR requires positive transcription blocks and nonnegative timestamp blocks"
+            )
+
+        def make_layer(index: int) -> EncoderLayerSANM:
             return EncoderLayerSANM(
-                in_size,
+                input_size if index == 0 else output_size,
                 output_size,
                 attention_heads,
                 linear_units,
@@ -249,17 +261,13 @@ class FunAsrNanoAudioEncoder(nn.Module):
                 attention_dropout_rate,
                 activation_dropout_rate,
                 activation_function,
+                layer_norm_eps,
+                index in {num_blocks - 1, num_blocks + tp_blocks - 1},
             )
 
-        self.stem = make_layer(input_size)
         self.layers = nn.ModuleList(
-            [make_layer(output_size) for _ in range(num_blocks - 1)]
+            [make_layer(i) for i in range(num_blocks + tp_blocks)]
         )
-        self.layer_norm = nn.LayerNorm(output_size, eps=1e-5)
-        self.timestamp_prediction_layers = nn.ModuleList(
-            [make_layer(output_size) for _ in range(tp_blocks)]
-        )
-        self.timestamp_prediction_layer_norm = nn.LayerNorm(output_size, eps=1e-5)
 
     def output_size(self) -> int:
         return self._output_size
@@ -269,15 +277,8 @@ class FunAsrNanoAudioEncoder(nn.Module):
     ) -> torch.Tensor:
         xs = xs * (self._output_size**0.5)
         xs = self.embed(xs)
-        xs = self.stem(xs, mask)
         for layer in self.layers:
             xs = layer(xs, mask)
-        xs = self.layer_norm(xs)
-        xs = _apply_time_mask(xs, mask)
-        for layer in self.timestamp_prediction_layers:
-            xs = layer(xs, mask)
-        xs = self.timestamp_prediction_layer_norm(xs)
-        xs = _apply_time_mask(xs, mask)
         return xs
 
 
@@ -296,7 +297,7 @@ class MultiHeadedAttention(nn.Module):
         self.q_proj = nn.Linear(n_feat, n_feat)
         self.k_proj = nn.Linear(n_feat, n_feat)
         self.v_proj = nn.Linear(n_feat, n_feat)
-        self.out_proj = nn.Linear(n_feat, n_feat)
+        self.o_proj = nn.Linear(n_feat, n_feat)
         self.attn_dropout_p = float(dropout_rate)
 
     def forward(
@@ -319,7 +320,7 @@ class MultiHeadedAttention(nn.Module):
             is_causal=False,
         )
         out = out.transpose(1, 2).contiguous().view(b, t, self.h * self.d_k)
-        return self.out_proj(out)
+        return self.o_proj(out)
 
 
 class AdaptorEncoderLayer(nn.Module):
@@ -331,13 +332,13 @@ class AdaptorEncoderLayer(nn.Module):
         feed_forward_dim: int,
         dropout_rate: float,
         activation_function: str,
+        layer_norm_eps: float = 1e-5,
     ) -> None:
         super().__init__()
         self.self_attn = self_attn
-        self.self_attn_layer_norm = nn.LayerNorm(size, eps=1e-5)
-        self.final_layer_norm = nn.LayerNorm(size, eps=1e-5)
-        self.fc1 = nn.Linear(size, feed_forward_dim)
-        self.fc2 = nn.Linear(feed_forward_dim, size)
+        self.input_layernorm = nn.LayerNorm(size, eps=layer_norm_eps)
+        self.post_attention_layernorm = nn.LayerNorm(size, eps=layer_norm_eps)
+        self.mlp = FunAsrNanoMLP(size, feed_forward_dim)
         self.activation = ACT2FN[activation_function]
         self.dropout = nn.Dropout(dropout_rate)
 
@@ -345,12 +346,12 @@ class AdaptorEncoderLayer(nn.Module):
         self, x: torch.Tensor, mask: Optional[torch.Tensor] = None
     ) -> torch.Tensor:
         residual = x
-        x = self.self_attn_layer_norm(x)
+        x = self.input_layernorm(x)
         x = residual + self.dropout(self.self_attn(x, mask))
         x = _apply_time_mask(x, mask)
         residual = x
-        x = self.final_layer_norm(x)
-        x = residual + self.dropout(self.fc2(self.activation(self.fc1(x))))
+        x = self.post_attention_layernorm(x)
+        x = residual + self.dropout(self.mlp.fc2(self.activation(self.mlp.fc1(x))))
         return _apply_time_mask(x, mask)
 
 
@@ -365,16 +366,21 @@ class FunAsrNanoAdaptor(nn.Module):
         attention_heads: int = 8,
         dropout_rate: float = 0.0,
         activation_function: str = "relu",
+        intermediate_size: int | None = None,
+        layer_norm_eps: float = 1e-5,
+        projector_activation_function: str | None = None,
     ) -> None:
         super().__init__()
         self.encoder_dim = encoder_dim
         self.llm_dim = llm_dim
         self.linear_1 = nn.Linear(encoder_dim, ffn_dim)
-        self.act = ACT2FN[activation_function]
+        self.act = ACT2FN[projector_activation_function or activation_function]
         self.linear_2 = nn.Linear(ffn_dim, llm_dim)
 
-        ffn_hidden = llm_dim // 4
-        self.blocks = nn.ModuleList(
+        ffn_hidden = (
+            intermediate_size if intermediate_size is not None else llm_dim // 4
+        )
+        self.layers = nn.ModuleList(
             [
                 AdaptorEncoderLayer(
                     llm_dim,
@@ -382,6 +388,7 @@ class FunAsrNanoAdaptor(nn.Module):
                     ffn_hidden,
                     dropout_rate,
                     activation_function,
+                    layer_norm_eps,
                 )
                 for _ in range(num_layers)
             ]
@@ -394,7 +401,7 @@ class FunAsrNanoAdaptor(nn.Module):
         x = self.act(x)
         x = self.linear_2(x)
         x = _apply_time_mask(x, mask)
-        for block in self.blocks:
+        for block in self.layers:
             x = block(x, mask)
         return x
 
@@ -440,6 +447,8 @@ class FunAsrNanoForConditionalGeneration(nn.Module):
             attention_dropout_rate=enc_cfg.attention_dropout,
             activation_dropout_rate=enc_cfg.activation_dropout,
             activation_function=enc_cfg.activation_function,
+            layer_norm_eps=enc_cfg.layer_norm_eps,
+            position_embedding_fp32=config.checkpoint_layout == "flat",
         )
         self.multi_modal_projector = FunAsrNanoAdaptor(
             encoder_dim=enc_cfg.d_model,
@@ -449,6 +458,9 @@ class FunAsrNanoForConditionalGeneration(nn.Module):
             attention_heads=config.adaptor_num_attention_heads,
             dropout_rate=0.0,
             activation_function=config.activation_function,
+            intermediate_size=config.adaptor_ffn_dim,
+            layer_norm_eps=config.adaptor_layer_norm_eps,
+            projector_activation_function=config.projector_hidden_act,
         )
         self.language_model = Qwen3ForCausalLM(
             config.text_config,
@@ -529,7 +541,13 @@ class FunAsrNanoForConditionalGeneration(nn.Module):
 
         embeddings: List[torch.Tensor] = []
         for b, length in enumerate(lengths):
-            num_tokens = max(int(fun_asr_low_frame_rate_length(length)), 1)
+            legacy = (
+                getattr(getattr(self, "config", None), "checkpoint_layout", "split")
+                == "split"
+            )
+            num_tokens = max(
+                int(fun_asr_low_frame_rate_length(length, legacy=legacy)), 1
+            )
             embeddings.append(adp_out[b, :num_tokens, :])
         return torch.cat(embeddings, dim=0)
 
@@ -552,7 +570,6 @@ class FunAsrNanoForConditionalGeneration(nn.Module):
         return hidden_states
 
     def load_weights(self, weights: Iterable[Tuple[str, torch.Tensor]]):
-        weights = FUN_ASR_HF_TO_SGLANG_MAPPER.apply(weights)
 
         # Qwen3 LLM: q/k/v → qkv_proj, gate/up → gate_up_proj (sglang stacked).
         llm_stacked_params = [
@@ -563,9 +580,17 @@ class FunAsrNanoForConditionalGeneration(nn.Module):
             ("gate_up_proj", "up_proj", 1),
         ]
         params_dict = dict(self.named_parameters(remove_duplicate=False))
+        loaded_audio = set()
 
         for name, loaded_weight in weights:
             checkpoint_name = name
+            enc = self.config.encoder_config
+            name = canonical_weight_name(
+                name,
+                layout=self.config.checkpoint_layout,
+                num_blocks=enc.encoder_layers,
+                tp_blocks=enc.num_timestamp_prediction_blocks,
+            )
             if "rotary_emb.inv_freq" in name:
                 continue
             if "rotary_emb.cos_cached" in name or "rotary_emb.sin_cached" in name:
@@ -612,7 +637,11 @@ class FunAsrNanoForConditionalGeneration(nn.Module):
                 if stacked:
                     continue
 
-            if name.endswith(".bias") and name not in params_dict:
+            if (
+                name.endswith(".bias")
+                and name not in params_dict
+                and not strict_multimodal
+            ):
                 continue
             if name not in params_dict:
                 if strict_multimodal:
@@ -622,8 +651,28 @@ class FunAsrNanoForConditionalGeneration(nn.Module):
                     )
                 continue
             param = params_dict[name]
+            if strict_multimodal:
+                if name in loaded_audio:
+                    raise ValueError(
+                        f"Duplicate Fun-ASR checkpoint destination: {name}"
+                    )
+                if param.shape != loaded_weight.shape:
+                    raise ValueError(
+                        f"Fun-ASR checkpoint shape mismatch for {checkpoint_name}: {loaded_weight.shape} != {param.shape}"
+                    )
+                loaded_audio.add(name)
             weight_loader = getattr(param, "weight_loader", default_weight_loader)
             weight_loader(param, loaded_weight)
+
+        missing = {
+            name
+            for name in params_dict
+            if name.startswith(("audio_tower.", "multi_modal_projector."))
+        } - loaded_audio
+        if missing:
+            raise ValueError(
+                f"Missing Fun-ASR checkpoint parameters: {sorted(missing)}"
+            )
 
 
 EntryClass = FunAsrNanoForConditionalGeneration

--- a/sglang_omni/models/fun_asr/sglang_model.py
+++ b/sglang_omni/models/fun_asr/sglang_model.py
@@ -27,7 +27,7 @@ from transformers.activations import ACT2FN
 
 from .checkpoint import canonical_weight_name
 from .configuration_fun_asr import FunAsrNanoConfig
-from .tool_funcs.audio_lengths import fun_asr_low_frame_rate_length
+from .tool_funcs.audio_lengths import fun_asr_audio_token_length
 
 logger = logging.getLogger(__name__)
 
@@ -70,22 +70,17 @@ def _fused_qkv_project(
 
 class SinusoidalPositionEncoder(nn.Module):
 
-    def __init__(self, *, compute_in_fp32: bool = True):
-        super().__init__()
-        self.compute_in_fp32 = compute_in_fp32
-
     def forward(self, x: torch.Tensor) -> torch.Tensor:
         batch_size, timesteps, input_dim = x.size()
-        dtype = torch.float32 if self.compute_in_fp32 else x.dtype
-        positions = torch.arange(1, timesteps + 1, device=x.device, dtype=dtype)
+        positions = torch.arange(1, timesteps + 1, device=x.device, dtype=x.dtype)
         log_timescale_increment = math.log(10000.0) / (input_dim / 2 - 1)
         inv_timescales = torch.exp(
-            torch.arange(input_dim / 2, device=x.device, dtype=dtype)
+            torch.arange(input_dim / 2, device=x.device, dtype=x.dtype)
             * (-log_timescale_increment)
         )
         scaled_time = positions.view(1, -1, 1) * inv_timescales.view(1, 1, -1)
         encoding = torch.cat([torch.sin(scaled_time), torch.cos(scaled_time)], dim=2)
-        return x + encoding.to(dtype=x.dtype)
+        return x + encoding
 
 
 class MultiHeadedAttentionSANM(nn.Module):
@@ -104,7 +99,7 @@ class MultiHeadedAttentionSANM(nn.Module):
         self.q_proj = nn.Linear(in_feat, n_feat)
         self.k_proj = nn.Linear(in_feat, n_feat)
         self.v_proj = nn.Linear(in_feat, n_feat)
-        self.o_proj = nn.Linear(n_feat, n_feat)
+        self.out_proj = nn.Linear(n_feat, n_feat)
         self.attn_dropout_p = float(dropout_rate)
 
     def forward(
@@ -128,7 +123,7 @@ class MultiHeadedAttentionSANM(nn.Module):
             is_causal=False,
         )
         out = out.transpose(1, 2).contiguous().view(b, t, self.h * self.d_k)
-        return self.o_proj(out), v
+        return self.out_proj(out), v
 
 
 class FunAsrNanoFSMN(nn.Module):
@@ -239,11 +234,10 @@ class FunAsrNanoAudioEncoder(nn.Module):
         activation_dropout_rate: float = 0.1,
         activation_function: str = "relu",
         layer_norm_eps: float = 1e-5,
-        position_embedding_fp32: bool = True,
     ) -> None:
         super().__init__()
         self._output_size = output_size
-        self.embed = SinusoidalPositionEncoder(compute_in_fp32=position_embedding_fp32)
+        self.embed = SinusoidalPositionEncoder()
 
         if num_blocks < 1 or tp_blocks < 0:
             raise ValueError(
@@ -297,7 +291,7 @@ class MultiHeadedAttention(nn.Module):
         self.q_proj = nn.Linear(n_feat, n_feat)
         self.k_proj = nn.Linear(n_feat, n_feat)
         self.v_proj = nn.Linear(n_feat, n_feat)
-        self.o_proj = nn.Linear(n_feat, n_feat)
+        self.out_proj = nn.Linear(n_feat, n_feat)
         self.attn_dropout_p = float(dropout_rate)
 
     def forward(
@@ -320,7 +314,7 @@ class MultiHeadedAttention(nn.Module):
             is_causal=False,
         )
         out = out.transpose(1, 2).contiguous().view(b, t, self.h * self.d_k)
-        return self.o_proj(out)
+        return self.out_proj(out)
 
 
 class AdaptorEncoderLayer(nn.Module):
@@ -448,7 +442,6 @@ class FunAsrNanoForConditionalGeneration(nn.Module):
             activation_dropout_rate=enc_cfg.activation_dropout,
             activation_function=enc_cfg.activation_function,
             layer_norm_eps=enc_cfg.layer_norm_eps,
-            position_embedding_fp32=config.checkpoint_layout == "flat",
         )
         self.multi_modal_projector = FunAsrNanoAdaptor(
             encoder_dim=enc_cfg.d_model,
@@ -541,12 +534,11 @@ class FunAsrNanoForConditionalGeneration(nn.Module):
 
         embeddings: List[torch.Tensor] = []
         for b, length in enumerate(lengths):
-            legacy = (
-                getattr(getattr(self, "config", None), "checkpoint_layout", "split")
-                == "split"
+            layout = getattr(
+                getattr(self, "config", None), "checkpoint_layout", "split"
             )
             num_tokens = max(
-                int(fun_asr_low_frame_rate_length(length, legacy=legacy)), 1
+                int(fun_asr_audio_token_length(length, checkpoint_layout=layout)), 1
             )
             embeddings.append(adp_out[b, :num_tokens, :])
         return torch.cat(embeddings, dim=0)

--- a/sglang_omni/models/fun_asr/tool_funcs/__init__.py
+++ b/sglang_omni/models/fun_asr/tool_funcs/__init__.py
@@ -1,7 +1,8 @@
 # SPDX-License-Identifier: Apache-2.0
 
-from .audio_lengths import fun_asr_low_frame_rate_length
+from .audio_lengths import fun_asr_audio_token_length, fun_asr_low_frame_rate_length
 
 __all__ = [
+    "fun_asr_audio_token_length",
     "fun_asr_low_frame_rate_length",
 ]

--- a/sglang_omni/models/fun_asr/tool_funcs/audio_lengths.py
+++ b/sglang_omni/models/fun_asr/tool_funcs/audio_lengths.py
@@ -5,16 +5,28 @@ from __future__ import annotations
 _LOW_FRAME_RATE_STAGES = 3
 
 
-def fun_asr_low_frame_rate_length(lfr_frames: int, *, legacy: bool = True) -> int:
-    """Preserve split-checkpoint serving lengths; native HF uses every LFR frame."""
-    if not legacy:
-        return lfr_frames
+def fun_asr_low_frame_rate_length(lfr_frames: int) -> int:
+    """Historical split-layout audio-embedding length."""
     out = lfr_frames
     for _ in range(_LOW_FRAME_RATE_STAGES):
         out = (out + 1) // 2
     return out
 
 
+def fun_asr_audio_token_length(lfr_frames: int, *, checkpoint_layout: str) -> int:
+    """Number of audio placeholders and embeddings for a checkpoint layout.
+
+    The native HF processor uses one placeholder for each valid LFR frame in
+    the flat layout. See transformers/models/fun_asr_nano/processing_fun_asr_nano.py.
+    """
+    if checkpoint_layout == "flat":
+        return lfr_frames
+    if checkpoint_layout == "split":
+        return fun_asr_low_frame_rate_length(lfr_frames)
+    raise ValueError(f"Unknown Fun-ASR checkpoint layout: {checkpoint_layout}")
+
+
 __all__ = [
     "fun_asr_low_frame_rate_length",
+    "fun_asr_audio_token_length",
 ]

--- a/sglang_omni/models/fun_asr/tool_funcs/audio_lengths.py
+++ b/sglang_omni/models/fun_asr/tool_funcs/audio_lengths.py
@@ -5,7 +5,10 @@ from __future__ import annotations
 _LOW_FRAME_RATE_STAGES = 3
 
 
-def fun_asr_low_frame_rate_length(lfr_frames: int) -> int:
+def fun_asr_low_frame_rate_length(lfr_frames: int, *, legacy: bool = True) -> int:
+    """Preserve split-checkpoint serving lengths; native HF uses every LFR frame."""
+    if not legacy:
+        return lfr_frames
     out = lfr_frames
     for _ in range(_LOW_FRAME_RATE_STAGES):
         out = (out + 1) // 2

--- a/tests/test_model/asr_ci_config.py
+++ b/tests/test_model/asr_ci_config.py
@@ -21,7 +21,6 @@ from dataclasses import dataclass
 
 from benchmarks.tasks.asr import (
     FUN_ASR_MODEL_PATH,
-    FUN_ASR_MODEL_REVISION,
     OMNI_WHISPER_MODEL_PATH,
     QWEN3_ASR_MODEL_PATH,
 )
@@ -191,7 +190,6 @@ WHISPER_ASR_RTF_P95_THRESHOLD = round(
 ASR_CI_PRESETS: dict[str, AsrCiPreset] = {
     "fun": AsrCiPreset(
         model_path=FUN_ASR_MODEL_PATH,
-        revision=FUN_ASR_MODEL_REVISION,
         display_name="Fun-ASR",
         thresholds=AsrCiThresholdPreset(
             en_corpus_wer_max=FUN_ASR_EN_CORPUS_WER_THRESHOLD,

--- a/tests/unit_test/fun_asr/test_checkpoint_compatibility.py
+++ b/tests/unit_test/fun_asr/test_checkpoint_compatibility.py
@@ -142,11 +142,16 @@ def split_key(name):
     return name
 
 
+def flat_key(name):
+    """Test export fixture: current HF uses o_proj for attention output."""
+    return "model." + name.replace(".self_attn.out_proj.", ".self_attn.o_proj.")
+
+
 @pytest.mark.parametrize("layout", ["flat", "split"])
 def test_full_audio_load_and_output(layout):
     source, target = tiny_model(), tiny_model(layout)
     weights = [
-        ("model." + name if layout == "flat" else split_key(name), tensor.clone())
+        (flat_key(name) if layout == "flat" else split_key(name), tensor.clone())
         for name, tensor in source.state_dict().items()
     ]
     target.load_weights(reversed(weights))
@@ -224,12 +229,11 @@ def test_feature_extractor_reads_layout_and_lfr_fields(tmp_path, flat):
     )
     assert extractor.lfr_m == 3
     assert extractor.lfr_n == 2
-    assert extractor.legacy_audio_lengths is not flat
+    assert extractor.checkpoint_layout == ("flat" if flat else "split")
 
 
-@pytest.mark.parametrize("dtype", [torch.float32, torch.bfloat16])
-def test_encoder_and_projector_match_native_hf(dtype):
-    # Optional reference check: serving remains on the repo's pinned Transformers.
+def test_encoder_and_projector_match_native_hf():
+    # Optional reference check against the current upstream architecture.
     reference = pytest.importorskip(
         "transformers.models.fun_asr_nano.modeling_fun_asr_nano"
     )
@@ -237,7 +241,7 @@ def test_encoder_and_projector_match_native_hf(dtype):
         "transformers.models.fun_asr_nano.configuration_fun_asr_nano"
     )
     torch.manual_seed(9)
-    model = tiny_model().to(dtype=dtype)
+    model = tiny_model().to(dtype=torch.float32)
     audio_config = configs.FunAsrNanoEncoderConfig(
         num_mel_bins=2,
         num_stacked_frames=3,
@@ -249,8 +253,14 @@ def test_encoder_and_projector_match_native_hf(dtype):
         fsmn_kernel_size=3,
     )
     audio_config._attn_implementation = "eager"
-    encoder = reference.FunAsrNanoEncoder(audio_config).eval().to(dtype=dtype)
-    encoder.load_state_dict(model.audio_tower.state_dict(), strict=True)
+    encoder = reference.FunAsrNanoEncoder(audio_config).eval()
+    encoder.load_state_dict(
+        {
+            name.replace(".self_attn.out_proj.", ".self_attn.o_proj."): tensor
+            for name, tensor in model.audio_tower.state_dict().items()
+        },
+        strict=True,
+    )
     adaptor_config = configs.FunAsrNanoAdaptorConfig(
         hidden_size=8,
         intermediate_size=2,
@@ -259,21 +269,23 @@ def test_encoder_and_projector_match_native_hf(dtype):
         projector_hidden_size=12,
     )
     adaptor_config._attn_implementation = "eager"
-    projector = (
-        reference.FunAsrNanoMultiModalProjector(
-            SimpleNamespace(audio_config=audio_config, adaptor_config=adaptor_config)
-        )
-        .eval()
-        .to(dtype=dtype)
+    projector = reference.FunAsrNanoMultiModalProjector(
+        SimpleNamespace(audio_config=audio_config, adaptor_config=adaptor_config)
+    ).eval()
+    projector.load_state_dict(
+        {
+            name.replace(".self_attn.out_proj.", ".self_attn.o_proj."): tensor
+            for name, tensor in model.multi_modal_projector.state_dict().items()
+        },
+        strict=True,
     )
-    projector.load_state_dict(model.multi_modal_projector.state_dict(), strict=True)
-    x = torch.randn(2, 7, 6, dtype=dtype)
+    x = torch.randn(2, 7, 6)
     mask = torch.tensor([[1] * 7, [1] * 4 + [0] * 3])
     with torch.no_grad():
         ours = model.audio_tower(x, mask[:, None, :])
         theirs = encoder(x, mask).last_hidden_state
         valid = mask.bool()
-        tolerance = 2e-5 if dtype == torch.float32 else 0.04
+        tolerance = 2e-5
         torch.testing.assert_close(
             ours[valid], theirs[valid], atol=tolerance, rtol=tolerance
         )

--- a/tests/unit_test/fun_asr/test_checkpoint_compatibility.py
+++ b/tests/unit_test/fun_asr/test_checkpoint_compatibility.py
@@ -1,0 +1,285 @@
+# SPDX-License-Identifier: Apache-2.0
+"""Check real loader destinations, format guards, and flat-encoder execution."""
+
+from types import SimpleNamespace
+
+import pytest
+import torch
+from torch import nn
+
+from sglang_omni.models.fun_asr.checkpoint import canonical_weight_name
+from sglang_omni.models.fun_asr.configuration_fun_asr import FunAsrNanoConfig
+from sglang_omni.models.fun_asr.sglang_model import (
+    FunAsrNanoAdaptor,
+    FunAsrNanoAudioEncoder,
+    FunAsrNanoForConditionalGeneration,
+)
+
+
+@pytest.mark.parametrize(
+    "source,target",
+    [
+        ("stem.input", "layers.0.input"),
+        ("layers.0.input", "layers.1.input"),
+        ("layers.48.input", "layers.49.input"),
+        ("timestamp_prediction_layers.0.input", "layers.50.input"),
+        ("timestamp_prediction_layers.19.input", "layers.69.input"),
+        ("layer_norm.weight", "layers.49.final_layernorm.weight"),
+        ("timestamp_prediction_layer_norm.bias", "layers.69.final_layernorm.bias"),
+    ],
+)
+def test_split_boundaries(source, target):
+    assert (
+        canonical_weight_name(
+            "model.audio_tower." + source, layout="split", num_blocks=50, tp_blocks=20
+        )
+        == "model.audio_tower." + target
+    )
+
+
+@pytest.mark.parametrize(
+    "layout,source",
+    [
+        ("flat", "stem.self_attn.q_proj.weight"),
+        ("split", "layers.0.input_layernorm.weight"),
+    ],
+)
+def test_mixed_layout_rejected(layout, source):
+    with pytest.raises(ValueError, match="disagrees"):
+        canonical_weight_name(
+            "model.audio_tower." + source, layout=layout, num_blocks=50, tp_blocks=20
+        )
+
+
+@pytest.mark.parametrize("flat", [False, True])
+def test_nested_config_counts_and_roundtrip(flat):
+    audio = dict(
+        hidden_size=8,
+        num_attention_heads=2,
+        intermediate_size=16,
+        num_hidden_layers=3 if flat else 2,
+        num_mel_bins=2,
+        num_stacked_frames=3,
+    )
+    audio[
+        "num_timestamp_prediction_layers" if flat else "num_timestamp_prediction_blocks"
+    ] = 1
+    config = FunAsrNanoConfig(
+        audio_config=audio,
+        adaptor_config=dict(
+            hidden_size=8,
+            intermediate_size=5,
+            projector_hidden_size=12,
+            num_attention_heads=2,
+        ),
+        text_config=dict(hidden_size=8, num_attention_heads=2),
+    )
+    assert config.encoder_config.encoder_layers == 2
+    assert config.encoder_config.num_timestamp_prediction_blocks == 1
+    assert config.encoder_config.input_size == 6
+    assert config.adaptor_ffn_dim == 5
+    assert config.adaptor_intermediate_size == 12
+    restored = FunAsrNanoConfig.from_dict(config.to_dict())
+    assert restored.checkpoint_layout == ("flat" if flat else "split")
+    assert restored.adaptor_ffn_dim == 5
+
+
+def tiny_model(layout="flat"):
+    model = FunAsrNanoForConditionalGeneration.__new__(
+        FunAsrNanoForConditionalGeneration
+    )
+    nn.Module.__init__(model)
+    model.config = SimpleNamespace(
+        checkpoint_layout=layout,
+        encoder_config=SimpleNamespace(
+            encoder_layers=2, num_timestamp_prediction_blocks=1
+        ),
+        text_config=SimpleNamespace(tie_word_embeddings=False),
+    )
+    model.audio_tower = FunAsrNanoAudioEncoder(
+        input_size=6,
+        output_size=8,
+        attention_heads=2,
+        linear_units=16,
+        num_blocks=2,
+        tp_blocks=1,
+        kernel_size=3,
+        dropout_rate=0,
+        attention_dropout_rate=0,
+        activation_dropout_rate=0,
+    )
+    model.multi_modal_projector = FunAsrNanoAdaptor(
+        encoder_dim=8, llm_dim=8, ffn_dim=12, num_layers=1, attention_heads=2
+    )
+    return model.eval()
+
+
+def split_key(name):
+    """Test export fixture: spell out the three blocks and two boundary norms."""
+    name = "model." + name
+    if name.startswith("model.audio_tower."):
+        for source, target in [
+            ("layers.1.final_layernorm.", "layer_norm."),
+            ("layers.2.final_layernorm.", "timestamp_prediction_layer_norm."),
+            ("layers.0.", "stem."),
+            ("layers.1.", "layers.0."),
+            ("layers.2.", "timestamp_prediction_layers.0."),
+        ]:
+            if name.startswith("model.audio_tower." + source):
+                name = name.replace(source, target, 1)
+                break
+    else:
+        name = name.replace("multi_modal_projector.layers.", "audio_adaptor.blocks.")
+    for source, target in [
+        (".input_layernorm.", ".self_attn_layer_norm."),
+        (".post_attention_layernorm.", ".final_layer_norm."),
+        (".self_attn.o_proj.", ".self_attn.out_proj."),
+        (".self_attn.fsmn.", ".feedforward_sequential_memory."),
+        (".mlp.fc1.", ".fc1."),
+        (".mlp.fc2.", ".fc2."),
+    ]:
+        name = name.replace(source, target)
+    return name
+
+
+@pytest.mark.parametrize("layout", ["flat", "split"])
+def test_full_audio_load_and_output(layout):
+    source, target = tiny_model(), tiny_model(layout)
+    weights = [
+        ("model." + name if layout == "flat" else split_key(name), tensor.clone())
+        for name, tensor in source.state_dict().items()
+    ]
+    target.load_weights(reversed(weights))
+    for name, tensor in source.state_dict().items():
+        torch.testing.assert_close(target.state_dict()[name], tensor, rtol=0, atol=0)
+    x = torch.randn(2, 7, 6)
+    mask = torch.tensor([[[1] * 7], [[1] * 4 + [0] * 3]], dtype=x.dtype)
+    with torch.no_grad():
+        torch.testing.assert_close(
+            target.audio_tower(x, mask), source.audio_tower(x, mask), rtol=0, atol=0
+        )
+
+
+@pytest.mark.parametrize("failure", ["missing", "duplicate", "shape", "unknown_bias"])
+def test_loader_rejects_incomplete_or_ambiguous_weights(failure):
+    model = tiny_model()
+    weights = [
+        ("model." + name, tensor.clone()) for name, tensor in model.state_dict().items()
+    ]
+    if failure == "missing":
+        weights.pop()
+    elif failure == "duplicate":
+        weights.append(weights[0])
+    elif failure == "shape":
+        weights[0] = (weights[0][0], torch.zeros(1))
+    else:
+        weights.append(("model.audio_tower.missing.bias", torch.zeros(1)))
+    with pytest.raises(ValueError):
+        model.load_weights(weights)
+
+
+def test_flat_model_keeps_all_valid_audio_frames():
+    model = tiny_model()
+    item = SimpleNamespace(
+        feature=torch.randn(1, 6, 17), feature_attention_mask=torch.ones(1, 17)
+    )
+    assert model.get_audio_feature([item]).shape == (17, 8)
+    model.config.checkpoint_layout = "split"
+    assert model.get_audio_feature([item]).shape == (3, 8)
+
+
+@pytest.mark.parametrize("flat", [False, True])
+def test_feature_extractor_reads_layout_and_lfr_fields(tmp_path, flat):
+    import json
+
+    from sglang_omni.models.fun_asr.configuration_fun_asr import (
+        FunAsrNanoFeatureExtractor,
+    )
+
+    audio = {
+        "num_hidden_layers": 3 if flat else 2,
+        (
+            "num_timestamp_prediction_layers"
+            if flat
+            else "num_timestamp_prediction_blocks"
+        ): 1,
+    }
+    (tmp_path / "config.json").write_text(
+        json.dumps({"model_type": "fun_asr_nano", "audio_config": audio})
+    )
+    (tmp_path / "processor_config.json").write_text(
+        json.dumps(
+            {
+                "feature_extractor": {
+                    "feature_extractor_type": "FunAsrNanoFeatureExtractor",
+                    "feature_size": 40,
+                    "num_frames_lfr": 3,
+                    "stride_lfr": 2,
+                }
+            }
+        )
+    )
+    extractor = FunAsrNanoFeatureExtractor.from_pretrained(
+        tmp_path, local_files_only=True
+    )
+    assert extractor.lfr_m == 3
+    assert extractor.lfr_n == 2
+    assert extractor.legacy_audio_lengths is not flat
+
+
+@pytest.mark.parametrize("dtype", [torch.float32, torch.bfloat16])
+def test_encoder_and_projector_match_native_hf(dtype):
+    # Optional reference check: serving remains on the repo's pinned Transformers.
+    reference = pytest.importorskip(
+        "transformers.models.fun_asr_nano.modeling_fun_asr_nano"
+    )
+    configs = pytest.importorskip(
+        "transformers.models.fun_asr_nano.configuration_fun_asr_nano"
+    )
+    torch.manual_seed(9)
+    model = tiny_model().to(dtype=dtype)
+    audio_config = configs.FunAsrNanoEncoderConfig(
+        num_mel_bins=2,
+        num_stacked_frames=3,
+        hidden_size=8,
+        intermediate_size=16,
+        num_attention_heads=2,
+        num_hidden_layers=3,
+        num_timestamp_prediction_layers=1,
+        fsmn_kernel_size=3,
+    )
+    audio_config._attn_implementation = "eager"
+    encoder = reference.FunAsrNanoEncoder(audio_config).eval().to(dtype=dtype)
+    encoder.load_state_dict(model.audio_tower.state_dict(), strict=True)
+    adaptor_config = configs.FunAsrNanoAdaptorConfig(
+        hidden_size=8,
+        intermediate_size=2,
+        num_hidden_layers=1,
+        num_attention_heads=2,
+        projector_hidden_size=12,
+    )
+    adaptor_config._attn_implementation = "eager"
+    projector = (
+        reference.FunAsrNanoMultiModalProjector(
+            SimpleNamespace(audio_config=audio_config, adaptor_config=adaptor_config)
+        )
+        .eval()
+        .to(dtype=dtype)
+    )
+    projector.load_state_dict(model.multi_modal_projector.state_dict(), strict=True)
+    x = torch.randn(2, 7, 6, dtype=dtype)
+    mask = torch.tensor([[1] * 7, [1] * 4 + [0] * 3])
+    with torch.no_grad():
+        ours = model.audio_tower(x, mask[:, None, :])
+        theirs = encoder(x, mask).last_hidden_state
+        valid = mask.bool()
+        tolerance = 2e-5 if dtype == torch.float32 else 0.04
+        torch.testing.assert_close(
+            ours[valid], theirs[valid], atol=tolerance, rtol=tolerance
+        )
+        torch.testing.assert_close(
+            model.multi_modal_projector(ours, mask[:, None, :])[valid],
+            projector(theirs, mask)[valid],
+            atol=tolerance,
+            rtol=tolerance,
+        )

--- a/tests/unit_test/fun_asr/test_model.py
+++ b/tests/unit_test/fun_asr/test_model.py
@@ -37,7 +37,7 @@ def test_fun_asr_audio_modules_match_current_checkpoint_parameter_names() -> Non
     assert "layers.0.self_attn.q_proj.weight" in encoder_names
     assert "layers.0.self_attn.k_proj.weight" in encoder_names
     assert "layers.0.self_attn.v_proj.weight" in encoder_names
-    assert "layers.0.self_attn.o_proj.weight" in encoder_names
+    assert "layers.0.self_attn.out_proj.weight" in encoder_names
     assert "layers.0.self_attn.fsmn.conv.weight" in encoder_names
     assert "layers.0.mlp.fc1.weight" in encoder_names
     assert "layers.0.input_layernorm.weight" in encoder_names

--- a/tests/unit_test/fun_asr/test_model.py
+++ b/tests/unit_test/fun_asr/test_model.py
@@ -34,17 +34,17 @@ def test_fun_asr_audio_modules_match_current_checkpoint_parameter_names() -> Non
     )
     encoder_names = set(dict(encoder.named_parameters()))
 
-    assert "stem.self_attn.q_proj.weight" in encoder_names
-    assert "stem.self_attn.k_proj.weight" in encoder_names
-    assert "stem.self_attn.v_proj.weight" in encoder_names
-    assert "stem.self_attn.out_proj.weight" in encoder_names
-    assert "stem.fsmn.conv.weight" in encoder_names
-    assert "stem.fc1.weight" in encoder_names
-    assert "layers.0.self_attn_layer_norm.weight" in encoder_names
-    assert "layers.0.final_layer_norm.weight" in encoder_names
-    assert "layer_norm.weight" in encoder_names
-    assert "timestamp_prediction_layers.0.fc2.weight" in encoder_names
-    assert "timestamp_prediction_layer_norm.weight" in encoder_names
+    assert "layers.0.self_attn.q_proj.weight" in encoder_names
+    assert "layers.0.self_attn.k_proj.weight" in encoder_names
+    assert "layers.0.self_attn.v_proj.weight" in encoder_names
+    assert "layers.0.self_attn.o_proj.weight" in encoder_names
+    assert "layers.0.self_attn.fsmn.conv.weight" in encoder_names
+    assert "layers.0.mlp.fc1.weight" in encoder_names
+    assert "layers.0.input_layernorm.weight" in encoder_names
+    assert "layers.0.post_attention_layernorm.weight" in encoder_names
+    assert "layers.1.final_layernorm.weight" in encoder_names
+    assert "layers.2.mlp.fc2.weight" in encoder_names
+    assert "layers.2.final_layernorm.weight" in encoder_names
 
     projector = FunAsrNanoAdaptor(
         encoder_dim=8,
@@ -57,10 +57,10 @@ def test_fun_asr_audio_modules_match_current_checkpoint_parameter_names() -> Non
 
     assert "linear_1.weight" in projector_names
     assert "linear_2.weight" in projector_names
-    assert "blocks.0.self_attn.q_proj.weight" in projector_names
-    assert "blocks.0.self_attn_layer_norm.weight" in projector_names
-    assert "blocks.0.fc1.weight" in projector_names
-    assert "blocks.0.final_layer_norm.weight" in projector_names
+    assert "layers.0.self_attn.q_proj.weight" in projector_names
+    assert "layers.0.input_layernorm.weight" in projector_names
+    assert "layers.0.mlp.fc1.weight" in projector_names
+    assert "layers.0.post_attention_layernorm.weight" in projector_names
 
 
 def _weight_loader_target() -> FunAsrNanoForConditionalGeneration:
@@ -69,12 +69,16 @@ def _weight_loader_target() -> FunAsrNanoForConditionalGeneration:
     )
     nn.Module.__init__(model)
     model.config = SimpleNamespace(
-        text_config=SimpleNamespace(tie_word_embeddings=False)
+        text_config=SimpleNamespace(tie_word_embeddings=False),
+        checkpoint_layout="split",
+        encoder_config=SimpleNamespace(
+            encoder_layers=2, num_timestamp_prediction_blocks=1
+        ),
     )
     model.audio_tower = nn.Module()
-    model.audio_tower.layer_norm = nn.LayerNorm(2)
+    model.audio_tower.layers = nn.ModuleList([nn.Module(), nn.Module()])
+    model.audio_tower.layers[1].final_layernorm = nn.LayerNorm(2, bias=False)
     model.multi_modal_projector = nn.Module()
-    model.multi_modal_projector.linear_1 = nn.Linear(2, 2)
     return model
 
 
@@ -84,19 +88,23 @@ def test_fun_asr_weight_loader_loads_current_audio_prefixes() -> None:
 
     model.load_weights([("model.audio_tower.layer_norm.weight", expected.clone())])
 
-    assert torch.equal(model.audio_tower.layer_norm.weight, expected)
+    assert torch.equal(model.audio_tower.layers[1].final_layernorm.weight, expected)
 
 
 def test_fun_asr_weight_loader_maps_new_checkpoint_names() -> None:
     model = _weight_loader_target()
-    model.audio_tower.stem = nn.Module()
-    model.audio_tower.stem.fsmn = nn.Module()
-    model.audio_tower.stem.fsmn.conv = nn.Conv1d(2, 2, 1, bias=False)
-    model.multi_modal_projector.blocks = nn.ModuleList([nn.Module()])
-    model.multi_modal_projector.blocks[0].fc1 = nn.Linear(2, 2, bias=False)
-    expected_fsmn = torch.full_like(model.audio_tower.stem.fsmn.conv.weight, 2.0)
+    model.audio_tower.layers[1].final_layernorm = nn.Identity()
+    model.audio_tower.layers[0].self_attn = nn.Module()
+    model.audio_tower.layers[0].self_attn.fsmn = nn.Module()
+    model.audio_tower.layers[0].self_attn.fsmn.conv = nn.Conv1d(2, 2, 1, bias=False)
+    model.multi_modal_projector.layers = nn.ModuleList([nn.Module()])
+    model.multi_modal_projector.layers[0].mlp = nn.Module()
+    model.multi_modal_projector.layers[0].mlp.fc1 = nn.Linear(2, 2, bias=False)
+    expected_fsmn = torch.full_like(
+        model.audio_tower.layers[0].self_attn.fsmn.conv.weight, 2.0
+    )
     expected_adaptor = torch.full_like(
-        model.multi_modal_projector.blocks[0].fc1.weight, 3.0
+        model.multi_modal_projector.layers[0].mlp.fc1.weight, 3.0
     )
 
     model.load_weights(
@@ -109,9 +117,11 @@ def test_fun_asr_weight_loader_maps_new_checkpoint_names() -> None:
         ]
     )
 
-    assert torch.equal(model.audio_tower.stem.fsmn.conv.weight, expected_fsmn)
     assert torch.equal(
-        model.multi_modal_projector.blocks[0].fc1.weight, expected_adaptor
+        model.audio_tower.layers[0].self_attn.fsmn.conv.weight, expected_fsmn
+    )
+    assert torch.equal(
+        model.multi_modal_projector.layers[0].mlp.fc1.weight, expected_adaptor
     )
 
 
@@ -247,7 +257,7 @@ def test_encoder_layer_runs_attention_once() -> None:
         dropout_rate=0.0,
         attention_dropout_rate=0.0,
         activation_dropout_rate=0.0,
-    ).stem
+    ).layers[0]
     layer.eval()
     calls = {"attn": 0}
     original = layer.self_attn.forward

--- a/tests/unit_test/fun_asr/test_pipeline.py
+++ b/tests/unit_test/fun_asr/test_pipeline.py
@@ -116,9 +116,9 @@ def test_fun_asr_stage_default_enables_async_decode() -> None:
     assert signature.parameters["async_decode_min_batch_size"].default == 2
 
 
-@pytest.mark.parametrize("legacy", [False, True])
+@pytest.mark.parametrize("layout", ["flat", "split"])
 def test_fun_asr_threads_generation_batch_and_request_build_policy(
-    monkeypatch, legacy
+    monkeypatch, layout
 ) -> None:
     from sglang_omni.scheduling.generation_batch_policy import (
         build_default_prefill_cuda_graph_bs,
@@ -148,7 +148,7 @@ def test_fun_asr_threads_generation_batch_and_request_build_policy(
         fun_asr_builder.AutoFeatureExtractor,
         "from_pretrained",
         lambda *args, **kwargs: SimpleNamespace(
-            nb_max_frames=500, legacy_audio_lengths=legacy
+            nb_max_frames=500, checkpoint_layout=layout
         ),
     )
     monkeypatch.setattr(
@@ -204,7 +204,7 @@ def test_fun_asr_threads_generation_batch_and_request_build_policy(
     )
 
     def _fake_server_args_builder(model_path, context_length, **overrides):
-        expected_audio_tokens = 63 if legacy else 500
+        expected_audio_tokens = 500 if layout == "flat" else 63
         assert (
             context_length
             == expected_audio_tokens

--- a/tests/unit_test/fun_asr/test_pipeline.py
+++ b/tests/unit_test/fun_asr/test_pipeline.py
@@ -116,7 +116,10 @@ def test_fun_asr_stage_default_enables_async_decode() -> None:
     assert signature.parameters["async_decode_min_batch_size"].default == 2
 
 
-def test_fun_asr_threads_generation_batch_and_request_build_policy(monkeypatch) -> None:
+@pytest.mark.parametrize("legacy", [False, True])
+def test_fun_asr_threads_generation_batch_and_request_build_policy(
+    monkeypatch, legacy
+) -> None:
     from sglang_omni.scheduling.generation_batch_policy import (
         build_default_prefill_cuda_graph_bs,
     )
@@ -144,7 +147,9 @@ def test_fun_asr_threads_generation_batch_and_request_build_policy(monkeypatch) 
     monkeypatch.setattr(
         fun_asr_builder.AutoFeatureExtractor,
         "from_pretrained",
-        lambda *args, **kwargs: SimpleNamespace(nb_max_frames=500),
+        lambda *args, **kwargs: SimpleNamespace(
+            nb_max_frames=500, legacy_audio_lengths=legacy
+        ),
     )
     monkeypatch.setattr(
         fun_asr_builder,
@@ -199,6 +204,13 @@ def test_fun_asr_threads_generation_batch_and_request_build_policy(monkeypatch) 
     )
 
     def _fake_server_args_builder(model_path, context_length, **overrides):
+        expected_audio_tokens = 63 if legacy else 500
+        assert (
+            context_length
+            == expected_audio_tokens
+            + 200
+            + request_builders.fun_asr_prompt_overhead_tokens(tokenizer)
+        )
         build_kwargs.clear()
         build_kwargs.update(overrides)
         prefill_bs = overrides.get("cuda_graph_bs_prefill")

--- a/tests/unit_test/fun_asr/test_request_builders.py
+++ b/tests/unit_test/fun_asr/test_request_builders.py
@@ -87,11 +87,14 @@ def _feature_extractor(num_lfr_frames: int):
     return _call
 
 
-def test_fun_asr_request_builder_records_inclusive_audio_offsets(monkeypatch) -> None:
-    # 17 LFR frames -> three ceil(x/2) reductions: 17->9->5->3 audio tokens
+@pytest.mark.parametrize("legacy", [False, True])
+def test_fun_asr_request_builder_records_inclusive_audio_offsets(
+    monkeypatch, legacy
+) -> None:
     num_lfr_frames = 17
-    num_audio_tokens = fun_asr_low_frame_rate_length(num_lfr_frames)
-    assert num_audio_tokens == 3
+    num_audio_tokens = 3 if legacy else 17
+    extractor = _feature_extractor(num_lfr_frames)
+    extractor.legacy_audio_lengths = legacy
 
     monkeypatch.setattr(
         transcription,
@@ -101,7 +104,7 @@ def test_fun_asr_request_builder_records_inclusive_audio_offsets(monkeypatch) ->
     request_builder, _ = request_builders.make_fun_asr_scheduler_adapters(
         tokenizer=_FakeTokenizer(),
         max_new_tokens=32,
-        feature_extractor=_feature_extractor(num_lfr_frames),
+        feature_extractor=extractor,
     )
     payload = StagePayload(
         request_id="req-fun-asr",

--- a/tests/unit_test/fun_asr/test_request_builders.py
+++ b/tests/unit_test/fun_asr/test_request_builders.py
@@ -87,14 +87,14 @@ def _feature_extractor(num_lfr_frames: int):
     return _call
 
 
-@pytest.mark.parametrize("legacy", [False, True])
+@pytest.mark.parametrize("layout", ["flat", "split"])
 def test_fun_asr_request_builder_records_inclusive_audio_offsets(
-    monkeypatch, legacy
+    monkeypatch, layout
 ) -> None:
     num_lfr_frames = 17
-    num_audio_tokens = 3 if legacy else 17
+    num_audio_tokens = 17 if layout == "flat" else 3
     extractor = _feature_extractor(num_lfr_frames)
-    extractor.legacy_audio_lengths = legacy
+    extractor.checkpoint_layout = layout
 
     monkeypatch.setattr(
         transcription,


### PR DESCRIPTION
Closes #2120

The latest Fun-ASR HF checkpoint stores a flat 70-layer audio encoder and native Transformers parameter names. The previous split stem / transcription / timestamp model layout rejected the current checkpoint during loading.

This draft uses the latest HF revision by default, consistent with the other ASR models in this repository. It detects the flat or older split checkpoint layout from configuration structure, then translates each layout into one stable local implementation at load time.

Compatibility details:
- Current flat checkpoints retain their native layer numbering; their attention o_proj names map to the existing local out_proj names.
- Older split checkpoints map stem, transcription, timestamp, boundary-norm, adaptor, FSMN, and MLP names to the same local model.
- Current flat checkpoints use one audio placeholder per LFR frame, matching the native HF processor. Older split checkpoints retain their historical three-stage stride-2 count.

The loader rejects layout/config disagreements, unknown multimodal weights, missing parameters, duplicate destinations, and shape mismatches.

Validation completed locally:
- All 1,230 audio/projector parameter names and shapes from each of three real HF safetensors headers map to the local model: current flat plus two older split revisions.
- 21 isolated CPU compatibility tests pass; one optional upstream-reference test is skipped because this environment lacks the newer Transformers Fun-ASR module.
- The legacy encoder matches the previous implementation exactly in float32.

## Perf/correctness validation (RunPod A100-SXM4-80GB)

Full SeedTTS-EN (short-clip) and LongLibriHeavy-30 (long-form) datasets, c=1/8/16/32, 2 repeats per level, compared against the pre-PR baseline on the same GPU class.

**Boot fix confirmed**: server boots cleanly against the previously-crashing unpinned `refs/main` checkpoint (`7ef6cafd`, flat 70-layer layout) and serves correct transcriptions. Unit tests: `pytest tests/unit_test/fun_asr/ -q` → 107 passed, 2 skipped, 0 failed.

**Throughput / latency** (pre-PR baseline → this PR):

| Workload | conc | throughput (req/s) | Δ | mean latency (ms) | p95 latency (ms) |
|---|---:|---:|---:|---:|---:|
| Short-clip | 1  | 15.11 → 15.79 | +4.5% | 66.0 → 63.2  | 79.6 → 76.5   |
| Short-clip | 8  | 87.60 → 91.42 | +4.4% | 91.0 → 87.0  | 118.2 → 116.2 |
| Short-clip | 16 | 137.1 → 145.1 | +5.9% | 115.1 → 108.6| 145.2 → 138.3 |
| Short-clip | 32 | 192.9 → 200.5 | +3.9% | 164.2 → 158.1| 213.7 → 203.3 |
| Long-form  | 1  | 4.06 → 4.16   | +2.5% | 236.2 → 230.1| 317.8 → 317.6 |
| Long-form  | 8  | 25.77 → 24.65 | −4.3% | 286.0 → 300.8| 391.0 → 417.3 |
| Long-form  | 16 | 42.60 → 40.52 | −4.9% | 337.4 → 356.4| 465.6 → 481.5 |
| Long-form  | 32 | 67.38 → 63.50 | −5.8% | 416.5 → 446.5| 572.6 → 625.2 |

All deltas fall within (or at the edge of) the ~5-9 point run-to-run noise band already established for this workload across independent runs — no code-attributable performance regression.

**WER by concurrency** (pre-PR baseline checkpoint `1fd03aa5` → this PR's checkpoint `7ef6cafd`):

| Workload | conc | prior WER | this PR WER | Δ | Δ% |
|---|---:|---:|---:|---:|---:|
| Short-clip | 1  | 0.0173 | 0.01763 | +0.00033 | +1.9% |
| Short-clip | 8  | 0.0171 | 0.01748 | +0.00038 | +2.2% |
| Short-clip | 16 | 0.0171 | 0.01744 | +0.00034 | +2.0% |
| Short-clip | 32 | 0.0171 | 0.01748 | +0.00038 | +2.2% |
| Long-form  | 1  | 0.1156 | 0.12586 | +0.0103 | +8.9% |
| Long-form  | 8  | 0.1155 | 0.12607 | +0.0106 | +9.2% |
| Long-form  | 16 | 0.1156 | 0.12561 | +0.0100 | +8.7% |
| Long-form  | 32 | 0.1157 | 0.12593 | +0.0102 | +8.8% |

The delta is flat across concurrency in both shapes (short-clip: +1.9-2.2%, long-form: +8.7-9.2%, no trend with conc) — concurrency does not appear to be a factor in the WER difference; it tracks checkpoint identity only.

**Long-form WER delta — observations**:
- Running this PR's code against the old checkpoint (`1fd03aa5`) reproduces the pre-PR baseline (0.11553 vs. 0.1155-0.1157) with the same code, ruling out this PR's weight-mapping logic as the source of the delta on that data point.
- Two clips (`longlibriheavy-30-000314`, `-000067`) show WER 0.15 and 0.09 on the old checkpoint vs. 2.16 and 1.88 on the new checkpoint, same code, same audio. The new-checkpoint transcriptions for these two clips contain repeated phrase loops.
- Excluding these 2 of 545 clips accounts for ~84% of the aggregate WER gap; the remaining clips show a difference within the range attributable to normal variation.

These observations point away from this PR's code as the cause and toward the checkpoint weights themselves (the `d93b302e` reconversion) as the more likely source, though this is based on 2 affected clips out of 545 in one long-form dataset — not a controlled, large-sample comparison of the two checkpoints' decode stability. Flagging to the checkpoint's upstream maintainers for further investigation rather than treating it as conclusively resolved here.
