### PR TITLE
[Qwen3-TTS] Stage the token ids before the code predictor

### DIFF
--- a/sglang_omni/models/qwen3_tts/model_runner.py
+++ b/sglang_omni/models/qwen3_tts/model_runner.py
@@ -118,8 +118,8 @@ class Qwen3TTSModelRunner(ModelRunner):
         return True
 
     def lookahead_eligible(self, batch: Any) -> bool:
-        # note(ratish): the codec collect runs in post_decode only, the launch
-        # and resolve halves would skip it and feed token embeddings back.
+        # note(ratish): the lookahead's launch and resolve hooks do not run the
+        # codec collect, they would feed token embeddings back.
         del batch
         return False
 
@@ -186,8 +186,8 @@ class Qwen3TTSModelRunner(ModelRunner):
         layer0_codes = result.next_token_ids
         if layer0_codes.ndim == 1:
             layer0_codes = layer0_codes.unsqueeze(1)
-        # note(ratish): the layer 0 id is the step's only host read, so its copy
-        # goes ahead of the predictor and the finalize wait no longer covers it.
+        # note(ratish): the layer 0 id is the step's only host read, staged ahead
+        # of the predictor so the finalize wait covers the sample, not the predictor.
         self._stage_token_ids(result, result.next_token_ids)
 
         hidden = result.logits_output.hidden_states

--- a/sglang_omni/models/qwen3_tts/model_runner.py
+++ b/sglang_omni/models/qwen3_tts/model_runner.py
@@ -180,6 +180,9 @@ class Qwen3TTSModelRunner(ModelRunner):
         layer0_codes = result.next_token_ids
         if layer0_codes.ndim == 1:
             layer0_codes = layer0_codes.unsqueeze(1)
+        # note(ratish): the layer 0 id is the step's only host read, so its copy
+        # goes ahead of the predictor and the finalize wait no longer covers it.
+        self._stage_token_ids(result, result.next_token_ids)
 
         hidden = result.logits_output.hidden_states
         if isinstance(hidden, torch.Tensor) and hidden.ndim == 2:
@@ -190,10 +193,6 @@ class Qwen3TTSModelRunner(ModelRunner):
             hidden,
             semantic_positions=semantic_positions,
         )
-        # Note: (Jiaxin Deng) stage the ids into pinned host memory now so the
-        # output processor's .tolist() waits on an event instead of issuing a
-        # blocking pageable copy inside the decode loop.
-        self._stage_token_ids(result, result.next_token_ids)
         self._has_pending_code_step = True
 
     def post_process_outputs(

--- a/sglang_omni/models/qwen3_tts/model_runner.py
+++ b/sglang_omni/models/qwen3_tts/model_runner.py
@@ -117,6 +117,12 @@ class Qwen3TTSModelRunner(ModelRunner):
         del forward_batch, schedule_batch, requests
         return True
 
+    def lookahead_eligible(self, batch: Any) -> bool:
+        # note(ratish): the codec collect runs in post_decode only, the launch
+        # and resolve halves would skip it and feed token embeddings back.
+        del batch
+        return False
+
     def _sample_next_token_ids(
         self,
         logits_output: Any,

--- a/tests/unit_test/qwen3_tts/test_decode_step_staging.py
+++ b/tests/unit_test/qwen3_tts/test_decode_step_staging.py
@@ -95,6 +95,22 @@ def test_collect_codes_stages_the_ids_before_the_predictor_runs():
     assert requests[2].data.pending_feedback_queue[0].tolist() == [9.0, 9.0]
 
 
+def test_lookahead_is_never_eligible():
+    runner = Qwen3TTSModelRunner.__new__(Qwen3TTSModelRunner)
+    history_free = SimpleNamespace(
+        sampling_params=SimpleNamespace(
+            repetition_penalty=1.0,
+            frequency_penalty=0.0,
+            presence_penalty=0.0,
+            min_new_tokens=0,
+        ),
+        custom_logit_processor=None,
+    )
+
+    assert runner.lookahead_eligible(SimpleNamespace(reqs=[history_free])) is False
+    assert runner.lookahead_eligible(SimpleNamespace(reqs=[])) is False
+
+
 @pytest.mark.accelerator
 def test_staged_ids_resolve_while_the_predictor_is_still_running():
     device = torch.device("cuda")

--- a/tests/unit_test/qwen3_tts/test_decode_step_staging.py
+++ b/tests/unit_test/qwen3_tts/test_decode_step_staging.py
@@ -1,0 +1,133 @@
+# SPDX-License-Identifier: Apache-2.0
+"""Contracts of the Qwen3-TTS decode step around the code predictor.
+
+The layer 0 token id is the only value the host reads from a step, so its
+pinned copy is enqueued before the predictor and the finalize wait returns
+while the predictor still runs. The code and feedback rows keep coming from a
+snapshot taken behind the predictor. The runner is sync only: its collect has
+no launch and resolve halves, so it never takes the lookahead path.
+"""
+
+from __future__ import annotations
+
+from types import SimpleNamespace
+
+import pytest
+import torch
+
+from sglang_omni.models.qwen3_tts.model_runner import Qwen3TTSModelRunner
+from sglang_omni.models.qwen3_tts.request_builders import Qwen3TTSSGLangRequestData
+from sglang_omni.scheduling.types import RequestOutput
+
+EOS = 42
+PREDICTOR_CYCLES = 1_000_000_000
+
+
+@pytest.fixture(autouse=True)
+def _require_cuda_for_accelerator_tests(request: pytest.FixtureRequest):
+    if request.node.get_closest_marker("accelerator") and not torch.cuda.is_available():
+        pytest.skip("token id staging on a stream needs CUDA")
+
+
+def _runner(code_predictor_forward, device: torch.device) -> Qwen3TTSModelRunner:
+    runner = Qwen3TTSModelRunner.__new__(Qwen3TTSModelRunner)
+    runner._has_pending_code_step = False
+    runner._token_id_host_bufs = None
+    runner._token_id_host_slot = 0
+    runner.model = SimpleNamespace(
+        config=SimpleNamespace(codec_eos_token_id=EOS),
+        code_predictor_forward=code_predictor_forward,
+        _output_codes=torch.zeros((4, 3), dtype=torch.long, device=device),
+        _output_embeds=torch.zeros((4, 2), device=device),
+    )
+    return runner
+
+
+def _step(ids: torch.Tensor):
+    batch_size = ids.shape[0]
+    result = SimpleNamespace(
+        next_token_ids=ids,
+        logits_output=SimpleNamespace(
+            hidden_states=torch.ones((batch_size, 2), device=ids.device)
+        ),
+    )
+    forward_batch = SimpleNamespace(
+        forward_mode=SimpleNamespace(is_decode=lambda: True),
+        positions=torch.full((batch_size,), 3, dtype=torch.long, device=ids.device),
+    )
+    requests = [
+        SimpleNamespace(request_id=f"r{row}", data=Qwen3TTSSGLangRequestData())
+        for row in range(batch_size)
+    ]
+    return result, forward_batch, requests
+
+
+def test_collect_codes_stages_the_ids_before_the_predictor_runs():
+    ids = torch.tensor([7, EOS, 9], dtype=torch.long)
+    result, forward_batch, requests = _step(ids)
+    staged_when_called = []
+
+    def code_predictor_forward(layer0_codes, hidden, semantic_positions=None):
+        staged_when_called.append(result._host_token_ids)
+        runner.model._output_codes[:3] = layer0_codes + torch.arange(3)
+        runner.model._output_embeds[:3] = layer0_codes.to(torch.float32)
+
+    runner = _runner(code_predictor_forward, torch.device("cpu"))
+
+    runner._collect_codes(result, forward_batch, object(), requests)
+
+    assert len(staged_when_called) == 1
+    assert staged_when_called[0] is ids
+
+    outputs = {
+        req.request_id: RequestOutput(req.request_id, data=int(ids[row]))
+        for row, req in enumerate(requests)
+    }
+    runner.post_process_outputs(result, SimpleNamespace(requests=requests), outputs)
+    runner.model._output_codes.zero_()
+    runner.model._output_embeds.zero_()
+
+    assert [c.tolist() for c in requests[0].data.output_codes] == [[7, 8, 9]]
+    assert requests[0].data.pending_feedback_queue[0].tolist() == [7.0, 7.0]
+    assert requests[1].data.output_codes == []
+    assert len(requests[1].data.pending_feedback_queue) == 0
+    assert [c.tolist() for c in requests[2].data.output_codes] == [[9, 10, 11]]
+    assert requests[2].data.pending_feedback_queue[0].tolist() == [9.0, 9.0]
+
+
+@pytest.mark.accelerator
+def test_staged_ids_resolve_while_the_predictor_is_still_running():
+    device = torch.device("cuda")
+    ids = torch.tensor([7, 8], dtype=torch.long, device=device)
+    result, forward_batch, requests = _step(ids)
+
+    def code_predictor_forward(layer0_codes, hidden, semantic_positions=None):
+        torch.cuda._sleep(PREDICTOR_CYCLES)
+
+    runner = _runner(code_predictor_forward, device)
+    stream = torch.cuda.current_stream(device)
+
+    runner._collect_codes(result, forward_batch, object(), requests)
+    host_ids = runner._resolve_host_token_ids(result)
+    predictor_done = stream.query()
+    torch.cuda.synchronize()
+
+    assert host_ids.tolist() == [7, 8]
+    assert predictor_done is False
+
+
+@pytest.mark.accelerator
+def test_staged_ids_keep_the_sampled_values_when_later_stream_work_overwrites_them():
+    device = torch.device("cuda")
+    ids = torch.tensor([7, 8], dtype=torch.long, device=device)
+    result, forward_batch, requests = _step(ids)
+
+    def code_predictor_forward(layer0_codes, hidden, semantic_positions=None):
+        layer0_codes.fill_(-1)
+
+    runner = _runner(code_predictor_forward, device)
+
+    runner._collect_codes(result, forward_batch, object(), requests)
+
+    assert runner._resolve_host_token_ids(result).tolist() == [7, 8]
+    assert result.next_token_ids.tolist() == [-1, -1]

--- a/tests/unit_test/qwen3_tts/test_mask_logit_shaping.py
+++ b/tests/unit_test/qwen3_tts/test_mask_logit_shaping.py
@@ -21,30 +21,6 @@ def _runner(*, vocab_size: int, codec_eos_token_id: int) -> Qwen3TTSModelRunner:
     return runner
 
 
-def _sampling_request(repetition_penalty: float) -> types.SimpleNamespace:
-    sampling_params = types.SimpleNamespace(
-        repetition_penalty=repetition_penalty,
-        frequency_penalty=0.0,
-        presence_penalty=0.0,
-        min_new_tokens=0,
-    )
-    return types.SimpleNamespace(
-        sampling_params=sampling_params,
-        custom_logit_processor=None,
-    )
-
-
-def test_qwen3_tts_public_penalty_disables_async_lookahead() -> None:
-    runner = _runner(vocab_size=128, codec_eos_token_id=127)
-
-    assert runner.lookahead_eligible(
-        types.SimpleNamespace(reqs=[_sampling_request(1.0)])
-    )
-    assert not runner.lookahead_eligible(
-        types.SimpleNamespace(reqs=[_sampling_request(1.05)])
-    )
-
-
 def test_qwen3_tts_suppresses_configured_codec_tail_with_basic_slices() -> None:
     configured_vocab = 3072
     codec_eos = 2150


### PR DESCRIPTION
## Summary

Every Qwen3-TTS decode step ends with the code predictor chain, a 4 ms CUDA graph replay whose outputs the host never reads: the next step's talker input is stacked from device views, the stream chunk leaves as a device view with an event, and the vocoder waits on that event. The only value the host reads from a step is the layer 0 token id, for the EOS gate. Today that id is copied to pinned host memory after the predictor is enqueued, so the one blocking wait of the step, in `_finalize`, covers the whole predictor, and the host tail, the next batch's preparation and the next backbone launch all run on an empty device.

This branch enqueues the pinned copy and its event before `code_predictor_forward`. The wait then returns as soon as the backbone and the sample are done, and the host tail overlaps the predictor: the next backbone launch is issued while the replay is still running, and the device sees it queued behind the replay. No kernel changes, only the position of one independent copy in the stream, so the output is bit identical (1088 of 1088 WAVs equal to main on a seeded c1 pass). The runner also declares itself sync only through `lookahead_eligible`: its codec collect runs in `post_decode` and has no launch and resolve halves, so the async decode loop must never run the plain LM hooks against it.

## Changes

- `model_runner.py`: `_stage_token_ids` moves ahead of the predictor in `_collect_codes`; `lookahead_eligible` returns False.
- Tests, `tests/unit_test/qwen3_tts/test_decode_step_staging.py`: the host ids are staged when the predictor is called and the code and feedback rows still come from the post predictor snapshot; a history free batch is not lookahead eligible; on CUDA, the resolved ids come back while a predictor that sleeps the stream is still running, and they keep the sampled values when later stream work overwrites the device tensor. The base gate test in `test_mask_logit_shaping.py` asserted the answer this runner no longer gives and is removed.

## Test results

H100 80GB, sglang 0.5.19, `Qwen/Qwen3-TTS-12Hz-1.7B-Base`, default config, full seed-tts-eval English corpus (1088 samples), voice clone with references, `--warmup 1`, c16. A is upstream main `b29084bfa`, B is this branch.

### Streaming

| Metric | A | B | Delta |
| --- | ---: | ---: | ---: |
| QPS | 16.43 | 19.01 | +15.7% |
| Audio s/s | 68.20 | 78.77 | +15.5% |
| RTF, mean | 0.2352 | 0.2037 | -13.4% |
| Latency, mean | 0.969 s | 0.836 s | -0.133 s |
| Latency, p99 | 1.544 s | 1.363 s | -0.181 s |
| TTFC, mean | 98.6 ms | 105.7 ms | +7.1 ms |
| TTFC, p99 | 254.9 ms | 247.9 ms | -7.0 ms |
| Inter chunk, mean | 107.8 ms | 90.8 ms | -17.0 ms |
| GR Active | 72.4% | 84.2% | +11.8 |
| SMs Active | 40.3% | 48.7% | +8.4 |
| SM Issue | 13.6% | 16.1% | +2.5 |

### Non streaming

| Metric | A | B | Delta |
| --- | ---: | ---: | ---: |
| QPS | 17.024 | 17.686 | +3.9% |
| Audio s/s | 70.67 | 73.25 | +3.7% |
| RTF, mean | 0.2283 | 0.2207 | -3.3% |
| Latency, mean | 0.934 s | 0.897 s | -0.037 s |
| Latency, p95 | 1.346 s | 1.288 s | -0.058 s |
| Latency, p99 | 1.492 s | 1.439 s | -0.053 s |
