### PR TITLE
[cosy3][perf] cache "seed" tensor to remove a H2D on every decode step

### DIFF
--- a/sglang_omni/model_runner/base.py
+++ b/sglang_omni/model_runner/base.py
@@ -118,6 +118,9 @@ class ModelRunner:
         self._token_id_host_bufs: list[torch.Tensor] | None = None
         self._token_id_host_slot: int = 0
         self._suppress_tensor_cache: dict[tuple, tuple[Any, torch.Tensor | None]] = {}
+        self._sampling_seed_cache: (
+            tuple[tuple[str, str, tuple[int, ...]], torch.Tensor] | None
+        ) = None
 
     def _stage_token_ids(self, result: Any, ids: torch.Tensor) -> None:
         # Note (wenyao): pinned host copy staged once at sample time so downstream
@@ -896,9 +899,20 @@ class ModelRunner:
                 seed = resolve_row_seed(seed)  # mask and cache user seed
                 sp.sampling_seed = seed
             row_seeds.append(seed)
-        sampling_info.sampling_seed = torch.tensor(
-            row_seeds, dtype=torch.long, device=sampling_info.device
-        )
+        # The sampler only reads this tensor. Reuse unchanged rows to avoid a
+        # blocking host-to-device copy on every step. Include row order and the
+        # worker device (sampling_info.device can be an unindexed "cuda").
+        cache_key = (str(self.device), str(sampling_info.device), tuple(row_seeds))
+        cached = self._sampling_seed_cache
+        if cached is None or cached[0] != cache_key:
+            seed_tensor = torch.tensor(
+                row_seeds, dtype=torch.long, device=sampling_info.device
+            )
+            # Keep one entry, never update its tensor in place: an in-flight
+            # ForwardBatch may still hold the previous entry after replacement.
+            cached = (cache_key, seed_tensor)
+            self._sampling_seed_cache = cached
+        sampling_info.sampling_seed = cached[1]
 
     @staticmethod
     def _validate_seeded_sampling_supported(sampling_info: Any) -> None:

--- a/tests/unit_test/model_runner/test_install_sampling_seeds.py
+++ b/tests/unit_test/model_runner/test_install_sampling_seeds.py
@@ -4,12 +4,20 @@
 from __future__ import annotations
 
 from types import SimpleNamespace
+from unittest.mock import patch
 
 import pytest
 import torch
 
 from sglang_omni.model_runner.base import ModelRunner
-from sglang_omni.sampling.seed import derive_sampling_seed
+from sglang_omni.sampling.seed import SAMPLING_SEED_MASK, derive_sampling_seed
+
+
+def _runner():
+    runner = object.__new__(ModelRunner)
+    runner.device = torch.device("cpu")
+    runner._sampling_seed_cache = None
+    return runner
 
 
 def _req(seed, request_id="req"):
@@ -33,7 +41,7 @@ def _fb(sampling_seed=None, *, top_p=False, top_k=False, min_p=False):
 
 
 def test_installs_per_row_seeds_and_noops_without_one():
-    runner = object.__new__(ModelRunner)
+    runner = _runner()
     # seeded rows -> per-row int64 seed tensor; mixed unseeded rows get a
     # rank-shared fallback derived from the request id.
     fb = _fb()
@@ -51,7 +59,7 @@ def test_installs_per_row_seeds_and_noops_without_one():
 
 
 def test_does_not_clobber_subclass_installed_seed():
-    runner = object.__new__(ModelRunner)
+    runner = _runner()
     preset = torch.tensor([1, 2, 3])
     fb = _fb(sampling_seed=preset)
     runner._install_sampling_seeds(fb, [_req(42), _req(42), _req(42)])
@@ -59,7 +67,7 @@ def test_does_not_clobber_subclass_installed_seed():
 
 
 def test_preinstalled_seed_requires_sampling_mode_contract():
-    runner = object.__new__(ModelRunner)
+    runner = _runner()
     preset = torch.tensor([1, 2])
     fb = SimpleNamespace(sampling_info=SimpleNamespace(sampling_seed=preset))
     with pytest.raises(AttributeError):
@@ -67,7 +75,7 @@ def test_preinstalled_seed_requires_sampling_mode_contract():
 
 
 def test_unseeded_row_in_seeded_batch_uses_rank_shared_fallback():
-    runner = object.__new__(ModelRunner)
+    runner = _runner()
     requests = [_req(42, "seeded"), _req(None, "unseeded")]
     fb = _fb()
     runner._install_sampling_seeds(fb, requests)
@@ -81,7 +89,7 @@ def test_unseeded_row_in_seeded_batch_uses_rank_shared_fallback():
 
 
 def test_rejects_seeded_min_p_before_upstream_sampler():
-    runner = object.__new__(ModelRunner)
+    runner = _runner()
     with pytest.raises(ValueError, match="min_p"):
         runner._install_sampling_seeds(_fb(min_p=True), [_req(42)])
 
@@ -91,7 +99,7 @@ def test_rejects_seeded_flashinfer_top_p_before_upstream_sampler(monkeypatch):
         "sglang_omni.model_runner.base._current_sglang_sampling_backend",
         lambda: "flashinfer",
     )
-    runner = object.__new__(ModelRunner)
+    runner = _runner()
     with pytest.raises(ValueError, match="flashinfer"):
         runner._install_sampling_seeds(_fb(top_p=True), [_req(42)])
 
@@ -101,7 +109,131 @@ def test_allows_seeded_pytorch_top_p(monkeypatch):
         "sglang_omni.model_runner.base._current_sglang_sampling_backend",
         lambda: "pytorch",
     )
-    runner = object.__new__(ModelRunner)
+    runner = _runner()
     fb = _fb(top_p=True)
     runner._install_sampling_seeds(fb, [_req(42)])
     assert int(fb.sampling_info.sampling_seed[0]) == 42
+
+
+def test_reuses_seed_tensor_across_steps_and_new_requests():
+    """Explicit seed values, not request identity, own the reusable tensor."""
+    runner = _runner()
+    first = _fb()
+    runner._install_sampling_seeds(first, [_req(7, "finished"), _req(101)])
+    with patch(
+        "sglang_omni.model_runner.base.torch.tensor", wraps=torch.tensor
+    ) as make:
+        following = _fb()
+        runner._install_sampling_seeds(following, [_req(7, "new"), _req(101)])
+    assert following.sampling_info.sampling_seed is first.sampling_info.sampling_seed
+    make.assert_not_called()
+
+
+@pytest.mark.parametrize("seeds", [[101, 7], [7], [7, 102], [7, 101, 42]])
+def test_changed_rows_do_not_overwrite_an_inflight_tensor(seeds):
+    runner = _runner()
+    first = _fb()
+    runner._install_sampling_seeds(first, [_req(7), _req(101)])
+    following = _fb()
+    runner._install_sampling_seeds(following, [_req(seed) for seed in seeds])
+    assert following.sampling_info.sampling_seed.tolist() == seeds
+    assert (
+        following.sampling_info.sampling_seed is not first.sampling_info.sampling_seed
+    )
+    assert first.sampling_info.sampling_seed.tolist() == [7, 101]
+
+
+def test_unseeded_request_replacement_changes_only_derived_row():
+    runner = _runner()
+    first, following = _fb(), _fb()
+    runner._install_sampling_seeds(first, [_req(42), _req(None, "old")])
+    replacement = [_req(42), _req(None, "new")]
+    runner._install_sampling_seeds(following, replacement)
+    assert following.sampling_info.sampling_seed.tolist() == [
+        42,
+        derive_sampling_seed("sglang-omni-unseeded-row", "new"),
+    ]
+    assert first.sampling_info.sampling_seed[1] == derive_sampling_seed(
+        "sglang-omni-unseeded-row", "old"
+    )
+    assert replacement[1].data.req.sampling_params.sampling_seed is None
+
+
+@pytest.mark.parametrize("seed", [-1, 1 << 80])
+def test_normalized_seed_is_reused(seed):
+    runner = _runner()
+    request = _req(seed)
+    first, following = _fb(), _fb()
+    runner._install_sampling_seeds(first, [request])
+    assert request.data.req.sampling_params.sampling_seed == seed & SAMPLING_SEED_MASK
+    runner._install_sampling_seeds(following, [request])
+    assert following.sampling_info.sampling_seed is first.sampling_info.sampling_seed
+
+
+def test_cache_hit_does_not_bypass_sampler_validation(monkeypatch):
+    runner = _runner()
+    runner._install_sampling_seeds(_fb(), [_req(42)])
+    with pytest.raises(ValueError, match="min_p"):
+        runner._install_sampling_seeds(_fb(min_p=True), [_req(42)])
+    monkeypatch.setattr(
+        "sglang_omni.model_runner.base._current_sglang_sampling_backend",
+        lambda: "flashinfer",
+    )
+    with pytest.raises(ValueError, match="flashinfer"):
+        runner._install_sampling_seeds(_fb(top_k=True), [_req(42)])
+
+
+def test_worker_device_is_part_of_cache_key():
+    """Simulate worker-device changes while keeping allocations CPU-only."""
+    runner = _runner()
+    first, following = _fb(), _fb()
+    runner.device = torch.device("cuda:0")
+    runner._install_sampling_seeds(first, [_req(42)])
+    runner.device = torch.device("cuda:1")
+    runner._install_sampling_seeds(following, [_req(42)])
+    assert (
+        following.sampling_info.sampling_seed is not first.sampling_info.sampling_seed
+    )
+    assert following.sampling_info.sampling_seed.tolist() == [42]
+
+
+def test_independent_runners_preserve_rank_shared_seed_values():
+    """Check TP fallback determinism without claiming a distributed GPU test."""
+    left, right = _fb(), _fb()
+    _runner()._install_sampling_seeds(left, [_req(42), _req(None, "same-request")])
+    _runner()._install_sampling_seeds(right, [_req(42), _req(None, "same-request")])
+    assert torch.equal(
+        left.sampling_info.sampling_seed, right.sampling_info.sampling_seed
+    )
+
+
+def test_cache_retains_only_latest_tensor():
+    import gc
+    import weakref
+
+    runner = _runner()
+    first = _fb()
+    runner._install_sampling_seeds(first, [_req(1)])
+    retired = weakref.ref(first.sampling_info.sampling_seed)
+    del first
+    for seed in range(2, 20):
+        runner._install_sampling_seeds(_fb(), [_req(seed)])
+    gc.collect()
+    assert retired() is None
+
+
+def test_failed_replacement_preserves_the_previous_entry():
+    runner = _runner()
+    first = _fb()
+    runner._install_sampling_seeds(first, [_req(1)])
+    with (
+        patch(
+            "sglang_omni.model_runner.base.torch.tensor",
+            side_effect=RuntimeError("allocation failed"),
+        ),
+        pytest.raises(RuntimeError, match="allocation failed"),
+    ):
+        runner._install_sampling_seeds(_fb(), [_req(2)])
+    following = _fb()
+    runner._install_sampling_seeds(following, [_req(1)])
+    assert following.sampling_info.sampling_seed is first.sampling_info.sampling_seed


### PR DESCRIPTION
## Motivation
### The seed finding

`ModelRunner._install_sampling_seeds` (`sglang_omni/model_runner/base.py`) ends
with:

    sampling_info.sampling_seed = torch.tensor(
        row_seeds, dtype=torch.long, device=sampling_info.device
    )

`row_seeds` is derived only from each row's resolved `sampling_params.sampling_seed`
and `request_id`, so within a fixed batch it is bit-identical on every step. The
early-out at the top of the function is supposed to prevent the repeat, but
`SGLangExecutionBridge.forward_context` calls `sampling_info.copy_for_forward()`
per step under `isolate_sampling=True`, so the copy always arrives with the field
empty.

`torch.tensor(list, device="cuda")` is a pageable H2D, which is synchronous:
it waits for everything already queued on the stream. So every decode step stops
the pipeline once, to move 8 bytes.

Splitting it with a bracketing `torch.cuda.synchronize()` shows 954 us/step ->
48 us/step, i.e. ~906 us of that was absorbed waiting for the forward. 

An 8-step trace with the fix shows all eight seed H2D copies and their stream
synchronizations gone, with GPU work unchanged.
<!-- Explain the purpose of this PR and the goals it aims to achieve. -->

## Modifications


`_install_sampling_seeds` rebuilds the per-row seed tensor on every decode step, even

when the rows have not changed. `torch.tensor(row_seeds, device=...)` is a pageable

host-to-device copy, and those are synchronous: the stream drains before sampling can

be submitted.


The entry is replaced rather than written in place, so an in-flight `ForwardBatch` still

holding the previous tensor is unaffected.


## Related Issues

<!-- Link to any related issues here. e.g. "Fixes #123" or "Closes #456" -->

## Accuracy Test

<!-- If this PR affects model-side code (e.g., kernels, model architecture), please provide accuracy test results. Ref: https://docs.sglang.io/docs/developer_guide/evaluating_new_models -->

## Benchmark & Profiling

<!-- If this PR is expected to impact performance, please provide benchmark and profiling results. Ref: https://docs.sglang.io/docs/developer_guide/benchmark_and_profiling -->

## Checklist

- [ ] Format your code according with pre-commit.
- [ ] Add unit tests.
- [ ] Update documentation / docstrings / example tutorials as needed.
- [ ] Provide throughput / latency benchmark results and accuracy evaluation results as needed.
- [ ] For reviewers: If you haven't made any contributions to this PR and are only assisting with merging the main branch, please remove yourself as a co-author when merging the PR.

## Tests
| Concurrency | E2E |
| --- | --- |
| 1 | -12.1% |
| 4 | no regression observed |
| 16 | no regression observed |

C1 is a matched ABBA pair with the profiler off, reproduced across two runs, with identical codec and WAV hashes on all 32 requests. An 8-step trace shows the eight per-step H2D copies and their stream synchronizations gone, with GPU work unchanged.

The same shape of problem — a per-step rebuild of a value that is constant for the request — may exist elsewhere in the sampling path. This PR only covers the seed tensor.

```bash
python3 -m pytest tests/unit_test/model_runner/test_install_sampling_seeds.py -q
```

Four added cases: reuse while rows are unchanged, a new tensor on reorder / shrink /

grow, the worker device as part of the key, and validation still running on a cache hit.



